### PR TITLE
Packing Hunk type with lots more data to help with various computations

### DIFF
--- a/packages/precision-diffs/src/DiffHunksRenderer.ts
+++ b/packages/precision-diffs/src/DiffHunksRenderer.ts
@@ -295,9 +295,9 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
             additionCount: 0,
             additionStart: lineCount,
             additionLines: 0,
-            deletedCount: 0,
-            deletedStart: lineCount,
-            deletedLines: 0,
+            deletionCount: 0,
+            deletionStart: lineCount,
+            deletionLines: 0,
             hunkContent: [],
             hunkContext: undefined,
             hunkSpecs: undefined,
@@ -603,7 +603,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
 
     const deletionContent: string[] = [];
     const deletionLineInfo: Record<number, LineInfo | undefined> = {};
-    let deletionLineNumber = hunk.deletedStart - 1;
+    let deletionLineNumber = hunk.deletionStart - 1;
 
     const unifiedContent: string[] = [];
     const unifiedLineInfo: Record<number, LineInfo | undefined> = {};
@@ -919,24 +919,24 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
       this.diff?.newLines != null &&
       preExpandedRegion.fromEnd > 0
     ) {
-      const { expandAddedStart, expandDeletedStart } = (() => {
+      const { expandAdditionStart, expandDeletionStart } = (() => {
         if (prevHunk != null) {
           return {
-            expandAddedStart: Math.max(
+            expandAdditionStart: Math.max(
               prevHunk.additionStart + prevHunk.additionCount - 1,
               hunk.additionStart - preExpandedRegion.fromEnd
             ),
-            expandDeletedStart: Math.max(
-              prevHunk.deletedStart + prevHunk.deletedCount - 1,
-              hunk.deletedStart - preExpandedRegion.fromEnd
+            expandDeletionStart: Math.max(
+              prevHunk.deletionStart + prevHunk.deletionCount - 1,
+              hunk.deletionStart - preExpandedRegion.fromEnd
             ),
           };
         }
-        return { expandAddedStart: 0, expandDeletedStart: 0 };
+        return { expandAdditionStart: 0, expandDeletionStart: 0 };
       })();
-      if (additionLineNumber - expandAddedStart > 0) {
-        additionLineNumber = expandAddedStart;
-        deletionLineNumber = expandDeletedStart;
+      if (additionLineNumber - expandAdditionStart > 0) {
+        additionLineNumber = expandAdditionStart;
+        deletionLineNumber = expandDeletionStart;
         for (let i = additionLineNumber; i < hunk.additionStart - 1; i++) {
           const line = this.diff.newLines[i];
           if (line == null) {

--- a/packages/precision-diffs/src/types.ts
+++ b/packages/precision-diffs/src/types.ts
@@ -71,9 +71,9 @@ export interface Hunk {
   additionCount: number;
   additionStart: number;
   additionLines: number;
-  deletedCount: number;
-  deletedStart: number;
-  deletedLines: number;
+  deletionCount: number;
+  deletionStart: number;
+  deletionLines: number;
   hunkContent: (ContextContent | ChangeContent)[];
   hunkContext: string | undefined;
   hunkSpecs: string | undefined;

--- a/packages/precision-diffs/src/utils/getTotalLineCountFromHunks.ts
+++ b/packages/precision-diffs/src/utils/getTotalLineCountFromHunks.ts
@@ -7,6 +7,6 @@ export function getTotalLineCountFromHunks(hunks: Hunk[]): number {
   }
   return Math.max(
     lastHunk.additionStart + lastHunk.additionCount,
-    lastHunk.deletedStart + lastHunk.deletedCount
+    lastHunk.deletionStart + lastHunk.deletionCount
   );
 }

--- a/packages/precision-diffs/src/utils/hast_utils.ts
+++ b/packages/precision-diffs/src/utils/hast_utils.ts
@@ -449,7 +449,7 @@ function createMetadataElement(
     let deletions = 0;
     for (const hunk of fileDiff.hunks) {
       additions += hunk.additionLines;
-      deletions += hunk.deletedLines;
+      deletions += hunk.deletionLines;
     }
     if (deletions > 0) {
       children.push(

--- a/packages/precision-diffs/src/utils/parsePatchFiles.ts
+++ b/packages/precision-diffs/src/utils/parsePatchFiles.ts
@@ -57,7 +57,7 @@ function processPatch(data: string): ParsedPatch {
       const match = firstLine.match(HUNK_HEADER);
       const hunkContent: (ContextContent | ChangeContent)[] = [];
       let additionLines = 0;
-      let deletedLines = 0;
+      let deletionLines = 0;
       if (match == null || currentFile == null) {
         if (currentFile != null) {
           console.error('parsePatchContent: Invalid hunk', hunk);
@@ -150,7 +150,7 @@ function processPatch(data: string): ParsedPatch {
               hunkContent.push(currentContent);
             }
             currentContent.deletions.push(line);
-            deletedLines++;
+            deletionLines++;
           } else {
             if (currentContent == null || currentContent.type !== 'context') {
               currentContent = createContentGroup('context');
@@ -169,18 +169,18 @@ function processPatch(data: string): ParsedPatch {
         additionCount: parseInt(match[4] ?? '0'),
         additionStart: parseInt(match[3]),
         additionLines,
-        deletedCount: parseInt(match[2] ?? '0'),
-        deletedStart: parseInt(match[1]),
-        deletedLines,
+        deletionCount: parseInt(match[2] ?? '0'),
+        deletionStart: parseInt(match[1]),
+        deletionLines,
         hunkContent,
         hunkContext: match[5],
         hunkSpecs: firstLine,
       };
       if (
         isNaN(hunkData.additionCount) ||
-        isNaN(hunkData.deletedCount) ||
+        isNaN(hunkData.deletionCount) ||
         isNaN(hunkData.additionStart) ||
-        isNaN(hunkData.deletedStart)
+        isNaN(hunkData.deletionStart)
       ) {
         console.error('parsePatchContent: invalid hunk metadata', hunkData);
         continue;
@@ -190,7 +190,7 @@ function processPatch(data: string): ParsedPatch {
       lastHunkEnd = hunkData.additionStart + hunkData.additionCount - 1;
       hunkData.splitLineCount = Math.max(
         hunkData.additionCount,
-        hunkData.deletedCount
+        hunkData.deletionCount
       );
       hunkData.splitLineStart = currentFile.splitLineCount;
       hunkData.unifiedLineStart = currentFile.unifiedLineCount;


### PR DESCRIPTION
As I've been working through both the virtualization and webworker shiki requirements, I'm coming across more scenarios that would be super helpful to have more precomputed data in the Hunk type, so starting to pack it up here.

Also taking the time to tweak a naming convention -- `addition` / `deletion` are the nouns, so we should use them instead of `added` `deleted`