### PR TITLE
Fix user-select: none in safari (it requires a vendor prefix I guess)

### DIFF
--- a/packages/precision-diffs/src/style.css
+++ b/packages/precision-diffs/src/style.css
@@ -340,6 +340,7 @@ code {
   position: sticky;
   left: 0;
   grid-column: 1 / 3;
+  -webkit-user-select: none;
   user-select: none;
   /* We multiply by 1.414 (√2) to better approximate the diagonal repeat distance */
   background-image: repeating-linear-gradient(
@@ -366,6 +367,7 @@ code {
 }
 
 [data-separator-content] {
+  -webkit-user-select: none;
   user-select: none;
   fill: currentColor;
 }
@@ -498,6 +500,7 @@ code {
     position: absolute;
     top: 0;
     left: 0;
+    -webkit-user-select: none;
     user-select: none;
   }
 }
@@ -523,6 +526,7 @@ code {
     position: absolute;
     top: 0;
     left: 0;
+    -webkit-user-select: none;
     user-select: none;
   }
 }
@@ -559,6 +563,7 @@ code {
   text-align: right;
   position: sticky;
   left: 0;
+  -webkit-user-select: none;
   user-select: none;
   background-color: var(--pjs-bg);
   color: var(--pjs-fg-number);
@@ -700,6 +705,7 @@ code {
 }
 
 [data-no-newline] {
+  -webkit-user-select: none;
   user-select: none;
   opacity: 0.6;
 }


### PR DESCRIPTION
@mdo and @SlexAxton you guys probably know a better build time fix for this, which we should probably prioritize asap because it sounds like cursor may be going live with us soon.

At the very least this is a quick hotfix in the interim for user-select not working in safari at the moment