### PR TITLE
Tweaks for supposedly properly hydrating in solid

### DIFF
--- a/apps/solid-diff-demo/src/components/FileDiffSSR.tsx
+++ b/apps/solid-diff-demo/src/components/FileDiffSSR.tsx
@@ -53,8 +53,12 @@ export function FileDiffSSR(props: FileDiffSSRProps) {
     // Don't call hydrate() - that would re-render content and cause duplication.
     // Instead, just set the fileContainer reference to attach event handlers.
     fileDiffInstance = new FileDiff(props.options ?? {}, true);
-    // @ts-expect-error - fileContainer is private but needed for SSR hydration
-    fileDiffInstance.fileContainer = fileDiffRef;
+
+    fileDiffInstance.hydrate({
+      oldFile: props.oldFile,
+      newFile: props.newFile,
+      fileContainer: fileDiffRef,
+    });
 
     // Hydrate annotation slots with interactive SolidJS components
     if (props.annotations.length > 0 && props.renderAnnotation != null) {
@@ -100,9 +104,10 @@ export function FileDiffSSR(props: FileDiffSSRProps) {
         {isServer && (
           <>
             {/* Declarative Shadow DOM - browsers parse this and create a shadow root */}
-            <template shadowrootmode="open">
-              <div innerHTML={props.preloadedHTML} />
-            </template>
+            <template
+              shadowrootmode="open"
+              innerHTML={props.preloadedHTML}
+            ></template>
             {/* Render static annotation slots on server.
                 Client will clear these and mount interactive components. */}
             <For each={props.annotations}>

--- a/apps/solid-diff-demo/src/lib/preload-diff.ts
+++ b/apps/solid-diff-demo/src/lib/preload-diff.ts
@@ -4,7 +4,8 @@ import type { DiffLineAnnotation } from '@pierre/precision-diffs';
 import { preloadMultiFileDiff } from '@pierre/precision-diffs/ssr';
 import { cache } from '@solidjs/router';
 
-import { NEW_FILE, OLD_FILE } from '../diff-data';
+import OLD_FILE from '../../../demo/src/mocks/fileNew.txt?raw';
+import NEW_FILE from '../../../demo/src/mocks/fileOld.txt?raw';
 
 /**
  * Type definition for annotation metadata.
@@ -38,8 +39,8 @@ export const getPreloadedDiff = cache(async () => {
   'use server';
 
   const preloadedFileDiff = await preloadMultiFileDiff<AnnotationMetadata>({
-    oldFile: OLD_FILE,
-    newFile: NEW_FILE,
+    oldFile: { name: 'file.ts', contents: OLD_FILE },
+    newFile: { name: 'file.ts', contents: NEW_FILE },
     options: {
       theme: 'pierre-dark',
       diffStyle: 'split',


### PR DESCRIPTION
The component was never properly hydrating which is why none of the functionality of the diff itself would work properly. These changes end up triggering some other issues i believe around how annotations are hydrated which i'm not sure how to fix...

But at least here's a start of what _should_ happen and then we can try to continue to fix forward