### PR TITLE
Fix end of line characters getting joined into line diff spans

### DIFF
--- a/packages/precision-diffs/src/utils/parseDiffDecorations.ts
+++ b/packages/precision-diffs/src/utils/parseDiffDecorations.ts
@@ -26,6 +26,7 @@ interface PushOrJoinSpanProps {
   arr: [0 | 1, string][];
   enableJoin: boolean;
   isNeutral?: boolean;
+  isLastItem?: boolean;
 }
 
 // For diff decoration spans, we want to be sure that if there is a single
@@ -38,16 +39,17 @@ export function pushOrJoinSpan({
   arr,
   enableJoin,
   isNeutral = false,
+  isLastItem = false,
 }: PushOrJoinSpanProps): void {
   const lastItem = arr[arr.length - 1];
-  if (lastItem == null || item.value === '\n' || !enableJoin) {
+  if (lastItem == null || isLastItem || !enableJoin) {
     arr.push([isNeutral ? 0 : 1, item.value]);
     return;
   }
   const isLastItemNeutral = lastItem[0] === 0;
   if (
     isNeutral === isLastItemNeutral ||
-    // If we have a single space neutral item, lets join it to a previously
+    // If we have a single space neutral item, lets join it to a previous
     // space non-neutral item to avoid single space gaps
     (isNeutral && item.value.length === 1 && !isLastItemNeutral)
   ) {

--- a/packages/precision-diffs/src/utils/renderDiffWithHighlighter.ts
+++ b/packages/precision-diffs/src/utils/renderDiffWithHighlighter.ts
@@ -169,23 +169,26 @@ function computeLineDiffDecorations({
   const additionSpans: [0 | 1, string][] = [];
   const enableJoin = lineDiffType === 'word-alt';
   for (const item of lineDiff) {
+    const isLastItem = item === lineDiff[lineDiff.length - 1];
     if (!item.added && !item.removed) {
       pushOrJoinSpan({
         item,
         arr: deletionSpans,
         enableJoin,
         isNeutral: true,
+        isLastItem,
       });
       pushOrJoinSpan({
         item,
         arr: additionSpans,
         enableJoin,
         isNeutral: true,
+        isLastItem,
       });
     } else if (item.removed) {
-      pushOrJoinSpan({ item, arr: deletionSpans, enableJoin });
+      pushOrJoinSpan({ item, arr: deletionSpans, enableJoin, isLastItem });
     } else {
-      pushOrJoinSpan({ item, arr: additionSpans, enableJoin });
+      pushOrJoinSpan({ item, arr: additionSpans, enableJoin, isLastItem });
     }
   }
   let spanIndex = 0;


### PR DESCRIPTION
We used to rely on `\n` characters for this, but that also introduced a whole class of bugs because now we strip out those newline characters before diffing

OOPSIES
<img width="954" height="414" alt="CleanShot 2025-12-01 at 20 56 29" src="https://github.com/user-attachments/assets/bf0bedfb-3713-4e26-b07a-54bc93363f2a" />
