### PR TITLE
Fix diffAcceptRejectHunk with partial FileDiffMetadata

### DIFF
--- a/packages/diffs/src/utils/resolveRegion.ts
+++ b/packages/diffs/src/utils/resolveRegion.ts
@@ -74,22 +74,18 @@ export function resolveRegion(
   const updatesEOFState =
     hunkIndex === hunks.length - 1 &&
     endContentIndex === currentHunk.hunkContent.length - 1;
+  const shouldProcessCollapsedContext = !diff.isPartial;
 
   for (const [index, hunk] of hunks.entries()) {
-    pushCollapsedContextLines(
+    processCollapsedContext(
+      diff,
       resolvedDiff,
-      deletionLines,
-      additionLines,
+      cursor,
       hunk.deletionLineIndex - hunk.collapsedBefore,
       hunk.additionLineIndex - hunk.collapsedBefore,
-      hunk.collapsedBefore
+      hunk.collapsedBefore,
+      shouldProcessCollapsedContext
     );
-    cursor.nextAdditionLineIndex += hunk.collapsedBefore;
-    cursor.nextDeletionLineIndex += hunk.collapsedBefore;
-    cursor.nextAdditionStart += hunk.collapsedBefore;
-    cursor.nextDeletionStart += hunk.collapsedBefore;
-    cursor.splitLineCount += hunk.collapsedBefore;
-    cursor.unifiedLineCount += hunk.collapsedBefore;
 
     const newHunk: Hunk = {
       ...hunk,
@@ -234,6 +230,41 @@ function pushCollapsedContextLines(
     diff.deletionLines.push(deletionLine);
     diff.additionLines.push(additionLine);
   }
+}
+
+// Partial patches track omitted context in `collapsedBefore`, but those lines do
+// not exist in the diff's line arrays. Keep the virtual row counts and file
+// positions in sync without inventing hidden lines.
+function processCollapsedContext(
+  sourceDiff: FileDiffMetadata,
+  resolvedDiff: FileDiffMetadata,
+  cursor: CursorState,
+  deletionLineIndex: number,
+  additionLineIndex: number,
+  lineCount: number,
+  shouldProcessContent: boolean
+) {
+  if (lineCount <= 0) {
+    return;
+  }
+
+  if (shouldProcessContent) {
+    pushCollapsedContextLines(
+      resolvedDiff,
+      sourceDiff.deletionLines,
+      sourceDiff.additionLines,
+      deletionLineIndex,
+      additionLineIndex,
+      lineCount
+    );
+    cursor.nextAdditionLineIndex += lineCount;
+    cursor.nextDeletionLineIndex += lineCount;
+  }
+
+  cursor.nextAdditionStart += lineCount;
+  cursor.nextDeletionStart += lineCount;
+  cursor.splitLineCount += lineCount;
+  cursor.unifiedLineCount += lineCount;
 }
 
 function pushContentLinesToDiff(

--- a/packages/diffs/test/diffAcceptRejectHunk.test.ts
+++ b/packages/diffs/test/diffAcceptRejectHunk.test.ts
@@ -8,6 +8,7 @@ import type {
 import { diffAcceptRejectHunk } from '../src/utils/diffAcceptRejectHunk';
 import { parseDiffFromFile } from '../src/utils/parseDiffFromFile';
 import { parseMergeConflictDiffFromFile } from '../src/utils/parseMergeConflictDiffFromFile';
+import { parsePatchFiles } from '../src/utils/parsePatchFiles';
 import { resolveConflict } from '../src/utils/resolveConflict';
 import { verifyFileDiffHunkValues } from './testUtils';
 
@@ -81,6 +82,32 @@ function createFixture() {
     { name: 'example.ts', contents: newContents },
     { context: 1 }
   );
+}
+
+function createPartialFixture() {
+  const patch = `diff --git a/index.html b/index.html
+index 36c553c..711c67c 100644
+--- a/index.html
++++ b/index.html
+@@ -6,8 +6,9 @@
+ </head>
+ <body>
+ <header>
+-  <h1>Welcome</h1>
+-  <p>Thanks for visiting</p>
++  <h1>Welcome to Our Site</h1>
++  <p>We're glad you're here</p>
++  <a href="/about" class="btn">Learn More</a>
+ </header>
+ <footer>
+   <p>&copy; Acme Inc.</p>`;
+
+  const diff = parsePatchFiles(patch)[0]?.files[0];
+  if (diff == null) {
+    throw new Error('Failed to parse partial patch fixture');
+  }
+
+  return diff;
 }
 
 // Convert a hunk into plain derived data that records the exact line content
@@ -405,6 +432,29 @@ describe('diffAcceptRejectHunk', () => {
     const result = diffAcceptRejectHunk(diff, 0, 'both');
 
     expect(result.cacheKey).toBe('old-key:new-key:b-0:0-0');
+  });
+
+  test('accept resolves a partial patch without materializing omitted context', () => {
+    const diff = createPartialFixture();
+    const snapshot = snapshotHunk(diff, 0);
+
+    const result = diffAcceptRejectHunk(diff, 0, 'accept');
+    const [hunk] = result.hunks;
+
+    expect(result.isPartial).toBe(true);
+    expect(result.deletionLines).toEqual(getResolvedLines(snapshot, 'accept'));
+    expect(result.additionLines).toEqual(getResolvedLines(snapshot, 'accept'));
+    expect(hunk?.collapsedBefore).toBe(5);
+    expect(hunk?.additionStart).toBe(6);
+    expect(hunk?.deletionStart).toBe(6);
+    expect(hunk?.additionLineIndex).toBe(0);
+    expect(hunk?.deletionLineIndex).toBe(0);
+    expect(result.splitLineCount).toBe(14);
+    expect(result.unifiedLineCount).toBe(14);
+    expect(verifyFileDiffHunkValues(result)).toEqual({
+      valid: true,
+      errors: [],
+    });
   });
 
   test('updates cacheKey when resolving a single content block', () => {


### PR DESCRIPTION
There was a regression when I refactored the patch resolving architecture, where i didn't account for FileDiffMetadata that was `isPartial = true`.

Fixed the issue and added a test to ensure we don't regress.

Fixes #427 