### PR TITLE
Workspace Script Slop

### DIFF
--- a/scripts/ws.js
+++ b/scripts/ws.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 
 const args = process.argv.slice(2);
 
@@ -42,12 +42,64 @@ const filter = isPath ? `./${pkgArg}` : `@pierre/${pkgArg}`;
 
 const elideLines = ['--elide-lines=0'];
 
+const SIGNAL_EXIT_CODES = {
+  SIGHUP: 129,
+  SIGINT: 130,
+  SIGTERM: 143,
+};
+
+let didRestoreTTY = false;
+const restoreTTY = () => {
+  if (didRestoreTTY) {
+    return;
+  }
+
+  didRestoreTTY = true;
+
+  if (!process.stdin.isTTY) {
+    return;
+  }
+
+  try {
+    process.stdin.setRawMode?.(false);
+  } catch {
+    // Ignore raw mode restoration errors.
+  }
+
+  try {
+    const stdinFd = process.stdin.fd;
+    if (typeof stdinFd === 'number') {
+      spawnSync('stty', ['sane'], {
+        stdio: [stdinFd, 'ignore', 'ignore'],
+      });
+    }
+  } catch {
+    // Ignore stty errors and allow normal exit handling.
+  }
+};
+
 const proc = spawn('bun', ['run', '-F', filter, ...elideLines, ...scriptArgs], {
   stdio: 'inherit',
   cwd: process.cwd(),
   env: { ...process.env, FORCE_COLOR: '1' },
 });
 
-proc.on('close', (code) => {
+const forwardSignal = (signal) => {
+  if (proc.exitCode === null && proc.signalCode === null) {
+    proc.kill(signal);
+  }
+};
+
+for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+  process.on(signal, () => {
+    forwardSignal(signal);
+  });
+}
+
+proc.on('close', (code, signal) => {
+  restoreTTY();
+  if (signal) {
+    process.exit(SIGNAL_EXIT_CODES[signal] ?? 1);
+  }
   process.exit(code ?? 0);
 });


### PR DESCRIPTION
Unclear if this is the best way to fix this or not, but I've been running into this issue a bunch with the ws script that's quite annoying:

https://github.com/user-attachments/assets/d12123e9-1908-421b-b292-cdd5e62ffef7

Basically anytime I `ctrl+c` a running process, it borks a lot of my input until i press Enter to start a new prompt.

Anyways, after this change, things appear to work nicely again:

https://github.com/user-attachments/assets/4847b159-52b8-40fa-b4e7-9340f7a440c3

Also, a general note. This script seems to be written for node, shouldn't we actually port it to be a bun script? Didn't want to muddy that here though