### PR TITLE
Dynamic Hover Slot Scroll Jump Workaround

### DIFF
--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -1031,6 +1031,8 @@ export class FileDiff<LAnnotation = undefined> {
     result: HunksRenderResult
   ): void {
     const { overflow = 'scroll' } = this.options;
+    const containerSize =
+      (this.options.hunkSeparators ?? 'line-info') === 'line-info';
     const rowSpan = overflow === 'wrap' ? result.rowCount : undefined;
     this.cleanupErrorWrapper();
     this.applyPreNodeAttributes(pre, result);
@@ -1057,6 +1059,7 @@ export class FileDiff<LAnnotation = undefined> {
         code: this.codeUnified,
         columnType: 'unified',
         rowSpan,
+        containerSize,
       });
       this.codeUnified.innerHTML =
         this.hunksRenderer.renderPartialHTML(unifiedAST);
@@ -1073,6 +1076,7 @@ export class FileDiff<LAnnotation = undefined> {
           code: this.codeDeletions,
           columnType: 'deletions',
           rowSpan,
+          containerSize,
         });
         this.codeDeletions.innerHTML =
           this.hunksRenderer.renderPartialHTML(deletionsAST);
@@ -1097,6 +1101,7 @@ export class FileDiff<LAnnotation = undefined> {
           code: this.codeAdditions,
           columnType: 'additions',
           rowSpan,
+          containerSize,
         });
         this.codeAdditions.innerHTML =
           this.hunksRenderer.renderPartialHTML(additionsAST);

--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -981,6 +981,8 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
     result: HunksRenderResult,
     children: ElementContent[] = []
   ): HASTElement {
+    const containerSize =
+      this.getOptionsWithDefaults().hunkSeparators === 'line-info';
     const unifiedAST = this.renderCodeAST('unified', result);
     if (unifiedAST != null) {
       children.push(
@@ -989,6 +991,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
           children: unifiedAST,
           properties: {
             'data-code': '',
+            'data-container-size': containerSize ? '' : undefined,
             'data-unified': '',
           },
         })
@@ -1004,6 +1007,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
           children: deletionsAST,
           properties: {
             'data-code': '',
+            'data-container-size': containerSize ? '' : undefined,
             'data-deletions': '',
           },
         })
@@ -1017,6 +1021,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
           children: additionsAST,
           properties: {
             'data-code': '',
+            'data-container-size': containerSize ? '' : undefined,
             'data-additions': '',
           },
         })
@@ -1045,6 +1050,10 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
         children,
         properties: {
           'data-code': '',
+          'data-container-size':
+            this.getOptionsWithDefaults().hunkSeparators === 'line-info'
+              ? ''
+              : undefined,
           [`data-${columnType}`]: '',
         },
       })

--- a/packages/diffs/src/style.css
+++ b/packages/diffs/src/style.css
@@ -408,6 +408,9 @@
       0px,
       calc(var(--diffs-gap-block, var(--diffs-gap-fallback)) - 6px)
     );
+  }
+
+  [data-container-size] {
     container-type: inline-size;
   }
 

--- a/packages/diffs/src/utils/getOrCreateCodeNode.ts
+++ b/packages/diffs/src/utils/getOrCreateCodeNode.ts
@@ -3,6 +3,7 @@ interface CreateCodeNodeProps {
   code?: HTMLElement;
   columnType?: 'additions' | 'deletions' | 'unified';
   rowSpan?: number;
+  containerSize?: boolean;
 }
 
 export function getOrCreateCodeNode({
@@ -10,12 +11,13 @@ export function getOrCreateCodeNode({
   pre,
   columnType,
   rowSpan,
+  containerSize = false,
 }: CreateCodeNodeProps = {}): HTMLElement {
   if (code == null) {
     code = document.createElement('code');
-    code.dataset.code = '';
+    code.setAttribute('data-code', '');
     if (columnType != null) {
-      code.dataset[columnType] = '';
+      code.setAttribute(`data-${columnType}`, '');
     }
     pre?.appendChild(code);
   }
@@ -23,6 +25,11 @@ export function getOrCreateCodeNode({
     code.style.setProperty('grid-row', `span ${rowSpan}`);
   } else {
     code.style.removeProperty('grid-row');
+  }
+  if (containerSize) {
+    code.setAttribute('data-container-size', '');
+  } else {
+    code.removeAttribute('data-container-size');
   }
   return code;
 }

--- a/packages/diffs/test/DiffHunksRender.test.ts
+++ b/packages/diffs/test/DiffHunksRender.test.ts
@@ -104,4 +104,28 @@ describe('DiffHunksRenderer', () => {
     expect(result.unifiedContentAST).toBeUndefined();
     expect(result).toMatchSnapshot('rendered result');
   });
+
+  test('adds data-container-size for line-info separators', async () => {
+    const instance = new DiffHunksRenderer({ hunkSeparators: 'line-info' });
+    const diff = parseDiffFromFile(
+      mockDiffs.diffRowBufferTest.oldFile,
+      mockDiffs.diffRowBufferTest.newFile
+    );
+    const result = await instance.asyncRender(diff);
+    const html = instance.renderFullHTML(result);
+    expect(html).toContain('data-container-size');
+  });
+
+  test('does not add data-container-size for non line-info separators', async () => {
+    const instance = new DiffHunksRenderer({
+      hunkSeparators: 'line-info-basic',
+    });
+    const diff = parseDiffFromFile(
+      mockDiffs.diffRowBufferTest.oldFile,
+      mockDiffs.diffRowBufferTest.newFile
+    );
+    const result = await instance.asyncRender(diff);
+    const html = instance.renderFullHTML(result);
+    expect(html).not.toContain('data-container-size');
+  });
 });


### PR DESCRIPTION
Basically we should only use the container-type css when we absolutely need it (when using `line-info`), so we can enable safari based workarounds for the dynamic hover slot breakage.

This means that if using enableHoverUtility in Safari, you can opt into any type other than `line-info` to not bug out scrolling when the hover utility jumps around