### PR TITLE
Fix Virtualization Expansion Bug

### DIFF
--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -199,6 +199,11 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
     if (direction === 'down' || direction === 'both') {
       region.fromEnd += expansionLineCount;
     }
+    // NOTE(amadeus): If our render cache is not highlighted, we need to clear
+    // it, otherwise we won't have the correct AST lines
+    if (this.renderCache?.highlighted !== true) {
+      this.renderCache = undefined;
+    }
     this.expandedHunks.set(index, region);
   }
 


### PR DESCRIPTION
Basically if you expanded before highlighting was finished, we'd attempt to render with the out of date partial plaintext AST.