### PR TITLE
Fix final blank line bug with processing patches

### DIFF
--- a/packages/diffs/src/utils/parseLineType.ts
+++ b/packages/diffs/src/utils/parseLineType.ts
@@ -18,8 +18,14 @@ export function parseLineType(line: string): ParsedLine | undefined {
     );
     return undefined;
   }
+  const processedLine = line.substring(1);
   return {
-    line: line.substring(1),
+    // NOTE(amadeus): If the line is empty, we should make it a
+    // newline to force shiki to highlight the row. This should
+    // only really ever apply as the last line of a hunk that was most likely
+    // processed via a string and not a file since patch files will include a
+    // newline here by default
+    line: processedLine === '' ? '\n' : processedLine,
     type:
       firstChar === ' '
         ? 'context'


### PR DESCRIPTION
This was a fun little bug to track down, but requires a bit of context:

When editing files normally in an editor, the final newline of a file is often `hidden` from us by default (some editors make it a setting). This `standard` is quite common across code rendered in browsers as well (see github files for reference).

However, when highlighting file in Shiki, this newline will always show, making files look like we added a blank newline when we actually didnt. As a workaround, we often truncate that final newline to match developer expectations in editors.

When using standard tools to generate patch files, these newlines are automatically appended for us. However if a user is amalgamating diff hunk strings from an existing patch hunk, this final newline may not exist on the final line of a change that is blank, which means when we truncate this newline, we end up removing that newline from the line before it (because appending a `''` string to `prior line\n` essentially amounts to adding nothing), and thus highlighting 1 less line

I am 99% confident this is a safe fix, but basically the idea is if our processed line is just an empty string, lets add it as a newline to preserve final newline trimming for shiki.

Fixes #269 