### PR TITLE
Fix NextJS header link navigation

### DIFF
--- a/apps/docs/components/ui/header.tsx
+++ b/apps/docs/components/ui/header.tsx
@@ -102,7 +102,6 @@ function HeaderNavLink({
 
   return (
     <NavigationMenuItem>
-      {/* @ts-expect-error todo: Alex type check this */}
       <NavigationMenuLink
         href={hrefString}
         className={cn(

--- a/apps/docs/components/ui/navigation-menu.tsx
+++ b/apps/docs/components/ui/navigation-menu.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils';
 import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu';
 import { cva } from 'class-variance-authority';
 import { ChevronDown } from 'lucide-react';
+import Link from 'next/link';
 import * as React from 'react';
 
 const NavigationMenu = React.forwardRef<
@@ -78,7 +79,7 @@ const NavigationMenuContent = React.forwardRef<
 ));
 NavigationMenuContent.displayName = NavigationMenuPrimitive.Content.displayName;
 
-const NavigationMenuLink = NavigationMenuPrimitive.Link;
+const NavigationMenuLink = Link;
 
 const NavigationMenuViewport = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Viewport>,


### PR DESCRIPTION
By not using NextJS's Link component here we were forcing every page to reload on nav... this should fix that from the header at least, I didn't audit further though