### PR TITLE
Invalid first chars might be `\r` on windows

### DIFF
--- a/packages/precision-diffs/src/utils/parseLineType.ts
+++ b/packages/precision-diffs/src/utils/parseLineType.ts
@@ -16,6 +16,7 @@ export function parseLineType(
     firstChar !== '-' &&
     firstChar !== ' ' &&
     firstChar !== '\n' &&
+    firstChar !== '\r' &&
     firstChar !== '\\'
   ) {
     throw new Error(
@@ -27,7 +28,7 @@ export function parseLineType(
     type:
       // NOTE(amadeus): Don't love allowing this, but it's
       // _probably_ generally safe
-      firstChar === ' ' || firstChar === '\n'
+      firstChar === ' ' || firstChar === '\n' || firstChar === '\r'
         ? 'context'
         : firstChar === '\\'
           ? 'metadata'


### PR DESCRIPTION
Invalid diffs bite us again