### PR TITLE
fix React renderGutterUtility prop not triggering slot creation in shadow DOM

### DIFF
--- a/packages/diffs/src/react/File.tsx
+++ b/packages/diffs/src/react/File.tsx
@@ -31,6 +31,8 @@ export function File<LAnnotation = undefined>({
     lineAnnotations,
     selectedLines,
     prerenderedHTML,
+    hasCustomGutterUtility:
+      renderGutterUtility != null || renderHoverUtility != null,
   });
   const children = renderFileChildren({
     file,

--- a/packages/diffs/src/react/FileDiff.tsx
+++ b/packages/diffs/src/react/FileDiff.tsx
@@ -37,6 +37,8 @@ export function FileDiff<LAnnotation = undefined>({
     lineAnnotations,
     selectedLines,
     prerenderedHTML,
+    hasCustomGutterUtility:
+      renderGutterUtility != null || renderHoverUtility != null,
   });
   const children = renderDiffChildren({
     fileDiff,

--- a/packages/diffs/src/react/MultiFileDiff.tsx
+++ b/packages/diffs/src/react/MultiFileDiff.tsx
@@ -40,6 +40,8 @@ export function MultiFileDiff<LAnnotation = undefined>({
     lineAnnotations,
     selectedLines,
     prerenderedHTML,
+    hasCustomGutterUtility:
+      renderGutterUtility != null || renderHoverUtility != null,
   });
   const children = renderDiffChildren({
     deletionFile: oldFile,

--- a/packages/diffs/src/react/PatchDiff.tsx
+++ b/packages/diffs/src/react/PatchDiff.tsx
@@ -39,6 +39,8 @@ export function PatchDiff<LAnnotation = undefined>({
     lineAnnotations,
     selectedLines,
     prerenderedHTML,
+    hasCustomGutterUtility:
+      renderGutterUtility != null || renderHoverUtility != null,
   });
   const children = renderDiffChildren({
     fileDiff,

--- a/packages/diffs/src/react/UnresolvedFile.tsx
+++ b/packages/diffs/src/react/UnresolvedFile.tsx
@@ -61,6 +61,8 @@ export function UnresolvedFile<LAnnotation = undefined>({
       selectedLines,
       prerenderedHTML,
       hasConflictUtility: renderMergeConflictUtility != null,
+      hasCustomGutterUtility:
+        renderGutterUtility != null || renderHoverUtility != null,
     });
   const children = renderDiffChildren({
     fileDiff,

--- a/packages/diffs/src/react/utils/useFileDiffInstance.ts
+++ b/packages/diffs/src/react/utils/useFileDiffInstance.ts
@@ -26,6 +26,8 @@ import { useStableCallback } from './useStableCallback';
 const useIsometricEffect =
   typeof window === 'undefined' ? useEffect : useLayoutEffect;
 
+const noopGutterUtility = () => null;
+
 interface UseFileDiffInstanceProps<LAnnotation> {
   oldFile?: FileContents;
   newFile?: FileContents;
@@ -35,6 +37,7 @@ interface UseFileDiffInstanceProps<LAnnotation> {
   selectedLines: SelectedLineRange | null | undefined;
   prerenderedHTML: string | undefined;
   metrics?: VirtualFileMetrics;
+  hasCustomGutterUtility?: boolean;
 }
 
 interface UseFileDiffInstanceReturn {
@@ -51,12 +54,21 @@ export function useFileDiffInstance<LAnnotation>({
   selectedLines,
   prerenderedHTML,
   metrics,
+  hasCustomGutterUtility,
 }: UseFileDiffInstanceProps<LAnnotation>): UseFileDiffInstanceReturn {
   const simpleVirtualizer = useVirtualizer();
   const poolManager = useContext(WorkerPoolContext);
   const instanceRef = useRef<
     FileDiff<LAnnotation> | VirtualizedFileDiff<LAnnotation> | null
   >(null);
+
+  const effectiveOptions =
+    hasCustomGutterUtility === true &&
+    options?.renderGutterUtility == null &&
+    options?.renderHoverUtility == null
+      ? { ...options, renderGutterUtility: noopGutterUtility }
+      : options;
+
   const ref = useStableCallback((fileContainer: HTMLElement | null) => {
     if (fileContainer != null) {
       if (instanceRef.current != null) {
@@ -66,14 +78,14 @@ export function useFileDiffInstance<LAnnotation>({
       }
       if (simpleVirtualizer != null) {
         instanceRef.current = new VirtualizedFileDiff(
-          options,
+          effectiveOptions,
           simpleVirtualizer,
           metrics,
           poolManager,
           true
         );
       } else {
-        instanceRef.current = new FileDiff(options, poolManager, true);
+        instanceRef.current = new FileDiff(effectiveOptions, poolManager, true);
       }
       void instanceRef.current.hydrate({
         fileDiff,
@@ -97,8 +109,8 @@ export function useFileDiffInstance<LAnnotation>({
   useIsometricEffect(() => {
     const { current: instance } = instanceRef;
     if (instance == null) return;
-    const forceRender = !areOptionsEqual(instance.options, options);
-    instance.setOptions(options);
+    const forceRender = !areOptionsEqual(instance.options, effectiveOptions);
+    instance.setOptions(effectiveOptions);
     void instance.render({
       forceRender,
       fileDiff,

--- a/packages/diffs/src/react/utils/useFileInstance.ts
+++ b/packages/diffs/src/react/utils/useFileInstance.ts
@@ -25,6 +25,8 @@ import { useStableCallback } from './useStableCallback';
 const useIsometricEffect =
   typeof window === 'undefined' ? useEffect : useLayoutEffect;
 
+const noopGutterUtility = () => null;
+
 interface UseFileInstanceProps<LAnnotation> {
   file: FileContents;
   options: FileOptions<LAnnotation> | undefined;
@@ -32,6 +34,7 @@ interface UseFileInstanceProps<LAnnotation> {
   selectedLines: SelectedLineRange | null | undefined;
   prerenderedHTML: string | undefined;
   metrics?: VirtualFileMetrics;
+  hasCustomGutterUtility?: boolean;
 }
 
 interface UseFileInstanceReturn {
@@ -46,12 +49,21 @@ export function useFileInstance<LAnnotation>({
   selectedLines,
   prerenderedHTML,
   metrics,
+  hasCustomGutterUtility,
 }: UseFileInstanceProps<LAnnotation>): UseFileInstanceReturn {
   const simpleVirtualizer = useVirtualizer();
   const poolManager = useContext(WorkerPoolContext);
   const instanceRef = useRef<
     File<LAnnotation> | VirtualizedFile<LAnnotation> | null
   >(null);
+
+  const effectiveOptions =
+    hasCustomGutterUtility === true &&
+    options?.renderGutterUtility == null &&
+    options?.renderHoverUtility == null
+      ? { ...options, renderGutterUtility: noopGutterUtility }
+      : options;
+
   const ref = useStableCallback((node: HTMLElement | null) => {
     if (node != null) {
       if (instanceRef.current != null) {
@@ -61,14 +73,14 @@ export function useFileInstance<LAnnotation>({
       }
       if (simpleVirtualizer != null) {
         instanceRef.current = new VirtualizedFile(
-          options,
+          effectiveOptions,
           simpleVirtualizer,
           metrics,
           poolManager,
           true
         );
       } else {
-        instanceRef.current = new File(options, poolManager, true);
+        instanceRef.current = new File(effectiveOptions, poolManager, true);
       }
       void instanceRef.current.hydrate({
         file,
@@ -87,8 +99,11 @@ export function useFileInstance<LAnnotation>({
 
   useIsometricEffect(() => {
     if (instanceRef.current == null) return;
-    const forceRender = !areOptionsEqual(instanceRef.current.options, options);
-    instanceRef.current.setOptions(options);
+    const forceRender = !areOptionsEqual(
+      instanceRef.current.options,
+      effectiveOptions
+    );
+    instanceRef.current.setOptions(effectiveOptions);
     void instanceRef.current.render({ file, lineAnnotations, forceRender });
     if (selectedLines !== undefined) {
       instanceRef.current.setSelectedLines(selectedLines);

--- a/packages/diffs/src/react/utils/useUnresolvedFileInstance.ts
+++ b/packages/diffs/src/react/utils/useUnresolvedFileInstance.ts
@@ -34,6 +34,8 @@ import { useStableCallback } from './useStableCallback';
 const useIsometricEffect =
   typeof window === 'undefined' ? useEffect : useLayoutEffect;
 
+const noopGutterUtility = () => null;
+
 interface UseUnresolvedFileInstanceProps<LAnnotation> {
   file: FileContents;
   options?: Omit<UnresolvedFileHunksRendererOptions, 'onMergeConflictAction'>;
@@ -41,6 +43,7 @@ interface UseUnresolvedFileInstanceProps<LAnnotation> {
   selectedLines: SelectedLineRange | null | undefined;
   prerenderedHTML: string | undefined;
   hasConflictUtility: boolean;
+  hasCustomGutterUtility?: boolean;
 }
 
 interface UseUnresolvedFileInstanceReturn<LAnnotation> {
@@ -58,6 +61,7 @@ export function useUnresolvedFileInstance<LAnnotation>({
   selectedLines,
   prerenderedHTML,
   hasConflictUtility,
+  hasCustomGutterUtility,
 }: UseUnresolvedFileInstanceProps<LAnnotation>): UseUnresolvedFileInstanceReturn<LAnnotation> {
   const [{ fileDiff, actions }, setState] = useState(() => {
     const { fileDiff, actions } = parseMergeConflictDiffFromFile(file);
@@ -97,7 +101,8 @@ export function useUnresolvedFileInstance<LAnnotation>({
         mergeUnresolvedOptions(
           options,
           onMergeConflictAction,
-          hasConflictUtility
+          hasConflictUtility,
+          hasCustomGutterUtility
         ),
         poolManager,
         true
@@ -126,7 +131,8 @@ export function useUnresolvedFileInstance<LAnnotation>({
     const newOptions = mergeUnresolvedOptions(
       options,
       onMergeConflictAction,
-      hasConflictUtility
+      hasConflictUtility,
+      hasCustomGutterUtility
     );
     const forceRender = !areOptionsEqual(instance.options, newOptions);
     instance.setOptions(newOptions);
@@ -157,21 +163,29 @@ export function useUnresolvedFileInstance<LAnnotation>({
 function mergeUnresolvedOptions<LAnnotation>(
   options: UnresolvedFileHunksRendererOptions | undefined,
   onMergeConflictAction: UnresolvedFileOptions<LAnnotation>['onMergeConflictAction'],
-  hasConflictUtility: boolean
+  hasConflictUtility: boolean,
+  hasCustomGutterUtility?: boolean
 ): UnresolvedFileOptions<LAnnotation> {
-  return {
+  const merged: UnresolvedFileOptions<LAnnotation> = {
     ...options,
     onMergeConflictAction,
     hunkSeparators:
       options?.hunkSeparators === 'custom'
         ? emptyRender
         : options?.hunkSeparators,
-    // Add a placeholder type for the custom render
     mergeConflictActionsType:
       hasConflictUtility || options?.mergeConflictActionsType === 'custom'
         ? emptyRender
         : options?.mergeConflictActionsType,
   };
+  if (
+    hasCustomGutterUtility === true &&
+    merged.renderGutterUtility == null &&
+    merged.renderHoverUtility == null
+  ) {
+    merged.renderGutterUtility = noopGutterUtility;
+  }
+  return merged;
 }
 
 function emptyRender() {


### PR DESCRIPTION
### Description

When using React diff components (`<FileDiff>`, `<PatchDiff>`, `<MultiFileDiff>`, `<File>`, `<UnresolvedFile>`) with the `renderGutterUtility` or `renderHoverUtility` React prop, the custom gutter utility content renders with zero dimensions because no `<slot name="gutter-utility-slot">` is created in the shadow DOM.

**Root cause:** `pluckInteractionOptions` derives `usesCustomGutterUtility` from `options.renderGutterUtility`, but React render functions (which return `ReactNode`) are separate props, not part of `options` (which expects `HTMLElement | null`). The React hooks pass only `options` to the vanilla component, so `pluckInteractionOptions` never sees a render function and sets `usesCustomGutterUtility: false`, causing `ensureGutterUtilityNode` to create a default `<button>` instead of a `<slot>`.

**Fix:** Follow the existing `hasConflictUtility` pattern from `useUnresolvedFileInstance`. Pass a boolean flag from each React component to its hook indicating a custom gutter utility React prop is present. The hook merges a noop `renderGutterUtility: () => null` into options when the flag is true, which signals to `pluckInteractionOptions` that `usesCustomGutterUtility` should be `true`. The noop is safe because `pluckInteractionOptions` only checks `renderGutterUtility != null` (never calls it), and the vanilla `renderGutterUtility()` method gets `null` and correctly skips rendering (React handles rendering via the slot).

### Motivation & Context

Fixes #405. Regression from #346.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality). You must have
      first discussed with the dev team and they should be aware that this PR is
      being opened
- [ ] Breaking change (fix or feature that would change existing functionality).
      You must have first discussed with the dev team and they should be aware
      that this PR is being opened
- [ ] Documentation update

### Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/pierrecomputer/pierre/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project (`bun run lint`)
- [x] My code is formatted properly (`bun run format`)
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have added tests to cover my changes (if applicable)
- [x] All new and existing tests pass (`bun run diffs:test`)

### How was AI used in generating this PR

AI (Claude Code) was used to implement the fix after the approach was designed collaboratively. All code was reviewed and verified by a human. The PR description was composed with AI assistance.

### Related issues

Fixes #405