### PR TITLE
Allow annotations to be selected along with their line

### DIFF
--- a/apps/docs/app/diff-examples/Annotations/Annotations.tsx
+++ b/apps/docs/app/diff-examples/Annotations/Annotations.tsx
@@ -230,28 +230,13 @@ function CommentForm({
   return (
     <div
       style={{
-        marginLeft: -43,
         overflow: 'hidden',
-        backgroundColor: 'var(--pjs-bg)',
         display: 'flex',
         flexDirection: 'row',
         gap: 1,
-        width: 'calc(100% + 43px)',
       }}
     >
-      <div
-        style={{
-          backgroundColor: 'var(--pjs-bg-selection-number-background)',
-          width: 43.5,
-          display: 'flex',
-        }}
-      />
-      <div
-        style={{
-          width: '100%',
-          backgroundColor: 'var(--pjs-bg-selection-background)',
-        }}
-      >
+      <div style={{ width: '100%' }}>
         <div
           className="max-w-[95%] sm:max-w-[70%]"
           style={{

--- a/packages/precision-diffs/src/LineSelectionManager.ts
+++ b/packages/precision-diffs/src/LineSelectionManager.ts
@@ -249,14 +249,38 @@ export class LineSelectionManager {
         const lineIndex = this.getLineIndex(element);
         if ((lineIndex ?? 0) > last) break;
         if (lineIndex == null || lineIndex < first) continue;
-        if (isSingle) {
-          element.setAttribute('data-selected-line', 'single');
-        } else if (lineIndex === first) {
-          element.setAttribute('data-selected-line', 'first');
-        } else if (lineIndex === last) {
-          element.setAttribute('data-selected-line', 'last');
-        } else {
-          element.setAttribute('data-selected-line', '');
+        let attributeValue = isSingle
+          ? 'single'
+          : lineIndex === first
+            ? 'first'
+            : lineIndex === last
+              ? 'last'
+              : '';
+        element.setAttribute('data-selected-line', attributeValue);
+        // If we have a line annotation following our selected line, we should
+        // mark it as selected as well
+        if (
+          element.nextSibling instanceof HTMLElement &&
+          element.nextSibling.hasAttribute('data-line-annotation')
+        ) {
+          // Depending on the line's attribute value, lets go ahead and correct
+          // it when adding in the annotation row
+          if (isSingle) {
+            // Single technically becomes 2 selected lines
+            attributeValue = 'last';
+            element.setAttribute('data-selected-line', 'first');
+          } else if (lineIndex === first) {
+            // We don't want apply 'first' to the line annotation
+            attributeValue = '';
+          } else if (lineIndex === last) {
+            // the annotation will become the last selected line and therefore
+            // our existing line should no longer be last
+            element.setAttribute('data-selected-line', '');
+          }
+          element.nextSibling.setAttribute(
+            'data-selected-line',
+            attributeValue
+          );
         }
       }
     }

--- a/packages/precision-diffs/src/style.css
+++ b/packages/precision-diffs/src/style.css
@@ -349,6 +349,21 @@ code {
   grid-column: 1 / 3;
 }
 
+[data-line-annotation][data-selected-line] {
+  background-color: unset;
+
+  &::before {
+    content: '';
+    display: block;
+    border-right: var(--pjs-gap-style, 1px solid var(--pjs-bg));
+    background-color: var(--pjs-bg-selection-number);
+  }
+
+  [data-annotation-content] {
+    background-color: var(--pjs-bg-selection);
+  }
+}
+
 [data-interactive-lines] [data-line] {
   cursor: pointer;
 }


### PR DESCRIPTION
This removes some of the tricky hacks required to fake an annotation being attached to its selected line. Now any annotation following a selected line will also become selected.