### PR TITLE
Use a more modern font stack

### DIFF
--- a/packages/precision-diffs/src/style.css
+++ b/packages/precision-diffs/src/style.css
@@ -5,8 +5,8 @@
     'SF Mono', Monaco, Consolas, 'Ubuntu Mono', 'Liberation Mono',
     'Courier New', monospace;
   --pjs-header-font-fallback:
-    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
-    Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+    system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', 'Noto Sans',
+    'Liberation Sans', Arial, sans-serif;
 
   --pjs-mixer: light-dark(black, white);
   --pjs-gap-fallback: 8px;


### PR DESCRIPTION
Some of the fonts in here are a bit wild—looking at you, Linux distros—and we had them years ago in Bootstrap, too. Since then, there are new system font keywords and a simplified stack.

Sidebar—are we testing these kind of things anywhere? BrowserStack or whatever?