### PR TITLE
Fix bug with react component's renderGutterUtility

### DIFF
--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -82,13 +82,13 @@ export interface FileOptions<LAnnotation>
   ): HTMLElement | undefined;
   renderGutterUtility?(
     getHoveredRow: () => GetHoveredLineResult<'file'> | undefined
-  ): HTMLElement | null;
+  ): HTMLElement | null | undefined;
   /**
    * @deprecated Use `renderGutterUtility` instead.
    */
   renderHoverUtility?(
     getHoveredRow: () => GetHoveredLineResult<'file'> | undefined
-  ): HTMLElement | null;
+  ): HTMLElement | null | undefined;
 }
 
 interface AnnotationElementCache<LAnnotation> {

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -88,7 +88,7 @@ export interface FileDiffOptions<LAnnotation>
     | ((
         hunk: HunkData,
         instance: FileDiff<LAnnotation>
-      ) => HTMLElement | DocumentFragment | undefined);
+      ) => HTMLElement | DocumentFragment | null | undefined);
   disableFileHeader?: boolean;
   /**
    * @deprecated Use `enableGutterUtility` instead.
@@ -107,13 +107,13 @@ export interface FileDiffOptions<LAnnotation>
   ): HTMLElement | undefined;
   renderGutterUtility?(
     getHoveredRow: () => GetHoveredLineResult<'diff'> | undefined
-  ): HTMLElement | null;
+  ): HTMLElement | null | undefined;
   /**
    * @deprecated Use `renderGutterUtility` instead.
    */
   renderHoverUtility?(
     getHoveredRow: () => GetHoveredLineResult<'diff'> | undefined
-  ): HTMLElement | null;
+  ): HTMLElement | null | undefined;
 }
 
 interface AnnotationElementCache<LAnnotation> {

--- a/packages/diffs/src/components/UnresolvedFile.ts
+++ b/packages/diffs/src/components/UnresolvedFile.ts
@@ -32,7 +32,7 @@ import {
 export type RenderMergeConflictActions<LAnnotation> = (
   action: MergeConflictDiffAction,
   instance: UnresolvedFile<LAnnotation>
-) => HTMLElement | DocumentFragment | undefined;
+) => HTMLElement | DocumentFragment | null | undefined;
 
 export type MergeConflictActionsTypeOption<LAnnotation> =
   | 'none'

--- a/packages/diffs/src/managers/InteractionManager.ts
+++ b/packages/diffs/src/managers/InteractionManager.ts
@@ -1440,10 +1440,10 @@ type InteractionPluckOptions<TMode extends InteractionManagerMode> =
     enableHoverUtility?: boolean;
     renderGutterUtility?(
       getHoveredRow: () => GetHoveredLineResult<TMode> | undefined
-    ): HTMLElement | null;
+    ): HTMLElement | null | undefined;
     renderHoverUtility?(
       getHoveredRow: () => GetHoveredLineResult<TMode> | undefined
-    ): HTMLElement | null;
+    ): HTMLElement | null | undefined;
   };
 
 export function pluckInteractionOptions<TMode extends InteractionManagerMode>(

--- a/packages/diffs/src/react/File.tsx
+++ b/packages/diffs/src/react/File.tsx
@@ -31,6 +31,8 @@ export function File<LAnnotation = undefined>({
     lineAnnotations,
     selectedLines,
     prerenderedHTML,
+    hasGutterRenderUtility:
+      renderGutterUtility != null || renderHoverUtility != null,
   });
   const children = renderFileChildren({
     file,

--- a/packages/diffs/src/react/FileDiff.tsx
+++ b/packages/diffs/src/react/FileDiff.tsx
@@ -37,6 +37,8 @@ export function FileDiff<LAnnotation = undefined>({
     lineAnnotations,
     selectedLines,
     prerenderedHTML,
+    hasGutterRenderUtility:
+      renderGutterUtility != null || renderHoverUtility != null,
   });
   const children = renderDiffChildren({
     fileDiff,

--- a/packages/diffs/src/react/MultiFileDiff.tsx
+++ b/packages/diffs/src/react/MultiFileDiff.tsx
@@ -40,6 +40,8 @@ export function MultiFileDiff<LAnnotation = undefined>({
     lineAnnotations,
     selectedLines,
     prerenderedHTML,
+    hasGutterRenderUtility:
+      renderGutterUtility != null || renderHoverUtility != null,
   });
   const children = renderDiffChildren({
     deletionFile: oldFile,

--- a/packages/diffs/src/react/PatchDiff.tsx
+++ b/packages/diffs/src/react/PatchDiff.tsx
@@ -39,6 +39,8 @@ export function PatchDiff<LAnnotation = undefined>({
     lineAnnotations,
     selectedLines,
     prerenderedHTML,
+    hasGutterRenderUtility:
+      renderGutterUtility != null || renderHoverUtility != null,
   });
   const children = renderDiffChildren({
     fileDiff,

--- a/packages/diffs/src/react/UnresolvedFile.tsx
+++ b/packages/diffs/src/react/UnresolvedFile.tsx
@@ -61,6 +61,8 @@ export function UnresolvedFile<LAnnotation = undefined>({
       selectedLines,
       prerenderedHTML,
       hasConflictUtility: renderMergeConflictUtility != null,
+      hasGutterRenderUtility:
+        renderGutterUtility != null || renderHoverUtility != null,
     });
   const children = renderDiffChildren({
     fileDiff,

--- a/packages/diffs/src/react/constants.ts
+++ b/packages/diffs/src/react/constants.ts
@@ -10,3 +10,7 @@ export const GutterUtilitySlotStyles: CSSProperties = {
 export const MergeConflictSlotStyles: CSSProperties = {
   display: 'contents',
 };
+
+export function noopRender() {
+  return null;
+}

--- a/packages/diffs/src/react/utils/useFileDiffInstance.ts
+++ b/packages/diffs/src/react/utils/useFileDiffInstance.ts
@@ -19,6 +19,7 @@ import type {
   VirtualFileMetrics,
 } from '../../types';
 import { areOptionsEqual } from '../../utils/areOptionsEqual';
+import { noopRender as renderGutterUtility } from '../constants';
 import { useVirtualizer } from '../Virtualizer';
 import { WorkerPoolContext } from '../WorkerPoolContext';
 import { useStableCallback } from './useStableCallback';
@@ -35,6 +36,7 @@ interface UseFileDiffInstanceProps<LAnnotation> {
   selectedLines: SelectedLineRange | null | undefined;
   prerenderedHTML: string | undefined;
   metrics?: VirtualFileMetrics;
+  hasGutterRenderUtility: boolean;
 }
 
 interface UseFileDiffInstanceReturn {
@@ -51,6 +53,7 @@ export function useFileDiffInstance<LAnnotation>({
   selectedLines,
   prerenderedHTML,
   metrics,
+  hasGutterRenderUtility,
 }: UseFileDiffInstanceProps<LAnnotation>): UseFileDiffInstanceReturn {
   const simpleVirtualizer = useVirtualizer();
   const poolManager = useContext(WorkerPoolContext);
@@ -66,14 +69,18 @@ export function useFileDiffInstance<LAnnotation>({
       }
       if (simpleVirtualizer != null) {
         instanceRef.current = new VirtualizedFileDiff(
-          options,
+          mergeFileDiffOptions(options, hasGutterRenderUtility),
           simpleVirtualizer,
           metrics,
           poolManager,
           true
         );
       } else {
-        instanceRef.current = new FileDiff(options, poolManager, true);
+        instanceRef.current = new FileDiff(
+          mergeFileDiffOptions(options, hasGutterRenderUtility),
+          poolManager,
+          true
+        );
       }
       void instanceRef.current.hydrate({
         fileDiff,
@@ -97,8 +104,9 @@ export function useFileDiffInstance<LAnnotation>({
   useIsometricEffect(() => {
     const { current: instance } = instanceRef;
     if (instance == null) return;
-    const forceRender = !areOptionsEqual(instance.options, options);
-    instance.setOptions(options);
+    const newOptions = mergeFileDiffOptions(options, hasGutterRenderUtility);
+    const forceRender = !areOptionsEqual(instance.options, newOptions);
+    instance.setOptions(newOptions);
     void instance.render({
       forceRender,
       fileDiff,
@@ -118,4 +126,14 @@ export function useFileDiffInstance<LAnnotation>({
   }, []);
 
   return { ref, getHoveredLine };
+}
+
+function mergeFileDiffOptions<LAnnotation>(
+  options: FileDiffOptions<LAnnotation> | undefined,
+  hasGutterRenderUtility: boolean
+): FileDiffOptions<LAnnotation> | undefined {
+  if (hasGutterRenderUtility) {
+    return { ...options, renderGutterUtility };
+  }
+  return options;
 }

--- a/packages/diffs/src/react/utils/useFileInstance.ts
+++ b/packages/diffs/src/react/utils/useFileInstance.ts
@@ -18,6 +18,7 @@ import type {
   VirtualFileMetrics,
 } from '../../types';
 import { areOptionsEqual } from '../../utils/areOptionsEqual';
+import { noopRender as renderGutterUtility } from '../constants';
 import { useVirtualizer } from '../Virtualizer';
 import { WorkerPoolContext } from '../WorkerPoolContext';
 import { useStableCallback } from './useStableCallback';
@@ -32,6 +33,7 @@ interface UseFileInstanceProps<LAnnotation> {
   selectedLines: SelectedLineRange | null | undefined;
   prerenderedHTML: string | undefined;
   metrics?: VirtualFileMetrics;
+  hasGutterRenderUtility: boolean;
 }
 
 interface UseFileInstanceReturn {
@@ -46,6 +48,7 @@ export function useFileInstance<LAnnotation>({
   selectedLines,
   prerenderedHTML,
   metrics,
+  hasGutterRenderUtility,
 }: UseFileInstanceProps<LAnnotation>): UseFileInstanceReturn {
   const simpleVirtualizer = useVirtualizer();
   const poolManager = useContext(WorkerPoolContext);
@@ -61,14 +64,18 @@ export function useFileInstance<LAnnotation>({
       }
       if (simpleVirtualizer != null) {
         instanceRef.current = new VirtualizedFile(
-          options,
+          mergeFileOptions(options, hasGutterRenderUtility),
           simpleVirtualizer,
           metrics,
           poolManager,
           true
         );
       } else {
-        instanceRef.current = new File(options, poolManager, true);
+        instanceRef.current = new File(
+          mergeFileOptions(options, hasGutterRenderUtility),
+          poolManager,
+          true
+        );
       }
       void instanceRef.current.hydrate({
         file,
@@ -87,8 +94,12 @@ export function useFileInstance<LAnnotation>({
 
   useIsometricEffect(() => {
     if (instanceRef.current == null) return;
-    const forceRender = !areOptionsEqual(instanceRef.current.options, options);
-    instanceRef.current.setOptions(options);
+    const newOptions = mergeFileOptions(options, hasGutterRenderUtility);
+    const forceRender = !areOptionsEqual(
+      instanceRef.current.options,
+      newOptions
+    );
+    instanceRef.current.setOptions(newOptions);
     void instanceRef.current.render({ file, lineAnnotations, forceRender });
     if (selectedLines !== undefined) {
       instanceRef.current.setSelectedLines(selectedLines);
@@ -101,4 +112,14 @@ export function useFileInstance<LAnnotation>({
     return instanceRef.current?.getHoveredLine();
   }, []);
   return { ref, getHoveredLine };
+}
+
+function mergeFileOptions<LAnnotation>(
+  options: FileOptions<LAnnotation> | undefined,
+  hasGutterRenderUtility: boolean
+): FileOptions<LAnnotation> | undefined {
+  if (hasGutterRenderUtility) {
+    return { ...options, renderGutterUtility };
+  }
+  return options;
 }

--- a/packages/diffs/src/react/utils/useUnresolvedFileInstance.ts
+++ b/packages/diffs/src/react/utils/useUnresolvedFileInstance.ts
@@ -28,6 +28,7 @@ import {
   type MergeConflictDiffAction,
   parseMergeConflictDiffFromFile,
 } from '../../utils/parseMergeConflictDiffFromFile';
+import { noopRender } from '../constants';
 import { WorkerPoolContext } from '../WorkerPoolContext';
 import { useStableCallback } from './useStableCallback';
 
@@ -41,6 +42,7 @@ interface UseUnresolvedFileInstanceProps<LAnnotation> {
   selectedLines: SelectedLineRange | null | undefined;
   prerenderedHTML: string | undefined;
   hasConflictUtility: boolean;
+  hasGutterRenderUtility: boolean;
 }
 
 interface UseUnresolvedFileInstanceReturn<LAnnotation> {
@@ -58,6 +60,7 @@ export function useUnresolvedFileInstance<LAnnotation>({
   selectedLines,
   prerenderedHTML,
   hasConflictUtility,
+  hasGutterRenderUtility,
 }: UseUnresolvedFileInstanceProps<LAnnotation>): UseUnresolvedFileInstanceReturn<LAnnotation> {
   const [{ fileDiff, actions }, setState] = useState(() => {
     const { fileDiff, actions } = parseMergeConflictDiffFromFile(file);
@@ -97,7 +100,8 @@ export function useUnresolvedFileInstance<LAnnotation>({
         mergeUnresolvedOptions(
           options,
           onMergeConflictAction,
-          hasConflictUtility
+          hasConflictUtility,
+          hasGutterRenderUtility
         ),
         poolManager,
         true
@@ -126,7 +130,8 @@ export function useUnresolvedFileInstance<LAnnotation>({
     const newOptions = mergeUnresolvedOptions(
       options,
       onMergeConflictAction,
-      hasConflictUtility
+      hasConflictUtility,
+      hasGutterRenderUtility
     );
     const forceRender = !areOptionsEqual(instance.options, newOptions);
     instance.setOptions(newOptions);
@@ -157,23 +162,21 @@ export function useUnresolvedFileInstance<LAnnotation>({
 function mergeUnresolvedOptions<LAnnotation>(
   options: UnresolvedFileHunksRendererOptions | undefined,
   onMergeConflictAction: UnresolvedFileOptions<LAnnotation>['onMergeConflictAction'],
-  hasConflictUtility: boolean
+  hasConflictUtility: boolean,
+  hasGutterRenderUtility: boolean
 ): UnresolvedFileOptions<LAnnotation> {
   return {
     ...options,
     onMergeConflictAction,
     hunkSeparators:
       options?.hunkSeparators === 'custom'
-        ? emptyRender
+        ? noopRender
         : options?.hunkSeparators,
     // Add a placeholder type for the custom render
     mergeConflictActionsType:
       hasConflictUtility || options?.mergeConflictActionsType === 'custom'
-        ? emptyRender
+        ? noopRender
         : options?.mergeConflictActionsType,
+    renderGutterUtility: hasGutterRenderUtility ? noopRender : undefined,
   };
-}
-
-function emptyRender() {
-  return undefined;
 }


### PR DESCRIPTION
As the bug outlines, there was a derp with regards to how we were calculating the custom render function in the react components. I've gone ahead and cleaned up these parts of the code bases.

Fixes #405 

From a high level I decided to take the time and clean up some times and ensure the code paths for the different instances all followed the same basic patterns as well.