### PR TITLE
Fix a bug hydrating from worker pool cache

### DIFF
--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -313,16 +313,16 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
     if (diff == null) {
       return undefined;
     }
-    const { options, forceRender } = this.getRenderOptions(diff);
-    let cache = this.workerManager?.getDiffResultCache(diff);
-    if (cache != null && !areRenderOptionsEqual(options, cache.options)) {
-      cache = undefined;
+    const cache = this.workerManager?.getDiffResultCache(diff);
+    if (cache != null && this.renderCache == null) {
+      this.renderCache = { diff, highlighted: true, ...cache };
     }
+    const { options, forceRender } = this.getRenderOptions(diff);
     this.renderCache ??= {
       diff,
-      highlighted: cache != null ? true : false,
-      options: cache?.options ?? options,
-      result: cache?.result,
+      highlighted: false,
+      options,
+      result: undefined,
     };
     if (this.workerManager?.isWorkingPool() === true) {
       this.renderCache.result ??= this.workerManager.getPlainDiffAST(diff);

--- a/packages/diffs/src/renderers/FileRenderer.ts
+++ b/packages/diffs/src/renderers/FileRenderer.ts
@@ -160,16 +160,16 @@ export class FileRenderer<LAnnotation = undefined> {
     if (file == null) {
       return undefined;
     }
-    const { options, forceRender } = this.getRenderOptions(file);
-    let cache = this.workerManager?.getFileResultCache(file);
-    if (cache != null && !areRenderOptionsEqual(options, cache.options)) {
-      cache = undefined;
+    const cache = this.workerManager?.getFileResultCache(file);
+    if (cache != null && this.renderCache == null) {
+      this.renderCache = { file, highlighted: true, ...cache };
     }
+    const { options, forceRender } = this.getRenderOptions(file);
     this.renderCache ??= {
       file,
-      highlighted: cache != null ? true : false,
-      options: cache?.options ?? options,
-      result: cache?.result,
+      highlighted: false,
+      options,
+      result: undefined,
     };
     if (this.workerManager?.isWorkingPool() === true) {
       this.renderCache.result ??= this.workerManager.getPlainFileAST(file);


### PR DESCRIPTION
lol whoopsies, classic lil order of operations shenanery.

Basically the bug was that because we were populating the renderCache AFTER we made a call to `getRenderOptions`, which in turn would return `forceRender: true` if renderCache was empty.

So the fix here is to fix here is to attempt to create renderCache from cache if it exists, then allow the forceRender to compute its thing if necessary.