### PR TITLE
Virtualization Windowing Fix

### DIFF
--- a/packages/diffs/src/utils/createWindowFromScrollPosition.ts
+++ b/packages/diffs/src/utils/createWindowFromScrollPosition.ts
@@ -36,10 +36,9 @@ export function createWindowFromScrollPosition({
   let bottom = top + windowHeight;
   if (top < 0) {
     top = 0;
-    bottom = Math.min(windowHeight, scrollHeight);
-  } else if (bottom > scrollHeight) {
+  }
+  if (bottom > scrollHeight) {
     bottom = scrollHeight;
-    top = Math.max(bottom - windowHeight, 0);
   }
   top = Math.floor(Math.max(top - containerOffset, 0));
   return {


### PR DESCRIPTION
This fixes a small bug that can occur with windowing logic when reaching the bottom of a file.

Basically the repro for this bug is hard to trigger but for me it was simply showing a diff in the demo app based on the fileNew.txt, that had no previous content, then scroll to the bottom and you'd see some lines that didn't render