### PR TITLE
[file-tree] Move useTree side effects into state initializer

### DIFF
--- a/packages/file-tree/src/components/hooks/useTree.ts
+++ b/packages/file-tree/src/components/hooks/useTree.ts
@@ -8,10 +8,13 @@ import { useEffect, useState } from 'preact/hooks';
 
 export const useTree = <T>(config: TreeConfig<T>): TreeInstance<T> => {
   'use no memo';
-  const [tree] = useState(() => ({ current: createTree(config) }));
-  // since we're server rendering we need to do this immediately
-  tree.current.setMounted(true);
-  tree.current.rebuildTree();
+  const [tree] = useState(() => {
+    const instance = createTree(config);
+    // Initialize immediately for SSR support
+    instance.setMounted(true);
+    instance.rebuildTree();
+    return { current: instance };
+  });
 
   const [state, setState] = useState<Partial<TreeState<T>>>(() =>
     tree.current.getState()


### PR DESCRIPTION
### Description / Motivation

Move setMounted(true) and rebuildTree() calls from the render phase into the useState initializer. This ensures these side effects run only once during initial tree creation rather than on every render.

The render phase should be pure with no side effects. Previously, these mutations were called on every render unnecessarily. @headless-tree/core handles rebuilds lazily via getItems() when rebuildScheduled is true, and setConfig() only triggers immediate rebuilds when expandedItems changes.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality). You must have
      first discussed with the dev team and they should be aware that this PR is
      being opened
- [ ] Breaking change (fix or feature that would change existing functionality).
      You must have first discussed with the dev team and they should be aware
      that this PR is being opened
- [ ] Documentation update

### Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/pierre-computer/diffs/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of the project (`bun run lint`)
- [x] My code is formatted properly (`bun run format`)
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have added tests to cover my changes (if applicable)
- [x] All new and existing tests pass (`bun run diffs:test`)