### PR TITLE
[file-tree] add Playwright style-isolation e2e tests and wire CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,20 @@ jobs:
       - name: Run tests - precision-diffs
         run: bun ws diffs test
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright browser - file-tree
+        run: bunx playwright@1.51.1 install --with-deps chromium
+
+      - name: Run tests - file-tree e2e
+        run: bun ws file-tree test:e2e
+
   typecheck:
     name: TypeScript
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,18 @@ packages. e.g. `bun run lint`
 We use Bun's built-in testing framework for unit tests. Tests are located in a
 `test/` folder within each package, separate from the source code.
 
+### Test Strategy
+
+- Prefer unit/integration tests (`bun test`) by default.
+- Add Playwright/browser E2E tests only when behavior cannot be validated
+  without a real browser engine.
+- Good Playwright candidates include computed style checks, shadow DOM
+  encapsulation boundaries, and browser-only rendering behavior.
+- Keep E2E coverage intentionally small and high-value.
+- Prefer explicit assertions over broad snapshots.
+- Avoid snapshot tests unless they are shallow and narrowly scoped to the exact
+  behavior under test.
+
 ### Running Tests
 
 For the diffs package:

--- a/bun.lock
+++ b/bun.lock
@@ -132,6 +132,7 @@
       },
       "devDependencies": {
         "@arethetypeswrong/core": "catalog:",
+        "@playwright/test": "catalog:",
         "@types/react": "catalog:",
         "@types/react-dom": "catalog:",
         "autoprefixer": "catalog:",
@@ -141,6 +142,7 @@
         "react-dom": "catalog:",
         "tsdown": "catalog:",
         "typescript": "catalog:",
+        "vite": "catalog:",
       },
       "peerDependencies": {
         "react": "^19.0.0",
@@ -213,6 +215,7 @@
     "@octokit/rest": "22.0.0",
     "@pierre/icons": "0.1.0",
     "@pierre/storage": "0.0.10",
+    "@playwright/test": "1.51.1",
     "@radix-ui/react-avatar": "1.1.10",
     "@radix-ui/react-dialog": "1.1.15",
     "@radix-ui/react-dropdown-menu": "2.1.16",
@@ -646,6 +649,8 @@
     "@pierre/storage-elements": ["@pierre/storage-elements@workspace:packages/storage-elements"],
 
     "@pierre/storage-elements-next": ["@pierre/storage-elements-next@workspace:packages/storage-elements-next"],
+
+    "@playwright/test": ["@playwright/test@1.51.1", "", { "dependencies": { "playwright": "1.51.1" }, "bin": { "playwright": "cli.js" } }, "sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q=="],
 
     "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
 
@@ -1623,6 +1628,10 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
+    "playwright": ["playwright@1.51.1", "", { "dependencies": { "playwright-core": "1.51.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw=="],
+
+    "playwright-core": ["playwright-core@1.51.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw=="],
+
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "postcss-html": ["postcss-html@1.7.0", "", { "dependencies": { "htmlparser2": "^8.0.0", "js-tokens": "^9.0.0", "postcss": "^8.4.0", "postcss-safe-parser": "^6.0.0" } }, "sha512-MfcMpSUIaR/nNgeVS8AyvyDugXlADjN9AcV7e5rDfrF1wduIAGSkL4q2+wgrZgA3sHVAHLDO9FuauHhZYW2nBw=="],
@@ -2060,6 +2069,8 @@
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
       "@octokit/rest": "22.0.0",
       "@pierre/icons": "0.1.0",
       "@pierre/storage": "0.0.10",
+      "@playwright/test": "1.51.1",
       "@radix-ui/react-avatar": "1.1.10",
       "@radix-ui/react-dialog": "1.1.15",
       "@radix-ui/react-dropdown-menu": "2.1.16",

--- a/packages/file-tree/README.md
+++ b/packages/file-tree/README.md
@@ -124,6 +124,11 @@ From `packages/file-tree`:
 
 ```bash
 bun test
+bun run test:e2e
 bun run tsc
 bun run build
 ```
+
+Testing policy and E2E guidance:
+
+- `test/TESTING.md`

--- a/packages/file-tree/package.json
+++ b/packages/file-tree/package.json
@@ -36,6 +36,9 @@
     "build": "tsdown --clean",
     "dev": "echo 'Watching for changes…' && tsdown --watch --log-level error",
     "test": "bun test",
+    "test:e2e": "bun run build && (bun ./test/e2e/check-playwright-binary.ts || bun run test:e2e:installbinary) && bunx playwright test -c test/e2e/playwright.config.ts",
+    "test:e2e:installbinary": "bunx playwright@1.51.1 install chromium",
+    "test:e2e:server": "vite --config test/e2e/vite.config.ts",
     "tsc": "tsgo --noEmit --pretty",
     "prepublishOnly": "bun run build"
   },
@@ -46,6 +49,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/core": "catalog:",
+    "@playwright/test": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "autoprefixer": "catalog:",
@@ -54,7 +58,8 @@
     "react": "catalog:",
     "react-dom": "catalog:",
     "tsdown": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vite": "catalog:"
   },
   "peerDependencies": {
     "react": "^19.0.0",

--- a/packages/file-tree/test/PLAYWRIGHT_STYLE_ISOLATION_PLAN.md
+++ b/packages/file-tree/test/PLAYWRIGHT_STYLE_ISOLATION_PLAN.md
@@ -1,0 +1,88 @@
+# Playwright Plan: FileTree Shadow Style Isolation
+
+## Goals
+
+1. Verify styles outside `file-tree-container` do not style internals inside its
+   shadow root.
+2. Verify FileTree internal styles do not leak into the light DOM outside the
+   component.
+3. Verify CSS custom properties (theming variables) set on host/light DOM are
+   consumed inside the shadow root.
+
+## Why Browser Tests
+
+This behavior depends on real CSS cascade + shadow DOM boundaries. Unit tests in
+jsdom are insufficient for robust style computation assertions. We need a real
+browser engine.
+
+## Test Surface
+
+Target package: `packages/file-tree`
+
+Fixture style:
+
+- Static HTML fixture loaded by Playwright.
+- Uses built package outputs from `packages/file-tree/dist`.
+- Renders one `file-tree-container` via `FileTree` and adds explicit control
+  nodes outside the component.
+
+## Assertions
+
+### 1) External styles do not leak into shadow root
+
+Setup:
+
+- Add global style in light DOM:
+  - `#some-known-internal-id { color: rgb(0, 128, 0) !important; }`
+- Place a light-DOM control node with that id (should turn green).
+- Also give the same id to an element inside the FileTree shadow root.
+
+Checks:
+
+- Light-DOM control node computed color is green.
+- Shadow-root element with same id is **not** green.
+
+### 2) Internal FileTree styles do not leak out
+
+Setup:
+
+- Render a light-DOM control node that mimics FileTree internal
+  attributes/classes.
+
+Checks:
+
+- Control node does not pick up FileTree internal visual rules (e.g. no selected
+  background/border from `[data-type='item'][data-item-selected='true']` shadow
+  styles).
+
+### 3) CSS custom properties flow into shadow root
+
+Setup:
+
+- Set a host-level custom property such as `--ft-selected-background-color`.
+- Select an item inside FileTree.
+
+Checks:
+
+- Selected item inside shadow root resolves to the configured value.
+
+## Implementation Steps
+
+1. Add Playwright dependency and scripts for `packages/file-tree`.
+2. Add Playwright config in `packages/file-tree` and run tests in Chromium.
+3. Add static fixture page under `packages/file-tree/test/e2e/fixtures`.
+4. Add spec file under `packages/file-tree/test/e2e` with three tests above.
+5. Run tests and stabilize selectors/assertions.
+
+## Non-goals (This Pass)
+
+- Cross-browser matrix (Chromium-only initially).
+- Screenshot snapshots/visual diffing.
+- Full docs app E2E coverage.
+
+## Follow-ups
+
+1. Add WebKit/Firefox once baseline is stable.
+2. Integrate into CI (job + browser install step).
+3. Add SSR fixture variant to validate style behavior for declarative shadow DOM
+   output.

--- a/packages/file-tree/test/TESTING.md
+++ b/packages/file-tree/test/TESTING.md
@@ -1,0 +1,45 @@
+# File Tree Testing Strategy
+
+## Default Approach
+
+- Prefer unit/integration tests with `bun test`.
+- Use browser E2E tests only for browser-only behavior that cannot be reliably
+  validated in jsdom.
+
+## When Playwright Is Appropriate
+
+Use Playwright when the behavior requires a real browser engine, for example:
+
+- computed style assertions
+- shadow DOM style encapsulation boundaries
+- CSS custom property flow into shadow roots
+
+If a unit test can prove behavior, write a unit test instead.
+
+## E2E Scope Rules
+
+- Keep Playwright coverage intentionally small and high-value.
+- Add the minimum number of end-to-end tests needed to protect critical
+  behavior.
+- Prefer direct assertions over broad page snapshots.
+
+## Snapshot Guidance
+
+- Avoid snapshots that capture large or incidental output.
+- If snapshots are used, keep them shallow and tightly scoped to the exact
+  contract being tested.
+
+## Commands
+
+From repo root:
+
+```bash
+bun ws file-tree test
+bun ws file-tree test:e2e
+```
+
+`test:e2e` automatically:
+
+1. builds `packages/file-tree/dist`
+2. installs Chromium binary if missing
+3. runs Playwright tests

--- a/packages/file-tree/test/e2e/check-playwright-binary.ts
+++ b/packages/file-tree/test/e2e/check-playwright-binary.ts
@@ -1,0 +1,13 @@
+import { chromium } from '@playwright/test';
+import { existsSync } from 'node:fs';
+
+const executablePath = chromium.executablePath();
+
+if (existsSync(executablePath)) {
+  process.exit(0);
+}
+
+console.error(
+  `[file-tree:e2e] Missing Playwright Chromium binary at: ${executablePath}`
+);
+process.exit(1);

--- a/packages/file-tree/test/e2e/fixtures/style-isolation.html
+++ b/packages/file-tree/test/e2e/fixtures/style-isolation.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>file-tree style isolation fixture</title>
+    <style>
+      /* Should style only light DOM */
+      #some-known-internal-id {
+        color: rgb(0, 128, 0) !important;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="some-known-internal-id" data-test-outside-duplicate-id>
+      outside duplicate-id control
+    </div>
+    <div
+      data-test-outside-pseudo-item
+      data-type="item"
+      data-item-selected="true"
+    >
+      outside pseudo file-tree item
+    </div>
+    <file-tree-container id="test-tree-host"></file-tree-container>
+
+    <script type="module">
+      import '/dist/web-components.js';
+      import { FileTree } from '/dist/index.js';
+
+      const host = document.getElementById('test-tree-host');
+      host.style.setProperty('--ft-selected-background-color', 'rgb(1, 2, 3)');
+      host.style.setProperty('--ft-color-foreground', 'rgb(40, 40, 40)');
+
+      const fileTree = new FileTree(
+        {
+          files: ['README.md', 'src/index.ts'],
+          flattenEmptyDirectories: false,
+        },
+        {
+          defaultExpandedItems: ['src'],
+          defaultSelectedItems: ['src/index.ts'],
+        }
+      );
+      fileTree.render({ fileTreeContainer: host });
+
+      const waitForShadowTree = async () => {
+        const started = performance.now();
+        while (true) {
+          const root = host.shadowRoot;
+          if (root != null && root.querySelector('[role="treeitem"]') != null) {
+            return;
+          }
+          if (performance.now() - started > 5000) {
+            throw new Error('Timed out waiting for file-tree render');
+          }
+          await new Promise((resolve) => setTimeout(resolve, 16));
+        }
+      };
+
+      await waitForShadowTree();
+      const root = host.shadowRoot;
+
+      const insideMatch = root?.querySelector('[data-type="item"]');
+      if (insideMatch != null) {
+        insideMatch.id = 'some-known-internal-id';
+        insideMatch.setAttribute('data-test-shadow-dup-id', 'true');
+      }
+
+      const selectedItem = root?.querySelector('[data-item-selected="true"]');
+      if (selectedItem != null) {
+        selectedItem.setAttribute('data-test-selected-item', 'true');
+      }
+
+      window.__fileTreeFixtureReady = true;
+    </script>
+  </body>
+</html>

--- a/packages/file-tree/test/e2e/playwright.config.ts
+++ b/packages/file-tree/test/e2e/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const e2ePort = 4173;
+const e2eBaseUrl = `http://127.0.0.1:${e2ePort}`;
+const e2eOutputDir = '/tmp/pierre-file-tree-playwright-results';
+
+export default defineConfig({
+  testDir: '.',
+  testMatch: ['**/*.pw.ts'],
+  outputDir: e2eOutputDir,
+  fullyParallel: true,
+  reporter: 'list',
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  use: {
+    baseURL: e2eBaseUrl,
+    headless: true,
+    viewport: { width: 1200, height: 800 },
+  },
+  webServer: {
+    command: `FILE_TREE_E2E_PORT=${e2ePort} bun run test:e2e:server`,
+    url: `${e2eBaseUrl}/test/e2e/fixtures/style-isolation.html`,
+    reuseExistingServer: false,
+    timeout: 60_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/packages/file-tree/test/e2e/style-isolation.pw.ts
+++ b/packages/file-tree/test/e2e/style-isolation.pw.ts
@@ -1,0 +1,77 @@
+import { expect, type Page, test } from '@playwright/test';
+
+async function openFixture(page: Page) {
+  await page.goto('/test/e2e/fixtures/style-isolation.html');
+  await page.waitForFunction(() => window.__fileTreeFixtureReady === true);
+}
+
+test.describe('file-tree shadow style isolation', () => {
+  test('external id selector does not style shadow-root node with same id', async ({
+    page,
+  }) => {
+    await openFixture(page);
+
+    const colors = await page.evaluate(() => {
+      const outside = document.querySelector(
+        '[data-test-outside-duplicate-id]'
+      );
+      const host = document.getElementById('test-tree-host');
+      const inside = host?.shadowRoot?.querySelector(
+        '[data-test-shadow-dup-id]'
+      );
+      return {
+        outside: outside != null ? getComputedStyle(outside).color : null,
+        inside: inside != null ? getComputedStyle(inside).color : null,
+      };
+    });
+
+    expect(colors.outside).toBe('rgb(0, 128, 0)');
+    expect(colors.inside).not.toBe('rgb(0, 128, 0)');
+  });
+
+  test('file-tree internal selected-item styles do not leak to light DOM', async ({
+    page,
+  }) => {
+    await openFixture(page);
+
+    const styles = await page.evaluate(() => {
+      const outside = document.querySelector('[data-test-outside-pseudo-item]');
+      if (outside == null) {
+        return null;
+      }
+      const computed = getComputedStyle(outside);
+      return {
+        backgroundColor: computed.backgroundColor,
+        boxShadow: computed.boxShadow,
+      };
+    });
+
+    expect(styles).not.toBeNull();
+    expect(styles?.backgroundColor).toBe('rgba(0, 0, 0, 0)');
+    expect(styles?.boxShadow).toBe('none');
+  });
+
+  test('css custom properties flow into the shadow root for theming', async ({
+    page,
+  }) => {
+    await openFixture(page);
+
+    const selectedBackground = await page.evaluate(() => {
+      const host = document.getElementById('test-tree-host');
+      const selected = host?.shadowRoot?.querySelector(
+        '[data-test-selected-item]'
+      );
+      return selected != null
+        ? getComputedStyle(selected).backgroundColor
+        : null;
+    });
+
+    expect(selectedBackground).toBe('rgb(1, 2, 3)');
+  });
+});
+
+declare global {
+  interface Window {
+    __fileTreeFixtureReady?: boolean;
+  }
+}

--- a/packages/file-tree/test/e2e/vite.config.ts
+++ b/packages/file-tree/test/e2e/vite.config.ts
@@ -1,0 +1,15 @@
+import { resolve } from 'node:path';
+import { defineConfig } from 'vite';
+
+const defaultPort = 4173;
+const portFromEnv = Number(process.env.FILE_TREE_E2E_PORT);
+const port = Number.isFinite(portFromEnv) ? portFromEnv : defaultPort;
+
+export default defineConfig({
+  root: resolve(import.meta.dirname, '..', '..'),
+  server: {
+    host: '127.0.0.1',
+    port,
+    strictPort: true,
+  },
+});


### PR DESCRIPTION
- add file-tree Playwright e2e coverage for shadow-style isolation and CSS var flow
- serve e2e fixture via Vite and add binary check/install helper scripts
- run file-tree e2e in CI with Playwright browser cache/install
- document testing strategy (unit-first, minimal high-value e2e)
- fix scripts/ws PATH handling so workspace scripts can resolve local bins
- update file-tree readme with e2e/testing guidance