### PR TITLE
fix: point to the correct sideeffect file

### DIFF
--- a/packages/diffs/package.json
+++ b/packages/diffs/package.json
@@ -9,7 +9,7 @@
   ],
   "type": "module",
   "sideEffects": [
-    "src/components/web-components.ts"
+    "dist/components/web-components.js"
   ],
   "typesVersions": {
     "*": {


### PR DESCRIPTION
### Description

change the sideEffects array in package json to point to the correct built file

### Motivation & Context

I was trying to use `@pierre/diffs` with vite(`@beta, v8`), it works really nice in dev, but then when I build it the diffs dont work. I debuged it to find out the code for registering the web component is not included as its a sideeffect and the file is not included in the side effects array, I patched the package json to point to the correct file in node_modules and it worked like a charm

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality). You must have
      first discussed with the dev team and they should be aware that this PR is
      being opened
- [ ] Breaking change (fix or feature that would change existing functionality).
      You must have first discussed with the dev team and they should be aware
      that this PR is being opened
- [ ] Documentation update

### Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/pierrecomputer/pierre/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project (`bun run lint`)
- [x] My code is formatted properly (`bun run format`)
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have added tests to cover my changes (if applicable)
- [ ] All new and existing tests pass (`bun run diffs:test`)

- Lint shows pre existing errors
- the test script doesn't exists


### How was AI used in generating this PR

I used gpt-codex-5.3 in Opencode to debug this issue, manually tested the patch with `pnpm patch`

### Related issues

<!-- Please link any related issues here. -->
