### PR TITLE
Fix scroll margin offset in docs examples

### DIFF
--- a/apps/docs/app/diff-examples/Annotations/Annotations.tsx
+++ b/apps/docs/app/diff-examples/Annotations/Annotations.tsx
@@ -95,7 +95,7 @@ export function Annotations({ prerenderedDiff }: AnnotationsProps) {
   );
 
   return (
-    <div className="scroll-mt-[20px] space-y-5" id="annotations">
+    <div className="scroll-mt-20 space-y-5" id="annotations">
       <FeatureHeader
         title="Comments & Annotations"
         description={
@@ -395,7 +395,7 @@ export function AcceptRejectExample({
   }, []);
 
   return (
-    <div className="scroll-mt-[20px] space-y-5" id="accept-reject">
+    <div className="scroll-mt-20 space-y-5" id="accept-reject">
       <FeatureHeader
         title="Accept/Reject Changes"
         description="Annotations can also be used to build interactive code review interfaces similar to AI-assisted coding tools like Cursor. Use it to track the state of each change, inject custom UI like accept/reject buttons, and provide immediate visual feedback."

--- a/apps/docs/app/diff-examples/ArbitraryFiles/ArbitraryFiles.tsx
+++ b/apps/docs/app/diff-examples/ArbitraryFiles/ArbitraryFiles.tsx
@@ -15,7 +15,7 @@ export function ArbitraryFiles({ prerenderedDiff }: ArbitraryFilesProps) {
   const [newFile, setNewFile] = useState(prerenderedDiff.newFile);
 
   return (
-    <div className="scroll-mt-[20px] space-y-5" id="arbitrary">
+    <div className="scroll-mt-20 space-y-5" id="arbitrary">
       <FeatureHeader
         title="Diff arbitrary files"
         description={

--- a/apps/docs/app/diff-examples/CustomHeader/CustomHeader.tsx
+++ b/apps/docs/app/diff-examples/CustomHeader/CustomHeader.tsx
@@ -32,7 +32,7 @@ export function CustomHeader({ prerenderedDiff }: CustomHeaderProps) {
   }
 
   return (
-    <div className="scroll-mt-[20px] space-y-5" id="custom-header">
+    <div className="scroll-mt-20 space-y-5" id="custom-header">
       <FeatureHeader
         title="Custom header metadata"
         description={

--- a/apps/docs/app/diff-examples/DiffStyles/DiffStyles.tsx
+++ b/apps/docs/app/diff-examples/DiffStyles/DiffStyles.tsx
@@ -70,7 +70,7 @@ export function DiffStyles({
   );
 
   return (
-    <div className="scroll-mt-[20px] space-y-5" id="styles">
+    <div className="scroll-mt-20 space-y-5" id="styles">
       <div className="space-y-4">
         <FeatureHeader
           title="Choose how changes are styled"

--- a/apps/docs/app/diff-examples/FontStyles/FontStyles.tsx
+++ b/apps/docs/app/diff-examples/FontStyles/FontStyles.tsx
@@ -43,7 +43,7 @@ export function FontStyles({ prerenderedDiff }: FontStylesProps) {
   const [fontFeatureSettings, setFontFeatureSettings] = useState('"aalt" 1');
 
   return (
-    <div className="scroll-mt-[20px] space-y-5" id="fonts">
+    <div className="scroll-mt-20 space-y-5" id="fonts">
       <div className="space-y-4">
         <FeatureHeader
           title="Bring your own fonts"

--- a/apps/docs/app/diff-examples/ShikiThemes/ShikiThemes.tsx
+++ b/apps/docs/app/diff-examples/ShikiThemes/ShikiThemes.tsx
@@ -124,7 +124,7 @@ export function ShikiThemes({
   >('system');
 
   return (
-    <div className="scroll-mt-[20px] space-y-5" id="themes">
+    <div className="scroll-mt-20 space-y-5" id="themes">
       <FeatureHeader
         title="Adapts to any Shiki theme"
         description={

--- a/apps/docs/app/diff-examples/SplitUnified/SplitUnified.tsx
+++ b/apps/docs/app/diff-examples/SplitUnified/SplitUnified.tsx
@@ -17,7 +17,7 @@ export function SplitUnified({
 }: SplitUnifiedProps) {
   const [diffStyle, setDiffStyle] = useState<'split' | 'unified'>('split');
   return (
-    <div className="scroll-mt-[20px] space-y-5" id="layout">
+    <div className="scroll-mt-20 space-y-5" id="layout">
       <FeatureHeader
         title="Diff layout styles"
         description="Choose from stacked (unified) or split (side-by-side). Both use CSS Grid and Shadow DOM under the hood, meaning fewer DOM nodes and faster rendering."

--- a/apps/docs/app/trees/tree-examples/TreeExampleSection.tsx
+++ b/apps/docs/app/trees/tree-examples/TreeExampleSection.tsx
@@ -8,7 +8,7 @@ export function TreeExampleSection({
   children: ReactNode;
 }) {
   return (
-    <div className="scroll-mt-[20px] space-y-5" id={id}>
+    <div className="scroll-mt-20 space-y-5" id={id}>
       {children}
     </div>
   );


### PR DESCRIPTION
Small fix, unsure when these all moved to `20px` when our fixed headers are much taller.