### PR TITLE
Fix patch parsing to trim newline from prevName on pure renames

### DIFF
--- a/packages/diffs/src/utils/parsePatchFiles.ts
+++ b/packages/diffs/src/utils/parsePatchFiles.ts
@@ -219,7 +219,7 @@ export function processFile(
           // We have to handle these for pure renames because there won't be
           // --- and +++ lines
           if (line.startsWith('rename from ')) {
-            currentFile.prevName = line.replace('rename from ', '');
+            currentFile.prevName = line.replace('rename from ', '').trim();
           }
           if (line.startsWith('rename to ')) {
             currentFile.name = line.replace('rename to ', '').trim();

--- a/packages/diffs/test/__snapshots__/parsePatchFiles.test.ts.snap
+++ b/packages/diffs/test/__snapshots__/parsePatchFiles.test.ts.snap
@@ -1206,10 +1206,7 @@ exports[`parsePatchFiles should parse diff.patch and match snapshot: git pr patc
         "hunks": [],
         "isPartial": true,
         "name": "packages/diffs/src/components/web-components.ts",
-        "prevName": 
-"packages/diffs/src/custom-components/Container.ts
-"
-,
+        "prevName": "packages/diffs/src/custom-components/Container.ts",
         "splitLineCount": 0,
         "type": "rename-pure",
         "unifiedLineCount": 0,
@@ -1932,10 +1929,7 @@ exports[`parsePatchFiles should parse diff.patch and match snapshot: git pr patc
         "hunks": [],
         "isPartial": true,
         "name": "packages/diffs/src/managers/ScrollSyncManager.ts",
-        "prevName": 
-"packages/diffs/src/ScrollSyncManager.ts
-"
-,
+        "prevName": "packages/diffs/src/ScrollSyncManager.ts",
         "splitLineCount": 0,
         "type": "rename-pure",
         "unifiedLineCount": 0,
@@ -1947,10 +1941,7 @@ exports[`parsePatchFiles should parse diff.patch and match snapshot: git pr patc
         "hunks": [],
         "isPartial": true,
         "name": "packages/diffs/src/managers/UniversalRenderingManager.ts",
-        "prevName": 
-"packages/diffs/src/UniversalRenderer.ts
-"
-,
+        "prevName": "packages/diffs/src/UniversalRenderer.ts",
         "splitLineCount": 0,
         "type": "rename-pure",
         "unifiedLineCount": 0,
@@ -71660,10 +71651,7 @@ Subject: [PATCH 7/9] Update test snapshots
         "hunks": [],
         "isPartial": true,
         "name": "apps/docs/app/ssr/SSRPage.tsx",
-        "prevName": 
-"apps/docs/app/ssr/SSR_Page.tsx
-"
-,
+        "prevName": "apps/docs/app/ssr/SSR_Page.tsx",
         "splitLineCount": 0,
         "type": "rename-pure",
         "unifiedLineCount": 0,


### PR DESCRIPTION
This fixes a bug where parsing a patch file with pure rename would include a trailing `\n` in the `prevName`. See the updates snapshots, which document both the bug and the fix.