### PR TITLE
Add workspace script runner (bun ws)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "ws": "bun scripts/ws.js",
     "demo:build": "(cd apps/demo && bun run build)",
     "demo:dev": "(cd apps/demo && bun run dev)",
     "demo:prod": "(cd apps/demo && bun run build && bun run start)",

--- a/scripts/ws.js
+++ b/scripts/ws.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+
+const args = process.argv.slice(2);
+
+// Check for --verbose or -v flag
+const verboseIndex = args.findIndex(
+  (arg) => arg === '--verbose' || arg === '-v'
+);
+const isVerbose = verboseIndex !== -1;
+if (isVerbose) {
+  args.splice(verboseIndex, 1);
+}
+
+const [pkgArg, ...scriptArgs] = args;
+
+if (!pkgArg || scriptArgs.length === 0) {
+  console.log('Usage: bun ws <package> <script> [args...] [--verbose]');
+  console.log('');
+  console.log('Filters:');
+  console.log('  <name>           Matches @pierre/<name> in package.json');
+  console.log('  packages/<name>  Matches directory on filesystem');
+  console.log('  apps/<name>      Matches directory on filesystem');
+  console.log('');
+  console.log('Options:');
+  console.log('  -v, --verbose    Show full output (no line elision)');
+  console.log('');
+  console.log('Examples:');
+  console.log('  bun ws diffs build');
+  console.log('  bun ws diffs test');
+  console.log('  bun ws diffs test --verbose    # full output');
+  console.log('  bun ws packages/diffs build    # path-based');
+  console.log("  bun ws 'packages/*' test       # all packages");
+  console.log("  bun ws 'apps/*' dev            # all apps");
+  console.log("  bun ws '*' build               # all workspaces");
+  process.exit(0);
+}
+
+const isPath = pkgArg.startsWith('packages/') || pkgArg.startsWith('apps/');
+const filter = isPath ? `./${pkgArg}` : `@pierre/${pkgArg}`;
+
+const elideLines = isVerbose ? ['--elide-lines=0'] : [];
+
+const proc = spawn('bun', ['run', '-F', filter, ...elideLines, ...scriptArgs], {
+  stdio: 'inherit',
+  cwd: process.cwd(),
+  env: { ...process.env, FORCE_COLOR: '1' },
+});
+
+proc.on('close', (code) => {
+  process.exit(code ?? 0);
+});


### PR DESCRIPTION
I'm used to using `npm run -w` in monorepos and Bun's `--filter` flag is similar in than it allows targeting individual workspace packages to run scripts, without needing to define them in the root `package.json`. Some benefits:

- Scripts run in parallel when packages don't depend on each other
- Bun automatically respects the dependency graph, running dependencies first
- No need to maintain script mapping in root `package.json`
- CI workflows scale automatically with pattern matching (e.g., 'packages/*')

However, the native commands might feel a bit verbose for regular use when compared to the root script aliases:
```sh
  bun -F './packages/diffs' test
  bun -F @pierre/diffs test
```

A little `bun ws` (workspace) script can provide a simpler syntax with the same benefits:
```sh
  bun ws diffs test              # matches @pierre/diffs
  bun ws packages/diffs build    # matches ./packages/diffs
  bun ws 'packages/*' build      # all packages (quote to prevent shell expansion)
  bun ws 'apps/*' dev            # all apps
```