### PR TITLE
[trees] Performance pass

### DIFF
--- a/packages/trees/package.json
+++ b/packages/trees/package.json
@@ -38,6 +38,7 @@
     "benchmark:file-list-to-tree": "bun run ./scripts/benchmarkFileListToTree.ts",
     "benchmark:core": "bun run ./scripts/benchmarkTreeCorePrimitives.ts",
     "benchmark:render": "bun run ./scripts/benchmarkVirtualizedFileTreeRender.ts",
+    "benchmark:render:client": "bun run ./scripts/benchmarkVirtualizedFileTreeClientMount.ts",
     "dev": "echo 'Watching for changes…' && tsdown --watch --log-level error",
     "test": "bun test",
     "coverage": "bun test --coverage",

--- a/packages/trees/scripts/benchmarkVirtualizedFileTreeClientMount.ts
+++ b/packages/trees/scripts/benchmarkVirtualizedFileTreeClientMount.ts
@@ -1,0 +1,518 @@
+// @ts-expect-error -- no @types/jsdom in benchmark scripts; package already depends on jsdom
+import { JSDOM } from 'jsdom';
+import { fileURLToPath } from 'node:url';
+
+import {
+  type BenchmarkEnvironment,
+  formatMs,
+  getEnvironment,
+  parseNonNegativeInteger,
+  parsePositiveInteger,
+  printTable,
+  summarizeSamples,
+  type TimingSummary,
+} from './lib/benchmarkUtils';
+import {
+  type FileListToTreeBenchmarkCase,
+  filterBenchmarkCases,
+  getFileListToTreeBenchmarkCases,
+} from './lib/fileListToTreeBenchmarkData';
+
+interface BenchmarkConfig {
+  runs: number;
+  warmupRuns: number;
+  outputJson: boolean;
+  caseFilters: string[];
+  viewportHeight: number;
+}
+
+interface BenchmarkRuntimeInfo {
+  codePath: 'dist';
+  nodeEnv: 'production';
+  renderer: 'preact-dom';
+  mountHarness: 'jsdom-fresh-filetree-render';
+  buildCommand: 'bun run build';
+}
+
+interface LoadedBenchmarkRuntime {
+  runtimeInfo: BenchmarkRuntimeInfo;
+  FileTree: typeof import('../src/FileTree').FileTree;
+}
+
+interface CaseSummary {
+  name: string;
+  source: FileListToTreeBenchmarkCase['source'];
+  fileCount: number;
+  uniqueFolderCount: number;
+  maxDepth: number;
+  expandedFolderCount: number;
+  viewportHeight: number;
+  renderedItemCount: number;
+  shadowHtmlLength: number;
+  shadowHtmlChecksum: number;
+  clientMount: TimingSummary;
+}
+
+interface BenchmarkOutput {
+  benchmark: 'virtualizedFileTreeClientMount';
+  environment: BenchmarkEnvironment;
+  runtime: BenchmarkRuntimeInfo;
+  config: BenchmarkConfig;
+  checksum: number;
+  cases: CaseSummary[];
+}
+
+interface ClientMountSnapshot {
+  renderedItemCount: number;
+  shadowHtmlLength: number;
+  shadowHtmlChecksum: number;
+}
+
+const DEFAULT_CONFIG: BenchmarkConfig = {
+  runs: 10,
+  warmupRuns: 2,
+  outputJson: false,
+  caseFilters: [],
+  viewportHeight: 500,
+};
+
+const DEFAULT_CASE_FILTERS = ['linux'];
+const packageRoot = fileURLToPath(new URL('../', import.meta.url));
+const textDecoder = new TextDecoder();
+
+let domReady = false;
+
+function printHelpAndExit(): never {
+  console.log('Usage: bun ws trees benchmark:render:client -- [options]');
+  console.log('');
+  console.log('Options:');
+  console.log(
+    '  --runs <number>            Measured runs per benchmark case (default: 10)'
+  );
+  console.log(
+    '  --warmup-runs <number>     Warmup runs per benchmark case before measurement (default: 2)'
+  );
+  console.log(
+    '  --viewport-height <number> Fixed viewport height for the mounted virtualized tree (default: 500)'
+  );
+  console.log(
+    '  --case <filter>            Run only cases whose name contains the filter (repeatable). Defaults to linux fixture only.'
+  );
+  console.log('  --json                     Emit machine-readable JSON output');
+  console.log('  -h, --help                 Show this help output');
+  process.exit(0);
+}
+
+function parseArgs(argv: string[]): BenchmarkConfig {
+  const config: BenchmarkConfig = { ...DEFAULT_CONFIG };
+
+  for (let index = 0; index < argv.length; index++) {
+    const rawArg = argv[index];
+    if (rawArg === '--help' || rawArg === '-h') {
+      printHelpAndExit();
+    }
+
+    if (rawArg === '--json') {
+      config.outputJson = true;
+      continue;
+    }
+
+    const [flag, inlineValue] = rawArg.split('=', 2);
+    if (
+      flag === '--runs' ||
+      flag === '--warmup-runs' ||
+      flag === '--viewport-height' ||
+      flag === '--case'
+    ) {
+      const value = inlineValue ?? argv[index + 1];
+      if (value == null) {
+        throw new Error(`Missing value for ${flag}`);
+      }
+      if (inlineValue == null) {
+        index += 1;
+      }
+
+      if (flag === '--runs') {
+        config.runs = parsePositiveInteger(value, '--runs');
+      } else if (flag === '--warmup-runs') {
+        config.warmupRuns = parseNonNegativeInteger(value, '--warmup-runs');
+      } else if (flag === '--viewport-height') {
+        config.viewportHeight = parsePositiveInteger(
+          value,
+          '--viewport-height'
+        );
+      } else {
+        config.caseFilters.push(value);
+      }
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${rawArg}`);
+  }
+
+  return config;
+}
+
+function decodeOutput(output: Uint8Array): string {
+  return textDecoder.decode(output).trim();
+}
+
+function ensureProductionDistBuild(): BenchmarkRuntimeInfo {
+  process.env.NODE_ENV = 'production';
+
+  const buildResult = Bun.spawnSync({
+    cmd: ['bun', 'run', 'build'],
+    cwd: packageRoot,
+    env: {
+      ...process.env,
+      AGENT: '1',
+      NODE_ENV: 'production',
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  if (buildResult.exitCode !== 0) {
+    const stdout = decodeOutput(buildResult.stdout);
+    const stderr = decodeOutput(buildResult.stderr);
+    throw new Error(
+      [
+        'Failed to build @pierre/trees before running the client render benchmark.',
+        stdout !== '' ? `stdout:\n${stdout}` : null,
+        stderr !== '' ? `stderr:\n${stderr}` : null,
+      ]
+        .filter((line): line is string => line != null)
+        .join('\n\n')
+    );
+  }
+
+  return {
+    codePath: 'dist',
+    nodeEnv: 'production',
+    renderer: 'preact-dom',
+    mountHarness: 'jsdom-fresh-filetree-render',
+    buildCommand: 'bun run build',
+  };
+}
+
+function parsePx(value: string): number {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function installBenchmarkDom(viewportHeight: number): void {
+  if (domReady) {
+    return;
+  }
+
+  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+    pretendToBeVisual: true,
+  });
+
+  Object.assign(globalThis, {
+    window: dom.window,
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    KeyboardEvent: dom.window.KeyboardEvent,
+    MouseEvent: dom.window.MouseEvent,
+    HTMLTemplateElement: dom.window.HTMLTemplateElement,
+    HTMLDivElement: dom.window.HTMLDivElement,
+    HTMLStyleElement: dom.window.HTMLStyleElement,
+    HTMLSlotElement: dom.window.HTMLSlotElement,
+    HTMLInputElement: dom.window.HTMLInputElement,
+    SVGElement: dom.window.SVGElement,
+    ShadowRoot: dom.window.ShadowRoot,
+    navigator: dom.window.navigator,
+    Node: dom.window.Node,
+    Event: dom.window.Event,
+    MutationObserver: dom.window.MutationObserver,
+    customElements: dom.window.customElements,
+    getComputedStyle: dom.window.getComputedStyle.bind(dom.window),
+    requestAnimationFrame: dom.window.requestAnimationFrame.bind(dom.window),
+    cancelAnimationFrame: dom.window.cancelAnimationFrame.bind(dom.window),
+  });
+
+  class MockCSSStyleSheet {
+    cssRules: unknown[] = [];
+    replaceSync(_text: string) {}
+  }
+  Object.assign(globalThis, { CSSStyleSheet: MockCSSStyleSheet });
+
+  class MockResizeObserver {
+    observe() {}
+    disconnect() {}
+    unobserve() {}
+  }
+  Object.assign(globalThis, { ResizeObserver: MockResizeObserver });
+
+  const proto = dom.window.HTMLElement.prototype as HTMLElement & {
+    __clientHeightPatched?: boolean;
+    __boundingClientRectPatched?: boolean;
+  };
+
+  if (
+    (proto as { __clientHeightPatched?: boolean }).__clientHeightPatched !==
+    true
+  ) {
+    Object.defineProperty(dom.window.HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      get(this: HTMLElement) {
+        const explicit = parsePx(this.style.height);
+        if (explicit > 0) {
+          return explicit;
+        }
+        if (
+          this.dataset.fileTreeVirtualizedScroll === 'true' ||
+          this.dataset.fileTreeVirtualizedRoot === 'true' ||
+          this.dataset.fileTreeVirtualizedWrapper === 'true'
+        ) {
+          return viewportHeight;
+        }
+        return 0;
+      },
+    });
+    (proto as { __clientHeightPatched?: boolean }).__clientHeightPatched = true;
+  }
+
+  if (
+    (proto as { __boundingClientRectPatched?: boolean })
+      .__boundingClientRectPatched !== true
+  ) {
+    dom.window.HTMLElement.prototype.getBoundingClientRect = function () {
+      const height = (this as HTMLElement).clientHeight;
+      const explicitWidth = parsePx((this as HTMLElement).style.width);
+      const width = explicitWidth > 0 ? explicitWidth : 300;
+      return {
+        x: 0,
+        y: 0,
+        top: 0,
+        right: width,
+        bottom: height,
+        left: 0,
+        width,
+        height,
+        toJSON() {
+          return this;
+        },
+      } as DOMRect;
+    };
+    (
+      proto as { __boundingClientRectPatched?: boolean }
+    ).__boundingClientRectPatched = true;
+  }
+
+  domReady = true;
+}
+
+async function loadBenchmarkRuntime(
+  viewportHeight: number
+): Promise<LoadedBenchmarkRuntime> {
+  const runtimeInfo = ensureProductionDistBuild();
+  installBenchmarkDom(viewportHeight);
+
+  const fileTreeModule = await import(
+    new URL('../dist/FileTree.js', import.meta.url).href
+  );
+  return {
+    runtimeInfo,
+    FileTree: fileTreeModule.FileTree as LoadedBenchmarkRuntime['FileTree'],
+  };
+}
+
+function checksumHtml(html: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < html.length; index++) {
+    hash ^= html.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function createFileTreeOptions(
+  caseConfig: FileListToTreeBenchmarkCase
+): import('../src/FileTree').FileTreeOptions {
+  return {
+    id: `benchmark-client-render-${caseConfig.name.replace(/[^A-Za-z0-9_-]/g, '-')}`,
+    initialFiles: caseConfig.files,
+    flattenEmptyDirectories: true,
+    sort: false,
+    virtualize: { threshold: 0 },
+  };
+}
+
+function createStateConfig(
+  caseConfig: FileListToTreeBenchmarkCase
+): import('../src/FileTree').FileTreeStateConfig {
+  return {
+    initialExpandedItems: caseConfig.expandedFolders ?? [],
+  };
+}
+
+async function mountClientRenderCase(
+  runtime: LoadedBenchmarkRuntime,
+  caseConfig: FileListToTreeBenchmarkCase,
+  config: BenchmarkConfig
+): Promise<ClientMountSnapshot> {
+  const host = document.createElement('div');
+  host.style.height = `${config.viewportHeight}px`;
+  host.style.width = '320px';
+  document.body.appendChild(host);
+
+  const fileTree = new runtime.FileTree(
+    createFileTreeOptions(caseConfig),
+    createStateConfig(caseConfig)
+  );
+
+  try {
+    fileTree.render({ containerWrapper: host });
+    await flushMicrotasks();
+
+    const container = fileTree.getFileTreeContainer();
+    const shadowRoot = container?.shadowRoot;
+    const html = shadowRoot?.innerHTML ?? '';
+
+    return {
+      renderedItemCount:
+        shadowRoot?.querySelectorAll('[data-type="item"]').length ?? 0,
+      shadowHtmlLength: html.length,
+      shadowHtmlChecksum: checksumHtml(html),
+    };
+  } finally {
+    fileTree.cleanUp();
+    host.remove();
+  }
+}
+
+export async function main(): Promise<void> {
+  const config = parseArgs(process.argv.slice(2));
+  const runtime = await loadBenchmarkRuntime(config.viewportHeight);
+  const selectedCaseConfigs = filterBenchmarkCases(
+    getFileListToTreeBenchmarkCases(),
+    config.caseFilters.length > 0 ? config.caseFilters : DEFAULT_CASE_FILTERS
+  );
+
+  if (selectedCaseConfigs.length === 0) {
+    throw new Error('No benchmark cases matched the provided --case filters.');
+  }
+
+  const samplesByCase = selectedCaseConfigs.map(() => [] as number[]);
+  const summaries: ClientMountSnapshot[] = [];
+
+  for (let warmupIndex = 0; warmupIndex < config.warmupRuns; warmupIndex++) {
+    for (const caseConfig of selectedCaseConfigs) {
+      await mountClientRenderCase(runtime, caseConfig, config);
+    }
+  }
+
+  for (let runIndex = 0; runIndex < config.runs; runIndex++) {
+    for (
+      let caseIndex = 0;
+      caseIndex < selectedCaseConfigs.length;
+      caseIndex++
+    ) {
+      const caseConfig = selectedCaseConfigs[caseIndex];
+      const startTime = performance.now();
+      const snapshot = await mountClientRenderCase(runtime, caseConfig, config);
+      samplesByCase[caseIndex].push(performance.now() - startTime);
+      if (runIndex === 0) {
+        summaries[caseIndex] = snapshot;
+      }
+    }
+  }
+
+  const caseSummaries: CaseSummary[] = selectedCaseConfigs.map(
+    (caseConfig, index) => ({
+      name: caseConfig.name,
+      source: caseConfig.source,
+      fileCount: caseConfig.fileCount,
+      uniqueFolderCount: caseConfig.uniqueFolderCount,
+      maxDepth: caseConfig.maxDepth,
+      expandedFolderCount: caseConfig.expandedFolders?.length ?? 0,
+      viewportHeight: config.viewportHeight,
+      renderedItemCount: summaries[index]?.renderedItemCount ?? 0,
+      shadowHtmlLength: summaries[index]?.shadowHtmlLength ?? 0,
+      shadowHtmlChecksum: summaries[index]?.shadowHtmlChecksum ?? 0,
+      clientMount: summarizeSamples(samplesByCase[index]),
+    })
+  );
+
+  const checksum = caseSummaries.reduce(
+    (sum, summary) =>
+      sum +
+      summary.shadowHtmlChecksum +
+      summary.shadowHtmlLength +
+      summary.renderedItemCount,
+    0
+  );
+  const environment = getEnvironment();
+
+  const output: BenchmarkOutput = {
+    benchmark: 'virtualizedFileTreeClientMount',
+    environment,
+    runtime: runtime.runtimeInfo,
+    config,
+    checksum,
+    cases: caseSummaries,
+  };
+
+  if (config.outputJson) {
+    console.log(JSON.stringify(output, null, 2));
+    return;
+  }
+
+  console.log('virtualized file tree client-mount benchmark');
+  console.log(
+    `bun=${environment.bunVersion} platform=${environment.platform} arch=${environment.arch}`
+  );
+  console.log(
+    `runtime=${runtime.runtimeInfo.codePath} nodeEnv=${runtime.runtimeInfo.nodeEnv} renderer=${runtime.runtimeInfo.renderer} harness=${runtime.runtimeInfo.mountHarness}`
+  );
+  console.log(`buildCommand=${runtime.runtimeInfo.buildCommand}`);
+  console.log(
+    `cases=${selectedCaseConfigs.length} runsPerCase=${config.runs} warmupRunsPerCase=${config.warmupRuns}`
+  );
+  console.log(`viewportHeight=${config.viewportHeight}`);
+  if (config.caseFilters.length > 0) {
+    console.log(`filters=${config.caseFilters.join(', ')}`);
+  } else {
+    console.log(`filters=${DEFAULT_CASE_FILTERS.join(', ')} (default)`);
+  }
+  console.log(`checksum=${checksum}`);
+  console.log('');
+
+  printTable(
+    caseSummaries.map((summary) => ({
+      case: summary.name,
+      source: summary.source,
+      files: String(summary.fileCount),
+      folders: String(summary.uniqueFolderCount),
+      depth: String(summary.maxDepth),
+      expanded: String(summary.expandedFolderCount),
+      htmlItems: String(summary.renderedItemCount),
+      shadowBytes: String(summary.shadowHtmlLength),
+      clientMountMedianMs: formatMs(summary.clientMount.medianMs),
+      clientMountP95Ms: formatMs(summary.clientMount.p95Ms),
+    })),
+    [
+      'case',
+      'source',
+      'files',
+      'folders',
+      'depth',
+      'expanded',
+      'htmlItems',
+      'shadowBytes',
+      'clientMountMedianMs',
+      'clientMountP95Ms',
+    ]
+  );
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/packages/trees/scripts/lib/benchmarkVirtualizedRenderRuntime.tsx
+++ b/packages/trees/scripts/lib/benchmarkVirtualizedRenderRuntime.tsx
@@ -3,6 +3,7 @@ import type { JSX } from 'preact';
 import { useCallback, useMemo, useRef } from 'preact/hooks';
 
 import type { ItemInstance, TreeInstance } from '../../src/core/types/core';
+import type { TreeDataRef } from '../../src/features/main/types';
 import type { FileTreeOptions, FileTreeStateConfig } from '../../src/FileTree';
 import type { SVGSpriteNames } from '../../src/sprite';
 import type { FileTreeNode } from '../../src/types';
@@ -10,6 +11,15 @@ import type { ChildrenSortOption } from '../../src/utils/sortChildren';
 
 const DEFAULT_ITEM_HEIGHT = 30;
 const EMPTY_ANCESTORS: string[] = [];
+
+// Reuses the last rebuild's visible ID list so the benchmark mirrors the real
+// virtualized path without forcing full item-instance materialization first.
+function getVisibleItemIds(tree: TreeInstance<FileTreeNode>): string[] {
+  return (
+    tree.getDataRef<TreeDataRef>().current.visibleItemIds ??
+    tree.getItems().map((item) => item.getId())
+  );
+}
 
 export interface BenchmarkVirtualRange {
   start: number;
@@ -366,32 +376,32 @@ function createBenchmarkVirtualizedRoot(
     const containerProps = tree.getContainerProps();
     const visibleIdSet = runtime.getSearchVisibleIdSet(tree);
     const gitStatusMap = runtime.getGitStatusMap(tree);
-    const allItems = tree.getItems();
-    const items =
+    const allItemIds = getVisibleItemIds(tree);
+    const itemIds =
       visibleIdSet != null
-        ? allItems.filter((item) => visibleIdSet.has(item.getId()))
-        : allItems;
+        ? allItemIds.filter((itemId) => visibleIdSet.has(itemId))
+        : allItemIds;
 
     const renderItemAtIndex = (index: number) => {
-      const item = items[index];
-      if (item == null) {
+      const itemId = itemIds[index];
+      if (itemId == null) {
         return null;
       }
 
+      const item = tree.getItemInstance(itemId);
       const itemData = item.getItemData();
       const itemMeta = item.getItemMeta();
       const hasChildren = itemData?.children?.direct != null;
-      const itemGitStatus = gitStatusMap?.statusById.get(item.getId());
+      const itemGitStatus = gitStatusMap?.statusById.get(itemId);
       const itemContainsGitChange =
-        hasChildren &&
-        (gitStatusMap?.foldersWithChanges.has(item.getId()) ?? false);
+        hasChildren && (gitStatusMap?.foldersWithChanges.has(itemId) ?? false);
 
       return (
         <runtime.TreeItem
-          key={item.getId()}
+          key={itemId}
           item={item}
           tree={tree}
-          itemId={item.getId()}
+          itemId={itemId}
           hasChildren={hasChildren}
           isExpanded={hasChildren && item.isExpanded()}
           itemName={item.getItemName()}
@@ -409,7 +419,7 @@ function createBenchmarkVirtualizedRoot(
           containsGitChange={itemContainsGitChange ?? false}
           flattens={itemData?.flattens}
           idToPath={idToPath}
-          ancestors={getAncestors(item.getId())}
+          ancestors={getAncestors(itemId)}
           treeDomId={treeDomId}
           remapIcon={remapIcon}
           detectFlattenedSubfolder={() => {}}
@@ -425,11 +435,11 @@ function createBenchmarkVirtualizedRoot(
         data-file-tree-virtualized-root={shouldVirtualize ? 'true' : undefined}
       >
         {shouldVirtualize &&
-        items.length > 0 &&
-        items.length >= virtualizeThreshold ? (
+        itemIds.length > 0 &&
+        itemIds.length >= virtualizeThreshold ? (
           <div data-file-tree-virtualized-scroll="true">
             <StaticBenchmarkVirtualizedList
-              itemCount={items.length}
+              itemCount={itemIds.length}
               renderItem={renderItemAtIndex}
               range={virtualizedRenderWindow.range}
               itemHeight={virtualizedRenderWindow.itemHeight}
@@ -437,7 +447,7 @@ function createBenchmarkVirtualizedRoot(
             />
           </div>
         ) : (
-          items.map((_, index) => renderItemAtIndex(index))
+          itemIds.map((_, index) => renderItemAtIndex(index))
         )}
       </div>
     );

--- a/packages/trees/src/FileTree.ts
+++ b/packages/trees/src/FileTree.ts
@@ -1,3 +1,4 @@
+import type { FileTreeRootProps } from './components/Root';
 import { FileTreeContainerLoaded } from './components/web-components';
 import {
   FILE_TREE_TAG_NAME,
@@ -80,7 +81,7 @@ export type FileTreeCollision = {
 export interface FileTreeHandle {
   tree: TreeInstance<FileTreeNode>;
   pathToId: Map<string, string>;
-  idToPath: Map<string, string>;
+  idToPath: Pick<Map<string, string>, 'get' | 'has'>;
   closeContextMenu?: () => void;
 }
 
@@ -542,12 +543,13 @@ export class FileTree {
     }
   }
 
-  private buildRootProps() {
+  private buildRootProps(overrides?: Partial<FileTreeRootProps>) {
     return {
       fileTreeOptions: this.options,
       stateConfig: this.stateConfig,
       handleRef: this.handleRef,
       callbacksRef: this.callbacksRef,
+      ...overrides,
     };
   }
 
@@ -799,7 +801,17 @@ export class FileTree {
     );
     const divWrapper = this.getOrCreateDivWrapperNode(fileTreeContainer);
     this.syncVirtualizedLayoutAttrs(fileTreeContainer, divWrapper);
-    preactRenderRoot(divWrapper, this.buildRootProps());
+
+    // Seed the first virtualized window with the outer mount height so client
+    // mounts can render the initial rows immediately before the layout effect
+    // performs the authoritative viewport measurement.
+    const initialViewportHeight =
+      containerWrapper?.clientHeight ?? fileTreeContainer.clientHeight;
+
+    preactRenderRoot(
+      divWrapper,
+      this.buildRootProps({ initialViewportHeight })
+    );
   }
 
   hydrate(props: FileTreeHydrationProps): void {

--- a/packages/trees/src/components/Root.tsx
+++ b/packages/trees/src/components/Root.tsx
@@ -27,6 +27,7 @@ import {
 } from '../features/git-status/feature';
 import { hotkeysCoreFeature } from '../features/hotkeys-core/feature';
 import { keyboardDragAndDropFeature } from '../features/keyboard-drag-and-drop/feature';
+import type { TreeDataRef } from '../features/main/types';
 import { propMemoizationFeature } from '../features/prop-memoization/feature';
 import { renamingFeature } from '../features/renaming/feature';
 import {
@@ -73,15 +74,26 @@ export interface FileTreeRootProps {
   stateConfig?: FileTreeStateConfig;
   handleRef?: { current: FileTreeHandle | null };
   callbacksRef?: { current: FileTreeCallbacks };
+  initialViewportHeight?: number | null;
 }
 
 const EMPTY_ANCESTORS: string[] = [];
+
+// Reuses the last rebuild's visible ID list so virtualized rendering can size
+// and slice the tree without forcing core to instantiate every visible item.
+function getVisibleItemIds(tree: TreeInstance<FileTreeNode>): string[] {
+  return (
+    tree.getDataRef<TreeDataRef>().current.visibleItemIds ??
+    tree.getItems().map((item) => item.getId())
+  );
+}
 
 export function Root({
   fileTreeOptions,
   stateConfig,
   handleRef,
   callbacksRef,
+  initialViewportHeight,
 }: FileTreeRootProps): JSX.Element {
   'use no memo';
   const {
@@ -155,16 +167,26 @@ export function Root({
     [files, sortComparator]
   );
 
-  // Build path<->id maps from treeData
-  const { pathToId, idToPath } = useMemo(() => {
-    const p2i = new Map<string, string>();
-    const i2p = new Map<string, string>();
-    for (const [id, node] of Object.entries(treeData)) {
-      p2i.set(node.path, id);
-      i2p.set(id, node.path);
+  // Build the hot path->id map with a direct for-in scan and answer id->path
+  // lookups straight from treeData so we do not duplicate the whole tree into a
+  // second Map on every fresh mount.
+  const pathToId = useMemo(() => {
+    const next = new Map<string, string>();
+    for (const id in treeData) {
+      const node = treeData[id];
+      if (node != null) {
+        next.set(node.path, id);
+      }
     }
-    return { pathToId: p2i, idToPath: i2p };
+    return next;
   }, [treeData]);
+  const idToPath = useMemo<Pick<Map<string, string>, 'get' | 'has'>>(
+    () => ({
+      get: (id: string) => treeData[id]?.path,
+      has: (id: string) => treeData[id] != null,
+    }),
+    [treeData]
+  );
 
   const ancestorChainsCacheRef = useRef<Map<string, string[]>>(new Map());
   const prevIdToPathForCacheRef = useRef(idToPath);
@@ -174,7 +196,6 @@ export function Root({
   }
 
   const restTreeConfig = useTreeStateConfig({
-    treeData,
     pathToId,
     stateConfig,
     flattenEmptyDirectories,
@@ -598,19 +619,28 @@ export function Root({
         </div>
       ) : null}
       {(() => {
-        const allItems = tree.getItems();
         const visibleIdSet = getSearchVisibleIdSet(tree);
         const gitStatusMap = getGitStatusMap(tree);
-        const items =
+        const allItemIds = getVisibleItemIds(tree);
+        const itemIds =
           visibleIdSet != null
-            ? allItems.filter((item) => visibleIdSet.has(item.getId()))
-            : allItems;
+            ? allItemIds.filter((itemId) => visibleIdSet.has(itemId))
+            : allItemIds;
+        const draggedItemIdSet = isDnD
+          ? new Set(
+              (tree.getState().dnd?.draggedItems ?? []).map(
+                (item: ItemInstance<FileTreeNode>) => item.getId()
+              )
+            )
+          : null;
 
         const renderItemAtIndex = (index: number) => {
-          const item = items[index];
-          if (item == null) {
+          const itemId = itemIds[index];
+          if (itemId == null) {
             return null;
           }
+
+          const item = tree.getItemInstance(itemId);
           const itemData = item.getItemData();
           const itemMeta = item.getItemMeta();
           const hasChildren = itemData?.children?.direct != null;
@@ -627,25 +657,19 @@ export function Root({
           const isFocused = hasFocusedItem && item.isFocused();
           const isDragTarget = isDnD && item.isUnorderedDragTarget?.() === true;
           const isRenaming = item.isRenaming?.() === true;
-          const isDragging =
-            isDnD &&
-            tree
-              .getState()
-              .dnd?.draggedItems?.some(
-                (d: ItemInstance<FileTreeNode>) => d.getId() === item.getId()
-              ) === true;
-          const itemGitStatus = gitStatusMap?.statusById.get(item.getId());
+          const isDragging = draggedItemIdSet?.has(itemId) === true;
+          const itemGitStatus = gitStatusMap?.statusById.get(itemId);
           const itemContainsGitChange =
             hasChildren &&
-            (gitStatusMap?.foldersWithChanges.has(item.getId()) ?? false);
-          const ancestors = getAncestors(item.getId());
+            (gitStatusMap?.foldersWithChanges.has(itemId) ?? false);
+          const ancestors = getAncestors(itemId);
 
           return (
             <TreeItem
-              key={item.getId()}
+              key={itemId}
               item={item}
               tree={tree}
-              itemId={item.getId()}
+              itemId={itemId}
               hasChildren={hasChildren}
               isExpanded={isExpanded}
               itemName={itemName}
@@ -697,23 +721,22 @@ export function Root({
 
         if (
           shouldVirtualize &&
-          items.length > 0 &&
-          items.length >= virtualizeThreshold
+          itemIds.length > 0 &&
+          itemIds.length >= virtualizeThreshold
         ) {
           const focusedIndex =
-            focusedItemId != null
-              ? items.findIndex((item) => item.getId() === focusedItemId)
-              : null;
+            focusedItemId != null ? itemIds.indexOf(focusedItemId) : null;
           return (
             <div data-file-tree-virtualized-scroll="true">
               <VirtualizedList
-                itemCount={items.length}
+                itemCount={itemIds.length}
                 renderItem={renderItemAtIndex}
                 scrollToIndex={
                   focusedIndex != null && focusedIndex >= 0
                     ? focusedIndex
                     : null
                 }
+                initialViewportHeight={initialViewportHeight}
               />
               {contextMenuTrigger}
             </div>
@@ -722,7 +745,7 @@ export function Root({
 
         return (
           <>
-            {items.map((_, i) => renderItemAtIndex(i))}
+            {itemIds.map((_, i) => renderItemAtIndex(i))}
             {contextMenuTrigger}
           </>
         );

--- a/packages/trees/src/components/TreeItem.tsx
+++ b/packages/trees/src/components/TreeItem.tsx
@@ -62,7 +62,7 @@ function FlattenedDirectoryName({
   renameInputProps,
 }: {
   tree: TreeInstance<FileTreeNode>;
-  idToPath: Map<string, string>;
+  idToPath: Pick<Map<string, string>, 'get' | 'has'>;
   flattens: string[];
   fallbackName: string;
   renameInputProps?: Record<string, unknown> | null;
@@ -145,7 +145,7 @@ export interface TreeItemProps {
   gitStatus: string | undefined;
   containsGitChange: boolean;
   flattens: string[] | undefined;
-  idToPath: Map<string, string>;
+  idToPath: Pick<Map<string, string>, 'get' | 'has'>;
   ancestors: string[];
   treeDomId: string;
   remapIcon: (name: SVGSpriteNames) => {

--- a/packages/trees/src/components/VirtualizedList.tsx
+++ b/packages/trees/src/components/VirtualizedList.tsx
@@ -12,6 +12,7 @@ export interface VirtualizedListProps {
   itemCount: number;
   renderItem: (index: number) => JSX.Element | null;
   scrollToIndex?: number | null;
+  initialViewportHeight?: number | null;
   /**
    * Optional explicit row height in px. If omitted, resolves from
    * --ft-internal-row-height (fallback 30).
@@ -237,6 +238,7 @@ export function VirtualizedList({
   itemCount,
   renderItem,
   scrollToIndex,
+  initialViewportHeight,
   itemHeight,
 }: VirtualizedListProps): JSX.Element {
   'use no memo';
@@ -244,11 +246,28 @@ export function VirtualizedList({
   const stickyOffsetRef = useRef<HTMLDivElement>(null);
   const stickyWindowRef = useRef<HTMLDivElement>(null);
   const viewportRef = useRef<HTMLElement | null>(null);
-  const [range, setRange] = useState<VirtualRange>(EMPTY_RANGE);
-  const [resolvedHeight, setResolvedHeight] = useState<number>(
-    itemHeight != null && itemHeight > 0 ? itemHeight : DEFAULT_ITEM_HEIGHT
+  const initialResolvedHeight =
+    itemHeight != null && itemHeight > 0 ? itemHeight : DEFAULT_ITEM_HEIGHT;
+  const hintedViewportHeight =
+    initialViewportHeight != null && initialViewportHeight > 0
+      ? initialViewportHeight
+      : 0;
+  const [range, setRange] = useState<VirtualRange>(() =>
+    hintedViewportHeight > 0
+      ? computeWindowRange({
+          scrollTop: 0,
+          viewportHeight: hintedViewportHeight,
+          offset: 0,
+          itemCount,
+          itemHeight: initialResolvedHeight,
+        })
+      : EMPTY_RANGE
   );
-  const [viewportHeight, setViewportHeight] = useState<number>(0);
+  const [resolvedHeight, setResolvedHeight] = useState<number>(
+    initialResolvedHeight
+  );
+  const [viewportHeight, setViewportHeight] =
+    useState<number>(hintedViewportHeight);
 
   // Find viewport and set up scroll/resize listeners
   useLayoutEffect(() => {

--- a/packages/trees/src/components/hooks/useContextMenuController.ts
+++ b/packages/trees/src/components/hooks/useContextMenuController.ts
@@ -25,7 +25,7 @@ export interface UseContextMenuControllerArgs {
   isContextMenuEnabled: boolean;
   callbacksRef?: { current: FileTreeCallbacks };
   files: string[];
-  idToPath: Map<string, string>;
+  idToPath: Pick<Map<string, string>, 'get' | 'has'>;
 }
 
 export interface UseContextMenuControllerResult {

--- a/packages/trees/src/components/hooks/useExpansionMigration.ts
+++ b/packages/trees/src/components/hooks/useExpansionMigration.ts
@@ -47,7 +47,7 @@ export interface UseExpansionMigrationArgs {
   tree: TreeInstance<FileTreeNode>;
   files: string[];
   pathToId: Map<string, string>;
-  idToPath: Map<string, string>;
+  idToPath: Pick<Map<string, string>, 'get' | 'has'>;
   flattenEmptyDirectories: boolean | undefined;
   pendingDropTargetExpandRef: { current: PendingDropTarget | null };
   pendingRenameExpandedRemapRef: {
@@ -83,7 +83,9 @@ export function useExpansionMigration({
   'use no memo';
   // Keep the previous idToPath so we can translate stale expanded IDs -> paths
   // when files change (DnD or controlled update).
-  const prevIdToPathRef = useRef<Map<string, string>>(idToPath);
+  const prevIdToPathRef = useRef<Pick<Map<string, string>, 'get' | 'has'>>(
+    idToPath
+  );
 
   // Detect stale expanded IDs when the file list changes. Flattened chains
   // may break or form, causing node IDs to change. We snapshot the expanded

--- a/packages/trees/src/components/hooks/useStateChangeCallbacks.ts
+++ b/packages/trees/src/components/hooks/useStateChangeCallbacks.ts
@@ -9,7 +9,7 @@ import { getSelectionPath } from '../../utils/getSelectionPath';
 export interface UseStateChangeCallbacksArgs {
   tree: TreeInstance<FileTreeNode>;
   callbacksRef: { current: FileTreeCallbacks } | undefined;
-  idToPath: Map<string, string>;
+  idToPath: Pick<Map<string, string>, 'get' | 'has'>;
   pathToId: Map<string, string>;
   flattenEmptyDirectories: boolean | undefined;
 }
@@ -60,7 +60,10 @@ export function useStateChangeCallbacks({
 
   // --- Expanded items change callback ---
   const expandedSnapshotRef = useRef<string | null>(null);
-  const expandedSnapshot = tree.getState().expandedItems?.join('|') ?? '';
+  const expandedSnapshot =
+    callbacksRef?.current.onExpandedItemsChange != null
+      ? (tree.getState().expandedItems?.join('|') ?? '')
+      : '';
 
   useEffect(() => {
     const onExpandedItemsChange = callbacksRef?.current.onExpandedItemsChange;
@@ -102,7 +105,10 @@ export function useStateChangeCallbacks({
 
   // --- Selected items change callback ---
   const selectedSnapshotRef = useRef<string | null>(null);
-  const selectedSnapshot = tree.getState().selectedItems?.join('|') ?? '';
+  const selectedSnapshot =
+    callbacksRef?.current.onSelectedItemsChange != null
+      ? (tree.getState().selectedItems?.join('|') ?? '')
+      : '';
 
   useEffect(() => {
     const onSelectedItemsChange = callbacksRef?.current.onSelectedItemsChange;

--- a/packages/trees/src/components/hooks/useTreeStateConfig.ts
+++ b/packages/trees/src/components/hooks/useTreeStateConfig.ts
@@ -7,134 +7,38 @@ import type { FileTreeNode } from '../../types';
 import { controlledExpandedPathsToExpandedIds } from '../../utils/controlledExpandedState';
 import { expandPathsWithAncestors } from '../../utils/expandPaths';
 
-type TreeStateConfig = {
-  expandedItems?: string[];
-  selectedItems?: string[];
-  focusedItem?: string | null;
-  renamingItem?: string | null;
-  checkedItems?: string[];
-  loadingCheckPropagationItems?: string[];
-  [key: string]: unknown;
-};
 type TreeConfigStateSlice = Pick<
   TreeConfig<FileTreeNode>,
   'initialState' | 'state'
 >;
 
 export interface UseTreeStateConfigArgs {
-  treeData: Record<string, FileTreeNode>;
   pathToId: Map<string, string>;
   stateConfig: FileTreeStateConfig | undefined;
   flattenEmptyDirectories: boolean | undefined;
 }
 
 /**
- * Assembles the tree's initial and controlled state by mapping external
- * path-based identifiers to the internal node IDs used by headless-tree.
- * Merges top-level initialExpandedItems/initialSelectedItems/initialSearchQuery
- * and controlled expandedItems/selectedItems from stateConfig.
+ * Maps the public path-based state config into the internal ID-based state that
+ * headless-tree expects. This hook only derives top-level expanded/selected
+ * state, so once those arrays are converted to IDs there is nothing left to
+ * remap.
  */
 export function useTreeStateConfig({
-  treeData,
   pathToId,
   stateConfig,
   flattenEmptyDirectories,
 }: UseTreeStateConfigArgs): TreeConfigStateSlice {
   'use no memo';
   return useMemo<TreeConfigStateSlice>(() => {
-    // Maps a single path-or-id reference to an internal tree node ID.
-    const mapId = (item: string): string => {
-      if (treeData[item] != null) {
-        return item;
-      }
-      return pathToId.get(item) ?? item;
-    };
-
-    // Maps an array of path-or-id references, returning the original array
-    // when nothing changed (for referential stability).
-    const mapIds = (items: string[] | undefined): string[] | undefined => {
-      if (items == null) {
-        return undefined;
-      }
-      let changed = false;
-      const mapped = items.map((item) => {
-        const mappedItem = mapId(item);
-        if (mappedItem !== item) {
-          changed = true;
-        }
-        return mappedItem;
-      });
-      return changed ? mapped : items;
-    };
-
-    // Maps all path-based state fields to their internal ID equivalents.
-    const mapState = (state: TreeStateConfig | undefined) => {
-      if (state == null) {
-        return { state, changed: false };
-      }
-      let changed = false;
-      const nextState: TreeStateConfig = { ...state };
-
-      const mappedExpanded = mapIds(state.expandedItems);
-      if (mappedExpanded !== state.expandedItems) {
-        nextState.expandedItems = mappedExpanded;
-        changed = true;
-      }
-
-      const mappedSelected = mapIds(state.selectedItems);
-      if (mappedSelected !== state.selectedItems) {
-        nextState.selectedItems = mappedSelected;
-        changed = true;
-      }
-
-      const mappedFocused =
-        state.focusedItem != null
-          ? mapId(state.focusedItem)
-          : state.focusedItem;
-      if (mappedFocused !== state.focusedItem) {
-        nextState.focusedItem = mappedFocused;
-        changed = true;
-      }
-
-      const mappedRenaming =
-        state.renamingItem != null
-          ? mapId(state.renamingItem)
-          : state.renamingItem;
-      if (mappedRenaming !== state.renamingItem) {
-        nextState.renamingItem = mappedRenaming;
-        changed = true;
-      }
-
-      const mappedChecked = mapIds(state.checkedItems);
-      if (mappedChecked !== state.checkedItems) {
-        nextState.checkedItems = mappedChecked;
-        changed = true;
-      }
-
-      const mappedLoadingChecked = mapIds(state.loadingCheckPropagationItems);
-      if (mappedLoadingChecked !== state.loadingCheckPropagationItems) {
-        nextState.loadingCheckPropagationItems = mappedLoadingChecked;
-        changed = true;
-      }
-
-      return { state: changed ? nextState : state, changed };
-    };
-
-    const baseConfig: TreeConfigStateSlice = {};
-
-    // Maps a file path to its rendered node ID, preferring flattened IDs
-    // when the tree is rendering flattened directories.
+    // Maps a file path to its rendered node ID, preferring flattened IDs when
+    // the tree is actually rendering flattened directories.
     const mapPathToId = (path: string): string | undefined => {
-      // If the caller explicitly passes a flattened path, respect it.
       if (path.startsWith(FLATTENED_PREFIX)) {
         return pathToId.get(path);
       }
 
       const shouldFlatten = flattenEmptyDirectories === true;
-
-      // Only prefer flattened IDs when the tree is actually rendering flattened
-      // directories. Otherwise, selecting a path that *could* be flattened would
-      // target a hidden node and the visible folder would not be marked selected.
       if (shouldFlatten) {
         return pathToId.get(FLATTENED_PREFIX + path) ?? pathToId.get(path);
       }
@@ -144,17 +48,22 @@ export function useTreeStateConfig({
     const mapPathsToIds = (
       paths: string[] | undefined
     ): string[] | undefined => {
-      if (paths == null) return undefined;
+      if (paths == null) {
+        return undefined;
+      }
+
       const ids = paths
         .map(mapPathToId)
         .filter((id): id is string => id != null);
       return ids.length > 0 ? ids : [];
     };
 
-    // Merge top-level initialExpandedItems/initialSelectedItems/initialSearchQuery into config.initialState
     const topLevelInitialExpanded = stateConfig?.initialExpandedItems;
     const topLevelInitialSelected = stateConfig?.initialSelectedItems;
     const topLevelInitialSearch = stateConfig?.initialSearchQuery;
+    const topLevelExpanded = stateConfig?.expandedItems;
+    const topLevelSelected = stateConfig?.selectedItems;
+
     const topLevelInitialExpandedIds =
       topLevelInitialExpanded != null
         ? expandPathsWithAncestors(topLevelInitialExpanded, pathToId, {
@@ -162,14 +71,24 @@ export function useTreeStateConfig({
           })
         : undefined;
     const topLevelInitialSelectedIds = mapPathsToIds(topLevelInitialSelected);
-    const hasTopLevelInitial =
+    const topLevelExpandedIds =
+      topLevelExpanded != null
+        ? controlledExpandedPathsToExpandedIds(topLevelExpanded, pathToId, {
+            flattenEmptyDirectories,
+          })
+        : undefined;
+    const topLevelSelectedIds = mapPathsToIds(topLevelSelected);
+
+    const hasInitialState =
       topLevelInitialExpanded != null ||
       topLevelInitialSelected != null ||
       topLevelInitialSearch != null;
+    const hasControlledState =
+      topLevelExpanded != null || topLevelSelected != null;
 
-    const mergedInitialState = hasTopLevelInitial
-      ? {
-          ...(baseConfig.initialState as TreeStateConfig | undefined),
+    return {
+      ...(hasInitialState && {
+        initialState: {
           ...(topLevelInitialExpandedIds != null && {
             expandedItems: topLevelInitialExpandedIds,
           }),
@@ -179,53 +98,18 @@ export function useTreeStateConfig({
           ...(topLevelInitialSearch != null && {
             search: topLevelInitialSearch,
           }),
-        }
-      : (baseConfig.initialState as TreeStateConfig | undefined);
-
-    // Merge top-level expandedItems/selectedItems into config.state
-    const topLevelExpanded = stateConfig?.expandedItems;
-    const topLevelSelected = stateConfig?.selectedItems;
-    const topLevelExpandedIds =
-      topLevelExpanded != null
-        ? controlledExpandedPathsToExpandedIds(topLevelExpanded, pathToId, {
-            flattenEmptyDirectories,
-          })
-        : undefined;
-    const topLevelSelectedIds = mapPathsToIds(topLevelSelected);
-    const hasTopLevelState =
-      topLevelExpanded != null || topLevelSelected != null;
-
-    const mergedState = hasTopLevelState
-      ? {
-          ...(baseConfig.state as TreeStateConfig | undefined),
+        },
+      }),
+      ...(hasControlledState && {
+        state: {
           ...(topLevelExpandedIds != null && {
             expandedItems: topLevelExpandedIds,
           }),
           ...(topLevelSelectedIds != null && {
             selectedItems: topLevelSelectedIds,
           }),
-        }
-      : (baseConfig.state as TreeStateConfig | undefined);
-
-    const configWithMergedState: TreeConfigStateSlice = {
-      ...baseConfig,
-      ...(mergedInitialState != null && { initialState: mergedInitialState }),
-      ...(mergedState != null && { state: mergedState }),
+        },
+      }),
     };
-
-    const initialState = mapState(
-      configWithMergedState.initialState as TreeStateConfig
-    );
-    const state = mapState(configWithMergedState.state as TreeStateConfig);
-
-    if (!initialState.changed && !state.changed) {
-      return configWithMergedState;
-    }
-
-    return {
-      ...configWithMergedState,
-      ...(initialState.state != null && { initialState: initialState.state }),
-      ...(state.state != null && { state: state.state }),
-    };
-  }, [treeData, pathToId, stateConfig, flattenEmptyDirectories]);
+  }, [pathToId, stateConfig, flattenEmptyDirectories]);
 }

--- a/packages/trees/src/core/create-tree.ts
+++ b/packages/trees/src/core/create-tree.ts
@@ -97,7 +97,8 @@ export const createTree = <T>(
 
   let rebuildScheduled = false;
   const itemInstancesMap: Record<string, ItemInstance<T>> = {};
-  let itemInstances: ItemInstance<T>[] = [];
+  let visibleItemIds: string[] = [];
+  let itemInstances: ItemInstance<T>[] | null = null;
   const itemElementsMap: Record<string, HTMLElement | undefined | null> = {};
   // oxlint-disable-next-line typescript-eslint/no-explicit-any
   const itemDataRefs: Record<string, { current: any }> = {};
@@ -105,17 +106,51 @@ export const createTree = <T>(
 
   const hotkeyPresets = {} as HotkeysConfig<T>;
 
-  const rebuildItemMeta = () => {
-    itemInstances = [];
-    itemMetaMap = {};
+  // Builds and caches a single item instance the first time a caller actually
+  // needs it. This lets virtualized renders size/slice the visible tree using
+  // IDs alone instead of eagerly materializing every visible item instance.
+  const getOrCreateItemInstance = (itemId: string): ItemInstance<T> => {
+    const existingInstance = itemInstancesMap[itemId];
+    if (existingInstance != null) {
+      return existingInstance;
+    }
 
+    const [instance, finalizeInstance] = buildInstance(
+      features,
+      'itemInstance',
+      (builtItem) => ({
+        item: builtItem,
+        tree: treeInstance,
+        itemId,
+      })
+    );
+    finalizeInstance();
+    itemInstancesMap[itemId] = instance;
+    return instance;
+  };
+
+  // Rebuilds the synthetic root item instance on every tree rebuild so core's
+  // existing instanceBuilder contract stays intact even when visible items are
+  // materialized lazily.
+  const rebuildRootItemInstance = (): void => {
     const [rootInstance, finalizeRootInstance] = buildInstance(
       features,
       'itemInstance',
-      (item) => ({ item, tree: treeInstance, itemId: config.rootItemId })
+      (builtItem) => ({
+        item: builtItem,
+        tree: treeInstance,
+        itemId: config.rootItemId,
+      })
     );
     finalizeRootInstance();
     itemInstancesMap[config.rootItemId] = rootInstance;
+  };
+
+  const rebuildItemMeta = () => {
+    itemInstances = null;
+    itemMetaMap = {};
+
+    rebuildRootItemInstance();
     itemMetaMap[config.rootItemId] = {
       itemId: config.rootItemId,
       index: -1,
@@ -125,26 +160,14 @@ export const createTree = <T>(
       setSize: 1,
     };
 
+    const nextVisibleItemIds: string[] = [];
     for (const item of treeInstance.getItemsMeta()) {
       itemMetaMap[item.itemId] = item;
-      if (itemInstancesMap[item.itemId] == null) {
-        const [instance, finalizeInstance] = buildInstance(
-          features,
-          'itemInstance',
-          (instance) => ({
-            item: instance,
-            tree: treeInstance,
-            itemId: item.itemId,
-          })
-        );
-        finalizeInstance();
-        itemInstancesMap[item.itemId] = instance;
-        itemInstances.push(instance);
-      } else {
-        itemInstances.push(itemInstancesMap[item.itemId]);
-      }
+      nextVisibleItemIds.push(item.itemId);
     }
 
+    visibleItemIds = nextVisibleItemIds;
+    (treeDataRef.current as TreeDataRef).visibleItemIds = visibleItemIds;
     rebuildScheduled = false;
   };
 
@@ -227,25 +250,12 @@ export const createTree = <T>(
           config.setState?.(state);
         }
       },
-      getItemInstance: (_opts, itemId) => {
-        const existingInstance = itemInstancesMap[itemId];
-        if (existingInstance == null) {
-          const [instance, finalizeInstance] = buildInstance(
-            features,
-            'itemInstance',
-            (instance) => ({
-              item: instance,
-              tree: treeInstance,
-              itemId,
-            })
-          );
-          finalizeInstance();
-          return instance;
-        }
-        return existingInstance;
-      },
+      getItemInstance: (_opts, itemId) => getOrCreateItemInstance(itemId),
       getItems: () => {
         if (rebuildScheduled) rebuildItemMeta();
+        itemInstances ??= visibleItemIds.map((itemId) =>
+          getOrCreateItemInstance(itemId)
+        );
         return itemInstances;
       },
       registerElement: (_opts, element) => {

--- a/packages/trees/src/features/main/types.ts
+++ b/packages/trees/src/features/main/types.ts
@@ -13,6 +13,12 @@ import type { ItemMeta } from '../tree/types';
 export interface TreeDataRef {
   isMounted?: boolean;
   waitingForMount?: (() => void)[];
+  /**
+   * Cached visible item IDs from the latest rebuild. Virtualized renderers can
+   * use this to size and slice the visible tree without materializing every
+   * item instance up front.
+   */
+  visibleItemIds?: string[];
 }
 
 export type InstanceTypeMap = {

--- a/packages/trees/src/utils/expandPaths.ts
+++ b/packages/trees/src/utils/expandPaths.ts
@@ -131,6 +131,56 @@ export interface ExpandPathsOptions {
   cache?: Map<string, string[]>;
 }
 
+// Resolves each ancestor segment in a path using a shared cache so expanding a
+// large folder set does not repeatedly rebuild the same prefix strings.
+function resolveAncestorIdsForPath(
+  path: string,
+  pathToId: Map<string, string>,
+  flatten: boolean,
+  ancestorIdCache: Map<string, string | null>
+): string[] {
+  const resolvedIds: string[] = [];
+  let segmentStart = 0;
+
+  while (true) {
+    const slashIndex = path.indexOf('/', segmentStart);
+    const endIndex = slashIndex === -1 ? path.length : slashIndex;
+    const ancestor = path.slice(0, endIndex);
+
+    if (ancestor.length > 0) {
+      if (ancestorIdCache.has(ancestor)) {
+        const cachedId = ancestorIdCache.get(ancestor);
+        if (cachedId != null) {
+          resolvedIds.push(cachedId);
+        }
+      } else {
+        let resolvedId: string | null;
+        if (flatten) {
+          // Prefer the flattened (f::) ID when it exists — that's the actual
+          // item headless-tree renders. Adding both the regular AND flattened
+          // IDs causes controlled-state round-trips to re-add IDs that the
+          // tree's built-in collapse removed.
+          resolvedId =
+            pathToId.get('f::' + ancestor) ?? pathToId.get(ancestor) ?? null;
+        } else {
+          // Without flattening, only use regular IDs — f:: nodes are not
+          // rendered and would create an ID mismatch in headless-tree.
+          resolvedId = pathToId.get(ancestor) ?? null;
+        }
+        ancestorIdCache.set(ancestor, resolvedId);
+        if (resolvedId != null) {
+          resolvedIds.push(resolvedId);
+        }
+      }
+    }
+
+    if (slashIndex === -1) {
+      return resolvedIds;
+    }
+    segmentStart = slashIndex + 1;
+  }
+}
+
 /**
  * Given a list of file/folder paths, returns the IDs of all those paths
  * plus every ancestor directory. This handles both regular and flattened
@@ -144,36 +194,18 @@ export function expandPathsWithAncestors(
   const cache = options?.cache;
   const flatten = options?.flattenEmptyDirectories !== false;
   const ids = new Set<string>();
+  const ancestorIdCache = new Map<string, string | null>();
+
   for (const path of paths) {
     let expanded = cache?.get(path);
     if (expanded == null) {
-      const parts = path.split('/');
-      const next: string[] = [];
-      for (let i = 1; i <= parts.length; i++) {
-        const ancestor = parts.slice(0, i).join('/');
-        if (flatten) {
-          // Prefer the flattened (f::) ID when it exists — that's the actual
-          // item headless-tree renders. Adding both the regular AND flattened
-          // IDs causes controlled-state round-trips to re-add IDs that the
-          // tree's built-in collapse removed.
-          const flatId = pathToId.get('f::' + ancestor);
-          if (flatId != null) {
-            next.push(flatId);
-          } else {
-            const id = pathToId.get(ancestor);
-            if (id != null) next.push(id);
-          }
-        } else {
-          // Without flattening, only use regular IDs — f:: nodes are not
-          // rendered and would create an ID mismatch in headless-tree.
-          const id = pathToId.get(ancestor);
-          if (id != null) next.push(id);
-        }
-      }
-      expanded = next;
-      if (cache != null) {
-        cache.set(path, expanded);
-      }
+      expanded = resolveAncestorIdsForPath(
+        path,
+        pathToId,
+        flatten,
+        ancestorIdCache
+      );
+      cache?.set(path, expanded);
     }
 
     for (const id of expanded) {

--- a/packages/trees/src/utils/fileListToTree.ts
+++ b/packages/trees/src/utils/fileListToTree.ts
@@ -278,7 +278,9 @@ function createStageContext(
     children: string[],
     parentPathLength?: number
   ): string[] =>
-    sortChildren(children, isFolder, sortComparator, parentPathLength);
+    sortComparator === false
+      ? children
+      : sortChildren(children, isFolder, sortComparator, parentPathLength);
   const childrenArrayCache = new Map<string, string[]>();
   const getChildrenArray = (path: string): string[] => {
     const cached = childrenArrayCache.get(path);

--- a/packages/trees/test/virtualized-client-render-benchmark.test.ts
+++ b/packages/trees/test/virtualized-client-render-benchmark.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'bun:test';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = fileURLToPath(new URL('../', import.meta.url));
+const textDecoder = new TextDecoder();
+
+function runClientRenderBenchmark(args: string[]) {
+  const result = Bun.spawnSync({
+    cmd: [
+      'bun',
+      'run',
+      './scripts/benchmarkVirtualizedFileTreeClientMount.ts',
+      ...args,
+    ],
+    cwd: packageRoot,
+    env: {
+      ...process.env,
+      AGENT: '1',
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  return {
+    result,
+    stdout: textDecoder.decode(result.stdout).trim(),
+    stderr: textDecoder.decode(result.stderr).trim(),
+  };
+}
+
+describe('virtualized client render benchmark CLI', () => {
+  test('emits JSON for a tiny-flat smoke run', () => {
+    const { result, stdout, stderr } = runClientRenderBenchmark([
+      '--case=tiny-flat',
+      '--runs=1',
+      '--warmup-runs=0',
+      '--json',
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(stderr).toBe('');
+
+    const payload = JSON.parse(stdout) as {
+      benchmark: string;
+      runtime: {
+        codePath: string;
+        nodeEnv: string;
+        renderer: string;
+        mountHarness: string;
+        buildCommand: string;
+      };
+      config: {
+        runs: number;
+        warmupRuns: number;
+        caseFilters: string[];
+        viewportHeight: number;
+      };
+      cases: Array<{
+        name: string;
+        fileCount: number;
+        renderedItemCount: number;
+        shadowHtmlChecksum: number;
+      }>;
+    };
+
+    expect(payload.benchmark).toBe('virtualizedFileTreeClientMount');
+    expect(payload.runtime).toMatchObject({
+      codePath: 'dist',
+      nodeEnv: 'production',
+      renderer: 'preact-dom',
+      mountHarness: 'jsdom-fresh-filetree-render',
+      buildCommand: 'bun run build',
+    });
+    expect(payload.config.runs).toBe(1);
+    expect(payload.config.warmupRuns).toBe(0);
+    expect(payload.config.caseFilters).toEqual(['tiny-flat']);
+    expect(payload.config.viewportHeight).toBe(500);
+    expect(payload.cases).toHaveLength(1);
+    expect(payload.cases[0]).toMatchObject({
+      name: 'tiny-flat',
+      fileCount: 128,
+    });
+    expect(payload.cases[0]?.renderedItemCount).toBeGreaterThan(0);
+    expect(payload.cases[0]?.shadowHtmlChecksum).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
   ## Summary

   Speed up large `@pierre/trees` fresh mounts and add benchmark coverage for the real client-side mount path.

   This PR adds production-style render benchmarks for large virtualized trees and removes several full-tree costs from the initial mount path. The main result is a substantial
 reduction in fresh client mount time for the large Linux fixture.

   ## Benchmark results

   Primary benchmark:
   - `client_mount_ms`: `73.9ms -> 58.3ms` (`-21.0%`)

   Related render-path benchmark:
   - `construct_and_render_ms`: `120.3ms -> 58.2ms` (`-51.6%`)

   These results were kept only after passing the trees checks and output guard metrics.

   ## What changed

   ### Benchmarking
   - Add a jsdom-based client-mount benchmark for `FileTree.render(...)`
   - Keep the SSR-oriented render benchmark as a secondary diagnostic benchmark
   - Add smoke tests for the benchmark CLIs
   - Wire the client benchmark into the package scripts and repo autoresearch harness

   ### Fresh-mount performance
   - Cache visible item IDs in core and let the virtualized render path consume IDs directly instead of forcing full visible-item materialization
   - Preserve rebuild-time root instance creation so existing core `instanceBuilder` expectations still hold
   - Remove a redundant state remap pass in `useTreeStateConfig`
   - Rework expanded-path ancestor expansion to reuse ancestor lookups instead of rebuilding prefixes repeatedly
   - Build Root lookup maps with a direct scan instead of allocating a full `Object.entries()` array
   - Stop rebuilding a full `idToPath` `Map` during mount; serve `id -> path` reads directly from `treeData`
   - Skip large expanded/selected snapshot joins when the corresponding external callbacks are absent
   - Reuse already-materialized child arrays in the `sort:false` `fileListToTree` path
   - Seed the initial virtualized window from the mount container height so the first client render can paint the initial rows immediately

   ## Why this matters

   The previous SSR benchmark was useful for isolated render-path work, but it missed too much of the real docs-page mount behavior. This PR adds a benchmark that measures the
 actual fresh client mount path and then optimizes the work that still happened before virtualization could limit rendering to the visible rows.

   ## Validation

   Passed during autoresearch checks:
   - `bun ws trees tsc`
   - `bun ws trees test`

   Additional benchmark smoke coverage:
   - client benchmark CLI test
   - virtualized render benchmark CLI test