### PR TITLE
Fix selection colors

### DIFF
--- a/packages/precision-diffs/src/style.css
+++ b/packages/precision-diffs/src/style.css
@@ -358,6 +358,9 @@ code {
 
   &::before {
     content: '';
+    position: sticky;
+    top: 0;
+    left: 0;
     display: block;
     border-right: var(--pjs-gap-style, 1px solid var(--pjs-bg));
     background-color: var(--pjs-bg-selection-number);


### PR DESCRIPTION
Update with latest from 0ba7073:

- Additions, deletions, and context-expanded lines set background via CSS variable reassignment. `--pjs-bg: suchandsuch`.
- This allows us to have one big selector group for selected lines in all three contexts using the same styles, remixing different `--pjs-bg` values the same way across their contextual background colors.

I still need to see if I can get rid of some existing CSS variables, or use those here instead. I think I can't do the latter because the values of the variable at that time are already computed or whatever. Will continue testing.