### PR TITLE
Fix: Mounting and unmounting file diffs in quick succession causes shiki highlighting to stop working

### DIFF
--- a/packages/diffs/src/worker/WorkerPoolManager.ts
+++ b/packages/diffs/src/worker/WorkerPoolManager.ts
@@ -754,7 +754,7 @@ export class WorkerPoolManager {
     task?: AllWorkerTasks
   ) {
     managedWorker.request_id = undefined;
-    if (task !== undefined) {
+    if (task != null) {
       if ('instance' in task) {
         this.instanceRequestMap.delete(task.instance);
       }


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail -->
Fixed a bookkeeping race condition in WorkerPoolManager where cleaned up in-flight tasks could leave a worker stuck as permanently busy. When a late response arrives for a task already removed from pendingTasks, we now clear managedWorker.request_id if the response id matches that worker, so stale responses are still ignored but worker capacity is correctly released.
### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Workers were stuck in busy state and not cleaned up properly when mounting and unmounting files very quickly

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality). You must have
      first discussed with the dev team and they should be aware that this PR is
      being opened
- [ ] Breaking change (fix or feature that would change existing functionality).
      You must have first discussed with the dev team and they should be aware
      that this PR is being opened
- [ ] Documentation update

### Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/pierrecomputer/pierre/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project (`bun run lint`)
- [x] My code is formatted properly (`bun run format`)
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have added tests to cover my changes (if applicable)
- [x] All new and existing tests pass (`bun run diffs:test`)

### How was AI used in generating this PR

AI was used to debug the issue and find the worker pool managment problem

### Related issues

<!-- Please link any related issues here. -->
#336 