### PR TITLE
Prevent output from being truncated with bun --filter commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,14 +39,14 @@
     }
   },
   "scripts": {
-    "demo:build": "bun run --elide-lines 0 --filter @pierre/js-demo-app build",
+    "demo:build": "bun run --filter @pierre/js-demo-app build",
     "demo:dev": "bun run --elide-lines 0 --filter @pierre/js-demo-app dev",
     "demo:prod": "bun run --elide-lines 0 --filter @pierre/js-demo-app prod",
     "demo:tsc": "bun run --elide-lines 0 --filter @pierre/js-demo-app tsc --noEmit --pretty",
-    "diff-ui:build": "bun run --elide-lines 0 --filter @pierre/diff-ui build",
+    "diff-ui:build": "bun run --filter @pierre/diff-ui build",
     "diff-ui:dev": "bun run --elide-lines 0 --filter @pierre/diff-ui dev",
     "diff-ui:tsc": "bun run --elide-lines 0 --filter @pierre/diff-ui tsc --noEmit --pretty",
-    "docs:build": "bun run --elide-lines 0 --filter @pierre/js-docs build",
+    "docs:build": "bun run --filter @pierre/js-docs build",
     "docs:dev": "bun run --elide-lines 0 --filter @pierre/js-docs dev",
     "docs:prod": "bun run --elide-lines 0 --filter @pierre/js-docs prod",
     "docs:start": "bun run --elide-lines 0 --filter @pierre/js-docs start",


### PR DESCRIPTION
Noticed bun was doing a very annoying thing where it was truncating the output from the `--filter` commands, so disabling this: 

https://github.com/oven-sh/bun/pull/15837