### PR TITLE
add visibleRanges support for FileRenderer

### DIFF
--- a/apps/demo/index.html
+++ b/apps/demo/index.html
@@ -15,6 +15,7 @@
         <div class="tools">
           <button id="toggle-theme">Toggle Theme</button>
           <button id="render-file">Render File</button>
+          <button id="visible-ranges">Visible Ranges</button>
           <button id="stream-code">Stream Code</button>
           <button id="diff-files">Diff Two Files</button>
           <button id="load-diff">Load Large-ish Diff</button>

--- a/apps/demo/src/main.ts
+++ b/apps/demo/src/main.ts
@@ -559,6 +559,37 @@ if (renderFileButton != null) {
   });
 }
 
+const visibleRangesButton = document.getElementById('visible-ranges');
+if (visibleRangesButton != null) {
+  visibleRangesButton.addEventListener('click', () => {
+    const wrapper = document.getElementById('wrapper');
+    if (wrapper == null) return;
+    cleanupInstances(wrapper);
+
+    const fileContainer = document.createElement(DIFFS_TAG_NAME);
+    wrapper.appendChild(fileContainer);
+    const instance = new File<LineCommentMetadata>(
+      {
+        theme: { dark: 'pierre-dark', light: 'pierre-light' },
+        themeType: getThemeType(),
+        visibleRanges: [
+          [1, 25],
+          [90, 110],
+          [200, 220],
+        ],
+        expansionLineCount: 20,
+      },
+      poolManager
+    );
+
+    void instance.render({
+      file: fileExample,
+      fileContainer,
+    });
+    fileInstances.push(instance);
+  });
+}
+
 const workerRenderButton = document.getElementById('worker-load-diff');
 workerRenderButton?.addEventListener('click', () => {
   void (async () => {

--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -15,6 +15,7 @@ import type {
   DiffLineAnnotation,
   DiffsHighlighter,
   ExpansionDirections,
+  ExpansionRegion,
   FileDiffMetadata,
   Hunk,
   HunkData,
@@ -111,11 +112,6 @@ interface GetRenderOptionsReturn {
 type OptionsWithDefaults = Required<
   Omit<BaseDiffOptions, 'lang' | 'unsafeCSS'>
 >;
-
-interface ExpansionRegion {
-  fromStart: number;
-  fromEnd: number;
-}
 
 export interface HunksRenderResult {
   additionsAST: ElementContent[] | undefined;

--- a/packages/diffs/src/types.ts
+++ b/packages/diffs/src/types.ts
@@ -51,6 +51,14 @@ export type ChangeTypes =
   | 'new'
   | 'deleted';
 
+export type LineRange = readonly [start: number, end: number];
+
+/** Represents the expanded portion of a collapsed region */
+export interface ExpansionRegion {
+  fromStart: number;
+  fromEnd: number;
+}
+
 export interface ParsedPatch {
   patchMetadata?: string;
   files: FileDiffMetadata[];


### PR DESCRIPTION
### Description

This PR adds collapse/expand functionality to the File component, mirroring the existing diff hunks UI/UX.

New FileRenderer API:
- `visibleRanges: LineRange[]` - specify which line ranges to show
- `expansionLineCount: number` - lines to reveal per expand click  
- `hunkSeparators: HunkSeparators` - separator style for collapsed regions

I've also added a demo to `apps/demo/index.html`

### Motivation & Context

I would like to have same UI/UX for collapsed or hidden lines, but for FileRenderer.

Screenshot
<img width="2070" height="1718" alt="CleanShot 2026-01-07 at 02 45 31@2x" src="https://github.com/user-attachments/assets/2a36fd5e-3f2a-4324-8c96-8e231fbcd2dc" />


### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Documentation update

### Checklist

- [ ] I have read the
      [contributing guidelines](https://github.com/pierre-computer/diffs/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of the project (`bun run lint`)
- [x] My code is formatted properly (`bun run format`)
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have added tests to cover my changes (if applicable)
- [ ] All new and existing tests pass (`bun run diffs:test`)