### PR TITLE
Replace inline hex values with variables

### DIFF
--- a/packages/diffs/src/style.css
+++ b/packages/diffs/src/style.css
@@ -14,6 +14,13 @@
     --diffs-mixer: light-dark(black, white);
     --diffs-gap-fallback: 8px;
 
+    --diffs-added-light: #0dbe4e;
+    --diffs-added-dark: #5ecc71;
+    --diffs-modified-light: #009fff;
+    --diffs-modified-dark: #69b1ff;
+    --diffs-deleted-light: #ff2e3f;
+    --diffs-deleted-dark: #ff6762;
+
     /*
     // Available CSS Color Overrides
     --diffs-bg-buffer-override
@@ -178,11 +185,11 @@
       light-dark(
         var(
           --diffs-light-deletion-color,
-          var(--diffs-deletion-color, rgb(255, 0, 0))
+          var(--diffs-deletion-color, var(--diffs-deleted-light))
         ),
         var(
           --diffs-dark-deletion-color,
-          var(--diffs-deletion-color, rgb(255, 0, 0))
+          var(--diffs-deletion-color, var(--diffs-deleted-dark))
         )
       )
     );
@@ -191,11 +198,11 @@
       light-dark(
         var(
           --diffs-light-addition-color,
-          var(--diffs-addition-color, rgb(0, 255, 0))
+          var(--diffs-addition-color, var(--diffs-added-light))
         ),
         var(
           --diffs-dark-addition-color,
-          var(--diffs-addition-color, rgb(0, 255, 0))
+          var(--diffs-addition-color, var(--diffs-added-dark))
         )
       )
     );
@@ -204,11 +211,11 @@
       light-dark(
         var(
           --diffs-light-modified-color,
-          var(--diffs-modified-color, rgb(0, 0, 255))
+          var(--diffs-modified-color, var(--diffs-modified-light))
         ),
         var(
           --diffs-dark-modified-color,
-          var(--diffs-modified-color, rgb(0, 0, 255))
+          var(--diffs-modified-color, var(--diffs-modified-dark))
         )
       )
     );

--- a/packages/trees/src/style.css
+++ b/packages/trees/src/style.css
@@ -85,6 +85,14 @@
       )
     );
     --trees-accent: var(--trees-accent-override, #009fff);
+
+    --trees-added-light: #0dbe4e;
+    --trees-added-dark: #5ecc71;
+    --trees-modified-light: #009fff;
+    --trees-modified-dark: #69b1ff;
+    --trees-deleted-light: #ff2e3f;
+    --trees-deleted-dark: #ff6762;
+
     --trees-border-color: var(
       --trees-border-color-override,
       var(
@@ -150,15 +158,24 @@
     /* Git status (e.g. from Shiki theme gitDecoration.*) */
     --trees-status-added: var(
       --trees-status-added-override,
-      var(--trees-theme-git-added-fg, light-dark(#0dbe4e, #5ecc71))
+      var(
+        --trees-theme-git-added-fg,
+        light-dark(var(--trees-added-light), var(--trees-added-dark))
+      )
     );
     --trees-status-modified: var(
       --trees-status-modified-override,
-      var(--trees-theme-git-modified-fg, light-dark(#009fff, #69b1ff))
+      var(
+        --trees-theme-git-modified-fg,
+        light-dark(var(--trees-modified-light), var(--trees-modified-dark))
+      )
     );
     --trees-status-deleted: var(
       --trees-status-deleted-override,
-      var(--trees-theme-git-deleted-fg, light-dark(#ff2e3f, #ff6762))
+      var(
+        --trees-theme-git-deleted-fg,
+        light-dark(var(--trees-deleted-light), var(--trees-deleted-dark))
+      )
     );
     --trees-git-modified-color: var(
       --trees-git-modified-color-override,


### PR DESCRIPTION
As a follow-up to #370, this replaces some inline hex values for Git status colors with more obvious CSS variables assigning those colors. This also does this across both Diffs and Trees—the former had some pure CSS colors vs our own Pierre theme tokens for those hues.