### PR TITLE
Hot fix for files hydrating incorrectly with the new architecture

### DIFF
--- a/apps/docs/app/docs/page.tsx
+++ b/apps/docs/app/docs/page.tsx
@@ -1,6 +1,5 @@
 import { HeaderWrapper } from '@/app/HeaderWrapper';
 import Footer from '@/components/Footer';
-import { WorkerPoolContext } from '@/components/WorkerPoolContext';
 import { preloadFile, preloadMultiFileDiff } from '@pierre/precision-diffs/ssr';
 
 import { CoreTypes } from './CoreTypes/CoreTypes';
@@ -99,32 +98,30 @@ import {
 
 export default function DocsPage() {
   return (
-    <WorkerPoolContext>
-      <div className="mx-auto min-h-screen max-w-5xl px-5 xl:max-w-[80rem]">
-        <HeaderWrapper />
-        <div className="relative gap-6 md:grid md:grid-cols-[220px_1fr] md:gap-12">
-          <SidebarWrapper />
-          <div className="prose prose-sm md:prose-base prose-neutral prose-headings:font-semibold prose-a:underline-offset-3 prose-a:hover:underline-offset-4 prose-code:before:content-none prose-code:after:content-none dark:prose-invert prose-li:mt-0 prose-li:mb-1 prose-li:last:mb-0 prose-headings:scroll-mt-28 md:prose-headings:scroll-mt-24 prose-headings:mb-2 w-full max-w-full min-w-0 pb-6 md:pt-6 md:pb-0 md:leading-[1.6] [&_p]:max-w-[48em]">
-            <HeadingAnchors />
-            <OverviewSection />
-            <InstallationSection />
-            <CoreTypesSection />
-            <ReactAPISection />
-            <VanillaAPISection />
-            <UtilitiesSection />
-            <StylingSection />
-            <WorkerPoolSection />
-            <SSRSection />
-            {/* <ComponentProps /> */}
-            {/* <RendererOptions /> */}
-            {/* <EventHandlers /> */}
-            {/* <CompleteExample /> */}
-            {/* <TypescriptSupport /> */}
-          </div>
+    <div className="mx-auto min-h-screen max-w-5xl px-5 xl:max-w-[80rem]">
+      <HeaderWrapper />
+      <div className="relative gap-6 md:grid md:grid-cols-[220px_1fr] md:gap-12">
+        <SidebarWrapper />
+        <div className="prose prose-sm md:prose-base prose-neutral prose-headings:font-semibold prose-a:underline-offset-3 prose-a:hover:underline-offset-4 prose-code:before:content-none prose-code:after:content-none dark:prose-invert prose-li:mt-0 prose-li:mb-1 prose-li:last:mb-0 prose-headings:scroll-mt-28 md:prose-headings:scroll-mt-24 prose-headings:mb-2 w-full max-w-full min-w-0 pb-6 md:pt-6 md:pb-0 md:leading-[1.6] [&_p]:max-w-[48em]">
+          <HeadingAnchors />
+          <OverviewSection />
+          <InstallationSection />
+          <CoreTypesSection />
+          <ReactAPISection />
+          <VanillaAPISection />
+          <UtilitiesSection />
+          <StylingSection />
+          <WorkerPoolSection />
+          <SSRSection />
+          {/* <ComponentProps /> */}
+          {/* <RendererOptions /> */}
+          {/* <EventHandlers /> */}
+          {/* <CompleteExample /> */}
+          {/* <TypescriptSupport /> */}
         </div>
-        <Footer />
       </div>
-    </WorkerPoolContext>
+      <Footer />
+    </div>
   );
 }
 

--- a/apps/docs/components/WorkerPoolContext.tsx
+++ b/apps/docs/components/WorkerPoolContext.tsx
@@ -8,6 +8,7 @@ import {
 import type { ReactNode } from 'react';
 
 const PoolOptions: WorkerPoolOptions = {
+  poolSize: Math.max(1, navigator.hardwareConcurrency - 1),
   workerFactory() {
     return new Worker(
       new URL('@pierre/precision-diffs/worker/worker.js', import.meta.url)

--- a/packages/diffs/src/DiffHunksRenderer.ts
+++ b/packages/diffs/src/DiffHunksRenderer.ts
@@ -1,4 +1,3 @@
-import deepEqual from 'fast-deep-equal';
 import type { ElementContent, Element as HASTElement } from 'hast';
 import { toHtml } from 'hast-util-to-html';
 
@@ -449,7 +448,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
     const triggerRenderUpdate =
       this.renderCache.diff !== diff ||
       !this.renderCache.highlighted ||
-      !deepEqual(this.renderCache.options, options);
+      !areRenderOptionsEqual(this.renderCache.options, options);
 
     this.renderCache = {
       diff,

--- a/packages/diffs/src/FileRenderer.ts
+++ b/packages/diffs/src/FileRenderer.ts
@@ -1,4 +1,3 @@
-import deepEqual from 'fast-deep-equal';
 import type { ElementContent, Element as HASTElement } from 'hast';
 import { toHtml } from 'hast-util-to-html';
 
@@ -147,7 +146,7 @@ export class FileRenderer<LAnnotation = undefined> {
     }
     if (
       file !== renderCache.file ||
-      areRenderOptionsEqual(options, renderCache.options)
+      !areRenderOptionsEqual(options, renderCache.options)
     ) {
       return { options, forceRender: true };
     }
@@ -368,7 +367,7 @@ export class FileRenderer<LAnnotation = undefined> {
     const triggerRenderUpdate =
       this.renderCache.file !== file ||
       !this.renderCache.highlighted ||
-      !deepEqual(options, this.renderCache.options);
+      !areRenderOptionsEqual(options, this.renderCache.options);
 
     this.renderCache = {
       file,

--- a/packages/diffs/src/worker/worker.ts
+++ b/packages/diffs/src/worker/worker.ts
@@ -114,10 +114,14 @@ async function handleRenderFile({
   if (resolvedLanguages != null) {
     attachResolvedLanguages(resolvedLanguages, highlighter);
   }
+  const fileOptions = {
+    theme: renderOptions.theme,
+    tokenizeMaxLineLength: renderOptions.tokenizeMaxLineLength,
+  };
   sendFileSuccess(
     id,
-    renderFileWithHighlighter(file, highlighter, renderOptions),
-    renderOptions
+    renderFileWithHighlighter(file, highlighter, fileOptions),
+    fileOptions
   );
 }
 


### PR DESCRIPTION
Found a small issue this evening on the docs page where files SSR'd files would try to over-hydrate.

There were a few issues

* An inverted boolean check on whether file render options were equal
* worker.ts was returning the diff render options for Files when it shouldn't have (which would trigger false positives comparing options via deepEqual
  * Fixed the worker to return the correct options
  * Removed the use of deepEqual there and used the manual comparator

Also I realized there's absolutely no reason to spin up the worker context on the docs page as we never need to kick off a a render change, and what it ends up doing is hammering the worker threads with a bunch of pre-renders that will serve no purpose ever.

I'm keeping that component around though so I can test things in NextJS easily. 