### PR TITLE
Remove needless/aggressive newline removal hack for diff parsing

### DIFF
--- a/packages/precision-diffs/src/utils/parsePatchFiles.ts
+++ b/packages/precision-diffs/src/utils/parsePatchFiles.ts
@@ -17,7 +17,6 @@ import type {
   Hunk,
   ParsedPatch,
 } from '../types';
-import { cleanLastNewline } from './cleanLastNewline';
 
 function processPatch(data: string): ParsedPatch {
   const isGitDiff = GIT_DIFF_FILE_BREAK_REGEX.test(data);
@@ -229,7 +228,7 @@ export function parsePatchFiles(data: string): ParsedPatch[] {
   const patches: ParsedPatch[] = [];
   for (const patch of data.split(COMMIT_METADATA_SPLIT)) {
     try {
-      patches.push(processPatch(cleanLastNewline(patch)));
+      patches.push(processPatch(patch));
     } catch (error) {
       console.error(error);
     }


### PR DESCRIPTION
Shouldn't _actually_ be required, and mostly just creates arbitrary differences in parsed diffs