### PR TITLE
Add file metadata support to file-tree component

### DIFF
--- a/apps/docs/app/file-tree/ClientPage.tsx
+++ b/apps/docs/app/file-tree/ClientPage.tsx
@@ -41,6 +41,7 @@ export function ClientPage({
   const [useLazyDataLoader, setUseLazyDataLoader] = useState(
     initialUseLazyDataLoader ?? defaultUseLazyDataLoader
   );
+  const [showMetadata, setShowMetadata] = useState(true);
   const skipCookieWriteRef = useRef(false);
 
   const fileTreeOptions = useMemo<FileTreeOptions>(
@@ -48,8 +49,11 @@ export function ClientPage({
       ...sharedDemoFileTreeOptions,
       flattenEmptyDirectories,
       useLazyDataLoader,
+      fileMetadata: showMetadata
+        ? sharedDemoFileTreeOptions.fileMetadata
+        : undefined,
     }),
-    [flattenEmptyDirectories, useLazyDataLoader]
+    [flattenEmptyDirectories, useLazyDataLoader, showMetadata]
   );
 
   const handleToggleFlatten = () => {
@@ -60,6 +64,11 @@ export function ClientPage({
   const handleToggleLazyLoader = () => {
     startTransition(() => {
       setUseLazyDataLoader((prev: boolean) => !prev);
+    });
+  };
+  const handleToggleMetadata = () => {
+    startTransition(() => {
+      setShowMetadata((prev: boolean) => !prev);
     });
   };
   const handleResetControls = () => {
@@ -128,6 +137,19 @@ export function ClientPage({
               onChange={handleToggleLazyLoader}
             />
             Lazy Loader
+          </label>
+          <label
+            htmlFor="show-metadata"
+            className="flex cursor-pointer items-center gap-2 select-none"
+          >
+            <input
+              type="checkbox"
+              id="show-metadata"
+              checked={showMetadata}
+              className="cursor-pointer"
+              onChange={handleToggleMetadata}
+            />
+            File Metadata
           </label>
           <button
             type="button"

--- a/apps/docs/app/file-tree/demo-data.ts
+++ b/apps/docs/app/file-tree/demo-data.ts
@@ -1,4 +1,17 @@
-import type { FileTreeOptions } from '@pierre/file-tree';
+import type { FileMetadata, FileTreeOptions } from '@pierre/file-tree';
+
+const sampleFileMetadata: Record<string, FileMetadata> = {
+  'README.md': { status: 'modified', additions: 12, deletions: 3 },
+  'src/components/Button.tsx': {
+    status: 'modified',
+    additions: 25,
+    deletions: 8,
+  },
+  'src/components/Card.tsx': { status: 'added', additions: 45 },
+  'src/lib/utils.ts': { status: 'deleted', deletions: 30 },
+  'src/utils/stream.ts': { status: 'renamed', additions: 2, deletions: 2 },
+  'Build/scripts.js': { status: 'modified', additions: 5, deletions: 1 },
+};
 
 const sampleFileList: string[] = [
   'README.md',
@@ -46,5 +59,6 @@ export const sharedDemoFileTreeOptions: FileTreeOptions = {
     console.log('selection', selection);
   },
   flattenEmptyDirectories: true,
+  fileMetadata: sampleFileMetadata,
   files: sampleFileList,
 };

--- a/packages/file-tree/src/FileTree.ts
+++ b/packages/file-tree/src/FileTree.ts
@@ -3,7 +3,7 @@ import { type TreeConfig } from '@headless-tree/core';
 import { FileTreeContainerLoaded } from './components/web-components';
 import { FILE_TREE_TAG_NAME } from './constants';
 import { SVGSpriteSheet } from './sprite';
-import { type FileTreeNode } from './types';
+import { type FileMetadata, type FileTreeNode } from './types';
 import {
   preactHydrateRoot,
   preactRenderRoot,
@@ -38,6 +38,7 @@ export type HeadlessTreeConfig = Omit<
 
 export interface FileTreeOptions {
   files: string[];
+  fileMetadata?: Record<string, FileMetadata>;
   id?: string;
   flattenEmptyDirectories?: boolean;
   useLazyDataLoader?: boolean;
@@ -149,6 +150,7 @@ export class FileTree {
       fileTreeOptions: {
         config: this.initialTreeConfig,
         files: this.files,
+        fileMetadata: this.options.fileMetadata,
         flattenEmptyDirectories: this.options.flattenEmptyDirectories,
         useLazyDataLoader: this.options.useLazyDataLoader,
         onSelection: this.options.onSelection,
@@ -185,6 +187,7 @@ export class FileTree {
         fileTreeOptions: {
           config: this.initialTreeConfig,
           files: this.files,
+          fileMetadata: this.options.fileMetadata,
           flattenEmptyDirectories: this.options.flattenEmptyDirectories,
           useLazyDataLoader: this.options.useLazyDataLoader,
           onSelection: this.options.onSelection,

--- a/packages/file-tree/src/components/MetadataBadge.tsx
+++ b/packages/file-tree/src/components/MetadataBadge.tsx
@@ -1,0 +1,32 @@
+import type { JSX } from 'preact';
+
+import type { FileMetadata } from '../types';
+
+export function MetadataBadge({
+  metadata,
+}: {
+  metadata: FileMetadata;
+}): JSX.Element | null {
+  'use no memo';
+  const { status, additions, deletions } = metadata;
+  const hasLineCounts = additions != null || deletions != null;
+
+  if (status == null && !hasLineCounts) {
+    return null;
+  }
+
+  return (
+    <span data-item-section="metadata" data-item-status={status}>
+      {hasLineCounts ? (
+        <span data-item-line-counts>
+          {additions != null ? (
+            <span data-item-additions>+{additions}</span>
+          ) : null}
+          {deletions != null ? (
+            <span data-item-deletions>-{deletions}</span>
+          ) : null}
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/packages/file-tree/src/components/Root.tsx
+++ b/packages/file-tree/src/components/Root.tsx
@@ -14,8 +14,9 @@ import type { FileTreeOptions, FileTreeSelectionItem } from '../FileTree';
 import { fileTreeSearchFeature } from '../features/fileTreeSearchFeature';
 import { generateLazyDataLoader } from '../loader/lazy';
 import { generateSyncDataLoader } from '../loader/sync';
-import type { FileTreeNode } from '../types';
+import type { FileMetadata, FileTreeNode } from '../types';
 import { Icon } from './Icon';
+import { MetadataBadge } from './MetadataBadge';
 import { useTree } from './hooks/useTree';
 
 export interface FileTreeRootProps {
@@ -60,8 +61,13 @@ function FlattenedDirectoryName({
 
 export function Root({ fileTreeOptions }: FileTreeRootProps): JSX.Element {
   'use no memo';
-  const { config, files, flattenEmptyDirectories, useLazyDataLoader } =
-    fileTreeOptions;
+  const {
+    config,
+    files,
+    fileMetadata,
+    flattenEmptyDirectories,
+    useLazyDataLoader,
+  } = fileTreeOptions;
   const treeData = useMemo(() => fileListToTree(files), [files]);
   const restTreeConfig = useMemo(() => {
     if (config == null) {
@@ -286,6 +292,8 @@ export function Root({ fileTreeOptions }: FileTreeRootProps): JSX.Element {
         const selectionProps = isSelected ? { 'data-item-selected': true } : {};
 
         const isFlattenedDirectory = itemData?.flattens != null;
+        const metadataPath = getSelectionPath(itemData.path);
+        const metadata: FileMetadata | undefined = fileMetadata?.[metadataPath];
         const isSearchMatch = item.isMatchingSearch();
         const isFocused = hasFocusedItem && item.isFocused();
         const focusedProps = isFocused ? { 'data-item-focused': true } : {};
@@ -331,6 +339,7 @@ export function Root({ fileTreeOptions }: FileTreeRootProps): JSX.Element {
                 itemName
               )}
             </div>
+            {metadata != null ? <MetadataBadge metadata={metadata} /> : null}
           </button>
         );
       })}

--- a/packages/file-tree/src/index.ts
+++ b/packages/file-tree/src/index.ts
@@ -1,5 +1,6 @@
 export * from './constants';
 export * from './FileTree';
 export * from './loader';
+export type { FileChangeStatus, FileMetadata } from './types';
 export * from './utils/sortChildren';
 export { default as fileTreeStyles } from './style.css';

--- a/packages/file-tree/src/style.css
+++ b/packages/file-tree/src/style.css
@@ -219,4 +219,56 @@
       height: calc(100% - 2px);
     }
   }
+
+  /* File metadata section */
+  [data-item-section='metadata'] {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-left: auto;
+    flex-shrink: 0;
+    font-size: calc(var(--ft-internal-font-size) - 1px);
+  }
+
+  /* Status dot indicator */
+  [data-item-status]::before {
+    content: '';
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  [data-item-status='added']::before {
+    background-color: var(--ft-status-color-added, oklch(65% 0.19 145));
+  }
+
+  [data-item-status='modified']::before {
+    background-color: var(--ft-status-color-modified, oklch(75% 0.15 75));
+  }
+
+  [data-item-status='deleted']::before {
+    background-color: var(--ft-status-color-deleted, oklch(60% 0.21 25));
+  }
+
+  [data-item-status='renamed']::before {
+    background-color: var(--ft-status-color-renamed, oklch(65% 0.15 250));
+  }
+
+  /* Line count badges */
+  [data-item-line-counts] {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  [data-item-additions] {
+    color: var(--ft-additions-color, oklch(65% 0.19 145));
+  }
+
+  [data-item-deletions] {
+    color: var(--ft-deletions-color, oklch(60% 0.21 25));
+  }
 }

--- a/packages/file-tree/src/types.ts
+++ b/packages/file-tree/src/types.ts
@@ -15,3 +15,11 @@ export type FileTreeNode = {
 };
 
 export type FileTreeData = Record<string, FileTreeNode>;
+
+export type FileChangeStatus = 'added' | 'modified' | 'deleted' | 'renamed';
+
+export interface FileMetadata {
+  status?: FileChangeStatus;
+  additions?: number;
+  deletions?: number;
+}

--- a/packages/file-tree/test/metadata.test.ts
+++ b/packages/file-tree/test/metadata.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test';
+
+import { FLATTENED_PREFIX } from '../src/constants';
+import type { FileChangeStatus, FileMetadata } from '../src/types';
+
+describe('FileMetadata types', () => {
+  test('accepts all valid status values', () => {
+    const statuses: FileChangeStatus[] = [
+      'added',
+      'modified',
+      'deleted',
+      'renamed',
+    ];
+    for (const status of statuses) {
+      const metadata: FileMetadata = { status };
+      expect(metadata.status).toBe(status);
+    }
+  });
+
+  test('accepts line counts without status', () => {
+    const metadata: FileMetadata = { additions: 10, deletions: 5 };
+    expect(metadata.additions).toBe(10);
+    expect(metadata.deletions).toBe(5);
+    expect(metadata.status).toBeUndefined();
+  });
+
+  test('all fields are optional', () => {
+    const metadata: FileMetadata = {};
+    expect(metadata.status).toBeUndefined();
+    expect(metadata.additions).toBeUndefined();
+    expect(metadata.deletions).toBeUndefined();
+  });
+});
+
+describe('metadata path resolution', () => {
+  const getMetadataPath = (path: string): string =>
+    path.startsWith(FLATTENED_PREFIX)
+      ? path.slice(FLATTENED_PREFIX.length)
+      : path;
+
+  test('returns file path unchanged', () => {
+    expect(getMetadataPath('src/index.ts')).toBe('src/index.ts');
+  });
+
+  test('strips flattened prefix from paths', () => {
+    expect(getMetadataPath(`${FLATTENED_PREFIX}src/components`)).toBe(
+      'src/components'
+    );
+  });
+
+  test('returns root-level path unchanged', () => {
+    expect(getMetadataPath('README.md')).toBe('README.md');
+  });
+
+  test('handles nested paths', () => {
+    expect(getMetadataPath('a/b/c/d.ts')).toBe('a/b/c/d.ts');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `FileMetadata` types (`status`, `additions`, `deletions`) and a `MetadataBadge` component that renders change status dot indicators and +/- line count badges inline with file tree items
- Add CSS styling with customizable color CSS variables (`--ft-status-color-*`, `--ft-additions-color`, `--ft-deletions-color`) for status dots and line counts
- Wire up the `fileMetadata` option through `FileTreeOptions` and pass it down to the tree root for rendering
- Add a "File Metadata" toggle to the docs demo page with sample metadata entries
- Add unit tests for the metadata types and path resolution logic

## Test plan
- [ ] Verify the file tree demo page renders metadata badges (status dots + line counts) next to files with metadata
- [ ] Toggle the "File Metadata" checkbox off and confirm badges disappear
- [ ] Run `bun test` in `packages/file-tree` to confirm metadata tests pass
- [ ] Verify CSS variables can override default status colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)