### PR TITLE
Don't depend on css psuedo selectors

### DIFF
--- a/packages/precision-diffs/src/DiffHunksRenderer.ts
+++ b/packages/precision-diffs/src/DiffHunksRenderer.ts
@@ -49,6 +49,7 @@ interface RenderHunkProps {
   hunk: Hunk;
   prevHunk: Hunk | undefined;
   isLastHunk: boolean;
+  isFirstHunk: boolean;
   hunkIndex: number;
   highlighter: PJSHighlighter;
   state: SharedRenderState;
@@ -293,6 +294,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
         highlighter,
         state,
         transformers,
+        isFirstHunk: hunkIndex === 0,
         isLastHunk: hunkIndex === fileDiff.hunks.length - 1,
         additionsAST,
         deletionsAST,
@@ -437,6 +439,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
     state,
     transformers,
     prevHunk,
+    isFirstHunk,
     isLastHunk,
     additionsAST,
     deletionsAST,
@@ -487,16 +490,25 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
                 content: getModifiedLinesString(lines),
                 expandIndex: expandable ? hunkIndex : undefined,
                 slotName,
+                isFirstHunk,
+                isLastHunk: false,
               })
             );
             hunkData.push({ slotName, lines, type, expandable });
           }
         } else if (hunkSeparators === 'metadata' && hunk.hunkSpecs != null) {
           linesAST.push(
-            createSeparator({ type: 'metadata', content: hunk.hunkSpecs })
+            createSeparator({
+              type: 'metadata',
+              content: hunk.hunkSpecs,
+              isFirstHunk,
+              isLastHunk: false,
+            })
           );
         } else if (hunkSeparators === 'simple' && hunkIndex > 0) {
-          linesAST.push(createSeparator({ type: 'simple' }));
+          linesAST.push(
+            createSeparator({ type: 'simple', isFirstHunk, isLastHunk: false })
+          );
         }
       }
       for (const line of getLineNodes(nodes)) {
@@ -519,6 +531,8 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
               content: getModifiedLinesString(lines),
               expandIndex: expandable ? hunkIndex + 1 : undefined,
               slotName,
+              isFirstHunk: false,
+              isLastHunk,
             })
           );
           hunkData.push({ slotName, lines, type, expandable });

--- a/packages/precision-diffs/src/style.css
+++ b/packages/precision-diffs/src/style.css
@@ -377,12 +377,16 @@ code {
   padding: 4px 1ch;
 }
 
-[data-separator='line-info']:not(:first-child) {
-  margin-top: var(--pjs-gap-block, var(--pjs-gap-fallback));
+[data-separator='line-info'] {
+  margin-block: var(--pjs-gap-block, var(--pjs-gap-fallback));
 }
 
-[data-separator='line-info']:not(:last-child) {
-  margin-bottom: var(--pjs-gap-block, var(--pjs-gap-fallback));
+[data-separator='line-info'][data-separator-first] {
+  margin-top: 0;
+}
+
+[data-separator='line-info'][data-separator-last] {
+  margin-bottom: 0;
 }
 
 [data-separator='line-info'] [data-separator-content] {

--- a/packages/precision-diffs/src/utils/hast_utils.ts
+++ b/packages/precision-diffs/src/utils/hast_utils.ts
@@ -61,6 +61,8 @@ interface CreateSeparatorProps {
   content?: string;
   expandIndex?: number;
   slotName?: string;
+  isFirstHunk: boolean;
+  isLastHunk: boolean;
 }
 
 export function createSeparator({
@@ -68,6 +70,8 @@ export function createSeparator({
   content,
   expandIndex,
   slotName,
+  isFirstHunk,
+  isLastHunk,
 }: CreateSeparatorProps): Element {
   const children = [];
   if (type === 'metadata' && content != null) {
@@ -106,6 +110,8 @@ export function createSeparator({
     properties: {
       'data-separator': children.length === 0 ? '' : type,
       'data-expand-index': expandIndex,
+      'data-separator-first': isFirstHunk ? '' : undefined,
+      'data-separator-last': isLastHunk ? '' : undefined,
     },
   });
 }


### PR DESCRIPTION
Quick tweak to remove the dependency on first-child/last-child