### PR TITLE
Force custom component to always be imported

### DIFF
--- a/apps/docs/app/docs/Overview/Overview.tsx
+++ b/apps/docs/app/docs/Overview/Overview.tsx
@@ -2,7 +2,7 @@
 
 import { IconCiWarningFill } from '@/components/icons';
 import { ButtonGroup, ButtonGroupItem } from '@/components/ui/button-group';
-import { FileDiff } from '@pierre/precision-diffs/react';
+import { MultiFileDiff } from '@pierre/precision-diffs/react';
 import type {
   PreloadedFileDiffResult,
   PreloadedFileResult,
@@ -64,7 +64,7 @@ export function Overview({
         </Link>{' '}
         which provides a lot of great theme and language support.
       </p>
-      <FileDiff
+      <MultiFileDiff
         {...initialDiffProps}
         // @ts-expect-error lol
         options={{ ...initialDiffProps.options, hunkSeparators: 'line-info' }}

--- a/packages/precision-diffs/src/File.ts
+++ b/packages/precision-diffs/src/File.ts
@@ -10,6 +10,7 @@ import {
 } from './FileRenderer';
 import { getSharedHighlighter } from './SharedHighlighter';
 import { HEADER_METADATA_SLOT_ID } from './constants';
+import { PJSContainerLoaded } from './custom-components/Container';
 import { SVGSpriteSheet } from './sprite';
 import type {
   FileContents,
@@ -72,7 +73,12 @@ export type FileOptions<LAnnotation> =
   | FileThemeOptions<LAnnotation>
   | FileThemesOptions<LAnnotation>;
 
+let instanceId = -1;
+
 export class File<LAnnotation = undefined> {
+  static LoadedCustomComponent: boolean = PJSContainerLoaded;
+
+  readonly __id: number = ++instanceId;
   private fileRenderer: FileRenderer<LAnnotation>;
   private headerRenderer: FileHeaderRenderer;
   private fileContainer: HTMLElement | undefined;

--- a/packages/precision-diffs/src/FileDiff.ts
+++ b/packages/precision-diffs/src/FileDiff.ts
@@ -8,7 +8,7 @@ import {
 } from './FileHeaderRenderer';
 import { getSharedHighlighter } from './SharedHighlighter';
 import { HEADER_METADATA_SLOT_ID } from './constants';
-import './custom-components/Container';
+import { PJSContainerLoaded } from './custom-components/Container';
 import { SVGSpriteSheet } from './sprite';
 import type {
   AnnotationSide,
@@ -106,7 +106,14 @@ export type DiffFileRendererOptions<LAnnotation> =
   | DiffFileThemeRendererOptions<LAnnotation>
   | DiffFileThemesRendererOptions<LAnnotation>;
 
+let instanceId = -1;
+
 export class FileDiff<LAnnotation = undefined> {
+  // NOTE(amadeus): We sorta need this to ensure the web-component file is
+  // properly loaded
+  static LoadedCustomComponent: boolean = PJSContainerLoaded;
+
+  readonly __id: number = ++instanceId;
   options: DiffFileRendererOptions<LAnnotation>;
   private fileContainer: HTMLElement | undefined;
   private pre: HTMLPreElement | undefined;

--- a/packages/precision-diffs/src/custom-components/Container.ts
+++ b/packages/precision-diffs/src/custom-components/Container.ts
@@ -32,3 +32,5 @@ if (
 
   customElements.define('file-diff', PJSContainer);
 }
+
+export const PJSContainerLoaded = true;


### PR DESCRIPTION
Not actually quite sure when/how this broke, but it's definitely an issue right now that the custom component js isn't loaded into the browser, which can cause a lot of problems. Anyways, this should fix that.

Also added some instance id tracking which is useful for when i'm debugging