### PR TITLE
perf: limit layout recalculations on hover style changes

### DIFF
--- a/packages/diffs/src/managers/MouseEventManager.ts
+++ b/packages/diffs/src/managers/MouseEventManager.ts
@@ -27,8 +27,16 @@ export interface OnDiffLineEnterLeaveProps extends DiffLineEventBaseProps {
 }
 
 type HandleMouseEventProps =
-  | { eventType: 'click'; event: PointerEvent | MouseEvent }
-  | { eventType: 'move'; event: PointerEvent };
+  | {
+      eventType: 'click';
+      event: PointerEvent | MouseEvent;
+      cachedComposedPath?: EventTarget[];
+    }
+  | {
+      eventType: 'move';
+      event: PointerEvent;
+      cachedComposedPath?: EventTarget[];
+    };
 
 type EventClickProps<TMode extends MouseEventManagerMode> = TMode extends 'file'
   ? OnLineClickProps
@@ -108,6 +116,7 @@ export class MouseEventManager<TMode extends MouseEventManagerMode> {
   private interactiveLinesAttr = false;
   private interactiveLineNumbersAttr = false;
   private hasEventListeners = false;
+  private _pendingAnimationFrame: number | null = null;
 
   constructor(
     private mode: TMode,
@@ -119,6 +128,10 @@ export class MouseEventManager<TMode extends MouseEventManagerMode> {
   }
 
   cleanUp(): void {
+    if (this._pendingAnimationFrame != null) {
+      cancelAnimationFrame(this._pendingAnimationFrame);
+      this._pendingAnimationFrame = null;
+    }
     this.pre?.removeEventListener('click', this.handleMouseClick);
     this.pre?.removeEventListener('pointermove', this.handleMouseMove);
     this.pre?.removeEventListener('pointerleave', this.handleMouseLeave);
@@ -303,16 +316,30 @@ export class MouseEventManager<TMode extends MouseEventManagerMode> {
     ) {
       return;
     }
-    debugLogIfEnabled(
-      this.options.__debugMouseEvents,
-      'move',
-      'FileDiff.DEBUG.handleMouseMove:',
-      event
-    );
-    this.handleMouseEvent({ eventType: 'move', event });
+    // Throttle: only process the latest pointermove per animation frame
+    if (this._pendingAnimationFrame != null) {
+      cancelAnimationFrame(this._pendingAnimationFrame);
+    }
+    // Capture composedPath synchronously - it's empty if read after the event dispatches
+    const cachedComposedPath = event.composedPath() as EventTarget[];
+    this._pendingAnimationFrame = requestAnimationFrame(() => {
+      this._pendingAnimationFrame = null;
+      debugLogIfEnabled(
+        this.options.__debugMouseEvents,
+        'move',
+        'FileDiff.DEBUG.handleMouseMove:',
+        event
+      );
+      this.handleMouseEvent({ eventType: 'move', event, cachedComposedPath });
+    });
   };
 
   handleMouseLeave = (event: PointerEvent): void => {
+    // Cancel any pending rAF move so stale hover doesn't fire after leave
+    if (this._pendingAnimationFrame != null) {
+      cancelAnimationFrame(this._pendingAnimationFrame);
+      this._pendingAnimationFrame = null;
+    }
     const { __debugMouseEvents } = this.options;
     debugLogIfEnabled(
       __debugMouseEvents,
@@ -335,9 +362,13 @@ export class MouseEventManager<TMode extends MouseEventManagerMode> {
     this.clearHoveredLine();
   };
 
-  private handleMouseEvent({ eventType, event }: HandleMouseEventProps) {
+  private handleMouseEvent({
+    eventType,
+    event,
+    cachedComposedPath,
+  }: HandleMouseEventProps) {
     const { __debugMouseEvents } = this.options;
-    const composedPath = event.composedPath();
+    const composedPath = cachedComposedPath ?? event.composedPath();
     debugLogIfEnabled(
       __debugMouseEvents,
       eventType,

--- a/packages/diffs/src/style.css
+++ b/packages/diffs/src/style.css
@@ -916,6 +916,10 @@
   [data-no-newline] {
     position: relative;
     padding-inline: 1ch;
+    /* Limit reflow scope: attribute/style changes on a line element (e.g.
+       data-hovered, hover-slot append) won't trigger layout recalc on
+       sibling lines or the parent grid. */
+    contain: layout style;
   }
 
   [data-indicators='classic'] [data-line] {


### PR DESCRIPTION
### Description

- Applies CSS to line elements that tells the browser that style changes on a code line do not affect the layout of other code lines.
- Throttles mouse move events with animation frames to reduce excessive events attempting to repaint hover highlighting.

Unfortunately I don't have a reproduction I can share with a large diff at this time, but these changes appeared to have a demonstrable improvement when testing in my own project.

### Motivation & Context

Large diffs (3k+ lines) had a lot of lag when it came to the mouse hover highlights when i was trying to integrate the library with a side project i'm working on.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality). You must have
      first discussed with the dev team and they should be aware that this PR is
      being opened
- [ ] Breaking change (fix or feature that would change existing functionality).
      You must have first discussed with the dev team and they should be aware
      that this PR is being opened
- [ ] Documentation update
- [x] Performance optimisation

### Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/pierrecomputer/pierre/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project (`bun run lint`)
- [x] My code is formatted properly (`bun run format`)
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have added tests to cover my changes (if applicable)
- [x] All new and existing tests pass (`bun run diffs:test`)

### How was AI used in generating this PR

Opus 4.6 was used to explore parts of the codebase that related to style changes from mouse hover events, and asked to come up with theories as to why large diffs would have lots of lag when applying the hover highlights on mouse movements.

One of the theories was that the browser is repainting the entire sticky layer whenever a child element style changes due to the gutter using position sticky. It's suggestion was to add contain to line elements to tell the browser that style changes on a line cannot affect the layout or paint of other lines.

The other theory it had was that event.composedPath was causing GC pressure from allocating lots of new arrays, and triggers lots of attempts to repaint the DOM / recalculate style and make mutations for hovers. It's suggestions was to throttle mouse move events with animation frames so that we handle the latest event per animation frame, as the hover state is a visual thing and can sacrifice sub-frame precision.

It also provided the patches that you see here.

### Related issues

<!-- Please link any related issues here. -->
