### PR TITLE
Update how font styles are applied

### DIFF
--- a/packages/precision-diffs/src/style.css
+++ b/packages/precision-diffs/src/style.css
@@ -53,7 +53,7 @@
   color-scheme: light dark;
   display: block;
   font-family: var(--pjs-header-font-family, var(--pjs-header-font-fallback));
-  font-size: var(--pjs-font-size, 14px);
+  font-size: var(--pjs-font-size, 13px);
   line-height: var(--pjs-line-height, 20px);
   font-feature-settings: var(--pjs-font-features);
 }


### PR DESCRIPTION
- `:host()` gets all the font properties—family, size, line-height, font-feature-settings
- `box-sizing` reset stays and applies universally, including to pseudo-elements
- The file itself, file headers, and separators default to the sans-serif fallback font. This is a change, and not one that really needs to happen, but feels more logical to me. By default, sans-serif, but code is always mono. @amadeus This could use your feedback the most—tell me if that feels wrong to you.
- This elevates the header-font-family declarations up the DOM tree a bit for separators, so it applies to more elements now as intended (I think)
- **This also sets the default fallback font-size to 13px.** Everything has felt a little too big to me textually in our diffs, so hoping this gets us back closer to original designs.