### PR TITLE
add patch options to parseDiffFromFile

### DIFF
--- a/packages/diffs/src/utils/parseDiffFromFile.ts
+++ b/packages/diffs/src/utils/parseDiffFromFile.ts
@@ -1,4 +1,4 @@
-import { createTwoFilesPatch } from 'diff';
+import { type CreatePatchOptionsNonabortable, createTwoFilesPatch } from 'diff';
 
 import { SPLIT_WITH_NEWLINES } from '../constants';
 import type { FileContents, FileDiffMetadata } from '../types';
@@ -12,7 +12,8 @@ import { parsePatchFiles } from './parsePatchFiles';
  */
 export function parseDiffFromFile(
   oldFile: FileContents,
-  newFile: FileContents
+  newFile: FileContents,
+  options?: CreatePatchOptionsNonabortable
 ): FileDiffMetadata {
   const patch = createTwoFilesPatch(
     oldFile.name,
@@ -20,7 +21,8 @@ export function parseDiffFromFile(
     oldFile.contents,
     newFile.contents,
     oldFile.header,
-    newFile.header
+    newFile.header,
+    options
   );
   const fileData = parsePatchFiles(patch)[0]?.files[0];
   if (fileData == null) {


### PR DESCRIPTION
### Description

Allows patch options to be passed to `parseDiffFromFile`. This comes from the upstream library (https://github.com/kpdecker/jsdiff), and are exposing that as an option to downstream consumers of this diffs lib.

### Motivation & Context

I want to customize the context lines for grouping hunks. Default right now is 3. However, coming from CodeMirror, it uses `context = 1` (https://github.com/codemirror/merge/blob/main/src/chunk.ts), so I would like this customizability for compatibility there.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Documentation update

### Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/pierre-computer/diffs/blob/main/CONTRIBUTING.md)
- [ ] My code follows the code style of the project (`bun run lint`)
- [ ] My code is formatted properly (`bun run format`)
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have added tests to cover my changes (if applicable)
- [ ] All new and existing tests pass (`bun run diffs:test`)

### Related issues

<!-- Please link any related issues here. -->
