### PR TITLE
Improve non-worker API to mimic WorkerPool with plain text rendering

### DIFF
--- a/packages/precision-diffs/src/File.ts
+++ b/packages/precision-diffs/src/File.ts
@@ -300,7 +300,6 @@ export class File<LAnnotation = undefined> {
         if (this.workerManager != null && !this.workerManager.isInitialized()) {
           void this.workerManager.initialize().then(() => this.rerender());
         }
-        // FIXME(amadeus): Probably figure out how to render a skeleton?
         return;
       }
       if (fileResult.headerAST != null) {

--- a/packages/precision-diffs/src/highlighter/languages.ts
+++ b/packages/precision-diffs/src/highlighter/languages.ts
@@ -136,6 +136,17 @@ export function attachResolvedLanguages(
   }
 }
 
+export function areLanguagesAttached(
+  languages: SupportedLanguages | SupportedLanguages[]
+): boolean {
+  for (const language of Array.isArray(languages) ? languages : [languages]) {
+    if (!attachedLanguages.has(language)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export function cleanUpResolvedLanguages(): void {
   ResolvedLanguages.clear();
   attachedLanguages.clear();

--- a/packages/precision-diffs/src/highlighter/themes.ts
+++ b/packages/precision-diffs/src/highlighter/themes.ts
@@ -5,7 +5,9 @@ import type {
   PJSHighlighter,
   PJSThemeNames,
   ThemeRegistrationResolved,
+  ThemesType,
 } from '../types';
+import { getThemes } from '../utils/getThemes';
 import { isWorkerContext } from '../utils/isWorkerContext';
 
 const ResolvedThemes: Map<PJSThemeNames, ThemeRegistrationResolved> = new Map();
@@ -159,6 +161,15 @@ export function attachResolvedThemes(
     attachedThemes.add(themeRef);
     highlighter.loadThemeSync(resolvedTheme);
   }
+}
+
+export function areThemesAttached(themes: PJSThemeNames | ThemesType): boolean {
+  for (const theme of getThemes(themes)) {
+    if (!attachedThemes.has(theme)) {
+      return false;
+    }
+  }
+  return true;
 }
 
 export function cleanUpResolvedThemes(): void {


### PR DESCRIPTION
This should help a bit with the immediacy factor.

I took a stab at making a skeleton, but then realized it wasn't worth the squeeze, since ultimately in order to render a nice skeleton, we'd need to have the theme data in the highlighter already, which if we already have the theme data then we can just render plain text anyways, so really it's just a matter of `if we don't have the language but we have the theme, lets just render the plain text`.

And to improve these things we can simply use some of the new APIs to grab the highlighter synchronously if we already have it.