### PR TITLE
[trees] Add a pseudo-virtualized render benchmark utility

### DIFF
--- a/packages/trees/README.md
+++ b/packages/trees/README.md
@@ -311,17 +311,22 @@ bun ws trees benchmark:render
 
 By default this benchmark runs only the Linux kernel fixture with all folders
 expanded, matching the trees-dev virtualization workload while keeping the
-virtualizer itself out of scope. It still exercises the full render pipeline:
+virtualizer itself out of scope. The runner rebuilds `dist/` first and then
+measures the production bundle with a benchmark-local static window adapter. It
+still exercises the full render pipeline:
 
 - `new FileTree(...)`
 - `fileListToTree(...)`
-- core tree creation inside the shared `Root` component
-- SSR rendering of a fixed first window (30 rows by default) through the real
+- core tree creation through the same built hooks and features that power `Root`
+- SSR rendering of a fixed first window (30 rows by default) through the built
   `TreeItem` path
 
 The fixed window avoids the misleading cost of serializing ~93k rows to HTML
 while still forcing the tree to process the full dataset before deciding which
 items to render.
+
+No baseline is required for normal runs. `--compare` is optional and only used
+when you want to validate a saved baseline.
 
 Useful flags:
 

--- a/packages/trees/scripts/benchmarkVirtualizedFileTreeRender.ts
+++ b/packages/trees/scripts/benchmarkVirtualizedFileTreeRender.ts
@@ -1,19 +1,8 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { h } from 'preact';
-import { renderToString } from 'preact-render-to-string';
+import { fileURLToPath } from 'node:url';
 
-import { type FileTreeRootProps, Root } from '../src/components/Root';
-import type { VirtualRange } from '../src/components/VirtualizedList';
-import {
-  FileTree,
-  type FileTreeOptions,
-  type FileTreeStateConfig,
-} from '../src/FileTree';
-import {
-  forEachFolderInNormalizedPath,
-  normalizeInputPath,
-} from '../src/utils/normalizeInputPath';
+import type { FileTreeOptions, FileTreeStateConfig } from '../src/FileTree';
 import {
   type BenchmarkEnvironment,
   calculateDeltaPercent,
@@ -27,6 +16,11 @@ import {
   summarizeSamples,
   type TimingSummary,
 } from './lib/benchmarkUtils';
+import type {
+  BenchmarkRenderRuntime,
+  BenchmarkVirtualizedRootProps,
+  BenchmarkVirtualRange,
+} from './lib/benchmarkVirtualizedRenderRuntime';
 import {
   type FileListToTreeBenchmarkCase,
   filterBenchmarkCases,
@@ -47,6 +41,26 @@ export interface BenchmarkConfig {
   viewportHeight: number;
 }
 
+interface BenchmarkRuntimeInfo {
+  codePath: 'dist';
+  nodeEnv: 'production';
+  renderer: 'preact-render-to-string';
+  renderHarness: 'benchmark-local-static-virtualizer';
+  buildCommand: 'bun run build';
+}
+
+interface LoadedBenchmarkRuntime {
+  runtimeInfo: BenchmarkRuntimeInfo;
+  h: typeof import('preact').h;
+  renderToString: typeof import('preact-render-to-string').renderToString;
+  benchmarkRuntime: BenchmarkRenderRuntime;
+}
+
+interface BenchmarkFileTreeInstance {
+  options: FileTreeOptions;
+  stateConfig: FileTreeStateConfig;
+}
+
 interface PreparedBenchmarkCase {
   name: string;
   source: FileListToTreeBenchmarkCase['source'];
@@ -56,8 +70,8 @@ interface PreparedBenchmarkCase {
   expandedFolderCount: number;
   options: FileTreeOptions;
   stateConfig: FileTreeStateConfig;
-  sharedRenderInstance: FileTree;
-  expectedWindowRange: VirtualRange;
+  sharedRenderInstance: BenchmarkFileTreeInstance;
+  expectedWindowRange: BenchmarkVirtualRange;
   expectedRenderedItemCount: number;
   expectedHtmlLength: number;
   htmlChecksum: number;
@@ -104,6 +118,7 @@ interface CaseComparison {
 interface BenchmarkComparison {
   baselinePath: string;
   baselineEnvironment: BenchmarkEnvironment;
+  baselineRuntime: BenchmarkRuntimeInfo;
   baselineConfig: BenchmarkConfig;
   unmatchedCurrentCases: string[];
   unmatchedBaselineCases: string[];
@@ -114,6 +129,7 @@ interface BenchmarkComparison {
 interface BenchmarkOutput {
   benchmark: 'virtualizedFileTreeRender';
   environment: BenchmarkEnvironment;
+  runtime: BenchmarkRuntimeInfo;
   config: BenchmarkConfig;
   checksum: number;
   cases: CaseSummary[];
@@ -156,16 +172,29 @@ const COMPARE_SENSITIVE_CONFIG_FIELDS = [
 ] as const;
 type CompareSensitiveConfigField =
   (typeof COMPARE_SENSITIVE_CONFIG_FIELDS)[number];
+const COMPARE_SENSITIVE_RUNTIME_FIELDS = [
+  'codePath',
+  'nodeEnv',
+  'renderer',
+  'renderHarness',
+] as const;
+type CompareSensitiveRuntimeField =
+  (typeof COMPARE_SENSITIVE_RUNTIME_FIELDS)[number];
+type ComparableRuntimeMetadata = Record<CompareSensitiveRuntimeField, string>;
 type ComparableRenderBenchmarkBaseline = {
   path: string;
   output: {
     config: Pick<BenchmarkConfig, CompareSensitiveConfigField>;
+    runtime?: Partial<ComparableRuntimeMetadata>;
   };
 };
 type ComparableRenderBenchmarkComparison = {
   unmatchedCurrentCases: string[];
   checksumMismatches: string[];
 };
+
+const packageRoot = fileURLToPath(new URL('../', import.meta.url));
+const textDecoder = new TextDecoder();
 
 function printHelpAndExit(): never {
   console.log('Usage: bun ws trees benchmark:render -- [options]');
@@ -262,6 +291,71 @@ function parseArgs(argv: string[]): BenchmarkConfig {
   return config;
 }
 
+function decodeOutput(output: Uint8Array): string {
+  return textDecoder.decode(output).trim();
+}
+
+// Benchmark the same code we publish by rebuilding `dist/` up front and then
+// importing the built modules under an explicit production NODE_ENV.
+function ensureProductionDistBuild(): BenchmarkRuntimeInfo {
+  process.env.NODE_ENV = 'production';
+
+  const buildResult = Bun.spawnSync({
+    cmd: ['bun', 'run', 'build'],
+    cwd: packageRoot,
+    env: {
+      ...process.env,
+      AGENT: '1',
+      NODE_ENV: 'production',
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  if (buildResult.exitCode !== 0) {
+    const stdout = decodeOutput(buildResult.stdout);
+    const stderr = decodeOutput(buildResult.stderr);
+    throw new Error(
+      [
+        'Failed to build @pierre/trees before running the render benchmark.',
+        stdout !== '' ? `stdout:\n${stdout}` : null,
+        stderr !== '' ? `stderr:\n${stderr}` : null,
+      ]
+        .filter((line): line is string => line != null)
+        .join('\n\n')
+    );
+  }
+
+  return {
+    codePath: 'dist',
+    nodeEnv: 'production',
+    renderer: 'preact-render-to-string',
+    renderHarness: 'benchmark-local-static-virtualizer',
+    buildCommand: 'bun run build',
+  };
+}
+
+async function loadBenchmarkRuntime(): Promise<LoadedBenchmarkRuntime> {
+  const runtimeInfo = ensureProductionDistBuild();
+  const [{ h }, renderToStringModule, runtimeModule] = await Promise.all([
+    import('preact'),
+    import('preact-render-to-string'),
+    import(
+      new URL('./lib/benchmarkVirtualizedRenderRuntime.tsx', import.meta.url)
+        .href
+    ),
+  ]);
+  const benchmarkRuntime =
+    await runtimeModule.loadBenchmarkVirtualizedRenderRuntime();
+
+  return {
+    runtimeInfo,
+    h,
+    renderToString: renderToStringModule.renderToString,
+    benchmarkRuntime,
+  };
+}
+
 function createOperationSampleStorage(): Record<
   TreeRenderOperationName,
   number[]
@@ -285,23 +379,26 @@ function countRenderedItems(html: string): number {
   return html.split('data-type="item"').length - 1;
 }
 
-function buildWindowRange(config: BenchmarkConfig): VirtualRange {
+function buildWindowRange(config: BenchmarkConfig): BenchmarkVirtualRange {
   return {
     start: config.windowStart,
     end: config.windowStart + config.windowSize - 1,
   };
 }
 
-function collectExpandedFolderPaths(files: string[]): string[] {
+function collectExpandedFolderPaths(
+  files: string[],
+  benchmarkRuntime: BenchmarkRenderRuntime
+): string[] {
   const expandedPaths = new Set<string>();
 
   for (const filePath of files) {
-    const normalizedPath = normalizeInputPath(filePath);
+    const normalizedPath = benchmarkRuntime.normalizeInputPath(filePath);
     if (normalizedPath == null) {
       continue;
     }
 
-    forEachFolderInNormalizedPath(
+    benchmarkRuntime.forEachFolderInNormalizedPath(
       normalizedPath.path,
       normalizedPath.isDirectory,
       (folderPath) => {
@@ -326,24 +423,23 @@ function createFileTreeOptions(
 }
 
 function createStateConfig(
-  caseConfig: FileListToTreeBenchmarkCase
+  caseConfig: FileListToTreeBenchmarkCase,
+  benchmarkRuntime: BenchmarkRenderRuntime
 ): FileTreeStateConfig {
   return {
     initialExpandedItems:
       caseConfig.expandedFolders ??
-      collectExpandedFolderPaths(caseConfig.files),
+      collectExpandedFolderPaths(caseConfig.files, benchmarkRuntime),
   };
 }
 
 function buildRootProps(
-  fileTree: FileTree,
+  fileTree: BenchmarkFileTreeInstance,
   config: BenchmarkConfig
-): FileTreeRootProps {
+): BenchmarkVirtualizedRootProps {
   return {
     fileTreeOptions: fileTree.options,
     stateConfig: fileTree.stateConfig,
-    handleRef: fileTree.handleRef,
-    callbacksRef: fileTree.callbacksRef,
     virtualizedRenderWindow: {
       range: buildWindowRange(config),
       itemHeight: config.itemHeight,
@@ -353,10 +449,16 @@ function buildRootProps(
 }
 
 function renderBenchmarkWindow(
-  fileTree: FileTree,
-  config: BenchmarkConfig
+  fileTree: BenchmarkFileTreeInstance,
+  config: BenchmarkConfig,
+  runtime: LoadedBenchmarkRuntime
 ): RenderSnapshot {
-  const html = renderToString(h(Root, buildRootProps(fileTree, config)));
+  const html = runtime.renderToString(
+    runtime.h(
+      runtime.benchmarkRuntime.BenchmarkVirtualizedRoot,
+      buildRootProps(fileTree, config)
+    )
+  );
   return {
     html,
     renderedItemCount: countRenderedItems(html),
@@ -369,12 +471,20 @@ function renderBenchmarkWindow(
 // for instance construction and/or SSR rendering, not fixture discovery.
 function prepareBenchmarkCase(
   caseConfig: FileListToTreeBenchmarkCase,
-  config: BenchmarkConfig
+  config: BenchmarkConfig,
+  runtime: LoadedBenchmarkRuntime
 ): PreparedBenchmarkCase {
   const options = createFileTreeOptions(caseConfig);
-  const stateConfig = createStateConfig(caseConfig);
-  const sharedRenderInstance = new FileTree(options, stateConfig);
-  const expectedSnapshot = renderBenchmarkWindow(sharedRenderInstance, config);
+  const stateConfig = createStateConfig(caseConfig, runtime.benchmarkRuntime);
+  const sharedRenderInstance = new runtime.benchmarkRuntime.FileTree(
+    options,
+    stateConfig
+  );
+  const expectedSnapshot = renderBenchmarkWindow(
+    sharedRenderInstance,
+    config,
+    runtime
+  );
 
   return {
     name: caseConfig.name,
@@ -434,6 +544,12 @@ function readBenchmarkBaseline(comparePath: string): LoadedBenchmarkBaseline {
   if (!Array.isArray(parsed.cases)) {
     throw new Error(
       `Invalid benchmark baseline at ${resolvedPath}. Expected a cases array.`
+    );
+  }
+
+  if (parsed.runtime == null || typeof parsed.runtime !== 'object') {
+    throw new Error(
+      `Invalid benchmark baseline at ${resolvedPath}. Expected runtime metadata from the current benchmark script.`
     );
   }
 
@@ -534,6 +650,7 @@ function buildComparison(
   return {
     baselinePath: baseline.path,
     baselineEnvironment: baseline.output.environment,
+    baselineRuntime: baseline.output.runtime,
     baselineConfig: baseline.output.config,
     unmatchedCurrentCases: caseSummaries
       .filter((summary) => !baselineCases.has(summary.name))
@@ -556,7 +673,8 @@ function buildComparison(
 function buildCompareCompatibilityErrors(
   baseline: ComparableRenderBenchmarkBaseline,
   comparison: ComparableRenderBenchmarkComparison,
-  currentConfig: Pick<BenchmarkConfig, CompareSensitiveConfigField>
+  currentConfig: Pick<BenchmarkConfig, CompareSensitiveConfigField>,
+  currentRuntime: ComparableRuntimeMetadata
 ): string[] {
   const errors: string[] = [];
 
@@ -564,6 +682,14 @@ function buildCompareCompatibilityErrors(
     if (baseline.output.config[field] !== currentConfig[field]) {
       errors.push(
         `baseline ${field}=${baseline.output.config[field]} does not match current ${field}=${currentConfig[field]}`
+      );
+    }
+  }
+
+  for (const field of COMPARE_SENSITIVE_RUNTIME_FIELDS) {
+    if (baseline.output.runtime?.[field] !== currentRuntime[field]) {
+      errors.push(
+        `baseline ${field}=${baseline.output.runtime?.[field] ?? 'missing'} does not match current ${field}=${currentRuntime[field]}`
       );
     }
   }
@@ -588,12 +714,14 @@ function buildCompareCompatibilityErrors(
 export function assertComparableRenderBenchmarkBaseline(
   baseline: ComparableRenderBenchmarkBaseline,
   comparison: ComparableRenderBenchmarkComparison,
-  currentConfig: Pick<BenchmarkConfig, CompareSensitiveConfigField>
+  currentConfig: Pick<BenchmarkConfig, CompareSensitiveConfigField>,
+  currentRuntime: ComparableRuntimeMetadata
 ): void {
   const errors = buildCompareCompatibilityErrors(
     baseline,
     comparison,
-    currentConfig
+    currentConfig,
+    currentRuntime
   );
   if (errors.length === 0) {
     return;
@@ -617,6 +745,9 @@ function printComparison(comparison: BenchmarkComparison): void {
   );
   console.log(
     `baselineRunsPerCase=${comparison.baselineConfig.runs} baselineWarmupRunsPerCase=${comparison.baselineConfig.warmupRuns}`
+  );
+  console.log(
+    `baselineCodePath=${comparison.baselineRuntime.codePath} baselineNodeEnv=${comparison.baselineRuntime.nodeEnv} baselineRenderer=${comparison.baselineRuntime.renderer} baselineHarness=${comparison.baselineRuntime.renderHarness}`
   );
   console.log(
     `baselineWindowStart=${comparison.baselineConfig.windowStart} baselineWindowSize=${comparison.baselineConfig.windowSize}`
@@ -675,8 +806,9 @@ function printComparison(comparison: BenchmarkComparison): void {
   );
 }
 
-export function main() {
+export async function main() {
   const config = parseArgs(process.argv.slice(2));
+  const runtime = await loadBenchmarkRuntime();
   const selectedCaseConfigs =
     config.caseFilters.length > 0
       ? filterBenchmarkCases(
@@ -693,7 +825,7 @@ export function main() {
   }
 
   const preparedCases = selectedCaseConfigs.map((caseConfig) =>
-    prepareBenchmarkCase(caseConfig, config)
+    prepareBenchmarkCase(caseConfig, config, runtime)
   );
   const samplesByCase = preparedCases.map(() => createOperationSampleStorage());
 
@@ -705,10 +837,17 @@ export function main() {
 
     const startTime = performance.now();
     if (operation === 'renderStaticWindow') {
-      snapshot = renderBenchmarkWindow(caseConfig.sharedRenderInstance, config);
+      snapshot = renderBenchmarkWindow(
+        caseConfig.sharedRenderInstance,
+        config,
+        runtime
+      );
     } else {
-      const fileTree = new FileTree(caseConfig.options, caseConfig.stateConfig);
-      snapshot = renderBenchmarkWindow(fileTree, config);
+      const fileTree = new runtime.benchmarkRuntime.FileTree(
+        caseConfig.options,
+        caseConfig.stateConfig
+      );
+      snapshot = renderBenchmarkWindow(fileTree, config, runtime);
     }
     const elapsedMs = performance.now() - startTime;
 
@@ -787,12 +926,18 @@ export function main() {
   const comparison =
     baseline != null ? buildComparison(baseline, caseSummaries) : undefined;
   if (baseline != null && comparison != null) {
-    assertComparableRenderBenchmarkBaseline(baseline, comparison, config);
+    assertComparableRenderBenchmarkBaseline(
+      baseline,
+      comparison,
+      config,
+      runtime.runtimeInfo
+    );
   }
 
   const output: BenchmarkOutput = {
     benchmark: 'virtualizedFileTreeRender',
     environment,
+    runtime: runtime.runtimeInfo,
     config,
     checksum,
     cases: caseSummaries,
@@ -808,6 +953,10 @@ export function main() {
   console.log(
     `bun=${environment.bunVersion} platform=${environment.platform} arch=${environment.arch}`
   );
+  console.log(
+    `runtime=${runtime.runtimeInfo.codePath} nodeEnv=${runtime.runtimeInfo.nodeEnv} renderer=${runtime.runtimeInfo.renderer} harness=${runtime.runtimeInfo.renderHarness}`
+  );
+  console.log(`buildCommand=${runtime.runtimeInfo.buildCommand}`);
   console.log(
     `cases=${preparedCases.length} runsPerCase=${config.runs} warmupRunsPerCase=${config.warmupRuns}`
   );
@@ -861,5 +1010,5 @@ export function main() {
 }
 
 if (import.meta.main) {
-  main();
+  await main();
 }

--- a/packages/trees/scripts/lib/benchmarkVirtualizedRenderRuntime.tsx
+++ b/packages/trees/scripts/lib/benchmarkVirtualizedRenderRuntime.tsx
@@ -1,0 +1,525 @@
+/** @jsxImportSource preact */
+import type { JSX } from 'preact';
+import { useCallback, useMemo, useRef } from 'preact/hooks';
+
+import type { ItemInstance, TreeInstance } from '../../src/core/types/core';
+import type { FileTreeOptions, FileTreeStateConfig } from '../../src/FileTree';
+import type { SVGSpriteNames } from '../../src/sprite';
+import type { FileTreeNode } from '../../src/types';
+import type { ChildrenSortOption } from '../../src/utils/sortChildren';
+
+const DEFAULT_ITEM_HEIGHT = 30;
+const EMPTY_ANCESTORS: string[] = [];
+
+export interface BenchmarkVirtualRange {
+  start: number;
+  end: number;
+}
+
+export interface BenchmarkVirtualizedRootProps {
+  fileTreeOptions: FileTreeOptions;
+  stateConfig?: FileTreeStateConfig;
+  virtualizedRenderWindow: {
+    range: BenchmarkVirtualRange;
+    itemHeight?: number;
+    viewportHeight?: number;
+  };
+}
+
+interface BenchmarkRuntimeModules {
+  FileTree: new (
+    options: FileTreeOptions,
+    stateConfig?: FileTreeStateConfig
+  ) => {
+    options: FileTreeOptions;
+    stateConfig: FileTreeStateConfig;
+  };
+  normalizeInputPath: (
+    path: string
+  ) => { path: string; isDirectory: boolean } | null;
+  forEachFolderInNormalizedPath: (
+    path: string,
+    isDirectory: boolean,
+    visitFolder: (folderPath: string) => void
+  ) => void;
+  computeStickyWindowLayout: (args: {
+    range: BenchmarkVirtualRange;
+    itemCount: number;
+    itemHeight: number;
+    viewportHeight: number;
+  }) => {
+    totalHeight: number;
+    offsetHeight: number;
+    windowHeight: number;
+    stickyInset: number;
+  };
+  syncDataLoaderFeature: unknown;
+  selectionFeature: unknown;
+  hotkeysCoreFeature: unknown;
+  fileTreeSearchFeature: unknown;
+  getSearchVisibleIdSet: (
+    tree: TreeInstance<FileTreeNode>
+  ) => Set<string> | null;
+  gitStatusFeature: unknown;
+  getGitStatusMap: (tree: TreeInstance<FileTreeNode>) => {
+    statusById: Map<string, string>;
+    foldersWithChanges: Set<string>;
+  } | null;
+  contextMenuFeature: unknown;
+  propMemoizationFeature: unknown;
+  generateLazyDataLoader: (
+    files: string[],
+    options: {
+      flattenEmptyDirectories?: boolean;
+      sortComparator?: ChildrenSortOption | undefined;
+    }
+  ) => unknown;
+  generateSyncDataLoaderFromTreeData: (
+    treeData: Record<string, FileTreeNode>,
+    options: { flattenEmptyDirectories?: boolean }
+  ) => unknown;
+  fileListToTree: (
+    files: string[],
+    options: { sortComparator?: ChildrenSortOption | undefined }
+  ) => Record<string, FileTreeNode>;
+  getGitStatusSignature: (entries: FileTreeOptions['gitStatus']) => string;
+  useTreeStateConfig: (args: {
+    treeData: Record<string, FileTreeNode>;
+    pathToId: Map<string, string>;
+    stateConfig: FileTreeStateConfig | undefined;
+    flattenEmptyDirectories: boolean | undefined;
+  }) => {
+    initialState?: Record<string, unknown>;
+    state?: Record<string, unknown>;
+  };
+  useTree: (config: Record<string, unknown>) => TreeInstance<FileTreeNode>;
+  TreeItem: (props: Record<string, unknown>) => JSX.Element;
+}
+
+export interface BenchmarkRenderRuntime {
+  FileTree: BenchmarkRuntimeModules['FileTree'];
+  normalizeInputPath: BenchmarkRuntimeModules['normalizeInputPath'];
+  forEachFolderInNormalizedPath: BenchmarkRuntimeModules['forEachFolderInNormalizedPath'];
+  BenchmarkVirtualizedRoot: (
+    props: BenchmarkVirtualizedRootProps
+  ) => JSX.Element;
+}
+
+function importDistModule(
+  relativePath: string
+): Promise<Record<string, unknown>> {
+  return import(new URL(relativePath, import.meta.url).href) as Promise<
+    Record<string, unknown>
+  >;
+}
+
+function normalizeRange(
+  range: BenchmarkVirtualRange,
+  itemCount: number
+): BenchmarkVirtualRange {
+  if (itemCount <= 0 || range.end < range.start) {
+    return { start: 0, end: -1 };
+  }
+  const start = Math.max(0, Math.min(range.start, itemCount - 1));
+  const end = Math.max(start, Math.min(range.end, itemCount - 1));
+  return { start, end };
+}
+
+function renderRangeChildren(
+  range: BenchmarkVirtualRange,
+  renderItem: (index: number) => JSX.Element | null
+): JSX.Element[] {
+  const children: JSX.Element[] = [];
+  for (let index = range.start; index <= range.end; index++) {
+    const item = renderItem(index);
+    if (item != null) {
+      children.push(item);
+    }
+  }
+  return children;
+}
+
+function createStaticBenchmarkVirtualizedList(
+  runtime: BenchmarkRuntimeModules
+): (props: {
+  itemCount: number;
+  renderItem: (index: number) => JSX.Element | null;
+  range: BenchmarkVirtualRange;
+  itemHeight?: number;
+  viewportHeight?: number;
+}) => JSX.Element {
+  return function StaticBenchmarkVirtualizedList({
+    itemCount,
+    renderItem,
+    range,
+    itemHeight,
+    viewportHeight,
+  }): JSX.Element {
+    'use no memo';
+    const resolvedHeight =
+      itemHeight != null && itemHeight > 0 ? itemHeight : DEFAULT_ITEM_HEIGHT;
+    const resolvedViewportHeight =
+      viewportHeight != null && viewportHeight > 0
+        ? viewportHeight
+        : resolvedHeight;
+    const normalizedRange = normalizeRange(range, itemCount);
+    const { totalHeight, offsetHeight, windowHeight, stickyInset } =
+      runtime.computeStickyWindowLayout({
+        range: normalizedRange,
+        itemCount,
+        itemHeight: resolvedHeight,
+        viewportHeight: resolvedViewportHeight,
+      });
+
+    return (
+      <div
+        data-file-tree-virtualized-list="true"
+        style={{ height: `${totalHeight}px` }}
+      >
+        <div
+          data-file-tree-virtualized-sticky-offset="true"
+          aria-hidden="true"
+          style={{ height: `${offsetHeight}px` }}
+        />
+        <div
+          data-file-tree-virtualized-sticky="true"
+          style={{
+            height: `${windowHeight}px`,
+            top: `${stickyInset}px`,
+            bottom: `${stickyInset}px`,
+          }}
+        >
+          {renderRangeChildren(normalizedRange, renderItem)}
+        </div>
+      </div>
+    );
+  };
+}
+
+function createBenchmarkVirtualizedRoot(
+  runtime: BenchmarkRuntimeModules
+): (props: BenchmarkVirtualizedRootProps) => JSX.Element {
+  const StaticBenchmarkVirtualizedList =
+    createStaticBenchmarkVirtualizedList(runtime);
+
+  return function BenchmarkVirtualizedRoot({
+    fileTreeOptions,
+    stateConfig,
+    virtualizedRenderWindow,
+  }: BenchmarkVirtualizedRootProps): JSX.Element {
+    'use no memo';
+    const {
+      initialFiles: files,
+      flattenEmptyDirectories,
+      fileTreeSearchMode,
+      gitStatus,
+      search,
+      sort: sortOption,
+      useLazyDataLoader,
+      virtualize,
+    } = fileTreeOptions;
+    const iconRemap = fileTreeOptions.icons?.remap;
+
+    const remapIcon = useCallback(
+      (
+        name: SVGSpriteNames
+      ): {
+        name: string;
+        remappedFrom?: string;
+        width?: number;
+        height?: number;
+        viewBox?: string;
+      } => {
+        const entry = iconRemap?.[name];
+        if (entry == null) return { name };
+        if (typeof entry === 'string') {
+          return { name: entry, remappedFrom: name };
+        }
+        return { ...entry, remappedFrom: name };
+      },
+      [iconRemap]
+    );
+
+    const treeDomId = useMemo(() => {
+      const base = fileTreeOptions.id ?? 'ft';
+      const safe = base.replace(/[^A-Za-z0-9_-]/g, '_');
+      return `ft-${safe}`;
+    }, [fileTreeOptions.id]);
+
+    const sortComparator = useMemo<ChildrenSortOption | undefined>(
+      () =>
+        sortOption === false
+          ? false
+          : sortOption != null && typeof sortOption === 'object'
+            ? sortOption.comparator
+            : undefined,
+      [sortOption]
+    );
+
+    const treeData = useMemo(
+      () => runtime.fileListToTree(files, { sortComparator }),
+      [files, sortComparator]
+    );
+
+    const { pathToId, idToPath } = useMemo(() => {
+      const p2i = new Map<string, string>();
+      const i2p = new Map<string, string>();
+      for (const [id, node] of Object.entries(treeData)) {
+        p2i.set(node.path, id);
+        i2p.set(id, node.path);
+      }
+      return { pathToId: p2i, idToPath: i2p };
+    }, [treeData]);
+
+    const ancestorChainsCacheRef = useRef<Map<string, string[]>>(new Map());
+    const prevIdToPathForCacheRef = useRef(idToPath);
+    if (prevIdToPathForCacheRef.current !== idToPath) {
+      prevIdToPathForCacheRef.current = idToPath;
+      ancestorChainsCacheRef.current.clear();
+    }
+
+    const restTreeConfig = runtime.useTreeStateConfig({
+      treeData,
+      pathToId,
+      stateConfig,
+      flattenEmptyDirectories,
+    });
+
+    const dataLoader = useMemo(
+      () =>
+        useLazyDataLoader === true
+          ? runtime.generateLazyDataLoader(files, {
+              flattenEmptyDirectories,
+              sortComparator,
+            })
+          : runtime.generateSyncDataLoaderFromTreeData(treeData, {
+              flattenEmptyDirectories,
+            }),
+      [
+        files,
+        flattenEmptyDirectories,
+        sortComparator,
+        treeData,
+        useLazyDataLoader,
+      ]
+    );
+
+    const features = useMemo(
+      () => [
+        runtime.syncDataLoaderFeature,
+        runtime.selectionFeature,
+        runtime.hotkeysCoreFeature,
+        runtime.fileTreeSearchFeature,
+        runtime.gitStatusFeature,
+        runtime.contextMenuFeature,
+        runtime.propMemoizationFeature,
+      ],
+      []
+    );
+
+    const tree = runtime.useTree({
+      ...restTreeConfig,
+      fileTreeSearchMode,
+      search,
+      gitStatus,
+      gitStatusSignature: runtime.getGitStatusSignature(gitStatus),
+      gitStatusPathToId: pathToId,
+      contextMenuEnabled: false,
+      rootItemId: 'root',
+      dataLoader,
+      getItemName: (item: ItemInstance<FileTreeNode>) =>
+        item.getItemData().name,
+      isItemFolder: (item: ItemInstance<FileTreeNode>) =>
+        item.getItemData()?.children?.direct != null,
+      hotkeys: {},
+      features,
+    });
+
+    const getAncestors = useCallback(
+      (itemId: string): string[] => {
+        const cache = ancestorChainsCacheRef.current;
+        const resolve = (id: string): string[] => {
+          const cached = cache.get(id);
+          if (cached != null) return cached;
+
+          const parentId = tree.getItemInstance(id).getItemMeta().parentId;
+          if (parentId == null || parentId === 'root') {
+            cache.set(id, EMPTY_ANCESTORS);
+            return EMPTY_ANCESTORS;
+          }
+
+          const chain = [...resolve(parentId), parentId];
+          cache.set(id, chain);
+          return chain;
+        };
+        return resolve(itemId);
+      },
+      [tree]
+    );
+
+    const focusedItemId = tree.getState().focusedItem ?? null;
+    const hasFocusedItem = focusedItemId != null;
+    const shouldVirtualize = virtualize != null && virtualize !== false;
+    const virtualizeThreshold = shouldVirtualize
+      ? Math.max(0, virtualize.threshold)
+      : Number.POSITIVE_INFINITY;
+    const containerProps = tree.getContainerProps();
+    const visibleIdSet = runtime.getSearchVisibleIdSet(tree);
+    const gitStatusMap = runtime.getGitStatusMap(tree);
+    const allItems = tree.getItems();
+    const items =
+      visibleIdSet != null
+        ? allItems.filter((item) => visibleIdSet.has(item.getId()))
+        : allItems;
+
+    const renderItemAtIndex = (index: number) => {
+      const item = items[index];
+      if (item == null) {
+        return null;
+      }
+
+      const itemData = item.getItemData();
+      const itemMeta = item.getItemMeta();
+      const hasChildren = itemData?.children?.direct != null;
+      const itemGitStatus = gitStatusMap?.statusById.get(item.getId());
+      const itemContainsGitChange =
+        hasChildren &&
+        (gitStatusMap?.foldersWithChanges.has(item.getId()) ?? false);
+
+      return (
+        <runtime.TreeItem
+          key={item.getId()}
+          item={item}
+          tree={tree}
+          itemId={item.getId()}
+          hasChildren={hasChildren}
+          isExpanded={hasChildren && item.isExpanded()}
+          itemName={item.getItemName()}
+          level={itemMeta.level}
+          isSelected={item.isSelected()}
+          isFocused={hasFocusedItem && item.isFocused()}
+          isSearchMatch={item.isMatchingSearch()}
+          isDragTarget={false}
+          isDragging={false}
+          isDnD={false}
+          isRenaming={item.isRenaming?.() === true}
+          isFlattenedDirectory={itemData?.flattens != null}
+          isLocked={false}
+          gitStatus={itemGitStatus}
+          containsGitChange={itemContainsGitChange ?? false}
+          flattens={itemData?.flattens}
+          idToPath={idToPath}
+          ancestors={getAncestors(item.getId())}
+          treeDomId={treeDomId}
+          remapIcon={remapIcon}
+          detectFlattenedSubfolder={() => {}}
+          clearFlattenedSubfolder={() => {}}
+        />
+      );
+    };
+
+    return (
+      <div
+        {...containerProps}
+        id={treeDomId}
+        data-file-tree-virtualized-root={shouldVirtualize ? 'true' : undefined}
+      >
+        {shouldVirtualize &&
+        items.length > 0 &&
+        items.length >= virtualizeThreshold ? (
+          <div data-file-tree-virtualized-scroll="true">
+            <StaticBenchmarkVirtualizedList
+              itemCount={items.length}
+              renderItem={renderItemAtIndex}
+              range={virtualizedRenderWindow.range}
+              itemHeight={virtualizedRenderWindow.itemHeight}
+              viewportHeight={virtualizedRenderWindow.viewportHeight}
+            />
+          </div>
+        ) : (
+          items.map((_, index) => renderItemAtIndex(index))
+        )}
+      </div>
+    );
+  };
+}
+
+export async function loadBenchmarkVirtualizedRenderRuntime(): Promise<BenchmarkRenderRuntime> {
+  const [
+    fileTreeModule,
+    normalizeInputPathModule,
+    virtualizedListModule,
+    syncLoaderModule,
+    lazyLoaderModule,
+    fileListToTreeModule,
+    searchFeatureModule,
+    gitStatusFeatureModule,
+    gitStatusSignatureModule,
+    treeStateConfigModule,
+    useTreeModule,
+    treeItemModule,
+    selectionFeatureModule,
+    hotkeysCoreFeatureModule,
+    contextMenuFeatureModule,
+    propMemoizationFeatureModule,
+    syncDataLoaderFeatureModule,
+  ] = await Promise.all([
+    importDistModule('../../dist/FileTree.js'),
+    importDistModule('../../dist/utils/normalizeInputPath.js'),
+    importDistModule('../../dist/components/VirtualizedList.js'),
+    importDistModule('../../dist/loader/sync.js'),
+    importDistModule('../../dist/loader/lazy.js'),
+    importDistModule('../../dist/utils/fileListToTree.js'),
+    importDistModule('../../dist/features/search/feature.js'),
+    importDistModule('../../dist/features/git-status/feature.js'),
+    importDistModule('../../dist/utils/getGitStatusSignature.js'),
+    importDistModule('../../dist/components/hooks/useTreeStateConfig.js'),
+    importDistModule('../../dist/components/hooks/useTree.js'),
+    importDistModule('../../dist/components/TreeItem.js'),
+    importDistModule('../../dist/features/selection/feature.js'),
+    importDistModule('../../dist/features/hotkeys-core/feature.js'),
+    importDistModule('../../dist/features/context-menu/feature.js'),
+    importDistModule('../../dist/features/prop-memoization/feature.js'),
+    importDistModule('../../dist/features/sync-data-loader/feature.js'),
+  ]);
+
+  const runtime: BenchmarkRuntimeModules = {
+    FileTree: fileTreeModule.FileTree as BenchmarkRuntimeModules['FileTree'],
+    normalizeInputPath:
+      normalizeInputPathModule.normalizeInputPath as BenchmarkRuntimeModules['normalizeInputPath'],
+    forEachFolderInNormalizedPath:
+      normalizeInputPathModule.forEachFolderInNormalizedPath as BenchmarkRuntimeModules['forEachFolderInNormalizedPath'],
+    computeStickyWindowLayout:
+      virtualizedListModule.computeStickyWindowLayout as BenchmarkRuntimeModules['computeStickyWindowLayout'],
+    syncDataLoaderFeature: syncDataLoaderFeatureModule.syncDataLoaderFeature,
+    selectionFeature: selectionFeatureModule.selectionFeature,
+    hotkeysCoreFeature: hotkeysCoreFeatureModule.hotkeysCoreFeature,
+    fileTreeSearchFeature: searchFeatureModule.fileTreeSearchFeature,
+    getSearchVisibleIdSet:
+      searchFeatureModule.getSearchVisibleIdSet as BenchmarkRuntimeModules['getSearchVisibleIdSet'],
+    gitStatusFeature: gitStatusFeatureModule.gitStatusFeature,
+    getGitStatusMap:
+      gitStatusFeatureModule.getGitStatusMap as BenchmarkRuntimeModules['getGitStatusMap'],
+    contextMenuFeature: contextMenuFeatureModule.contextMenuFeature,
+    propMemoizationFeature: propMemoizationFeatureModule.propMemoizationFeature,
+    generateLazyDataLoader:
+      lazyLoaderModule.generateLazyDataLoader as BenchmarkRuntimeModules['generateLazyDataLoader'],
+    generateSyncDataLoaderFromTreeData:
+      syncLoaderModule.generateSyncDataLoaderFromTreeData as BenchmarkRuntimeModules['generateSyncDataLoaderFromTreeData'],
+    fileListToTree:
+      fileListToTreeModule.fileListToTree as BenchmarkRuntimeModules['fileListToTree'],
+    getGitStatusSignature:
+      gitStatusSignatureModule.getGitStatusSignature as BenchmarkRuntimeModules['getGitStatusSignature'],
+    useTreeStateConfig:
+      treeStateConfigModule.useTreeStateConfig as BenchmarkRuntimeModules['useTreeStateConfig'],
+    useTree: useTreeModule.useTree as BenchmarkRuntimeModules['useTree'],
+    TreeItem: treeItemModule.TreeItem as BenchmarkRuntimeModules['TreeItem'],
+  };
+
+  return {
+    FileTree: runtime.FileTree,
+    normalizeInputPath: runtime.normalizeInputPath,
+    forEachFolderInNormalizedPath: runtime.forEachFolderInNormalizedPath,
+    BenchmarkVirtualizedRoot: createBenchmarkVirtualizedRoot(runtime),
+  };
+}

--- a/packages/trees/src/components/Root.tsx
+++ b/packages/trees/src/components/Root.tsx
@@ -66,26 +66,13 @@ import { useTree } from './hooks/useTree';
 import { useTreeStateConfig } from './hooks/useTreeStateConfig';
 import { Icon } from './Icon';
 import { TreeItem } from './TreeItem';
-import {
-  StaticVirtualizedList,
-  VirtualizedList,
-  type VirtualRange,
-} from './VirtualizedList';
+import { VirtualizedList } from './VirtualizedList';
 
 export interface FileTreeRootProps {
   fileTreeOptions: FileTreeOptions;
   stateConfig?: FileTreeStateConfig;
   handleRef?: { current: FileTreeHandle | null };
   callbacksRef?: { current: FileTreeCallbacks };
-  /**
-   * Benchmark-only escape hatch that renders a deterministic virtualized window
-   * during SSR without relying on DOM measurement.
-   */
-  virtualizedRenderWindow?: {
-    range: VirtualRange;
-    itemHeight?: number;
-    viewportHeight?: number;
-  };
 }
 
 const EMPTY_ANCESTORS: string[] = [];
@@ -95,7 +82,6 @@ export function Root({
   stateConfig,
   handleRef,
   callbacksRef,
-  virtualizedRenderWindow,
 }: FileTreeRootProps): JSX.Element {
   'use no memo';
   const {
@@ -720,25 +706,15 @@ export function Root({
               : null;
           return (
             <div data-file-tree-virtualized-scroll="true">
-              {virtualizedRenderWindow != null ? (
-                <StaticVirtualizedList
-                  itemCount={items.length}
-                  renderItem={renderItemAtIndex}
-                  range={virtualizedRenderWindow.range}
-                  itemHeight={virtualizedRenderWindow.itemHeight}
-                  viewportHeight={virtualizedRenderWindow.viewportHeight}
-                />
-              ) : (
-                <VirtualizedList
-                  itemCount={items.length}
-                  renderItem={renderItemAtIndex}
-                  scrollToIndex={
-                    focusedIndex != null && focusedIndex >= 0
-                      ? focusedIndex
-                      : null
-                  }
-                />
-              )}
+              <VirtualizedList
+                itemCount={items.length}
+                renderItem={renderItemAtIndex}
+                scrollToIndex={
+                  focusedIndex != null && focusedIndex >= 0
+                    ? focusedIndex
+                    : null
+                }
+              />
               {contextMenuTrigger}
             </div>
           );

--- a/packages/trees/src/components/VirtualizedList.tsx
+++ b/packages/trees/src/components/VirtualizedList.tsx
@@ -19,14 +19,6 @@ export interface VirtualizedListProps {
   itemHeight?: number;
 }
 
-export interface StaticVirtualizedListProps {
-  itemCount: number;
-  renderItem: (index: number) => JSX.Element | null;
-  range: VirtualRange;
-  itemHeight?: number;
-  viewportHeight?: number;
-}
-
 const OVERSCAN = 10;
 const DEFAULT_ITEM_HEIGHT = 30;
 const EMPTY_RANGE: VirtualRange = { start: 0, end: -1 };
@@ -239,55 +231,6 @@ function renderRangeChildren(
     }
   }
   return children;
-}
-
-// Renders the same DOM structure as VirtualizedList, but with a fixed window.
-// This lets SSR benchmarks measure a deterministic "first visible rows" pass
-// without depending on layout effects or DOM viewport measurement.
-export function StaticVirtualizedList({
-  itemCount,
-  renderItem,
-  range,
-  itemHeight,
-  viewportHeight,
-}: StaticVirtualizedListProps): JSX.Element {
-  const resolvedHeight =
-    itemHeight != null && itemHeight > 0 ? itemHeight : DEFAULT_ITEM_HEIGHT;
-  const resolvedViewportHeight =
-    viewportHeight != null && viewportHeight > 0
-      ? viewportHeight
-      : resolvedHeight;
-  const normalizedRange = normalizeRange(range, itemCount);
-  const { totalHeight, offsetHeight, windowHeight, stickyInset } =
-    computeStickyWindowLayout({
-      range: normalizedRange,
-      itemCount,
-      itemHeight: resolvedHeight,
-      viewportHeight: resolvedViewportHeight,
-    });
-
-  return (
-    <div
-      data-file-tree-virtualized-list="true"
-      style={{ height: `${totalHeight}px` }}
-    >
-      <div
-        data-file-tree-virtualized-sticky-offset="true"
-        aria-hidden="true"
-        style={{ height: `${offsetHeight}px` }}
-      />
-      <div
-        data-file-tree-virtualized-sticky="true"
-        style={{
-          height: `${windowHeight}px`,
-          top: `${stickyInset}px`,
-          bottom: `${stickyInset}px`,
-        }}
-      >
-        {renderRangeChildren(normalizedRange, renderItem)}
-      </div>
-    </div>
-  );
 }
 
 export function VirtualizedList({

--- a/packages/trees/test/virtualized-render-benchmark.test.tsx
+++ b/packages/trees/test/virtualized-render-benchmark.test.tsx
@@ -3,16 +3,14 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { h } from 'preact';
-import { renderToString } from 'preact-render-to-string';
 
 import {
   assertComparableRenderBenchmarkBaseline,
   type BenchmarkConfig,
 } from '../scripts/benchmarkVirtualizedFileTreeRender';
-import { Root } from '../src/components/Root';
 
 const packageRoot = fileURLToPath(new URL('../', import.meta.url));
+const textDecoder = new TextDecoder();
 
 function createConfig(
   overrides: Partial<BenchmarkConfig> = {}
@@ -30,11 +28,37 @@ function createConfig(
   };
 }
 
-function createBaseline(configOverrides: Partial<BenchmarkConfig> = {}) {
+function createRuntime(
+  overrides: Partial<{
+    codePath: string;
+    nodeEnv: string;
+    renderer: string;
+    renderHarness: string;
+  }> = {}
+) {
+  return {
+    codePath: 'dist',
+    nodeEnv: 'production',
+    renderer: 'preact-render-to-string',
+    renderHarness: 'benchmark-local-static-virtualizer',
+    ...overrides,
+  };
+}
+
+function createBaseline(
+  configOverrides: Partial<BenchmarkConfig> = {},
+  runtimeOverrides: Partial<{
+    codePath: string;
+    nodeEnv: string;
+    renderer: string;
+    renderHarness: string;
+  }> = {}
+) {
   return {
     path: '/tmp/baseline.json',
     output: {
       config: createConfig(configOverrides),
+      runtime: createRuntime(runtimeOverrides),
     },
   };
 }
@@ -52,38 +76,51 @@ function createComparison(
   };
 }
 
-describe('virtualized render benchmark helpers', () => {
-  test('Root can SSR a deterministic virtualized window', () => {
-    const html = renderToString(
-      h(Root, {
-        fileTreeOptions: {
-          id: 'benchmark-ssr-window',
-          initialFiles: ['a.ts', 'b.ts', 'c.ts'],
-          sort: false,
-          virtualize: { threshold: 0 },
-        },
-        virtualizedRenderWindow: {
-          range: { start: 0, end: 1 },
-          itemHeight: 30,
-          viewportHeight: 60,
-        },
-      })
-    );
-
-    expect(html).toContain('a.ts');
-    expect(html).toContain('b.ts');
-    expect(html).not.toContain('c.ts');
-    expect(html.split('data-type="item"')).toHaveLength(3);
+function runRenderBenchmark(args: string[]) {
+  const result = Bun.spawnSync({
+    cmd: [
+      'bun',
+      'run',
+      './scripts/benchmarkVirtualizedFileTreeRender.ts',
+      ...args,
+    ],
+    cwd: packageRoot,
+    env: {
+      ...process.env,
+      AGENT: '1',
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
   });
 
+  return {
+    result,
+    stdout: textDecoder.decode(result.stdout).trim(),
+    stderr: textDecoder.decode(result.stderr).trim(),
+  };
+}
+
+describe('virtualized render benchmark helpers', () => {
   test('compare validation rejects incompatible virtual window settings', () => {
     expect(() =>
       assertComparableRenderBenchmarkBaseline(
         createBaseline({ windowSize: 10 }),
         createComparison(),
-        createConfig()
+        createConfig(),
+        createRuntime()
       )
     ).toThrow('baseline windowSize=10 does not match current windowSize=5');
+  });
+
+  test('compare validation rejects incompatible runtime metadata', () => {
+    expect(() =>
+      assertComparableRenderBenchmarkBaseline(
+        createBaseline({}, { codePath: 'src' }),
+        createComparison(),
+        createConfig(),
+        createRuntime()
+      )
+    ).toThrow('baseline codePath=src does not match current codePath=dist');
   });
 
   test('compare validation rejects HTML mismatches', () => {
@@ -91,109 +128,35 @@ describe('virtualized render benchmark helpers', () => {
       assertComparableRenderBenchmarkBaseline(
         createBaseline(),
         createComparison({ checksumMismatches: ['tiny-flat'] }),
-        createConfig()
+        createConfig(),
+        createRuntime()
       )
     ).toThrow(
       'baseline HTML output does not match current output for cases: tiny-flat'
     );
   });
 
-  test('CLI compare exits non-zero when the baseline window is incompatible', () => {
-    const tempDir = mkdtempSync(join(tmpdir(), 'render-benchmark-cli-'));
-    const baselinePath = join(tempDir, 'baseline.json');
-
-    try {
-      const baselineResult = Bun.spawnSync({
-        cmd: [
-          'bun',
-          'run',
-          './scripts/benchmarkVirtualizedFileTreeRender.ts',
-          '--case=tiny-flat',
-          '--runs=1',
-          '--warmup-runs=0',
-          '--window-size=5',
-          '--json',
-        ],
-        cwd: packageRoot,
-        env: {
-          ...process.env,
-          AGENT: '1',
-        },
-        stdout: 'pipe',
-        stderr: 'pipe',
-      });
-
-      expect(baselineResult.exitCode).toBe(0);
-      writeFileSync(baselinePath, baselineResult.stdout);
-
-      const compareResult = Bun.spawnSync({
-        cmd: [
-          'bun',
-          'run',
-          './scripts/benchmarkVirtualizedFileTreeRender.ts',
-          '--case=tiny-flat',
-          '--runs=1',
-          '--warmup-runs=0',
-          '--window-size=10',
-          '--compare',
-          baselinePath,
-          '--json',
-        ],
-        cwd: packageRoot,
-        env: {
-          ...process.env,
-          AGENT: '1',
-        },
-        stdout: 'pipe',
-        stderr: 'pipe',
-      });
-
-      const compareStderr = new TextDecoder()
-        .decode(compareResult.stderr)
-        .trim();
-
-      expect(compareResult.exitCode).not.toBe(0);
-      expect(compareStderr).toContain(
-        'baseline windowSize=5 does not match current windowSize=10'
-      );
-    } finally {
-      rmSync(tempDir, { force: true, recursive: true });
-    }
-  });
-});
-
-// These tests spawn benchmark subprocesses and are meant for local iteration,
-// not CI. Run them explicitly with: bun test --test-name-pattern "render benchmark CLI"
-describe.skip('render benchmark CLI', () => {
-  test('emits JSON for a filtered smoke run', () => {
-    const result = Bun.spawnSync({
-      cmd: [
-        'bun',
-        'run',
-        './scripts/benchmarkVirtualizedFileTreeRender.ts',
-        '--case=tiny-flat',
-        '--runs=1',
-        '--warmup-runs=0',
-        '--window-size=5',
-        '--json',
-      ],
-      cwd: packageRoot,
-      env: {
-        ...process.env,
-        AGENT: '1',
-      },
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
-
-    const stdout = new TextDecoder().decode(result.stdout).trim();
-    const stderr = new TextDecoder().decode(result.stderr).trim();
+  test('CLI emits JSON for a standalone dist/production smoke run', () => {
+    const { result, stdout, stderr } = runRenderBenchmark([
+      '--case=tiny-flat',
+      '--runs=1',
+      '--warmup-runs=0',
+      '--window-size=5',
+      '--json',
+    ]);
 
     expect(result.exitCode).toBe(0);
     expect(stderr).toBe('');
 
     const payload = JSON.parse(stdout) as {
       benchmark: string;
+      runtime: {
+        codePath: string;
+        nodeEnv: string;
+        renderer: string;
+        renderHarness: string;
+        buildCommand: string;
+      };
       config: {
         runs: number;
         warmupRuns: number;
@@ -209,6 +172,13 @@ describe.skip('render benchmark CLI', () => {
     };
 
     expect(payload.benchmark).toBe('virtualizedFileTreeRender');
+    expect(payload.runtime).toMatchObject({
+      codePath: 'dist',
+      nodeEnv: 'production',
+      renderer: 'preact-render-to-string',
+      renderHarness: 'benchmark-local-static-virtualizer',
+      buildCommand: 'bun run build',
+    });
     expect(payload.config.runs).toBe(1);
     expect(payload.config.warmupRuns).toBe(0);
     expect(payload.config.caseFilters).toEqual(['tiny-flat']);
@@ -222,95 +192,37 @@ describe.skip('render benchmark CLI', () => {
     expect(payload.cases[0]?.htmlChecksum).toBeGreaterThan(0);
   });
 
-  test('compares the current run against a saved baseline', () => {
-    const tempDir = mkdtempSync(join(tmpdir(), 'render-benchmark-compare-'));
+  test('CLI compare exits non-zero when the baseline window is incompatible', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'render-benchmark-cli-'));
     const baselinePath = join(tempDir, 'baseline.json');
 
     try {
-      const baselineResult = Bun.spawnSync({
-        cmd: [
-          'bun',
-          'run',
-          './scripts/benchmarkVirtualizedFileTreeRender.ts',
-          '--case=tiny-flat',
-          '--runs=1',
-          '--warmup-runs=0',
-          '--window-size=5',
-          '--json',
-        ],
-        cwd: packageRoot,
-        env: {
-          ...process.env,
-          AGENT: '1',
-        },
-        stdout: 'pipe',
-        stderr: 'pipe',
-      });
+      const baselineRun = runRenderBenchmark([
+        '--case=tiny-flat',
+        '--runs=1',
+        '--warmup-runs=0',
+        '--window-size=5',
+        '--json',
+      ]);
 
-      expect(baselineResult.exitCode).toBe(0);
-      expect(new TextDecoder().decode(baselineResult.stderr).trim()).toBe('');
-      writeFileSync(baselinePath, baselineResult.stdout);
+      expect(baselineRun.result.exitCode).toBe(0);
+      expect(baselineRun.stderr).toBe('');
+      writeFileSync(baselinePath, baselineRun.result.stdout);
 
-      const compareResult = Bun.spawnSync({
-        cmd: [
-          'bun',
-          'run',
-          './scripts/benchmarkVirtualizedFileTreeRender.ts',
-          '--case=tiny-flat',
-          '--runs=1',
-          '--warmup-runs=0',
-          '--window-size=5',
-          '--compare',
-          baselinePath,
-          '--json',
-        ],
-        cwd: packageRoot,
-        env: {
-          ...process.env,
-          AGENT: '1',
-        },
-        stdout: 'pipe',
-        stderr: 'pipe',
-      });
+      const compareRun = runRenderBenchmark([
+        '--case=tiny-flat',
+        '--runs=1',
+        '--warmup-runs=0',
+        '--window-size=10',
+        '--compare',
+        baselinePath,
+        '--json',
+      ]);
 
-      const compareStdout = new TextDecoder()
-        .decode(compareResult.stdout)
-        .trim();
-      const compareStderr = new TextDecoder()
-        .decode(compareResult.stderr)
-        .trim();
-
-      expect(compareResult.exitCode).toBe(0);
-      expect(compareStderr).toBe('');
-
-      const payload = JSON.parse(compareStdout) as {
-        config: { comparePath?: string };
-        comparison: {
-          baselinePath: string;
-          unmatchedCurrentCases: string[];
-          unmatchedBaselineCases: string[];
-          checksumMismatches: string[];
-          cases: Array<{
-            name: string;
-            htmlChecksumMatches: boolean;
-            renderedItemCountMatches: boolean;
-            htmlLengthMatches: boolean;
-          }>;
-        };
-      };
-
-      expect(payload.config.comparePath).toBe(baselinePath);
-      expect(payload.comparison.baselinePath).toBe(baselinePath);
-      expect(payload.comparison.unmatchedCurrentCases).toEqual([]);
-      expect(payload.comparison.unmatchedBaselineCases).toEqual([]);
-      expect(payload.comparison.checksumMismatches).toEqual([]);
-      expect(payload.comparison.cases).toHaveLength(1);
-      expect(payload.comparison.cases[0]).toMatchObject({
-        name: 'tiny-flat',
-        htmlChecksumMatches: true,
-        renderedItemCountMatches: true,
-        htmlLengthMatches: true,
-      });
+      expect(compareRun.result.exitCode).not.toBe(0);
+      expect(compareRun.stderr).toContain(
+        'baseline windowSize=5 does not match current windowSize=10'
+      );
     } finally {
       rmSync(tempDir, { force: true, recursive: true });
     }

--- a/packages/trees/tsconfig.json
+++ b/packages/trees/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.options.json",
   "include": [
     "scripts/**/*.ts",
+    "scripts/**/*.tsx",
     "src/**/*.ts",
     "src/**/*.tsx",
     "src/**/*.json",


### PR DESCRIPTION
  - bun ws trees benchmark:render for a one-off measurement
  - bun ws trees benchmark:render -- --json if you want machine-readable output
  - --compare <baseline> only when you explicitly want regression checking

```sh
❯ bun ws trees benchmark:render
$ bun --silent scripts/ws.ts trees benchmark:render
virtualized file tree render benchmark
bun=1.3.8 platform=darwin arch=arm64
cases=1 runsPerCase=12 warmupRunsPerCase=3
windowStart=0 windowSize=30 itemHeight=30 viewportHeight=500
filters=linux (default)
checksum=1589595385

case                        source   files  folders  depth  expanded  htmlItems  htmlBytes  renderMedianMs  renderP95Ms  endToEndMedianMs  endToEndP95Ms
--------------------------  -------  -----  -------  -----  --------  ---------  ---------  --------------  -----------  ----------------  -------------
fixture-linux-kernel-files  fixture  92914  6102     11     6102      30         49533      124.098         156.514      115.738           138.910
```