### PR TITLE
Add react compiler to docs

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -43,6 +43,7 @@ const nextConfig = {
   // },
   experimental: {
     cssChunking: 'strict',
+    reactCompiler: true,
   },
 };
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-tooltip": "catalog:",
     "@radix-ui/react-use-controllable-state": "catalog:",
     "@shikijs/transformers": "catalog:",
+    "babel-plugin-react-compiler": "catalog:",
     "class-variance-authority": "catalog:",
     "clsx": "catalog:",
     "cmdk": "catalog:",

--- a/bun.lock
+++ b/bun.lock
@@ -58,6 +58,7 @@
         "@radix-ui/react-tooltip": "catalog:",
         "@radix-ui/react-use-controllable-state": "catalog:",
         "@shikijs/transformers": "catalog:",
+        "babel-plugin-react-compiler": "catalog:",
         "class-variance-authority": "catalog:",
         "clsx": "catalog:",
         "cmdk": "catalog:",
@@ -93,7 +94,7 @@
     },
     "packages/precision-diffs": {
       "name": "@pierre/precision-diffs",
-      "version": "0.0.1-alpha.1-1",
+      "version": "0.0.1-alpha.1-4",
       "dependencies": {
         "@shikijs/core": "catalog:",
         "diff": "catalog:",
@@ -187,6 +188,7 @@
     "@types/react": "19.1.13",
     "@types/react-dom": "19.1.9",
     "@vitejs/plugin-react": "5.0.3",
+    "babel-plugin-react-compiler": "1.0.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "cmdk": "1.1.1",
@@ -913,6 +915,8 @@
     "axe-core": ["axe-core@4.10.3", "", {}, "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
+
+    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@1.0.0", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
       "@types/react": "19.1.13",
       "@types/react-dom": "19.1.9",
       "@vitejs/plugin-react": "5.0.3",
+      "babel-plugin-react-compiler": "1.0.0",
       "class-variance-authority": "0.7.1",
       "clsx": "2.1.1",
       "cmdk": "1.1.1",


### PR DESCRIPTION
Hopefully there wasn't an intentional reason that didn't have this enabled @SlexAxton, but I assume it was just lost in the chaos