### PR TITLE
Fix title displacing dot in dotfiles

### DIFF
--- a/packages/diffs/src/utils/createFileHeaderElement.ts
+++ b/packages/diffs/src/utils/createFileHeaderElement.ts
@@ -90,7 +90,12 @@ function createHeaderElement({
   children.push(
     createHastElement({
       tagName: 'div',
-      children: [createTextNodeElement(name)],
+      children: [
+        createHastElement({
+          tagName: 'bdi',
+          children: [createTextNodeElement(name)],
+        }),
+      ],
       properties: { 'data-title': '' },
     })
   );

--- a/packages/diffs/src/utils/hast_utils.ts
+++ b/packages/diffs/src/utils/hast_utils.ts
@@ -25,7 +25,8 @@ interface CreateHastElementProps {
     | 'svg'
     | 'use'
     | 'style'
-    | 'template';
+    | 'template'
+    | 'bdi';
   children?: ElementContent[];
   properties?: Properties;
 }

--- a/packages/diffs/test/__snapshots__/DiffHunksRender.test.ts.snap
+++ b/packages/diffs/test/__snapshots__/DiffHunksRender.test.ts.snap
@@ -2385,8 +2385,15 @@ exports[`DiffHunksRenderer proper buffers should be prepended to additions colum
           {
             "children": [
               {
-                "type": "text",
-                "value": "file.tsx",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "file.tsx",
+                  },
+                ],
+                "properties": {},
+                "tagName": "bdi",
+                "type": "element",
               },
             ],
             "properties": {
@@ -4866,8 +4873,15 @@ exports[`DiffHunksRenderer proper buffers should be prepended to deletions colum
           {
             "children": [
               {
-                "type": "text",
-                "value": "file.tsx",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "file.tsx",
+                  },
+                ],
+                "properties": {},
+                "tagName": "bdi",
+                "type": "element",
               },
             ],
             "properties": {
@@ -5201,8 +5215,15 @@ exports[`DiffHunksRenderer additions and deletions should be empty when unified:
           {
             "children": [
               {
-                "type": "text",
-                "value": "file.tsx",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "file.tsx",
+                  },
+                ],
+                "properties": {},
+                "tagName": "bdi",
+                "type": "element",
               },
             ],
             "properties": {
@@ -7903,8 +7924,15 @@ exports[`DiffHunksRenderer a diff with only additions should have an empty delet
           {
             "children": [
               {
-                "type": "text",
-                "value": "file.tsx",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "file.tsx",
+                  },
+                ],
+                "properties": {},
+                "tagName": "bdi",
+                "type": "element",
               },
             ],
             "properties": {
@@ -9049,8 +9077,15 @@ exports[`DiffHunksRenderer a diff with only deletions should have an empty addit
           {
             "children": [
               {
-                "type": "text",
-                "value": "file.tsx",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "file.tsx",
+                  },
+                ],
+                "properties": {},
+                "tagName": "bdi",
+                "type": "element",
               },
             ],
             "properties": {

--- a/packages/diffs/test/__snapshots__/DiffHunksRendererVirtualization.test.ts.snap
+++ b/packages/diffs/test/__snapshots__/DiffHunksRendererVirtualization.test.ts.snap
@@ -45,8 +45,15 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.2: Part
           {
             "children": [
               {
-                "type": "text",
-                "value": "test.txt",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "test.txt",
+                  },
+                ],
+                "properties": {},
+                "tagName": "bdi",
+                "type": "element",
               },
             ],
             "properties": {
@@ -29247,8 +29254,15 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.3: Part
           {
             "children": [
               {
-                "type": "text",
-                "value": "test.txt",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "test.txt",
+                  },
+                ],
+                "properties": {},
+                "tagName": "bdi",
+                "type": "element",
               },
             ],
             "properties": {
@@ -58214,8 +58228,15 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.4: Part
           {
             "children": [
               {
-                "type": "text",
-                "value": "test.txt",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "test.txt",
+                  },
+                ],
+                "properties": {},
+                "tagName": "bdi",
+                "type": "element",
               },
             ],
             "properties": {
@@ -87544,8 +87565,15 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.5: Wind
           {
             "children": [
               {
-                "type": "text",
-                "value": "test.txt",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "test.txt",
+                  },
+                ],
+                "properties": {},
+                "tagName": "bdi",
+                "type": "element",
               },
             ],
             "properties": {
@@ -90339,8 +90367,15 @@ exports[`DiffHunksRenderer - Virtualization correct lines rendered 6.1: Rendered
           {
             "children": [
               {
-                "type": "text",
-                "value": "test.txt",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "test.txt",
+                  },
+                ],
+                "properties": {},
+                "tagName": "bdi",
+                "type": "element",
               },
             ],
             "properties": {
@@ -91588,8 +91623,15 @@ exports[`DiffHunksRenderer - Virtualization correct lines rendered 6.2: Rendered
           {
             "children": [
               {
-                "type": "text",
-                "value": "test.txt",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "test.txt",
+                  },
+                ],
+                "properties": {},
+                "tagName": "bdi",
+                "type": "element",
               },
             ],
             "properties": {

--- a/packages/diffs/test/__snapshots__/patchFileRender.test.ts.snap
+++ b/packages/diffs/test/__snapshots__/patchFileRender.test.ts.snap
@@ -2624,8 +2624,15 @@ exports[`file.patch fixture parses and renders the patch file: rendered patch 1`
           {
             "children": [
               {
-                "type": "text",
-                "value": "/Users/shijie.rao/code/openai/project/oai-airflow-shared/oai_airflow_shared/applied_data_platform/lodestone/lodestone_config_notifications.yaml",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "/Users/shijie.rao/code/openai/project/oai-airflow-shared/oai_airflow_shared/applied_data_platform/lodestone/lodestone_config_notifications.yaml",
+                  },
+                ],
+                "properties": {},
+                "tagName": "bdi",
+                "type": "element",
               },
             ],
             "properties": {


### PR DESCRIPTION
Currently the header title has `rtl` style:

https://github.com/pierrecomputer/pierre/blob/d7db28ebccaf6bb67728acd6cf71492f7dce42bc/packages/diffs/src/style.css#L1413-L1415

However, for files like `.gitignore`, since the dot is as the word boundary, it displaces it to the end of the word:

<img width="1274" height="60" alt="image" src="https://github.com/user-attachments/assets/825ee6eb-26a9-4601-b33d-39d315e68778" />

This fixes it by wrapping the file name in [`<bdi>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/bdi) tag:

<img width="1270" height="68" alt="image" src="https://github.com/user-attachments/assets/0871d010-82e2-4fdf-b2be-85ada2fc5339" />

The ellipsis still appears properly on the left:

<img width="183" height="62" alt="image" src="https://github.com/user-attachments/assets/2c6fa8e0-8de1-4857-aca0-a7d9fe5b6894" />