### PR TITLE
Fix dot placement in previous file name

### DIFF
--- a/packages/diffs/src/utils/createFileHeaderElement.ts
+++ b/packages/diffs/src/utils/createFileHeaderElement.ts
@@ -78,7 +78,12 @@ function createHeaderElement({
     children.push(
       createHastElement({
         tagName: 'div',
-        children: [createTextNodeElement(prevName)],
+        children: [
+          createHastElement({
+            tagName: 'bdi',
+            children: [createTextNodeElement(prevName)],
+          }),
+        ],
         properties: {
           'data-prev-name': '',
         },

--- a/packages/diffs/test/__snapshots__/createFileHeaderElement.test.ts.snap
+++ b/packages/diffs/test/__snapshots__/createFileHeaderElement.test.ts.snap
@@ -107,3 +107,130 @@ exports[`createFileHeaderElement renders custom file header AST 1`] = `
   "type": "element",
 }
 `;
+
+exports[`createFileHeaderElement renders default renamed file header AST 1`] = `
+{
+  "children": [
+    {
+      "children": [
+        {
+          "children": [],
+          "properties": {
+            "name": "header-prefix",
+          },
+          "tagName": "slot",
+          "type": "element",
+        },
+        {
+          "children": [
+            {
+              "children": [],
+              "properties": {
+                "href": "#diffs-icon-file-code",
+              },
+              "tagName": "use",
+              "type": "element",
+            },
+          ],
+          "properties": {
+            "data-change-icon": "file",
+            "height": 16,
+            "viewBox": "0 0 16 16",
+            "width": 16,
+          },
+          "tagName": "svg",
+          "type": "element",
+        },
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "src/old-index.ts",
+                },
+              ],
+              "properties": {},
+              "tagName": "bdi",
+              "type": "element",
+            },
+          ],
+          "properties": {
+            "data-prev-name": "",
+          },
+          "tagName": "div",
+          "type": "element",
+        },
+        {
+          "children": [
+            {
+              "children": [],
+              "properties": {
+                "href": "#diffs-icon-arrow-right-short",
+              },
+              "tagName": "use",
+              "type": "element",
+            },
+          ],
+          "properties": {
+            "data-rename-icon": "",
+            "height": 16,
+            "viewBox": "0 0 16 16",
+            "width": 16,
+          },
+          "tagName": "svg",
+          "type": "element",
+        },
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "src/index.ts",
+                },
+              ],
+              "properties": {},
+              "tagName": "bdi",
+              "type": "element",
+            },
+          ],
+          "properties": {
+            "data-title": "",
+          },
+          "tagName": "div",
+          "type": "element",
+        },
+      ],
+      "properties": {
+        "data-header-content": "",
+      },
+      "tagName": "div",
+      "type": "element",
+    },
+    {
+      "children": [
+        {
+          "children": [],
+          "properties": {
+            "name": "header-metadata",
+          },
+          "tagName": "slot",
+          "type": "element",
+        },
+      ],
+      "properties": {
+        "data-metadata": "",
+      },
+      "tagName": "div",
+      "type": "element",
+    },
+  ],
+  "properties": {
+    "data-change-type": undefined,
+    "data-diffs-header": "default",
+  },
+  "tagName": "div",
+  "type": "element",
+}
+`;

--- a/packages/diffs/test/createFileHeaderElement.test.ts
+++ b/packages/diffs/test/createFileHeaderElement.test.ts
@@ -15,6 +15,19 @@ describe('createFileHeaderElement', () => {
     expect(header).toMatchSnapshot();
   });
 
+  test('renders default renamed file header AST', () => {
+    const header = createFileHeaderElement({
+      fileOrDiff: {
+        name: 'src/index.ts',
+        prevName: 'src/old-index.ts',
+        contents: 'export {}\n',
+      },
+      mode: 'default',
+    });
+
+    expect(header).toMatchSnapshot();
+  });
+
   test('renders custom file header AST', () => {
     const header = createFileHeaderElement({
       fileOrDiff: {


### PR DESCRIPTION
In #434 I missed that the same problem applies to previous file name, this PR applies the same fix. After the change, no tests failed, so I added a new one to cover it.

<img width="271" height="68" alt="image" src="https://github.com/user-attachments/assets/22761b73-38e7-49de-9fb3-c5f7e6a9ca83" />