### PR TITLE
fix(diffs): auto-scroll when dragging past viewport

### DIFF
--- a/packages/diffs/src/managers/LineSelectionManager.ts
+++ b/packages/diffs/src/managers/LineSelectionManager.ts
@@ -35,11 +35,16 @@ interface MouseInfo {
  * - DOM attribute updates (data-selected-line)
  */
 export class LineSelectionManager {
+  private static readonly EDGE_SCROLL_ZONE = 80; // px from viewport edge
+  private static readonly MAX_SCROLL_SPEED = 20; // px per rAF tick
+
   private pre: HTMLPreElement | undefined;
   private selectedRange: SelectedLineRange | null = null;
   private renderedSelectionRange: SelectedLineRange | null | undefined;
   private anchor: { line: number; side: SelectionSide | undefined } | undefined;
   private _queuedRender: number | undefined;
+  private lastPointerPosition: { clientX: number; clientY: number } | undefined;
+  private scrollRafId: number | undefined;
 
   constructor(private options: LineSelectionOptions = {}) {}
 
@@ -57,6 +62,8 @@ export class LineSelectionManager {
       cancelAnimationFrame(this._queuedRender);
       this._queuedRender = undefined;
     }
+    this.stopAutoScroll();
+    this.lastPointerPosition = undefined;
     this.pre?.removeAttribute('data-interactive-line-numbers');
     this.pre = undefined;
   }
@@ -181,17 +188,29 @@ export class LineSelectionManager {
   };
 
   private handleMouseMove = (event: PointerEvent): void => {
-    const mouseEventData = this.getMouseEventDataForPath(
-      event.composedPath(),
-      'move'
-    );
-    if (mouseEventData == null || this.anchor == null) return;
-    const { lineNumber, eventSide } = mouseEventData;
-    this.updateSelection(lineNumber, eventSide);
+    this.lastPointerPosition = {
+      clientX: event.clientX,
+      clientY: event.clientY,
+    };
+    if (this.anchor == null) return;
+
+    const data = this.getMouseEventDataForPath(event.composedPath(), 'move');
+    if (data != null) {
+      this.updateSelection(data.lineNumber, data.eventSide);
+    }
+
+    const speed = this.getEdgeScrollSpeed(event.clientY);
+    if (speed !== 0 && this.scrollRafId == null) {
+      this.scrollRafId = requestAnimationFrame(this.runAutoScroll);
+    } else if (speed === 0) {
+      this.stopAutoScroll();
+    }
   };
 
   private handleMouseUp = (): void => {
     this.anchor = undefined;
+    this.lastPointerPosition = undefined;
+    this.stopAutoScroll();
     document.removeEventListener('pointermove', this.handleMouseMove);
     document.removeEventListener('pointerup', this.handleMouseUp);
     this.notifySelectionEnd(this.selectedRange);
@@ -368,6 +387,55 @@ export class LineSelectionManager {
     if (onLineSelectionEnd == null) return;
     onLineSelectionEnd(range);
   }
+
+  private getMouseEventDataForPoint(
+    x: number,
+    y: number
+  ): MouseInfo | undefined {
+    const path: Element[] = [];
+    let el = document.elementFromPoint(x, y);
+    while (el != null) {
+      path.push(el);
+      if (el === this.pre) break;
+      el = el.parentElement;
+    }
+    return this.getMouseEventDataForPath(path, 'move');
+  }
+
+  private getEdgeScrollSpeed(clientY: number): number {
+    const zone = LineSelectionManager.EDGE_SCROLL_ZONE;
+    const max = LineSelectionManager.MAX_SCROLL_SPEED;
+    if (clientY < zone) {
+      return -Math.round(((zone - clientY) / zone) * max);
+    }
+    const distFromBottom = window.innerHeight - clientY;
+    if (distFromBottom < zone) {
+      return Math.round(((zone - distFromBottom) / zone) * max);
+    }
+    return 0;
+  }
+
+  private stopAutoScroll(): void {
+    if (this.scrollRafId != null) {
+      cancelAnimationFrame(this.scrollRafId);
+      this.scrollRafId = undefined;
+    }
+  }
+
+  private runAutoScroll = (): void => {
+    this.scrollRafId = undefined;
+    if (this.lastPointerPosition == null || this.anchor == null) return;
+    const { clientX, clientY } = this.lastPointerPosition;
+    const speed = this.getEdgeScrollSpeed(clientY);
+    if (speed === 0) return;
+    window.scrollBy(0, speed);
+    // After scrolling, update selection at same screen coords (elements have moved).
+    const data = this.getMouseEventDataForPoint(clientX, clientY);
+    if (data != null) {
+      this.updateSelection(data.lineNumber, data.eventSide);
+    }
+    this.scrollRafId = requestAnimationFrame(this.runAutoScroll);
+  };
 
   private getMouseEventDataForPath(
     path: (EventTarget | undefined)[],


### PR DESCRIPTION
### Description

Before:
https://github.com/user-attachments/assets/b8681a0f-ab62-4df6-9b5d-bff0bad6f982

After:

https://github.com/user-attachments/assets/743ce734-f10a-4fba-8331-1a411dd61635



Before:
When clicking a line number and dragging past the top or bottom of the viewport:

No auto-scroll: the page doesn't scroll, so lines outside the current viewport are unreachable during a drag.

After:
- Edge auto-scroll: a self-rescheduling `requestAnimationFrame` loop kicks in when the pointer is within 80px of the viewport top or bottom. Each frame it calls `window.scrollBy`, then re-queries the element at the same screen coordinates (which have shifted after scrolling) to extend the selection to newly visible lines. The loop stops on pointer up or when the cursor moves back into the safe zone.

The scroll speed ramps linearly from 0 at the zone boundary up to 20px/frame at the screen edge.
Note: the 80px and 20px/frame may need to change.

### Motivation & Context

When selecting lines that goes past the view window, you must cancel your selection, scroll down, and redo the selection. If said selection is larger than the view window, you must make your screen larger to select all content.

This change make it so the page auto scrolls with the selected lines.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality). You must have
      first discussed with the dev team and they should be aware that this PR is
      being opened
- [ ] Breaking change (fix or feature that would change existing functionality).
      You must have first discussed with the dev team and they should be aware
      that this PR is being opened
- [ ] Documentation update

### Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/pierrecomputer/pierre/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project (`bun run lint`)
- [x] My code is formatted properly (`bun run format`)
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have added tests to cover my changes (if applicable)
- [x] All new and existing tests pass (`bun run diffs:test`)

### How was AI used in generating this PR

Used to assess whether to use requestAnimationFrame or setInterval on scrolling.

### Related issues

<!-- Please link any related issues here. -->
