### PR TITLE
Update styling and theming docs for Trees

### DIFF
--- a/apps/docs/app/trees/docs/Styling/constants.ts
+++ b/apps/docs/app/trees/docs/Styling/constants.ts
@@ -8,18 +8,33 @@ const options = {
 export const STYLING_CODE_GLOBAL: PreloadFileOptions<undefined> = {
   file: {
     name: 'global.css',
-    contents: `/* Target the file tree host (custom element or React root) */
+    contents: `/* Target the FileTree host (custom element or React root). */
 file-tree-container,
-.my-file-tree {
-  --trees-font-size-override: 14px;
-  --trees-row-height-override: 32px;
-  --trees-fg-override: oklch(0.25 0 0);
-  --trees-bg-override: oklch(0.98 0 0);
-  --trees-border-color-override: oklch(0.9 0 0);
-  --trees-border-radius-override: 8px;
-  --trees-selected-bg-override: oklch(0.92 0.02 250);
-  --trees-selected-border-color-override: oklch(0.7 0.15 250);
-  /* Optional. Used for gitStatus. */
+.project-sidebar {
+  width: 320px;
+  max-height: 420px;
+  border-radius: 12px;
+  overflow: hidden;
+
+  --trees-font-family-override: 'Berkeley Mono', monospace;
+  --trees-font-size-override: 13px;
+  --trees-row-height-override: 28px;
+  --trees-item-padding-x-override: 10px;
+  --trees-border-radius-override: 10px;
+
+  --trees-fg-override: oklch(25% 0 0);
+  --trees-bg-override: oklch(98% 0 0);
+  --trees-bg-muted-override: oklch(95% 0 0);
+  --trees-border-color-override: oklch(90% 0 0);
+
+  --trees-selected-fg-override: oklch(29% 0.09 255);
+  --trees-selected-bg-override: oklch(92% 0.05 255);
+  --trees-selected-focused-border-color-override: oklch(67% 0.16 255);
+
+  --trees-search-bg-override: white;
+  --trees-search-fg-override: oklch(28% 0 0);
+
+  /* Optional: tune git decoration colors independently. */
   --trees-git-added-color-override: #0dbe4e;
   --trees-git-modified-color-override: #009fff;
   --trees-git-deleted-color-override: #ff2e3f;
@@ -30,18 +45,52 @@ file-tree-container,
 
 export const STYLING_CODE_INLINE: PreloadFileOptions<undefined> = {
   file: {
-    name: 'FileExplorer.tsx',
+    name: 'DenseTree.tsx',
     contents: `import { FileTree } from '@pierre/trees/react';
+import type { CSSProperties } from 'react';
 
 <FileTree
   options={{ initialFiles: ['src/index.ts', 'package.json'] }}
-  className="rounded-lg border p-3"
+  className="rounded-xl border p-2"
   style={{
-    maxHeight: 400,
+    maxHeight: 360,
+    width: 320,
+    '--trees-font-family-override': 'Berkeley Mono, monospace',
     '--trees-font-size-override': '13px',
     '--trees-row-height-override': '28px',
-  } as React.CSSProperties}
+    '--trees-level-gap-override': '6px',
+    '--trees-item-row-gap-override': '4px',
+    '--trees-icon-width-override': '14px',
+  } as CSSProperties}
 />`,
+  },
+  options,
+};
+
+export const STYLING_CODE_VANILLA: PreloadFileOptions<undefined> = {
+  file: {
+    name: 'file-tree.ts',
+    contents: `import { FileTree } from '@pierre/trees';
+
+const fileTree = new FileTree({
+  initialFiles: ['src/index.ts', 'src/lib/utils.ts', 'package.json'],
+});
+
+fileTree.render({
+  containerWrapper: document.getElementById('tree-root') ?? undefined,
+});
+
+const host = fileTree.getFileTreeContainer();
+
+Object.assign(host.style, {
+  width: '320px',
+  maxHeight: '420px',
+});
+
+host.style.setProperty('--trees-row-height-override', '30px');
+host.style.setProperty('--trees-font-size-override', '13px');
+host.style.setProperty('--trees-selected-bg-override', 'oklch(90% 0.05 255)');
+host.style.setProperty('--trees-git-modified-color-override', '#009fff');`,
   },
   options,
 };

--- a/apps/docs/app/trees/docs/Styling/content.mdx
+++ b/apps/docs/app/trees/docs/Styling/content.mdx
@@ -3,15 +3,29 @@
 The file tree is rendered inside a shadow DOM host (the `file-tree-container`
 custom element), so its styles are isolated from your page.
 
-Customize it by passing **class and style** on the host: use `className` and
-`style` on the React `FileTree` component, or set them on the host element after
-`render()` in vanilla JS. That lets you control layout (e.g. `maxHeight`,
-`width`) and override the tree’s CSS variables (e.g.
-`--trees-font-size-override`, `--trees-row-height-override`) in global CSS, on a
-wrapper, or via the `style` prop.
+Customize it by passing `className` and `style` on the host: use those props on
+the React `FileTree` component, or style the host returned by
+`getFileTreeContainer()` after `render()` in vanilla JS. That lets you control
+layout (`width`, `maxHeight`, borders, overflow) and override the tree’s CSS
+variables from global CSS, a wrapper, or the host element directly.
 
-For the full list of CSS variables, review `style.css` in the `@pierre/trees`
-package.
+<Notice icon={<IconBulbFill />}>
+  Think of styling in two layers: host styles change the outer panel, and
+  `--trees-*` variables change the UI rendered inside the shadow DOM.
+</Notice>
 
 <DocsCodeExample {...stylingGlobal} />
 <DocsCodeExample {...stylingInline} />
+<DocsCodeExample {...stylingVanilla} />
+
+### Fallback order
+
+Trees uses a consistent fallback chain for colors and theme tokens:
+
+1. `--trees-*-override`
+2. `--trees-theme-*`
+3. library defaults
+
+That means explicit overrides always win. Theme-derived values from
+`themeToTreeStyles()` sit in the middle, and the built-in defaults are only used
+when neither of those is present.

--- a/apps/docs/app/trees/docs/Theming/constants.ts
+++ b/apps/docs/app/trees/docs/Theming/constants.ts
@@ -1,0 +1,72 @@
+import type { PreloadFileOptions } from '@pierre/diffs/ssr';
+
+const options = {
+  theme: { dark: 'pierre-dark', light: 'pierre-light' },
+  disableFileHeader: true,
+} as const;
+
+export const THEMING_CODE_RESOLVE_THEME: PreloadFileOptions<undefined> = {
+  file: {
+    name: 'TreeWithTheme.tsx',
+    contents: `import { resolveTheme } from '@pierre/diffs';
+import { themeToTreeStyles } from '@pierre/trees';
+import { FileTree } from '@pierre/trees/react';
+import { useEffect, useState } from 'react';
+
+export function TreeWithTheme() {
+  const [treeStyles, setTreeStyles] = useState<Record<string, string> | null>(null);
+
+  useEffect(() => {
+    async function loadTheme() {
+      const theme = await resolveTheme('github-dark');
+      setTreeStyles(themeToTreeStyles(theme));
+    }
+
+    void loadTheme();
+  }, []);
+
+  return (
+    <FileTree
+      options={{ initialFiles: ['src/index.ts', 'package.json'] }}
+      style={{
+        ...(treeStyles ?? {}),
+        '--trees-row-height-override': '28px',
+      }}
+    />
+  );
+}`,
+  },
+  options,
+};
+
+export const THEMING_CODE_CUSTOM_THEME: PreloadFileOptions<undefined> = {
+  file: {
+    name: 'custom-theme.ts',
+    contents: `import { themeToTreeStyles } from '@pierre/trees';
+
+const customTheme = {
+  type: 'dark',
+  bg: '#0b1020',
+  fg: '#e5eefc',
+  colors: {
+    'sideBar.background': '#0b1020',
+    'sideBar.foreground': '#e5eefc',
+    'sideBar.border': 'rgba(148, 163, 184, 0.18)',
+    'list.hoverBackground': 'rgba(96, 165, 250, 0.08)',
+    'list.activeSelectionBackground': 'rgba(96, 165, 250, 0.16)',
+    'list.activeSelectionForeground': '#ffffff',
+    'gitDecoration.addedResourceForeground': '#4ade80',
+    'gitDecoration.modifiedResourceForeground': '#60a5fa',
+    'gitDecoration.deletedResourceForeground': '#f87171',
+  },
+} as const;
+
+const treeStyles = themeToTreeStyles(customTheme);
+
+<FileTree
+  options={{ initialFiles: ['src/index.ts', 'package.json'] }}
+  style={treeStyles}
+/>`,
+  },
+  options,
+};

--- a/apps/docs/app/trees/docs/Theming/content.mdx
+++ b/apps/docs/app/trees/docs/Theming/content.mdx
@@ -1,0 +1,30 @@
+## Themes
+
+Trees can reuse the same Shiki or VS Code theme data that powers
+`@pierre/diffs`. If you already have a resolved theme object, pass it through
+`themeToTreeStyles()` and spread the result onto `FileTree`.
+
+<DocsCodeExample {...themingResolveTheme} />
+
+`themeToTreeStyles()` fills the `--trees-theme-*` layer in the styling fallback
+chain, so you still retain the option to add explicit `--trees-*-override`
+variables on top for density, spacing, or app-specific touches.
+
+### When to use themes vs overrides
+
+- Use `themeToTreeStyles()` when you want the tree to match an editor, Shiki, or
+  VS Code palette.
+- Use `--trees-*-override` variables when you want to tweak density, search
+  styling, selection emphasis, or git colors after the base theme is applied.
+
+### Custom theme objects
+
+You do not need to use a built-in theme name. Any object with the same basic
+shape as a Shiki or VS Code theme works:
+
+<DocsCodeExample {...themingCustomTheme} />
+
+`themeToTreeStyles()` reads common sidebar, selection, focus, input, and
+`gitDecoration.*` tokens, then maps them to the tree’s CSS variables. This is
+the safest way to keep Trees and Diffs visually aligned without duplicating a
+large set of `--trees-*` overrides by hand.

--- a/apps/docs/app/trees/docs/page.tsx
+++ b/apps/docs/app/trees/docs/page.tsx
@@ -29,7 +29,15 @@ import {
   REACT_API_GIT_STATUS_EXAMPLE,
 } from './ReactAPI/constants';
 import { SSR_HYDRATION_EXAMPLE, SSR_PRELOAD_FILE_TREE } from './SSR/constants';
-import { STYLING_CODE_GLOBAL, STYLING_CODE_INLINE } from './Styling/constants';
+import {
+  STYLING_CODE_GLOBAL,
+  STYLING_CODE_INLINE,
+  STYLING_CODE_VANILLA,
+} from './Styling/constants';
+import {
+  THEMING_CODE_CUSTOM_THEME,
+  THEMING_CODE_RESOLVE_THEME,
+} from './Theming/constants';
 import {
   HELPER_GENERATE_LAZY_DATA_LOADER,
   HELPER_GENERATE_SYNC_DATA_LOADER,
@@ -65,6 +73,7 @@ export default function TreesDocsPage() {
           <CustomIconsSection />
           <UtilitiesSection />
           <StylingSection />
+          <ThemingSection />
           <SSRSection />
         </div>
       </DocsLayout>
@@ -223,15 +232,32 @@ async function SSRSection() {
 }
 
 async function StylingSection() {
-  const [stylingGlobal, stylingInline] = await Promise.all([
+  const [stylingGlobal, stylingInline, stylingVanilla] = await Promise.all([
     preloadFile(STYLING_CODE_GLOBAL),
     preloadFile(STYLING_CODE_INLINE),
+    preloadFile(STYLING_CODE_VANILLA),
   ]);
   const content = await renderMDX({
     filePath: 'trees/docs/Styling/content.mdx',
     scope: {
       stylingGlobal,
       stylingInline,
+      stylingVanilla,
+    },
+  });
+  return <ProseWrapper>{content}</ProseWrapper>;
+}
+
+async function ThemingSection() {
+  const [themingResolveTheme, themingCustomTheme] = await Promise.all([
+    preloadFile(THEMING_CODE_RESOLVE_THEME),
+    preloadFile(THEMING_CODE_CUSTOM_THEME),
+  ]);
+  const content = await renderMDX({
+    filePath: 'trees/docs/Theming/content.mdx',
+    scope: {
+      themingResolveTheme,
+      themingCustomTheme,
     },
   });
   return <ProseWrapper>{content}</ProseWrapper>;


### PR DESCRIPTION
Since adding support for Shiki themes, and redoing the global tokens, needed to update our docs.