### PR TITLE
Fix FileDiff.tsx Hydration

### DIFF
--- a/apps/docs/lib/useEffectEvent.ts
+++ b/apps/docs/lib/useEffectEvent.ts
@@ -1,0 +1,14 @@
+import { useCallback, useInsertionEffect, useRef } from 'react';
+
+// A temp hack for useEffectEvent until we can upgrade to NextJS16
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function useEffectEvent<T extends (...args: any[]) => any>(
+  callback: T
+): T {
+  const callbackRef = useRef(callback);
+  useInsertionEffect(() => void (callbackRef.current = callback));
+  return useCallback((...args: Parameters<T>): ReturnType<T> => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return callbackRef.current(...args);
+  }, []) as T;
+}


### PR DESCRIPTION
While I had a basic hydration implementation, it wasn't very robust and could break both in strict mode and on page back navigation in NextJS.

Here's a video showing it working on the interactive FileDiff component:

https://github.com/user-attachments/assets/f5456073-81d5-42d8-88ba-cdd8831f87cd

## Notes

Basically I took this opportunity to make hydration a lot smarter, and also utilize a ref function over layout effect. I think this better handles a separation of concerns, `useIsometricEffect` handles updates (is smart to not update if the content rendered does not need updates) and the ref function ties the logic of instantiation more directly to the node itself.

Hydration will now automatically call render if stuff was NOT already pre-rendered.

I also took the opportunity to fix a few bugs that strictmode surfaced in how renders could race and not render anything. So overall the render code on FileDiffUI should be a lot stronger now.