### PR TITLE
[exploratory][trees] Hack in a new Tree Structure, or "oh god, every file"

### DIFF
--- a/apps/docs/app/trees-dev/_components/ReactClientRendered.tsx
+++ b/apps/docs/app/trees-dev/_components/ReactClientRendered.tsx
@@ -1,7 +1,12 @@
 'use client';
 
-import type { FileTreeOptions, FileTreeStateConfig } from '@pierre/trees';
+import type { FileTreeStateConfig } from '@pierre/trees';
 import { FileTree as FileTreeReact } from '@pierre/trees/react';
+
+import {
+  toRuntimeFileTreeOptions,
+  type TreesDevFileTreeOptions,
+} from '../demo-data';
 
 /**
  * React FileTree - Client-Side Rendered
@@ -12,14 +17,20 @@ export function ReactClientRendered({
   initialFiles,
   stateConfig,
 }: {
-  options: Omit<FileTreeOptions, 'initialFiles'>;
+  options: Omit<TreesDevFileTreeOptions, 'initialFiles'>;
   initialFiles?: string[];
   stateConfig?: FileTreeStateConfig;
 }) {
+  const runtimeOptions = toRuntimeFileTreeOptions({
+    ...options,
+    initialFiles: initialFiles ?? [],
+  });
+  const { model, ...reactOptions } = runtimeOptions;
+
   return (
     <FileTreeReact
-      options={options}
-      initialFiles={initialFiles}
+      model={model}
+      options={reactOptions}
       initialExpandedItems={stateConfig?.initialExpandedItems}
       initialSelectedItems={stateConfig?.initialSelectedItems}
       onSelection={stateConfig?.onSelection}

--- a/apps/docs/app/trees-dev/_components/ReactServerRendered.tsx
+++ b/apps/docs/app/trees-dev/_components/ReactServerRendered.tsx
@@ -1,7 +1,12 @@
 'use client';
 
-import type { FileTreeOptions, FileTreeStateConfig } from '@pierre/trees';
+import type { FileTreeStateConfig } from '@pierre/trees';
 import { FileTree as FileTreeReact } from '@pierre/trees/react';
+
+import {
+  toRuntimeFileTreeOptions,
+  type TreesDevFileTreeOptions,
+} from '../demo-data';
 
 /**
  * React FileTree - Server-Side Rendered
@@ -13,15 +18,21 @@ export function ReactServerRendered({
   stateConfig,
   prerenderedHTML,
 }: {
-  options: Omit<FileTreeOptions, 'initialFiles'>;
+  options: Omit<TreesDevFileTreeOptions, 'initialFiles'>;
   initialFiles?: string[];
   stateConfig?: FileTreeStateConfig;
   prerenderedHTML: string;
 }) {
+  const runtimeOptions = toRuntimeFileTreeOptions({
+    ...options,
+    initialFiles: initialFiles ?? [],
+  });
+  const { model, ...reactOptions } = runtimeOptions;
+
   return (
     <FileTreeReact
-      options={options}
-      initialFiles={initialFiles}
+      model={model}
+      options={reactOptions}
       prerenderedHTML={prerenderedHTML}
       initialExpandedItems={stateConfig?.initialExpandedItems}
       initialSelectedItems={stateConfig?.initialSelectedItems}

--- a/apps/docs/app/trees-dev/_components/TreesDevSettingsProvider.tsx
+++ b/apps/docs/app/trees-dev/_components/TreesDevSettingsProvider.tsx
@@ -18,7 +18,11 @@ import {
   FILE_TREE_COOKIE_VERSION,
   FILE_TREE_COOKIE_VERSION_NAME,
 } from '../cookies';
-import { sharedDemoFileTreeOptions } from '../demo-data';
+import {
+  sharedDemoFileTreeOptions,
+  toRuntimeFileTreeOptions,
+  type TreesDevFileTreeOptions,
+} from '../demo-data';
 
 interface TreesDevSettingsContextValue {
   flattenEmptyDirectories: boolean;
@@ -26,8 +30,8 @@ interface TreesDevSettingsContextValue {
   setFlattenEmptyDirectories: (val: boolean) => void;
   setUseLazyDataLoader: (val: boolean) => void;
   handleResetControls: () => void;
-  fileTreeOptions: FileTreeOptions;
-  reactOptions: Omit<FileTreeOptions, 'initialFiles'>;
+  fileTreeOptions: TreesDevFileTreeOptions;
+  reactOptions: Omit<FileTreeOptions, 'model'>;
   reactFiles: string[] | undefined;
 }
 
@@ -102,7 +106,7 @@ export function TreesDevSettingsProvider({
     }${cookieSuffix}`;
   }, [cookieMaxAge, flattenEmptyDirectories, useLazyDataLoader]);
 
-  const fileTreeOptions = useMemo<FileTreeOptions>(
+  const fileTreeOptions = useMemo<TreesDevFileTreeOptions>(
     () => ({
       ...sharedDemoFileTreeOptions,
       flattenEmptyDirectories,
@@ -111,7 +115,9 @@ export function TreesDevSettingsProvider({
     [flattenEmptyDirectories, useLazyDataLoader]
   );
 
-  const { initialFiles: reactFiles, ...reactOptions } = fileTreeOptions;
+  const reactFiles = fileTreeOptions.initialFiles;
+  const runtimeReactOptions = toRuntimeFileTreeOptions(fileTreeOptions);
+  const { model: _reactModel, ...reactOptions } = runtimeReactOptions;
 
   const value = useMemo<TreesDevSettingsContextValue>(
     () => ({

--- a/apps/docs/app/trees-dev/_components/VanillaClientRendered.tsx
+++ b/apps/docs/app/trees-dev/_components/VanillaClientRendered.tsx
@@ -1,8 +1,13 @@
 'use client';
 
 import { FileTree } from '@pierre/trees';
-import type { FileTreeOptions, FileTreeStateConfig } from '@pierre/trees';
+import type { FileTreeStateConfig } from '@pierre/trees';
 import { useCallback, useRef } from 'react';
+
+import {
+  toRuntimeFileTreeOptions,
+  type TreesDevFileTreeOptions,
+} from '../demo-data';
 
 /**
  * Vanilla FileTree - Client-Side Rendered
@@ -12,7 +17,7 @@ export function VanillaClientRendered({
   options,
   stateConfig,
 }: {
-  options: FileTreeOptions;
+  options: TreesDevFileTreeOptions;
   stateConfig?: FileTreeStateConfig;
 }) {
   const instanceRef = useRef<FileTree | null>(null);
@@ -29,7 +34,10 @@ export function VanillaClientRendered({
         node.innerHTML = '';
       }
 
-      const fileTree = new FileTree(options, stateConfig);
+      const fileTree = new FileTree(
+        toRuntimeFileTreeOptions(options),
+        stateConfig
+      );
       fileTree.render({ containerWrapper: node });
       instanceRef.current = fileTree;
 

--- a/apps/docs/app/trees-dev/_components/VanillaServerRendered.tsx
+++ b/apps/docs/app/trees-dev/_components/VanillaServerRendered.tsx
@@ -1,9 +1,14 @@
 'use client';
 
 import { FileTree } from '@pierre/trees';
-import type { FileTreeOptions, FileTreeStateConfig } from '@pierre/trees';
+import type { FileTreeStateConfig } from '@pierre/trees';
 import '@pierre/trees/web-components';
 import { useCallback, useRef } from 'react';
+
+import {
+  toRuntimeFileTreeOptions,
+  type TreesDevFileTreeOptions,
+} from '../demo-data';
 
 /**
  * Vanilla FileTree - Server-Side Rendered
@@ -16,7 +21,7 @@ export function VanillaServerRendered({
   stateConfig,
   containerHtml,
 }: {
-  options: FileTreeOptions;
+  options: TreesDevFileTreeOptions;
   stateConfig?: FileTreeStateConfig;
   containerHtml: string;
 }) {
@@ -46,7 +51,10 @@ export function VanillaServerRendered({
         }
       }
 
-      const fileTree = new FileTree(options, stateConfig);
+      const fileTree = new FileTree(
+        toRuntimeFileTreeOptions(options),
+        stateConfig
+      );
 
       if (!hasHydratedRef.current) {
         // Initial mount - hydrate the prerendered HTML

--- a/apps/docs/app/trees-dev/context-menu/ContextMenuDemoClient.tsx
+++ b/apps/docs/app/trees-dev/context-menu/ContextMenuDemoClient.tsx
@@ -117,10 +117,11 @@ function VanillaSSRContextMenu({
         }),
         {
           ...stateConfig,
-          onFilesChange: (nextFiles) => {
+          onFilesChange: (changeSet, context) => {
+            const nextFiles = context.getFiles();
             filesRef.current = nextFiles;
             setFiles(nextFiles);
-            stateConfig?.onFilesChange?.(nextFiles);
+            stateConfig?.onFilesChange?.(changeSet, context);
           },
           onContextMenuOpen: (item, context) => {
             renderVanillaContextMenuSlot({
@@ -198,11 +199,21 @@ function ReactSSRContextMenu({
   );
   const { model, ...reactTreeOptions } = runtimeOptions;
 
+  const handleFilesChange = useCallback(
+    (
+      _changeSet: import('@pierre/trees').FileTreeChangeSet,
+      context: import('@pierre/trees').FileTreeChangeContext
+    ) => {
+      setFiles(context.getFiles());
+    },
+    []
+  );
+
   return (
     <FileTreeReact
       model={model}
       options={reactTreeOptions}
-      onFilesChange={setFiles}
+      onFilesChange={handleFilesChange}
       prerenderedHTML={prerenderedHTML}
       initialExpandedItems={stateConfig?.initialExpandedItems}
       onSelection={stateConfig?.onSelection}

--- a/apps/docs/app/trees-dev/context-menu/ContextMenuDemoClient.tsx
+++ b/apps/docs/app/trees-dev/context-menu/ContextMenuDemoClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { CONTEXT_MENU_SLOT_NAME, FileTree } from '@pierre/trees';
-import type { FileTreeOptions, FileTreeStateConfig } from '@pierre/trees';
+import type { FileTreeStateConfig } from '@pierre/trees';
 import { FileTree as FileTreeReact } from '@pierre/trees/react';
 import '@pierre/trees/web-components';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -16,7 +16,11 @@ import {
   TreeDemoContextMenu,
 } from '../_components/TreeDemoContextMenu';
 import { useTreesDevSettings } from '../_components/TreesDevSettingsProvider';
-import { sharedDemoStateConfig } from '../demo-data';
+import {
+  sharedDemoStateConfig,
+  toRuntimeFileTreeOptions,
+  type TreesDevFileTreeOptions,
+} from '../demo-data';
 
 interface ContextMenuDemoClientProps {
   preloadedContextMenuFileTreeHtml: string;
@@ -64,7 +68,7 @@ function VanillaSSRContextMenu({
   stateConfig,
   containerHtml,
 }: {
-  options: FileTreeOptions;
+  options: TreesDevFileTreeOptions;
   stateConfig?: FileTreeStateConfig;
   containerHtml: string;
 }) {
@@ -106,11 +110,11 @@ function VanillaSSRContextMenu({
       };
 
       const fileTree = new FileTree(
-        {
+        toRuntimeFileTreeOptions({
           ...options,
           initialFiles: filesRef.current,
           renaming: renamingOptions,
-        },
+        }),
         {
           ...stateConfig,
           onFilesChange: (nextFiles) => {
@@ -172,7 +176,7 @@ function ReactSSRContextMenu({
   stateConfig,
   prerenderedHTML,
 }: {
-  options: Omit<FileTreeOptions, 'initialFiles'>;
+  options: Omit<TreesDevFileTreeOptions, 'initialFiles'>;
   initialFiles?: string[];
   stateConfig?: FileTreeStateConfig;
   prerenderedHTML: string;
@@ -183,10 +187,21 @@ function ReactSSRContextMenu({
     []
   );
 
+  const runtimeOptions = useMemo(
+    () =>
+      toRuntimeFileTreeOptions({
+        ...options,
+        initialFiles: files,
+        renaming: renamingOptions,
+      }),
+    [files, options, renamingOptions]
+  );
+  const { model, ...reactTreeOptions } = runtimeOptions;
+
   return (
     <FileTreeReact
-      options={{ ...options, renaming: renamingOptions }}
-      files={files}
+      model={model}
+      options={reactTreeOptions}
       onFilesChange={setFiles}
       prerenderedHTML={prerenderedHTML}
       initialExpandedItems={stateConfig?.initialExpandedItems}

--- a/apps/docs/app/trees-dev/context-menu/page.tsx
+++ b/apps/docs/app/trees-dev/context-menu/page.tsx
@@ -1,7 +1,11 @@
 import { preloadFileTree } from '@pierre/trees/ssr';
 
 import { readSettingsCookies } from '../_components/readSettingsCookies';
-import { sharedDemoFileTreeOptions, sharedDemoStateConfig } from '../demo-data';
+import {
+  sharedDemoFileTreeOptions,
+  sharedDemoStateConfig,
+  toRuntimeFileTreeOptions,
+} from '../demo-data';
 import { ContextMenuDemoClient } from './ContextMenuDemoClient';
 
 export default async function ContextMenuPage() {
@@ -14,11 +18,14 @@ export default async function ContextMenuPage() {
   };
 
   const noop = () => {};
-  const contextMenuSsr = preloadFileTree(fileTreeOptions, {
-    ...sharedDemoStateConfig,
-    onContextMenuOpen: noop,
-    onContextMenuClose: noop,
-  });
+  const contextMenuSsr = preloadFileTree(
+    toRuntimeFileTreeOptions(fileTreeOptions),
+    {
+      ...sharedDemoStateConfig,
+      onContextMenuOpen: noop,
+      onContextMenuClose: noop,
+    }
+  );
 
   return (
     <ContextMenuDemoClient

--- a/apps/docs/app/trees-dev/custom-icons/CustomIconsDemoClient.tsx
+++ b/apps/docs/app/trees-dev/custom-icons/CustomIconsDemoClient.tsx
@@ -1,13 +1,18 @@
 'use client';
 
 import { FileTree } from '@pierre/trees';
-import type { FileTreeOptions, FileTreeStateConfig } from '@pierre/trees';
+import type { FileTreeStateConfig } from '@pierre/trees';
 import { FileTree as FileTreeReact } from '@pierre/trees/react';
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import { ExampleCard } from '../_components/ExampleCard';
 import { useTreesDevSettings } from '../_components/TreesDevSettingsProvider';
-import { customSpriteSheet, sharedDemoStateConfig } from '../demo-data';
+import {
+  customSpriteSheet,
+  sharedDemoStateConfig,
+  toRuntimeFileTreeOptions,
+  type TreesDevFileTreeOptions,
+} from '../demo-data';
 
 const CUSTOM_ICONS_REMAP = {
   'file-tree-icon-file': 'custom-hamburger-icon',
@@ -62,7 +67,7 @@ function VanillaCustomIcons({
   options,
   stateConfig,
 }: {
-  options: FileTreeOptions;
+  options: TreesDevFileTreeOptions;
   stateConfig?: FileTreeStateConfig;
 }) {
   const ref = useCallback(
@@ -70,10 +75,10 @@ function VanillaCustomIcons({
       if (node == null) return;
       node.innerHTML = '';
       const fileTree = new FileTree(
-        {
+        toRuntimeFileTreeOptions({
           ...options,
           icons: { spriteSheet: customSpriteSheet, remap: CUSTOM_ICONS_REMAP },
-        },
+        }),
         stateConfig
       );
       fileTree.render({ containerWrapper: node });
@@ -99,21 +104,29 @@ function ReactCustomIcons({
   initialFiles,
   stateConfig,
 }: {
-  options: Omit<FileTreeOptions, 'initialFiles'>;
+  options: Omit<TreesDevFileTreeOptions, 'initialFiles'>;
   initialFiles?: string[];
   stateConfig?: FileTreeStateConfig;
 }) {
+  const runtimeOptions = useMemo(
+    () =>
+      toRuntimeFileTreeOptions({
+        ...options,
+        initialFiles: initialFiles ?? [],
+        icons: { spriteSheet: customSpriteSheet, remap: CUSTOM_ICONS_REMAP },
+      }),
+    [initialFiles, options]
+  );
+  const { model, ...reactTreeOptions } = runtimeOptions;
+
   return (
     <ExampleCard
       title="React — Custom Icons"
       description="React CSR tree with a custom spritesheet replacing the file icon with a custom file icon"
     >
       <FileTreeReact
-        options={{
-          ...options,
-          icons: { spriteSheet: customSpriteSheet, remap: CUSTOM_ICONS_REMAP },
-        }}
-        initialFiles={initialFiles}
+        model={model}
+        options={reactTreeOptions}
         initialExpandedItems={stateConfig?.initialExpandedItems}
         onSelection={stateConfig?.onSelection}
       />
@@ -127,22 +140,30 @@ function ReactSSRCustomIcons({
   stateConfig,
   prerenderedHTML,
 }: {
-  options: Omit<FileTreeOptions, 'initialFiles'>;
+  options: Omit<TreesDevFileTreeOptions, 'initialFiles'>;
   initialFiles?: string[];
   stateConfig?: FileTreeStateConfig;
   prerenderedHTML: string;
 }) {
+  const runtimeOptions = useMemo(
+    () =>
+      toRuntimeFileTreeOptions({
+        ...options,
+        initialFiles: initialFiles ?? [],
+        icons: { spriteSheet: customSpriteSheet, remap: CUSTOM_ICONS_REMAP },
+      }),
+    [initialFiles, options]
+  );
+  const { model, ...reactTreeOptions } = runtimeOptions;
+
   return (
     <ExampleCard
       title="React (SSR) — Custom Icons"
       description="SSR-hydrated React tree with a custom spritesheet replacing the chevron with a folder icon"
     >
       <FileTreeReact
-        options={{
-          ...options,
-          icons: { spriteSheet: customSpriteSheet, remap: CUSTOM_ICONS_REMAP },
-        }}
-        initialFiles={initialFiles}
+        model={model}
+        options={reactTreeOptions}
         prerenderedHTML={prerenderedHTML}
         initialExpandedItems={stateConfig?.initialExpandedItems}
         onSelection={stateConfig?.onSelection}

--- a/apps/docs/app/trees-dev/custom-icons/page.tsx
+++ b/apps/docs/app/trees-dev/custom-icons/page.tsx
@@ -5,6 +5,7 @@ import {
   customSpriteSheet,
   sharedDemoFileTreeOptions,
   sharedDemoStateConfig,
+  toRuntimeFileTreeOptions,
 } from '../demo-data';
 import { CustomIconsDemoClient } from './CustomIconsDemoClient';
 
@@ -18,7 +19,7 @@ export default async function CustomIconsPage() {
   };
 
   const customIconsSsr = preloadFileTree(
-    {
+    toRuntimeFileTreeOptions({
       ...fileTreeOptions,
       icons: {
         spriteSheet: customSpriteSheet,
@@ -31,7 +32,7 @@ export default async function CustomIconsPage() {
           },
         },
       },
-    },
+    }),
     sharedDemoStateConfig
   );
 

--- a/apps/docs/app/trees-dev/demo-data.ts
+++ b/apps/docs/app/trees-dev/demo-data.ts
@@ -1,8 +1,9 @@
-import type {
-  FileTreeOptions,
-  FileTreeSelectionItem,
-  FileTreeStateConfig,
-  GitStatusEntry,
+import {
+  FileTreeModel,
+  type FileTreeOptions,
+  type FileTreeSelectionItem,
+  type FileTreeStateConfig,
+  type GitStatusEntry,
 } from '@pierre/trees';
 
 import linuxData from './linux-files.json';
@@ -76,10 +77,32 @@ const sampleFileList: string[] = [
   '.gitignore',
 ];
 
-export const sharedDemoFileTreeOptions: FileTreeOptions = {
+export type TreesDevFileTreeOptions = Omit<FileTreeOptions, 'model'> & {
+  initialFiles: string[];
+};
+
+export const sharedDemoFileTreeOptions: TreesDevFileTreeOptions = {
   flattenEmptyDirectories: true,
   initialFiles: sampleFileList,
 };
+
+export function toRuntimeFileTreeOptions(
+  options: TreesDevFileTreeOptions
+): FileTreeOptions {
+  const { initialFiles, sort, ...rest } = options;
+  const sortComparator =
+    sort === false
+      ? false
+      : sort != null && typeof sort === 'object'
+        ? sort.comparator
+        : undefined;
+
+  return {
+    ...rest,
+    sort,
+    model: FileTreeModel.fromFiles(initialFiles, { sortComparator }),
+  };
+}
 
 export const GIT_STATUSES_A: GitStatusEntry[] = [
   { path: 'src/index.ts', status: 'modified' },

--- a/apps/docs/app/trees-dev/drag-and-drop/DragAndDropDemoClient.tsx
+++ b/apps/docs/app/trees-dev/drag-and-drop/DragAndDropDemoClient.tsx
@@ -59,7 +59,8 @@ function VanillaDnDUncontrolled({
   const mergedStateConfig = useMemo<FileTreeStateConfig>(
     () => ({
       ...stateConfig,
-      onFilesChange: (files) => {
+      onFilesChange: (_changeSet, context) => {
+        const files = context.getFiles();
         addLog(`files: [${files.join(', ')}]`);
       },
     }),
@@ -124,7 +125,11 @@ function ReactDnDControlled({
   const { log, addLog } = useStateLog();
 
   const handleFilesChange = useCallback(
-    (nextFiles: string[]) => {
+    (
+      _changeSet: import('@pierre/trees').FileTreeChangeSet,
+      context: import('@pierre/trees').FileTreeChangeContext
+    ) => {
+      const nextFiles = context.getFiles();
       if (lockGitignore) {
         const oldGitignore = files.find((f) => f.endsWith('.gitignore'));
         const newGitignore = nextFiles.find((f) => f.endsWith('.gitignore'));
@@ -203,7 +208,11 @@ function ReactDnDControlledSSR({
   const { log, addLog } = useStateLog();
 
   const handleFilesChange = useCallback(
-    (nextFiles: string[]) => {
+    (
+      _changeSet: import('@pierre/trees').FileTreeChangeSet,
+      context: import('@pierre/trees').FileTreeChangeContext
+    ) => {
+      const nextFiles = context.getFiles();
       if (lockGitignore) {
         const oldGitignore = files.find((f) => f.endsWith('.gitignore'));
         const newGitignore = nextFiles.find((f) => f.endsWith('.gitignore'));

--- a/apps/docs/app/trees-dev/drag-and-drop/DragAndDropDemoClient.tsx
+++ b/apps/docs/app/trees-dev/drag-and-drop/DragAndDropDemoClient.tsx
@@ -1,14 +1,19 @@
 'use client';
 
 import { FileTree } from '@pierre/trees';
-import type { FileTreeOptions, FileTreeStateConfig } from '@pierre/trees';
+import type { FileTreeStateConfig } from '@pierre/trees';
 import { FileTree as FileTreeReact } from '@pierre/trees/react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { ExampleCard } from '../_components/ExampleCard';
 import { StateLog, useStateLog } from '../_components/StateLog';
 import { useTreesDevSettings } from '../_components/TreesDevSettingsProvider';
-import { sharedDemoFileTreeOptions, sharedDemoStateConfig } from '../demo-data';
+import {
+  sharedDemoFileTreeOptions,
+  sharedDemoStateConfig,
+  toRuntimeFileTreeOptions,
+  type TreesDevFileTreeOptions,
+} from '../demo-data';
 
 interface DragAndDropDemoClientProps {
   preloadedFileTreeHtml: string;
@@ -45,7 +50,7 @@ function VanillaDnDUncontrolled({
   options,
   stateConfig,
 }: {
-  options: FileTreeOptions;
+  options: TreesDevFileTreeOptions;
   stateConfig?: FileTreeStateConfig;
 }) {
   const instanceRef = useRef<FileTree | null>(null);
@@ -73,11 +78,11 @@ function VanillaDnDUncontrolled({
       }
 
       const fileTree = new FileTree(
-        {
+        toRuntimeFileTreeOptions({
           ...options,
           dragAndDrop: true,
           initialFiles: sharedDemoFileTreeOptions.initialFiles,
-        },
+        }),
         mergedStateConfig
       );
       fileTree.render({ containerWrapper: node });
@@ -111,7 +116,7 @@ function ReactDnDControlled({
   options,
   stateConfig,
 }: {
-  options: Omit<FileTreeOptions, 'initialFiles'>;
+  options: Omit<TreesDevFileTreeOptions, 'initialFiles'>;
   stateConfig?: FileTreeStateConfig;
 }) {
   const [files, setFiles] = useState(sharedDemoFileTreeOptions.initialFiles);
@@ -133,6 +138,17 @@ function ReactDnDControlled({
     },
     [lockGitignore, files, addLog]
   );
+
+  const runtimeOptions = useMemo(
+    () =>
+      toRuntimeFileTreeOptions({
+        ...options,
+        initialFiles: files,
+        dragAndDrop: true,
+      }),
+    [files, options]
+  );
+  const { model, ...reactTreeOptions } = runtimeOptions;
 
   return (
     <ExampleCard
@@ -163,8 +179,8 @@ function ReactDnDControlled({
       }
     >
       <FileTreeReact
-        options={{ ...options, dragAndDrop: true }}
-        files={files}
+        model={model}
+        options={reactTreeOptions}
         onFilesChange={handleFilesChange}
         initialExpandedItems={stateConfig?.initialExpandedItems}
         onSelection={stateConfig?.onSelection}
@@ -178,7 +194,7 @@ function ReactDnDControlledSSR({
   stateConfig,
   prerenderedHTML,
 }: {
-  options: Omit<FileTreeOptions, 'initialFiles'>;
+  options: Omit<TreesDevFileTreeOptions, 'initialFiles'>;
   stateConfig?: FileTreeStateConfig;
   prerenderedHTML: string;
 }) {
@@ -201,6 +217,17 @@ function ReactDnDControlledSSR({
     },
     [lockGitignore, files, addLog]
   );
+
+  const runtimeOptions = useMemo(
+    () =>
+      toRuntimeFileTreeOptions({
+        ...options,
+        initialFiles: files,
+        dragAndDrop: true,
+      }),
+    [files, options]
+  );
+  const { model, ...reactTreeOptions } = runtimeOptions;
 
   return (
     <ExampleCard
@@ -231,9 +258,9 @@ function ReactDnDControlledSSR({
       }
     >
       <FileTreeReact
-        options={{ ...options, dragAndDrop: true }}
+        model={model}
+        options={reactTreeOptions}
         prerenderedHTML={prerenderedHTML}
-        files={files}
         onFilesChange={handleFilesChange}
         initialExpandedItems={stateConfig?.initialExpandedItems}
         onSelection={stateConfig?.onSelection}

--- a/apps/docs/app/trees-dev/drag-and-drop/page.tsx
+++ b/apps/docs/app/trees-dev/drag-and-drop/page.tsx
@@ -1,7 +1,11 @@
 import { preloadFileTree } from '@pierre/trees/ssr';
 
 import { readSettingsCookies } from '../_components/readSettingsCookies';
-import { sharedDemoFileTreeOptions, sharedDemoStateConfig } from '../demo-data';
+import {
+  sharedDemoFileTreeOptions,
+  sharedDemoStateConfig,
+  toRuntimeFileTreeOptions,
+} from '../demo-data';
 import { DragAndDropDemoClient } from './DragAndDropDemoClient';
 
 export default async function DragAndDropPage() {
@@ -13,7 +17,10 @@ export default async function DragAndDropPage() {
     useLazyDataLoader,
   };
 
-  const mainSsr = preloadFileTree(fileTreeOptions, sharedDemoStateConfig);
+  const mainSsr = preloadFileTree(
+    toRuntimeFileTreeOptions(fileTreeOptions),
+    sharedDemoStateConfig
+  );
 
   return <DragAndDropDemoClient preloadedFileTreeHtml={mainSsr.shadowHtml} />;
 }

--- a/apps/docs/app/trees-dev/dynamic-files/DynamicFilesDemoClient.tsx
+++ b/apps/docs/app/trees-dev/dynamic-files/DynamicFilesDemoClient.tsx
@@ -144,10 +144,16 @@ function ReactControlledFiles({
   );
   const [onFilesChangeCalls, setOnFilesChangeCalls] = useState(0);
 
-  const handleFilesChange = useCallback((nextFiles: string[]) => {
-    setOnFilesChangeCalls((count) => count + 1);
-    setFiles(nextFiles);
-  }, []);
+  const handleFilesChange = useCallback(
+    (
+      _changeSet: import('@pierre/trees').FileTreeChangeSet,
+      context: import('@pierre/trees').FileTreeChangeContext
+    ) => {
+      setOnFilesChangeCalls((count) => count + 1);
+      setFiles(context.getFiles());
+    },
+    []
+  );
 
   const runtimeOptions = useMemo(
     () =>
@@ -225,10 +231,16 @@ function ReactSSRControlledFiles({
   );
   const [onFilesChangeCalls, setOnFilesChangeCalls] = useState(0);
 
-  const handleFilesChange = useCallback((nextFiles: string[]) => {
-    setOnFilesChangeCalls((count) => count + 1);
-    setFiles(nextFiles);
-  }, []);
+  const handleFilesChange = useCallback(
+    (
+      _changeSet: import('@pierre/trees').FileTreeChangeSet,
+      context: import('@pierre/trees').FileTreeChangeContext
+    ) => {
+      setOnFilesChangeCalls((count) => count + 1);
+      setFiles(context.getFiles());
+    },
+    []
+  );
 
   const runtimeOptions = useMemo(
     () =>

--- a/apps/docs/app/trees-dev/dynamic-files/DynamicFilesDemoClient.tsx
+++ b/apps/docs/app/trees-dev/dynamic-files/DynamicFilesDemoClient.tsx
@@ -1,13 +1,18 @@
 'use client';
 
 import { FileTree } from '@pierre/trees';
-import type { FileTreeOptions, FileTreeStateConfig } from '@pierre/trees';
+import type { FileTreeStateConfig } from '@pierre/trees';
 import { FileTree as FileTreeReact } from '@pierre/trees/react';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { ExampleCard } from '../_components/ExampleCard';
 import { useTreesDevSettings } from '../_components/TreesDevSettingsProvider';
-import { sharedDemoFileTreeOptions, sharedDemoStateConfig } from '../demo-data';
+import {
+  sharedDemoFileTreeOptions,
+  sharedDemoStateConfig,
+  toRuntimeFileTreeOptions,
+  type TreesDevFileTreeOptions,
+} from '../demo-data';
 
 const EXTRA_FILE = 'Build/assets/images/social/logo2.png';
 
@@ -46,7 +51,7 @@ function VanillaDynamicFiles({
   options,
   stateConfig,
 }: {
-  options: FileTreeOptions;
+  options: TreesDevFileTreeOptions;
   stateConfig?: FileTreeStateConfig;
 }) {
   const instanceRef = useRef<FileTree | null>(null);
@@ -64,7 +69,10 @@ function VanillaDynamicFiles({
       }
 
       const fileTree = new FileTree(
-        { ...options, initialFiles: sharedDemoFileTreeOptions.initialFiles },
+        toRuntimeFileTreeOptions({
+          ...options,
+          initialFiles: sharedDemoFileTreeOptions.initialFiles,
+        }),
         stateConfig
       );
       fileTree.render({ containerWrapper: node });
@@ -81,7 +89,7 @@ function VanillaDynamicFiles({
   return (
     <ExampleCard
       title="Vanilla — Dynamic Files"
-      description="Uses setFiles() imperatively to add/remove files without recreating the tree"
+      description="Uses model.replaceAll() imperatively to add/remove files without recreating the tree"
       controls={
         <div className="grid grid-cols-2 gap-2">
           <button
@@ -89,7 +97,7 @@ function VanillaDynamicFiles({
             className="rounded-sm border px-2 py-1 text-xs"
             style={{ borderColor: 'var(--color-border)' }}
             onClick={() => {
-              instanceRef.current?.setFiles([
+              instanceRef.current?.model.replaceAll([
                 ...sharedDemoFileTreeOptions.initialFiles,
                 EXTRA_FILE,
               ]);
@@ -103,7 +111,7 @@ function VanillaDynamicFiles({
             className="rounded-sm border px-2 py-1 text-xs"
             style={{ borderColor: 'var(--color-border)' }}
             onClick={() => {
-              instanceRef.current?.setFiles(
+              instanceRef.current?.model.replaceAll(
                 sharedDemoFileTreeOptions.initialFiles
               );
               setHasExtra(false);
@@ -128,10 +136,12 @@ function ReactControlledFiles({
   options,
   stateConfig,
 }: {
-  options: Omit<FileTreeOptions, 'initialFiles'>;
+  options: Omit<TreesDevFileTreeOptions, 'initialFiles'>;
   stateConfig?: FileTreeStateConfig;
 }) {
-  const [files, setFiles] = useState(sharedDemoFileTreeOptions.initialFiles);
+  const [files, setFiles] = useState<string[]>(
+    sharedDemoFileTreeOptions.initialFiles
+  );
   const [onFilesChangeCalls, setOnFilesChangeCalls] = useState(0);
 
   const handleFilesChange = useCallback((nextFiles: string[]) => {
@@ -139,10 +149,20 @@ function ReactControlledFiles({
     setFiles(nextFiles);
   }, []);
 
+  const runtimeOptions = useMemo(
+    () =>
+      toRuntimeFileTreeOptions({
+        ...options,
+        initialFiles: files,
+      }),
+    [files, options]
+  );
+  const { model, ...reactTreeOptions } = runtimeOptions;
+
   return (
     <ExampleCard
       title="React — Controlled Files"
-      description="files prop is controlled by React state, with onFilesChange wired for full control"
+      description="Model is derived from React state, with onFilesChange wired for full control"
       controls={
         <div className="grid grid-cols-2 gap-2">
           <button
@@ -181,8 +201,8 @@ function ReactControlledFiles({
       }
     >
       <FileTreeReact
-        options={options}
-        files={files}
+        model={model}
+        options={reactTreeOptions}
         onFilesChange={handleFilesChange}
         initialExpandedItems={stateConfig?.initialExpandedItems}
         onSelection={stateConfig?.onSelection}
@@ -196,11 +216,13 @@ function ReactSSRControlledFiles({
   stateConfig,
   prerenderedHTML,
 }: {
-  options: Omit<FileTreeOptions, 'initialFiles'>;
+  options: Omit<TreesDevFileTreeOptions, 'initialFiles'>;
   stateConfig?: FileTreeStateConfig;
   prerenderedHTML: string;
 }) {
-  const [files, setFiles] = useState(sharedDemoFileTreeOptions.initialFiles);
+  const [files, setFiles] = useState<string[]>(
+    sharedDemoFileTreeOptions.initialFiles
+  );
   const [onFilesChangeCalls, setOnFilesChangeCalls] = useState(0);
 
   const handleFilesChange = useCallback((nextFiles: string[]) => {
@@ -208,10 +230,20 @@ function ReactSSRControlledFiles({
     setFiles(nextFiles);
   }, []);
 
+  const runtimeOptions = useMemo(
+    () =>
+      toRuntimeFileTreeOptions({
+        ...options,
+        initialFiles: files,
+      }),
+    [files, options]
+  );
+  const { model, ...reactTreeOptions } = runtimeOptions;
+
   return (
     <ExampleCard
       title="React (SSR) — Controlled Files"
-      description="SSR hydration with controlled files, using onFilesChange to keep parent state authoritative"
+      description="SSR hydration with model state controlled by React"
       controls={
         <div className="grid grid-cols-2 gap-2">
           <button
@@ -250,9 +282,9 @@ function ReactSSRControlledFiles({
       }
     >
       <FileTreeReact
-        options={options}
+        model={model}
+        options={reactTreeOptions}
         prerenderedHTML={prerenderedHTML}
-        files={files}
         onFilesChange={handleFilesChange}
         initialExpandedItems={stateConfig?.initialExpandedItems}
         onSelection={stateConfig?.onSelection}

--- a/apps/docs/app/trees-dev/dynamic-files/page.tsx
+++ b/apps/docs/app/trees-dev/dynamic-files/page.tsx
@@ -1,7 +1,11 @@
 import { preloadFileTree } from '@pierre/trees/ssr';
 
 import { readSettingsCookies } from '../_components/readSettingsCookies';
-import { sharedDemoFileTreeOptions, sharedDemoStateConfig } from '../demo-data';
+import {
+  sharedDemoFileTreeOptions,
+  sharedDemoStateConfig,
+  toRuntimeFileTreeOptions,
+} from '../demo-data';
 import { DynamicFilesDemoClient } from './DynamicFilesDemoClient';
 
 export default async function DynamicFilesPage() {
@@ -13,7 +17,10 @@ export default async function DynamicFilesPage() {
     useLazyDataLoader,
   };
 
-  const mainSsr = preloadFileTree(fileTreeOptions, sharedDemoStateConfig);
+  const mainSsr = preloadFileTree(
+    toRuntimeFileTreeOptions(fileTreeOptions),
+    sharedDemoStateConfig
+  );
 
   return <DynamicFilesDemoClient preloadedFileTreeHtml={mainSsr.shadowHtml} />;
 }

--- a/apps/docs/app/trees-dev/git-status/GitStatusDemoClient.tsx
+++ b/apps/docs/app/trees-dev/git-status/GitStatusDemoClient.tsx
@@ -1,14 +1,18 @@
 'use client';
 
 import { FileTree } from '@pierre/trees';
-import type { FileTreeOptions, FileTreeStateConfig } from '@pierre/trees';
+import type { FileTreeStateConfig } from '@pierre/trees';
 import { FileTree as FileTreeReact } from '@pierre/trees/react';
-import { useCallback, useRef } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 
 import { ExampleCard } from '../_components/ExampleCard';
 import { useTreesDevSettings } from '../_components/TreesDevSettingsProvider';
 import { useGitStatusControls } from '../_components/useGitStatusControls';
-import { sharedDemoStateConfig } from '../demo-data';
+import {
+  sharedDemoStateConfig,
+  toRuntimeFileTreeOptions,
+  type TreesDevFileTreeOptions,
+} from '../demo-data';
 
 interface GitStatusDemoClientProps {
   preloadedGitStatusFileTreeHtml: string;
@@ -47,7 +51,7 @@ function VanillaGitStatus({
   options,
   stateConfig,
 }: {
-  options: FileTreeOptions;
+  options: TreesDevFileTreeOptions;
   stateConfig?: FileTreeStateConfig;
 }) {
   const instanceRef = useRef<FileTree | null>(null);
@@ -64,7 +68,10 @@ function VanillaGitStatus({
         node.innerHTML = '';
       }
 
-      const fileTree = new FileTree({ ...options, gitStatus }, stateConfig);
+      const fileTree = new FileTree(
+        toRuntimeFileTreeOptions({ ...options, gitStatus }),
+        stateConfig
+      );
       fileTree.render({ containerWrapper: node });
       instanceRef.current = fileTree;
 
@@ -92,11 +99,21 @@ function GitStatusDemo({
   initialFiles,
   stateConfig,
 }: {
-  options: Omit<FileTreeOptions, 'initialFiles'>;
+  options: Omit<TreesDevFileTreeOptions, 'initialFiles'>;
   initialFiles?: string[];
   stateConfig?: FileTreeStateConfig;
 }) {
   const { gitStatus, controls } = useGitStatusControls('react');
+
+  const runtimeOptions = useMemo(
+    () =>
+      toRuntimeFileTreeOptions({
+        ...options,
+        initialFiles: initialFiles ?? [],
+      }),
+    [initialFiles, options]
+  );
+  const { model, ...reactTreeOptions } = runtimeOptions;
 
   return (
     <ExampleCard
@@ -105,8 +122,8 @@ function GitStatusDemo({
       controls={controls}
     >
       <FileTreeReact
-        options={options}
-        initialFiles={initialFiles}
+        model={model}
+        options={reactTreeOptions}
         initialExpandedItems={stateConfig?.initialExpandedItems}
         onSelection={stateConfig?.onSelection}
         gitStatus={gitStatus}
@@ -121,12 +138,22 @@ function ReactSSRGitStatus({
   stateConfig,
   prerenderedHTML,
 }: {
-  options: Omit<FileTreeOptions, 'initialFiles'>;
+  options: Omit<TreesDevFileTreeOptions, 'initialFiles'>;
   initialFiles?: string[];
   stateConfig?: FileTreeStateConfig;
   prerenderedHTML: string;
 }) {
   const { gitStatus, controls } = useGitStatusControls('react-ssr');
+
+  const runtimeOptions = useMemo(
+    () =>
+      toRuntimeFileTreeOptions({
+        ...options,
+        initialFiles: initialFiles ?? [],
+      }),
+    [initialFiles, options]
+  );
+  const { model, ...reactTreeOptions } = runtimeOptions;
 
   return (
     <ExampleCard
@@ -135,8 +162,8 @@ function ReactSSRGitStatus({
       controls={controls}
     >
       <FileTreeReact
-        options={options}
-        initialFiles={initialFiles}
+        model={model}
+        options={reactTreeOptions}
         prerenderedHTML={prerenderedHTML}
         initialExpandedItems={stateConfig?.initialExpandedItems}
         onSelection={stateConfig?.onSelection}

--- a/apps/docs/app/trees-dev/git-status/page.tsx
+++ b/apps/docs/app/trees-dev/git-status/page.tsx
@@ -5,6 +5,7 @@ import {
   GIT_STATUSES_A,
   sharedDemoFileTreeOptions,
   sharedDemoStateConfig,
+  toRuntimeFileTreeOptions,
 } from '../demo-data';
 import { GitStatusDemoClient } from './GitStatusDemoClient';
 
@@ -18,7 +19,10 @@ export default async function GitStatusPage() {
   };
 
   const gitStatusSsr = preloadFileTree(
-    { ...fileTreeOptions, gitStatus: GIT_STATUSES_A },
+    toRuntimeFileTreeOptions({
+      ...fileTreeOptions,
+      gitStatus: GIT_STATUSES_A,
+    }),
     sharedDemoStateConfig
   );
 

--- a/apps/docs/app/trees-dev/header-slot/HeaderSlotDemoClient.tsx
+++ b/apps/docs/app/trees-dev/header-slot/HeaderSlotDemoClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { FileTree } from '@pierre/trees';
-import type { FileTreeOptions, FileTreeStateConfig } from '@pierre/trees';
+import type { FileTreeStateConfig } from '@pierre/trees';
 import { FileTree as FileTreeReact } from '@pierre/trees/react';
 import '@pierre/trees/web-components';
 import { useCallback, useMemo, useRef } from 'react';
@@ -15,7 +15,11 @@ import {
 import { ExampleCard } from '../_components/ExampleCard';
 import { StateLog, useStateLog } from '../_components/StateLog';
 import { useTreesDevSettings } from '../_components/TreesDevSettingsProvider';
-import { sharedDemoStateConfig } from '../demo-data';
+import {
+  sharedDemoStateConfig,
+  toRuntimeFileTreeOptions,
+  type TreesDevFileTreeOptions,
+} from '../demo-data';
 
 interface HeaderSlotDemoClientProps {
   preloadedFileTreeHtml: string;
@@ -53,7 +57,7 @@ function VanillaSSRHeaderSlot({
   stateConfig,
   containerHtml,
 }: {
-  options: FileTreeOptions;
+  options: TreesDevFileTreeOptions;
   stateConfig?: FileTreeStateConfig;
   containerHtml: string;
 }) {
@@ -88,7 +92,10 @@ function VanillaSSRHeaderSlot({
       };
       headerButton?.addEventListener('click', handleHeaderClick);
 
-      const fileTree = new FileTree(options, stateConfig);
+      const fileTree = new FileTree(
+        toRuntimeFileTreeOptions(options),
+        stateConfig
+      );
 
       if (!hasHydratedRef.current) {
         fileTree.hydrate({
@@ -136,12 +143,22 @@ function ReactSSRHeaderSlot({
   stateConfig,
   prerenderedHTML,
 }: {
-  options: Omit<FileTreeOptions, 'initialFiles'>;
+  options: Omit<TreesDevFileTreeOptions, 'initialFiles'>;
   initialFiles?: string[];
   stateConfig?: FileTreeStateConfig;
   prerenderedHTML: string;
 }) {
   const { log, addLog } = useStateLog();
+
+  const runtimeOptions = useMemo(
+    () =>
+      toRuntimeFileTreeOptions({
+        ...options,
+        initialFiles: initialFiles ?? [],
+      }),
+    [initialFiles, options]
+  );
+  const { model, ...reactTreeOptions } = runtimeOptions;
 
   return (
     <ExampleCard
@@ -155,8 +172,8 @@ function ReactSSRHeaderSlot({
       }
     >
       <FileTreeReact
-        options={options}
-        initialFiles={initialFiles}
+        model={model}
+        options={reactTreeOptions}
         prerenderedHTML={prerenderedHTML}
         initialExpandedItems={stateConfig?.initialExpandedItems}
         onSelection={stateConfig?.onSelection}

--- a/apps/docs/app/trees-dev/header-slot/page.tsx
+++ b/apps/docs/app/trees-dev/header-slot/page.tsx
@@ -1,7 +1,11 @@
 import { preloadFileTree } from '@pierre/trees/ssr';
 
 import { readSettingsCookies } from '../_components/readSettingsCookies';
-import { sharedDemoFileTreeOptions, sharedDemoStateConfig } from '../demo-data';
+import {
+  sharedDemoFileTreeOptions,
+  sharedDemoStateConfig,
+  toRuntimeFileTreeOptions,
+} from '../demo-data';
 import { HeaderSlotDemoClient } from './HeaderSlotDemoClient';
 
 export default async function HeaderSlotPage() {
@@ -13,7 +17,10 @@ export default async function HeaderSlotPage() {
     useLazyDataLoader,
   };
 
-  const mainSsr = preloadFileTree(fileTreeOptions, sharedDemoStateConfig);
+  const mainSsr = preloadFileTree(
+    toRuntimeFileTreeOptions(fileTreeOptions),
+    sharedDemoStateConfig
+  );
 
   return (
     <HeaderSlotDemoClient

--- a/apps/docs/app/trees-dev/page.tsx
+++ b/apps/docs/app/trees-dev/page.tsx
@@ -1,7 +1,11 @@
 import { preloadFileTree } from '@pierre/trees/ssr';
 
 import { readSettingsCookies } from './_components/readSettingsCookies';
-import { sharedDemoFileTreeOptions, sharedDemoStateConfig } from './demo-data';
+import {
+  sharedDemoFileTreeOptions,
+  sharedDemoStateConfig,
+  toRuntimeFileTreeOptions,
+} from './demo-data';
 import { RenderingDemoClient } from './RenderingDemoClient';
 
 export default async function TreesDevIndexPage() {
@@ -13,7 +17,10 @@ export default async function TreesDevIndexPage() {
     useLazyDataLoader,
   };
 
-  const mainSsr = preloadFileTree(fileTreeOptions, sharedDemoStateConfig);
+  const mainSsr = preloadFileTree(
+    toRuntimeFileTreeOptions(fileTreeOptions),
+    sharedDemoStateConfig
+  );
 
   return (
     <RenderingDemoClient

--- a/apps/docs/app/trees-dev/state/StateDemoClient.tsx
+++ b/apps/docs/app/trees-dev/state/StateDemoClient.tsx
@@ -10,7 +10,11 @@ import { cleanupFileTreeInstance } from '../_components/cleanupFileTreeInstance'
 import { ExampleCard } from '../_components/ExampleCard';
 import { StateLog, useStateLog } from '../_components/StateLog';
 import { useTreesDevSettings } from '../_components/TreesDevSettingsProvider';
-import { sharedDemoStateConfig } from '../demo-data';
+import {
+  sharedDemoStateConfig,
+  toRuntimeFileTreeOptions,
+  type TreesDevFileTreeOptions,
+} from '../demo-data';
 
 interface StateDemoClientProps {
   preloadedFileTreeHtml: string;
@@ -59,7 +63,7 @@ function VanillaSSRState({
   stateConfig,
   containerHtml,
 }: {
-  options: import('@pierre/trees').FileTreeOptions;
+  options: TreesDevFileTreeOptions;
   stateConfig?: FileTreeStateConfig;
   containerHtml: string;
 }) {
@@ -91,7 +95,10 @@ function VanillaSSRState({
 
       cleanupFileTreeInstance(fileTreeContainer, instanceRef);
 
-      const fileTree = new FileTree(options, mergedStateConfig);
+      const fileTree = new FileTree(
+        toRuntimeFileTreeOptions(options),
+        mergedStateConfig
+      );
 
       if (!hasHydratedRef.current) {
         fileTree.hydrate({
@@ -174,12 +181,21 @@ function ReactSSRUncontrolled({
   stateConfig,
   prerenderedHTML,
 }: {
-  options: Omit<import('@pierre/trees').FileTreeOptions, 'initialFiles'>;
+  options: Omit<TreesDevFileTreeOptions, 'initialFiles'>;
   initialFiles?: string[];
   stateConfig?: FileTreeStateConfig;
   prerenderedHTML: string;
 }) {
   const { log, addLog } = useStateLog();
+  const runtimeOptions = useMemo(
+    () =>
+      toRuntimeFileTreeOptions({
+        ...options,
+        initialFiles: initialFiles ?? [],
+      }),
+    [initialFiles, options]
+  );
+  const { model, ...reactTreeOptions } = runtimeOptions;
 
   return (
     <ExampleCard
@@ -194,8 +210,8 @@ function ReactSSRUncontrolled({
       }
     >
       <FileTreeReact
-        options={options}
-        initialFiles={initialFiles}
+        model={model}
+        options={reactTreeOptions}
         prerenderedHTML={prerenderedHTML}
         initialExpandedItems={stateConfig?.initialExpandedItems}
         initialSelectedItems={stateConfig?.initialSelectedItems}
@@ -217,7 +233,7 @@ function ReactSSRControlled({
   stateConfig,
   prerenderedHTML,
 }: {
-  options: Omit<import('@pierre/trees').FileTreeOptions, 'initialFiles'>;
+  options: Omit<TreesDevFileTreeOptions, 'initialFiles'>;
   initialFiles?: string[];
   stateConfig?: FileTreeStateConfig;
   prerenderedHTML: string;
@@ -245,6 +261,16 @@ function ReactSSRControlled({
     },
     [addLog]
   );
+
+  const runtimeOptions = useMemo(
+    () =>
+      toRuntimeFileTreeOptions({
+        ...options,
+        initialFiles: initialFiles ?? [],
+      }),
+    [initialFiles, options]
+  );
+  const { model, ...reactTreeOptions } = runtimeOptions;
 
   return (
     <ExampleCard
@@ -301,8 +327,8 @@ function ReactSSRControlled({
       }
     >
       <FileTreeReact
-        options={options}
-        initialFiles={initialFiles}
+        model={model}
+        options={reactTreeOptions}
         prerenderedHTML={prerenderedHTML}
         onSelection={stateConfig?.onSelection}
         expandedItems={expandedItems}

--- a/apps/docs/app/trees-dev/state/page.tsx
+++ b/apps/docs/app/trees-dev/state/page.tsx
@@ -1,7 +1,11 @@
 import { preloadFileTree } from '@pierre/trees/ssr';
 
 import { readSettingsCookies } from '../_components/readSettingsCookies';
-import { sharedDemoFileTreeOptions, sharedDemoStateConfig } from '../demo-data';
+import {
+  sharedDemoFileTreeOptions,
+  sharedDemoStateConfig,
+  toRuntimeFileTreeOptions,
+} from '../demo-data';
 import { StateDemoClient } from './StateDemoClient';
 
 export default async function StatePage() {
@@ -13,8 +17,9 @@ export default async function StatePage() {
     useLazyDataLoader,
   };
 
-  const mainSsr = preloadFileTree(fileTreeOptions, sharedDemoStateConfig);
-  const controlledSsr = preloadFileTree(fileTreeOptions, {
+  const runtimeOptions = toRuntimeFileTreeOptions(fileTreeOptions);
+  const mainSsr = preloadFileTree(runtimeOptions, sharedDemoStateConfig);
+  const controlledSsr = preloadFileTree(runtimeOptions, {
     ...sharedDemoStateConfig,
     initialSelectedItems: ['Build/assets/images/social/logo.png'],
   });

--- a/apps/docs/app/trees-dev/themes/ThemesGridClient.tsx
+++ b/apps/docs/app/trees-dev/themes/ThemesGridClient.tsx
@@ -2,6 +2,7 @@
 
 import type { FileDiffMetadata } from '@pierre/diffs';
 import { FileDiff } from '@pierre/diffs/react';
+import { FileTreeModel } from '@pierre/trees';
 import { FileTree } from '@pierre/trees/react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useRef, useState } from 'react';
@@ -67,8 +68,8 @@ function TreePanel({
     <div ref={panelRef}>
       <FileTree
         className={className ?? 'rounded-sm border p-3'}
+        model={FileTreeModel.fromFiles(PREVIEW_FILES)}
         options={TREE_OPTIONS}
-        initialFiles={PREVIEW_FILES}
         initialExpandedItems={INITIAL_EXPANDED_ITEMS}
         gitStatus={GIT_STATUSES}
         style={{

--- a/apps/docs/app/trees-dev/virtualization/page.tsx
+++ b/apps/docs/app/trees-dev/virtualization/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CONTEXT_MENU_SLOT_NAME, FileTree } from '@pierre/trees';
+import { CONTEXT_MENU_SLOT_NAME, FileTree, FileTreeModel } from '@pierre/trees';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import type { Root as ReactDomRoot } from 'react-dom/client';
 
@@ -55,7 +55,9 @@ function VirtualizedLinuxKernelCard() {
           // TODO: this shouldnt be in a different place than
           // initialExpandedItems (this should probably move to
           // the state config)
-          initialFiles: linuxKernelFiles,
+          model: FileTreeModel.fromFiles(linuxKernelFiles, {
+            sortComparator: false,
+          }),
           virtualize: { threshold: 0 },
           flattenEmptyDirectories: true,
           sort: false,
@@ -138,7 +140,7 @@ function UnvirtualizedLinuxKernelCard() {
     if (node == null) return;
     const fileTree = new FileTree(
       {
-        initialFiles: linuxKernelFiles,
+        model: FileTreeModel.fromFiles(linuxKernelFiles),
         virtualize: false,
         flattenEmptyDirectories: true,
       },

--- a/apps/docs/app/trees/demo-data.ts
+++ b/apps/docs/app/trees/demo-data.ts
@@ -1,7 +1,8 @@
-import type {
-  FileTreeOptions,
-  FileTreeSelectionItem,
-  FileTreeStateConfig,
+import {
+  FileTreeModel,
+  type FileTreeOptions,
+  type FileTreeSelectionItem,
+  type FileTreeStateConfig,
 } from '@pierre/trees';
 
 export const sampleFileList: string[] = [
@@ -25,10 +26,32 @@ export const sampleFileList: string[] = [
   '.gitignore',
 ];
 
-export const sharedDemoFileTreeOptions: FileTreeOptions = {
+export type TreesDocsFileTreeOptions = Omit<FileTreeOptions, 'model'> & {
+  initialFiles: string[];
+};
+
+export const sharedDemoFileTreeOptions: TreesDocsFileTreeOptions = {
   flattenEmptyDirectories: true,
   initialFiles: sampleFileList,
 };
+
+export function toRuntimeFileTreeOptions(
+  options: TreesDocsFileTreeOptions
+): FileTreeOptions {
+  const { initialFiles, sort, ...rest } = options;
+  const sortComparator =
+    sort === false
+      ? false
+      : sort != null && typeof sort === 'object'
+        ? sort.comparator
+        : undefined;
+
+  return {
+    ...rest,
+    sort,
+    model: FileTreeModel.fromFiles(initialFiles, { sortComparator }),
+  };
+}
 
 export const sharedDemoStateConfig: FileTreeStateConfig = {
   initialExpandedItems: ['Build/assets/images/social'],

--- a/apps/docs/app/trees/docs/Overview/constants.ts
+++ b/apps/docs/app/trees/docs/Overview/constants.ts
@@ -1,10 +1,10 @@
 import type { PreloadFileOptions } from '@pierre/diffs/ssr';
-import type { FileTreeOptions } from '@pierre/trees';
 
+import type { TreesDocsFileTreeOptions } from '../../demo-data';
 import { CustomScrollbarCSS } from '@/components/CustomScrollbarCSS';
 
 /** File list and options for the live FileTree in the Overview section */
-export const OVERVIEW_FILE_TREE_OPTIONS: FileTreeOptions = {
+export const OVERVIEW_FILE_TREE_OPTIONS: TreesDocsFileTreeOptions = {
   initialFiles: [
     'README.md',
     'package.json',

--- a/apps/docs/app/trees/docs/ReactAPI/constants.ts
+++ b/apps/docs/app/trees/docs/ReactAPI/constants.ts
@@ -11,7 +11,8 @@ const options = {
 export const REACT_API_FILE_TREE: PreloadFileOptions<undefined> = {
   file: {
     name: 'FileExplorer.tsx',
-    contents: `import { FileTree } from '@pierre/trees/react';
+    contents: `import { FileTreeModel } from '@pierre/trees';
+import { FileTree } from '@pierre/trees/react';
 
 const files = [
   'src/index.ts',
@@ -20,8 +21,10 @@ const files = [
   'package.json',
 ];
 
+const model = FileTreeModel.fromFiles(files);
+
 export function FileExplorer() {
-  return <FileTree options={{}} initialFiles={files} />;
+  return <FileTree model={model} options={{}} />;
 }`,
   },
   options,
@@ -30,12 +33,15 @@ export function FileExplorer() {
 export const REACT_API_FILE_TREE_PROPS: PreloadFileOptions<undefined> = {
   file: {
     name: 'file_tree_props.tsx',
-    contents: `import { FileTree } from '@pierre/trees/react';
+    contents: `import { FileTreeModel } from '@pierre/trees';
+import { FileTree } from '@pierre/trees/react';
 
 // FileTree accepts these props:
+const model = FileTreeModel.fromFiles(['src/index.ts', 'package.json']);
 
 <FileTree
-  // Required: options object + initialFiles (or controlled files)
+  // Required: model + options
+  model={model}
   options={{
     flattenEmptyDirectories: true,
     fileTreeSearchMode: 'expand-matches',
@@ -46,7 +52,6 @@ export const REACT_API_FILE_TREE_PROPS: PreloadFileOptions<undefined> = {
       }
     \`,
   }}
-  initialFiles={['src/index.ts', 'package.json']}
 
   // Optional: uncontrolled state defaults
   initialExpandedItems={['src']}
@@ -54,7 +59,6 @@ export const REACT_API_FILE_TREE_PROPS: PreloadFileOptions<undefined> = {
   initialSearchQuery="Button"
 
   // Optional: controlled state (overrides internal state each render)
-  // files={controlledFiles}
   // expandedItems={controlledExpanded}
   // selectedItems={controlledSelected}
 
@@ -62,7 +66,9 @@ export const REACT_API_FILE_TREE_PROPS: PreloadFileOptions<undefined> = {
   onSelection={(items) => console.log(items)}
   onExpandedItemsChange={(items) => console.log('expanded', items)}
   onSelectedItemsChange={(items) => console.log('selected', items)}
-  onFilesChange={(files) => console.log('files', files)}
+  onModelChange={(changeSet, { getFiles }) => {
+    console.log(changeSet.kind, getFiles());
+  }}
 
   // Optional: git status
   gitStatus={gitStatusEntries}
@@ -81,7 +87,14 @@ export const REACT_API_FILE_TREE_PROPS: PreloadFileOptions<undefined> = {
 export const REACT_API_CUSTOM_ICONS_EXAMPLE: PreloadFileOptions<undefined> = {
   file: {
     name: 'custom_icons_file_tree.tsx',
-    contents: `import { FileTree } from '@pierre/trees/react';
+    contents: `import { FileTreeModel } from '@pierre/trees';
+import { FileTree } from '@pierre/trees/react';
+
+const model = FileTreeModel.fromFiles([
+  'src/index.ts',
+  'src/components/Button.tsx',
+  'package.json',
+]);
 
 const customSpriteSheet = \`
   <svg data-icon-sprite aria-hidden="true" width="0" height="0">
@@ -96,6 +109,7 @@ const customSpriteSheet = \`
 export function CustomIconsTree() {
   return (
     <FileTree
+      model={model}
       options={{
         id: 'custom-icons-tree',
         icons: {
@@ -105,11 +119,6 @@ export function CustomIconsTree() {
           },
         },
       }}
-      initialFiles={[
-        'src/index.ts',
-        'src/components/Button.tsx',
-        'package.json',
-      ]}
       initialExpandedItems={['src', 'src/components']}
     />
   );
@@ -122,7 +131,7 @@ export const REACT_API_GIT_STATUS_EXAMPLE: PreloadFileOptions<undefined> = {
   file: {
     name: 'git_status_file_tree.tsx',
     contents: `import { useEffect, useState } from 'react';
-import type { GitStatusEntry } from '@pierre/trees';
+import { FileTreeModel, type GitStatusEntry } from '@pierre/trees';
 import { FileTree } from '@pierre/trees/react';
 
 const files = [
@@ -132,6 +141,8 @@ const files = [
   'src/components/Button.tsx',
   'src/lib/utils.ts',
 ];
+
+const model = FileTreeModel.fromFiles(files);
 
 export function GitAwareTree() {
   const [gitStatus, setGitStatus] = useState<GitStatusEntry[] | undefined>();
@@ -147,8 +158,8 @@ export function GitAwareTree() {
 
   return (
     <FileTree
+      model={model}
       options={{ id: 'git-aware-tree' }}
-      initialFiles={files}
       initialExpandedItems={['src', 'src/components']}
       gitStatus={gitStatus}
     />

--- a/apps/docs/app/trees/docs/VanillaAPI/content.mdx
+++ b/apps/docs/app/trees/docs/VanillaAPI/content.mdx
@@ -32,7 +32,6 @@ tree state programmatically:
 
 | Method                              | Description                                               |
 | ----------------------------------- | --------------------------------------------------------- |
-| `setFiles(files)`                   | Replace the file list and re-render                       |
 | `getFiles()`                        | Return the current file list                              |
 | `setExpandedItems(items)`           | Set which folders are expanded                            |
 | `getExpandedItems()`                | Return the currently expanded folder paths                |
@@ -50,6 +49,7 @@ tree state programmatically:
 constructor's second argument. Use it for defaults (`initialExpandedItems`,
 `initialSelectedItems`, `initialSearchQuery`) and callbacks/controlled values
 (`onSelection`, `onExpandedItemsChange`, `onSelectedItemsChange`,
-`onFilesChange`, plus `expandedItems`/`selectedItems`/`files` when controlled).
+`onModelChange` (or legacy `onFilesChange`), plus `expandedItems`/
+`selectedItems` when controlled).
 
 <DocsCodeExample {...fileTreeStateConfigType} />

--- a/apps/docs/app/trees/tree-examples/A11ySection.tsx
+++ b/apps/docs/app/trees/tree-examples/A11ySection.tsx
@@ -3,15 +3,27 @@ import { preloadFileTree } from '@pierre/trees/ssr';
 import type { CSSProperties } from 'react';
 
 import { FeatureHeader } from '../../diff-examples/FeatureHeader';
-import { baseTreeOptions, DEFAULT_FILE_TREE_PANEL_CLASS } from './demo-data';
+import {
+  baseTreeOptions,
+  DEFAULT_FILE_TREE_PANEL_CLASS,
+  toReactTreeProps,
+} from './demo-data';
 import { TreeExampleSection } from './TreeExampleSection';
 
 const a11yStyle: CSSProperties = {
   colorScheme: 'dark',
 };
 
+const { model: a11yModel, options: a11yReactOptions } = toReactTreeProps({
+  ...baseTreeOptions,
+  id: 'a11y-demo',
+});
+
 const a11yPrerenderedHTML = preloadFileTree(
-  { ...baseTreeOptions, id: 'a11y-demo' },
+  {
+    model: a11yModel,
+    ...a11yReactOptions,
+  },
   {
     initialSelectedItems: ['package.json'],
     initialExpandedItems: ['src', 'src/components'],
@@ -41,9 +53,10 @@ export function A11ySection() {
       />
       <div className="grid grid-cols-1 items-start gap-6 md:grid-cols-2">
         <FileTree
+          model={a11yModel}
           className={DEFAULT_FILE_TREE_PANEL_CLASS}
           prerenderedHTML={a11yPrerenderedHTML}
-          options={{ ...baseTreeOptions, id: 'a11y-demo' }}
+          options={a11yReactOptions}
           initialSelectedItems={['package.json']}
           initialExpandedItems={['src', 'src/components']}
           style={a11yStyle}

--- a/apps/docs/app/trees/tree-examples/CustomIconsSection.tsx
+++ b/apps/docs/app/trees/tree-examples/CustomIconsSection.tsx
@@ -9,6 +9,7 @@ import {
   baseTreeOptions,
   DEFAULT_FILE_TREE_PANEL_CLASS,
   DEFAULT_FILE_TREE_PANEL_STYLE,
+  toReactTreeProps,
 } from './demo-data';
 import { TreeExampleSection } from './TreeExampleSection';
 
@@ -31,19 +32,24 @@ const panelStyle = {
   '--trees-search-bg-override': 'light-dark(#fff, oklch(14.5% 0 0))',
 } as CSSProperties;
 
+const { model: defaultModel, options: defaultReactOptions } = toReactTreeProps({
+  ...baseTreeOptions,
+  id: 'custom-icons-default',
+  lockedPaths: ['package.json'],
+});
+
 const defaultPrerenderedHTML = preloadFileTree(
   {
-    ...baseTreeOptions,
-    id: 'custom-icons-default',
-    lockedPaths: ['package.json'],
+    model: defaultModel,
+    ...defaultReactOptions,
   },
   {
     initialExpandedItems: ['src', 'src/components'],
   }
 ).shadowHtml;
 
-const remappedPrerenderedHTML = preloadFileTree(
-  {
+const { model: remappedModel, options: remappedReactOptions } =
+  toReactTreeProps({
     ...baseTreeOptions,
     id: 'custom-icons-remapped',
     lockedPaths: ['package.json'],
@@ -67,6 +73,12 @@ const remappedPrerenderedHTML = preloadFileTree(
         },
       },
     },
+  });
+
+const remappedPrerenderedHTML = preloadFileTree(
+  {
+    model: remappedModel,
+    ...remappedReactOptions,
   },
   {
     initialExpandedItems: ['src', 'src/components'],
@@ -103,13 +115,10 @@ export function CustomIconsSection() {
             Default
           </TreeExampleHeading>
           <FileTree
+            model={defaultModel}
             className={DEFAULT_FILE_TREE_PANEL_CLASS}
             prerenderedHTML={defaultPrerenderedHTML}
-            options={{
-              ...baseTreeOptions,
-              id: 'custom-icons-default',
-              lockedPaths: ['package.json'],
-            }}
+            options={defaultReactOptions}
             initialExpandedItems={['src', 'src/components']}
             style={panelStyle}
           />
@@ -127,33 +136,10 @@ export function CustomIconsSection() {
             Remapped
           </TreeExampleHeading>
           <FileTree
+            model={remappedModel}
             className={DEFAULT_FILE_TREE_PANEL_CLASS}
             prerenderedHTML={remappedPrerenderedHTML}
-            options={{
-              ...baseTreeOptions,
-              id: 'custom-icons-remapped',
-              lockedPaths: ['package.json'],
-              icons: {
-                spriteSheet: customSpriteSheet,
-                remap: {
-                  'file-tree-icon-file': {
-                    name: 'custom-file-icon',
-                    width: 12,
-                    height: 12,
-                  },
-                  'file-tree-icon-chevron': {
-                    name: 'custom-folder-icon',
-                    width: 12,
-                    height: 12,
-                  },
-                  'file-tree-icon-lock': {
-                    name: 'custom-lock-icon',
-                    width: 12,
-                    height: 12,
-                  },
-                },
-              },
-            }}
+            options={remappedReactOptions}
             initialExpandedItems={['src', 'src/components']}
             style={panelStyle}
           />

--- a/apps/docs/app/trees/tree-examples/DragDropSection.tsx
+++ b/apps/docs/app/trees/tree-examples/DragDropSection.tsx
@@ -1,11 +1,17 @@
 import { preloadFileTree } from '@pierre/trees/ssr';
 
-import { dragDropOptions } from './demo-data';
+import { dragDropOptions, toReactTreeProps } from './demo-data';
 import { DragDropSectionClient } from './DragDropSectionClient';
 
+const { model: dragDropModel, options: dragDropReactOptions } =
+  toReactTreeProps({
+    ...dragDropOptions(['package.json']),
+    id: 'drag-drop-demo-locked',
+  });
+
 const prerenderedHTML = preloadFileTree({
-  ...dragDropOptions(['package.json']),
-  id: 'drag-drop-demo-locked',
+  model: dragDropModel,
+  ...dragDropReactOptions,
 }).shadowHtml;
 
 export function DragDropSection() {

--- a/apps/docs/app/trees/tree-examples/DragDropSectionClient.tsx
+++ b/apps/docs/app/trees/tree-examples/DragDropSectionClient.tsx
@@ -7,7 +7,11 @@ import type { CSSProperties } from 'react';
 import { useCallback, useMemo, useState } from 'react';
 
 import { FeatureHeader } from '../../diff-examples/FeatureHeader';
-import { DEFAULT_FILE_TREE_PANEL_CLASS, dragDropOptions } from './demo-data';
+import {
+  DEFAULT_FILE_TREE_PANEL_CLASS,
+  dragDropOptions,
+  toReactTreeProps,
+} from './demo-data';
 import { TreeExampleSection } from './TreeExampleSection';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
@@ -26,11 +30,12 @@ export function DragDropSectionClient({
   const [hasDragged, setHasDragged] = useState(false);
   const [resetKey, setResetKey] = useState(0);
 
-  const options = useMemo(
-    () => ({
-      ...dragDropOptions(lockPackageJson ? ['package.json'] : undefined),
-      id: 'drag-drop-demo-locked',
-    }),
+  const treeProps = useMemo(
+    () =>
+      toReactTreeProps({
+        ...dragDropOptions(lockPackageJson ? ['package.json'] : undefined),
+        id: 'drag-drop-demo-locked',
+      }),
     [lockPackageJson]
   );
 
@@ -98,9 +103,10 @@ export function DragDropSectionClient({
 
         <FileTree
           key={resetKey}
+          model={treeProps.model}
           className={DEFAULT_FILE_TREE_PANEL_CLASS}
           prerenderedHTML={prerenderedHTML}
-          options={options}
+          options={treeProps.options}
           onFilesChange={handleFilesChange}
           style={dragDropStyle}
         />

--- a/apps/docs/app/trees/tree-examples/FlatteningSection.tsx
+++ b/apps/docs/app/trees/tree-examples/FlatteningSection.tsx
@@ -6,7 +6,11 @@ import type { CSSProperties } from 'react';
 
 import { TreeExampleHeading } from '../../components/TreeExampleHeading';
 import { FeatureHeader } from '../../diff-examples/FeatureHeader';
-import { DEFAULT_FILE_TREE_PANEL_CLASS, flatteningOptions } from './demo-data';
+import {
+  DEFAULT_FILE_TREE_PANEL_CLASS,
+  flatteningOptions,
+  toReactTreeProps,
+} from './demo-data';
 import { TreeExampleSection } from './TreeExampleSection';
 
 const flattenStyle = {
@@ -14,10 +18,16 @@ const flattenStyle = {
   '--trees-search-bg-override': 'light-dark(#fff, oklch(14.5% 0 0))',
 } as CSSProperties;
 
-const hierarchicalPrerenderedHTML = preloadFileTree(
-  {
+const { model: hierarchicalModel, options: hierarchicalReactOptions } =
+  toReactTreeProps({
     ...flatteningOptions(false),
     id: 'flatten-demo-hierarchical',
+  });
+
+const hierarchicalPrerenderedHTML = preloadFileTree(
+  {
+    model: hierarchicalModel,
+    ...hierarchicalReactOptions,
   },
   {
     initialExpandedItems: [
@@ -29,10 +39,16 @@ const hierarchicalPrerenderedHTML = preloadFileTree(
   }
 ).shadowHtml;
 
-const flattenedPrerenderedHTML = preloadFileTree(
-  {
+const { model: flattenedModel, options: flattenedReactOptions } =
+  toReactTreeProps({
     ...flatteningOptions(true),
     id: 'flatten-demo-flattened',
+  });
+
+const flattenedPrerenderedHTML = preloadFileTree(
+  {
+    model: flattenedModel,
+    ...flattenedReactOptions,
   },
   {
     initialExpandedItems: ['build', 'f::build/assets/images/social'],
@@ -66,12 +82,10 @@ export function FlatteningSection() {
             Hierarchical
           </TreeExampleHeading>
           <FileTree
+            model={hierarchicalModel}
             className={DEFAULT_FILE_TREE_PANEL_CLASS}
             prerenderedHTML={hierarchicalPrerenderedHTML}
-            options={{
-              ...flatteningOptions(false),
-              id: 'flatten-demo-hierarchical',
-            }}
+            options={hierarchicalReactOptions}
             initialExpandedItems={[
               'build',
               'build/assets',
@@ -86,12 +100,10 @@ export function FlatteningSection() {
             Flattened
           </TreeExampleHeading>
           <FileTree
+            model={flattenedModel}
             className={DEFAULT_FILE_TREE_PANEL_CLASS}
             prerenderedHTML={flattenedPrerenderedHTML}
-            options={{
-              ...flatteningOptions(true),
-              id: 'flatten-demo-flattened',
-            }}
+            options={flattenedReactOptions}
             initialExpandedItems={['build', 'f::build/assets/images/social']}
             style={flattenStyle}
           />

--- a/apps/docs/app/trees/tree-examples/GitStatusSection.tsx
+++ b/apps/docs/app/trees/tree-examples/GitStatusSection.tsx
@@ -1,15 +1,20 @@
 import { preloadFileTree } from '@pierre/trees/ssr';
 
-import { baseTreeOptions, GIT_STATUSES_A } from './demo-data';
+import { sampleFileList } from '../../trees/demo-data';
+import { baseTreeOptions, GIT_STATUSES_A, toReactTreeProps } from './demo-data';
 import { GitStatusSectionClient } from './GitStatusSectionClient';
 
-const initialVisibleFiles = baseTreeOptions.initialFiles ?? [];
+const { model: gitStatusModel, options: gitStatusOptions } = toReactTreeProps({
+  ...baseTreeOptions,
+  id: 'path-colors-git-status-demo',
+  initialFiles: sampleFileList,
+  gitStatus: GIT_STATUSES_A,
+});
+
 const prerenderedHTML = preloadFileTree(
   {
-    ...baseTreeOptions,
-    id: 'path-colors-git-status-demo',
-    initialFiles: initialVisibleFiles,
-    gitStatus: GIT_STATUSES_A,
+    model: gitStatusModel,
+    ...gitStatusOptions,
   },
   {
     initialExpandedItems: ['src', 'src/components'],

--- a/apps/docs/app/trees/tree-examples/GitStatusSectionClient.tsx
+++ b/apps/docs/app/trees/tree-examples/GitStatusSectionClient.tsx
@@ -11,11 +11,13 @@ import type { CSSProperties } from 'react';
 import { useMemo, useState } from 'react';
 
 import { FeatureHeader } from '../../diff-examples/FeatureHeader';
+import { sampleFileList } from '../../trees/demo-data';
 import {
   baseTreeOptions,
   DEFAULT_FILE_TREE_PANEL_CLASS,
   GIT_STATUSES_A,
   GIT_STATUSES_B,
+  toReactTreeProps,
 } from './demo-data';
 import { TreeExampleSection } from './TreeExampleSection';
 import { Button } from '@/components/ui/button';
@@ -46,13 +48,21 @@ export function GitStatusSectionClient({
 
   const visibleFiles = useMemo(() => {
     if (!enabled || showUnmodified) {
-      return baseTreeOptions.initialFiles;
+      return sampleFileList;
     }
     const changedPaths = new Set(activeGitStatus.map((entry) => entry.path));
-    return baseTreeOptions.initialFiles.filter((path) =>
-      changedPaths.has(path)
-    );
+    return sampleFileList.filter((path) => changedPaths.has(path));
   }, [activeGitStatus, enabled, showUnmodified]);
+  const treeProps = useMemo(
+    () =>
+      toReactTreeProps({
+        ...baseTreeOptions,
+        id: 'path-colors-git-status-demo',
+        initialFiles: visibleFiles,
+      }),
+    [visibleFiles]
+  );
+
   const panelStyle = {
     colorScheme: colorMode,
     '--trees-search-bg-override': isDark ? 'oklch(14.5% 0 0)' : '#fff',
@@ -136,13 +146,10 @@ export function GitStatusSectionClient({
 
         <div className={isDark ? 'dark' : ''}>
           <FileTree
+            model={treeProps.model}
             className={DEFAULT_FILE_TREE_PANEL_CLASS}
             prerenderedHTML={prerenderedHTML}
-            options={{
-              ...baseTreeOptions,
-              id: 'path-colors-git-status-demo',
-            }}
-            files={visibleFiles}
+            options={treeProps.options}
             initialExpandedItems={['src', 'src/components']}
             gitStatus={gitStatus}
             style={panelStyle}

--- a/apps/docs/app/trees/tree-examples/SearchSection.tsx
+++ b/apps/docs/app/trees/tree-examples/SearchSection.tsx
@@ -6,7 +6,11 @@ import type { CSSProperties } from 'react';
 
 import { TreeExampleHeading } from '../../components/TreeExampleHeading';
 import { FeatureHeader } from '../../diff-examples/FeatureHeader';
-import { DEFAULT_FILE_TREE_PANEL_CLASS, searchOptions } from './demo-data';
+import {
+  DEFAULT_FILE_TREE_PANEL_CLASS,
+  searchOptions,
+  toReactTreeProps,
+} from './demo-data';
 import { TreeExampleSection } from './TreeExampleSection';
 
 const PREPOPULATED_SEARCH = 'tsx';
@@ -17,31 +21,38 @@ const searchModeStyle = {
   '--trees-search-bg-override': 'light-dark(#fff, oklch(14.5% 0 0))',
 } as CSSProperties;
 
-function createSearchPrerenderedHTML(
+function createSearchTreeProps(
   mode: 'hide-non-matches' | 'collapse-non-matches' | 'expand-matches',
   id: string
-): string {
-  return preloadFileTree(
+) {
+  const { model, options } = toReactTreeProps({
+    ...searchOptions(mode),
+    id,
+  });
+
+  const prerenderedHTML = preloadFileTree(
     {
-      ...searchOptions(mode),
-      id,
+      model,
+      ...options,
     },
     {
       initialSearchQuery: PREPOPULATED_SEARCH,
       initialSelectedItems: [PRESELECTED_FILE],
     }
   ).shadowHtml;
+
+  return { model, options, prerenderedHTML };
 }
 
-const hideNonMatchesPrerenderedHTML = createSearchPrerenderedHTML(
+const hideNonMatchesTree = createSearchTreeProps(
   'hide-non-matches',
   'search-demo-hide-non-matches'
 );
-const collapseNonMatchesPrerenderedHTML = createSearchPrerenderedHTML(
+const collapseNonMatchesTree = createSearchTreeProps(
   'collapse-non-matches',
   'search-demo-collapse-non-matches'
 );
-const expandMatchesPrerenderedHTML = createSearchPrerenderedHTML(
+const expandMatchesTree = createSearchTreeProps(
   'expand-matches',
   'search-demo-expand-matches'
 );
@@ -77,12 +88,10 @@ export function SearchSection() {
               <code>hide-non-matches</code>
             </TreeExampleHeading>
             <FileTree
+              model={hideNonMatchesTree.model}
               className={DEFAULT_FILE_TREE_PANEL_CLASS}
-              prerenderedHTML={hideNonMatchesPrerenderedHTML}
-              options={{
-                ...searchOptions('hide-non-matches'),
-                id: 'search-demo-hide-non-matches',
-              }}
+              prerenderedHTML={hideNonMatchesTree.prerenderedHTML}
+              options={hideNonMatchesTree.options}
               initialSearchQuery={PREPOPULATED_SEARCH}
               initialSelectedItems={[PRESELECTED_FILE]}
               style={searchModeStyle}
@@ -96,12 +105,10 @@ export function SearchSection() {
               <code>collapse-non-matches</code>
             </TreeExampleHeading>
             <FileTree
+              model={collapseNonMatchesTree.model}
               className={DEFAULT_FILE_TREE_PANEL_CLASS}
-              prerenderedHTML={collapseNonMatchesPrerenderedHTML}
-              options={{
-                ...searchOptions('collapse-non-matches'),
-                id: 'search-demo-collapse-non-matches',
-              }}
+              prerenderedHTML={collapseNonMatchesTree.prerenderedHTML}
+              options={collapseNonMatchesTree.options}
               initialSearchQuery={PREPOPULATED_SEARCH}
               initialSelectedItems={[PRESELECTED_FILE]}
               style={searchModeStyle}
@@ -115,12 +122,10 @@ export function SearchSection() {
               <code>expand-matches</code>
             </TreeExampleHeading>
             <FileTree
+              model={expandMatchesTree.model}
               className={DEFAULT_FILE_TREE_PANEL_CLASS}
-              prerenderedHTML={expandMatchesPrerenderedHTML}
-              options={{
-                ...searchOptions('expand-matches'),
-                id: 'search-demo-expand-matches',
-              }}
+              prerenderedHTML={expandMatchesTree.prerenderedHTML}
+              options={expandMatchesTree.options}
               initialSearchQuery={PREPOPULATED_SEARCH}
               initialSelectedItems={[PRESELECTED_FILE]}
               style={searchModeStyle}

--- a/apps/docs/app/trees/tree-examples/StylingSection.tsx
+++ b/apps/docs/app/trees/tree-examples/StylingSection.tsx
@@ -7,7 +7,7 @@ import type { CSSProperties } from 'react';
 import { IconFootnote } from '../../components/IconFootnote';
 import { TreeExampleHeading } from '../../components/TreeExampleHeading';
 import { FeatureHeader } from '../../diff-examples/FeatureHeader';
-import { baseTreeOptions } from './demo-data';
+import { baseTreeOptions, toReactTreeProps } from './demo-data';
 import { styleObjectToCss } from './styleToCss';
 import { TreeCssViewer } from './TreeCssViewer';
 import { TreeExampleSection } from './TreeExampleSection';
@@ -68,30 +68,46 @@ function synthwaveTheme(): CSSProperties {
   };
 }
 
+const { model: lightModel, options: lightReactOptions } = toReactTreeProps({
+  ...baseTreeOptions,
+  id: 'theming-demo-light',
+});
+
 const lightPrerenderedHTML = preloadFileTree(
   {
-    ...baseTreeOptions,
-    id: 'theming-demo-light',
+    model: lightModel,
+    ...lightReactOptions,
   },
   {
     initialSelectedItems: ['package.json'],
   }
 ).shadowHtml;
+
+const { model: darkModel, options: darkReactOptions } = toReactTreeProps({
+  ...baseTreeOptions,
+  id: 'theming-demo-dark',
+});
 
 const darkPrerenderedHTML = preloadFileTree(
   {
-    ...baseTreeOptions,
-    id: 'theming-demo-dark',
+    model: darkModel,
+    ...darkReactOptions,
   },
   {
     initialSelectedItems: ['package.json'],
   }
 ).shadowHtml;
 
-const synthwavePrerenderedHTML = preloadFileTree(
-  {
+const { model: synthwaveModel, options: synthwaveReactOptions } =
+  toReactTreeProps({
     ...baseTreeOptions,
     id: 'theming-demo-synthwave',
+  });
+
+const synthwavePrerenderedHTML = preloadFileTree(
+  {
+    model: synthwaveModel,
+    ...synthwaveReactOptions,
   },
   {
     initialSelectedItems: ['package.json'],
@@ -121,12 +137,10 @@ export function StylingSection() {
         <div>
           <TreeExampleHeading>Light mode</TreeExampleHeading>
           <FileTree
+            model={lightModel}
             className="min-h-[320px] rounded-lg border border-neutral-200 bg-neutral-50 p-2"
             prerenderedHTML={lightPrerenderedHTML}
-            options={{
-              ...baseTreeOptions,
-              id: 'theming-demo-light',
-            }}
+            options={lightReactOptions}
             initialSelectedItems={['package.json']}
             style={lightTheme()}
           />
@@ -138,12 +152,10 @@ export function StylingSection() {
         <div>
           <TreeExampleHeading>Dark mode</TreeExampleHeading>
           <FileTree
+            model={darkModel}
             className="min-h-[320px] rounded-lg border border-neutral-700 bg-neutral-900 p-2"
             prerenderedHTML={darkPrerenderedHTML}
-            options={{
-              ...baseTreeOptions,
-              id: 'theming-demo-dark',
-            }}
+            options={darkReactOptions}
             initialSelectedItems={['package.json']}
             style={darkTheme()}
           />
@@ -155,12 +167,10 @@ export function StylingSection() {
         <div>
           <TreeExampleHeading>Synthwave &apos;84</TreeExampleHeading>
           <FileTree
+            model={synthwaveModel}
             className="min-h-[320px] rounded-lg border border-[#f92aad]/40 bg-[#1e1b2b] p-2 shadow-[inset_0_0_60px_rgba(249,42,173,0.08)]"
             prerenderedHTML={synthwavePrerenderedHTML}
-            options={{
-              ...baseTreeOptions,
-              id: 'theming-demo-synthwave',
-            }}
+            options={synthwaveReactOptions}
             initialSelectedItems={['package.json']}
             style={synthwaveTheme()}
           />

--- a/apps/docs/app/trees/tree-examples/ThemingSection.tsx
+++ b/apps/docs/app/trees/tree-examples/ThemingSection.tsx
@@ -1,14 +1,19 @@
 import type { TreeThemeStyles } from '@pierre/trees';
 import { preloadFileTree } from '@pierre/trees/ssr';
 
-import { baseTreeOptions, GIT_STATUSES_A } from './demo-data';
+import { baseTreeOptions, GIT_STATUSES_A, toReactTreeProps } from './demo-data';
 import { ThemingSectionClient } from './ThemingSectionClient';
+
+const { model: themingModel, options: themingReactOptions } = toReactTreeProps({
+  ...baseTreeOptions,
+  id: 'shiki-themes-tree',
+  gitStatus: GIT_STATUSES_A,
+});
 
 const prerenderedHTML = preloadFileTree(
   {
-    ...baseTreeOptions,
-    id: 'shiki-themes-tree',
-    gitStatus: GIT_STATUSES_A,
+    model: themingModel,
+    ...themingReactOptions,
   },
   {
     initialExpandedItems: ['src', 'src/components'],

--- a/apps/docs/app/trees/tree-examples/ThemingSectionClient.tsx
+++ b/apps/docs/app/trees/tree-examples/ThemingSectionClient.tsx
@@ -19,6 +19,7 @@ import {
   baseTreeOptions,
   DEFAULT_FILE_TREE_PANEL_CLASS,
   GIT_STATUSES_A,
+  toReactTreeProps,
 } from './demo-data';
 import { TreeExampleSection } from './TreeExampleSection';
 import { Button } from '@/components/ui/button';
@@ -115,6 +116,11 @@ function themeDisplayName(theme: string): string {
 function isDefaultTheme(theme: string): boolean {
   return theme === DEFAULT_LIGHT || theme === DEFAULT_DARK;
 }
+
+const { model: themingModel, options: themingReactOptions } = toReactTreeProps({
+  ...baseTreeOptions,
+  id: 'shiki-themes-tree',
+});
 
 export function ThemingSectionClient({
   prerenderedHTML,
@@ -293,12 +299,10 @@ export function ThemingSectionClient({
         {error && <p className="text-destructive py-4 text-sm">{error}</p>}
         {themeStyles != null && (
           <FileTree
+            model={themingModel}
             className={`${DEFAULT_FILE_TREE_PANEL_CLASS} min-h-[320px]`}
             prerenderedHTML={prerenderedHTML}
-            options={{
-              ...baseTreeOptions,
-              id: 'shiki-themes-tree',
-            }}
+            options={themingReactOptions}
             gitStatus={GIT_STATUSES_A}
             initialExpandedItems={['src', 'src/components']}
             initialSelectedItems={['package.json']}

--- a/apps/docs/app/trees/tree-examples/VirtualizationSection.tsx
+++ b/apps/docs/app/trees/tree-examples/VirtualizationSection.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import type { CSSProperties } from 'react';
 
 import { FeatureHeader } from '../../diff-examples/FeatureHeader';
-import { DEFAULT_FILE_TREE_PANEL_CLASS } from './demo-data';
+import { DEFAULT_FILE_TREE_PANEL_CLASS, toReactTreeProps } from './demo-data';
 import { TreeExampleSection } from './TreeExampleSection';
 
 const EXTENSIONS = ['.ts', '.tsx', '.css', '.json', '.md', '.test.ts'];
@@ -193,12 +193,18 @@ const panelStyle: CSSProperties = {
 };
 
 const virtualizationDemoData = generateLargeTree();
-const virtualizationPrerenderedHTML = preloadFileTree(
-  {
+const { model: virtualizationModel, options: virtualizationReactOptions } =
+  toReactTreeProps({
     virtualize: { threshold: 0 },
     flattenEmptyDirectories: true,
     id: 'virtualization-demo',
     initialFiles: virtualizationDemoData.files,
+  });
+
+const virtualizationPrerenderedHTML = preloadFileTree(
+  {
+    model: virtualizationModel,
+    ...virtualizationReactOptions,
   },
   {
     initialExpandedItems: virtualizationDemoData.expandedItems,
@@ -232,14 +238,10 @@ export function VirtualizationSection() {
       />
 
       <FileTree
+        model={virtualizationModel}
         className={DEFAULT_FILE_TREE_PANEL_CLASS}
         prerenderedHTML={virtualizationPrerenderedHTML}
-        options={{
-          virtualize: { threshold: 0 },
-          flattenEmptyDirectories: true,
-          id: 'virtualization-demo',
-        }}
-        initialFiles={files}
+        options={virtualizationReactOptions}
         initialExpandedItems={expandedItems}
         style={panelStyle}
       />

--- a/apps/docs/app/trees/tree-examples/demo-data.ts
+++ b/apps/docs/app/trees/tree-examples/demo-data.ts
@@ -1,11 +1,11 @@
-import type {
-  FileTreeOptions,
-  FileTreeSearchMode,
-  GitStatusEntry,
-} from '@pierre/trees';
+import type { FileTreeSearchMode, GitStatusEntry } from '@pierre/trees';
 import type { CSSProperties } from 'react';
 
-import { sharedDemoFileTreeOptions } from '../../trees/demo-data';
+import {
+  sharedDemoFileTreeOptions,
+  toRuntimeFileTreeOptions,
+  type TreesDocsFileTreeOptions,
+} from '../../trees/demo-data';
 
 /** Default panel look for FileTree in docs examples. Apply via className + style on FileTree. */
 export const DEFAULT_FILE_TREE_PANEL_CLASS =
@@ -28,7 +28,7 @@ export const GIT_STATUSES_B: GitStatusEntry[] = [
 ];
 
 /** Options with flatten empty directories enabled (nested folders collapsed). Pass initialExpandedItems on the component for initial open folders (e.g. ['build']). */
-export function flatteningOptions(flatten: boolean): FileTreeOptions {
+export function flatteningOptions(flatten: boolean): TreesDocsFileTreeOptions {
   return {
     ...sharedDemoFileTreeOptions,
     flattenEmptyDirectories: flatten,
@@ -39,7 +39,9 @@ export function flatteningOptions(flatten: boolean): FileTreeOptions {
 export const baseTreeOptions = sharedDemoFileTreeOptions;
 
 /** Options for drag-and-drop examples. Optional lockedPaths prevents those paths from being dragged. */
-export function dragDropOptions(lockedPaths?: string[]): FileTreeOptions {
+export function dragDropOptions(
+  lockedPaths?: string[]
+): TreesDocsFileTreeOptions {
   return {
     ...baseTreeOptions,
     dragAndDrop: true,
@@ -48,10 +50,22 @@ export function dragDropOptions(lockedPaths?: string[]): FileTreeOptions {
 }
 
 /** Options with search mode for the search example. Pass fileTreeSearchMode at top level so the tree applies it. Use stateConfig.initialSearchQuery in the component for prepopulated search. */
-export function searchOptions(mode: FileTreeSearchMode): FileTreeOptions {
+export function searchOptions(
+  mode: FileTreeSearchMode
+): TreesDocsFileTreeOptions {
   return {
     ...sharedDemoFileTreeOptions,
     fileTreeSearchMode: mode,
     search: true,
   };
+}
+
+// Converts demo-friendly options (with initialFiles) into React FileTree props.
+export function toReactTreeProps(options: TreesDocsFileTreeOptions): {
+  model: ReturnType<typeof toRuntimeFileTreeOptions>['model'];
+  options: Omit<ReturnType<typeof toRuntimeFileTreeOptions>, 'model'>;
+} {
+  const runtimeOptions = toRuntimeFileTreeOptions(options);
+  const { model, ...reactOptions } = runtimeOptions;
+  return { model, options: reactOptions };
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
       "@tailwindcss/postcss": "4.1.13",
       "@types/bun": "1.3.8",
       "@types/hast": "3.0.4",
+      "@types/jsdom": "28.0.1",
       "@types/mdast": "4.0.4",
       "@types/node": "^20",
       "@types/react": "19.2.7",

--- a/packages/trees/package.json
+++ b/packages/trees/package.json
@@ -38,6 +38,7 @@
     "benchmark:file-list-to-tree": "bun run ./scripts/benchmarkFileListToTree.ts",
     "benchmark:core": "bun run ./scripts/benchmarkTreeCorePrimitives.ts",
     "benchmark:incremental-index": "bun run ./scripts/benchmarkIncrementalTreeIndex.ts",
+    "benchmark:model-mutations": "bun run ./scripts/benchmarkModelMutationComplexity.ts",
     "benchmark:render": "bun run ./scripts/benchmarkVirtualizedFileTreeRender.ts",
     "benchmark:render:client": "bun run ./scripts/benchmarkVirtualizedFileTreeClientMount.ts",
     "profile:virtualization": "bun run ./scripts/profileTreesDevVirtualization.ts",

--- a/packages/trees/package.json
+++ b/packages/trees/package.json
@@ -37,6 +37,7 @@
     "benchmark": "bun run ./scripts/benchmarkFileListToTree.ts",
     "benchmark:file-list-to-tree": "bun run ./scripts/benchmarkFileListToTree.ts",
     "benchmark:core": "bun run ./scripts/benchmarkTreeCorePrimitives.ts",
+    "benchmark:incremental-index": "bun run ./scripts/benchmarkIncrementalTreeIndex.ts",
     "benchmark:render": "bun run ./scripts/benchmarkVirtualizedFileTreeRender.ts",
     "benchmark:render:client": "bun run ./scripts/benchmarkVirtualizedFileTreeClientMount.ts",
     "profile:virtualization": "bun run ./scripts/profileTreesDevVirtualization.ts",
@@ -56,6 +57,7 @@
   "devDependencies": {
     "@arethetypeswrong/core": "catalog:",
     "@playwright/test": "catalog:",
+    "@types/jsdom": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "autoprefixer": "catalog:",

--- a/packages/trees/scripts/benchmarkIncrementalTreeIndex.ts
+++ b/packages/trees/scripts/benchmarkIncrementalTreeIndex.ts
@@ -1,0 +1,721 @@
+import { createTree } from '../src/core/create-tree';
+import type { TreeInstance } from '../src/core/types/core';
+import { syncDataLoaderFeature } from '../src/features/sync-data-loader/feature';
+import {
+  formatMs,
+  getEnvironment,
+  parseNonNegativeInteger,
+  parsePositiveInteger,
+  printTable,
+  summarizeSamples,
+  type TimingSummary,
+} from './lib/benchmarkUtils';
+
+type RebuildMode = 'incremental' | 'full';
+
+interface BenchmarkItem {
+  id: string;
+  name: string;
+  isFolder: boolean;
+}
+
+interface FixtureBlueprint {
+  items: Record<string, BenchmarkItem>;
+  children: Record<string, string[]>;
+  folderIdsByDepth: string[][];
+  leafIds: string[];
+  expandedItems: string[];
+}
+
+interface MutableFixtureState {
+  items: Map<string, BenchmarkItem>;
+  children: Map<string, string[]>;
+}
+
+interface BenchmarkTargets {
+  renameItemId: string;
+  insertParentId: string;
+  deleteParentId: string;
+  deleteSubtreeId: string;
+  expandCollapseId: string;
+  moveSourceParentId: string;
+  moveTargetParentId: string;
+  moveSubtreeId: string;
+}
+
+interface ScenarioSummary {
+  operation: string;
+  incremental: TimingSummary;
+  full: TimingSummary;
+}
+
+interface BenchmarkConfig {
+  runs: number;
+  warmupRuns: number;
+  outputJson: boolean;
+  branching: number;
+  depth: number;
+  filesPerFolder: number;
+}
+
+interface BenchmarkOutput {
+  benchmark: 'incrementalTreeIndex';
+  environment: ReturnType<typeof getEnvironment>;
+  config: BenchmarkConfig;
+  summaries: Array<{
+    operation: string;
+    incremental: TimingSummary;
+    full: TimingSummary;
+    speedupMedianX: number;
+  }>;
+}
+
+const DEFAULT_CONFIG: BenchmarkConfig = {
+  runs: 60,
+  warmupRuns: 8,
+  outputJson: false,
+  branching: 8,
+  depth: 5,
+  filesPerFolder: 2,
+};
+
+function printHelpAndExit(): never {
+  console.log('Usage: bun ws trees benchmark:incremental-index -- [options]');
+  console.log('');
+  console.log('Options:');
+  console.log(
+    '  --runs <number>            Measured runs per operation (default: 60)'
+  );
+  console.log(
+    '  --warmup-runs <number>     Warmup runs per operation (default: 8)'
+  );
+  console.log(
+    '  --branching <number>       Folder branching factor (default: 8)'
+  );
+  console.log('  --depth <number>           Folder depth (default: 5)');
+  console.log(
+    '  --files-per-folder <num>   Leaf files per folder (default: 2)'
+  );
+  console.log('  --json                     Emit machine-readable JSON output');
+  console.log('  -h, --help                 Show this help output');
+  process.exit(0);
+}
+
+function parseArgs(argv: string[]): BenchmarkConfig {
+  const config: BenchmarkConfig = { ...DEFAULT_CONFIG };
+
+  for (let index = 0; index < argv.length; index++) {
+    const rawArg = argv[index];
+
+    if (rawArg === '--help' || rawArg === '-h') {
+      printHelpAndExit();
+    }
+
+    if (rawArg === '--json') {
+      config.outputJson = true;
+      continue;
+    }
+
+    const [flag, inlineValue] = rawArg.split('=', 2);
+    if (
+      flag !== '--runs' &&
+      flag !== '--warmup-runs' &&
+      flag !== '--branching' &&
+      flag !== '--depth' &&
+      flag !== '--files-per-folder'
+    ) {
+      throw new Error(`Unknown argument: ${rawArg}`);
+    }
+
+    const value = inlineValue ?? argv[index + 1];
+    if (value == null) {
+      throw new Error(`Missing value for ${flag}`);
+    }
+
+    if (inlineValue == null) {
+      index += 1;
+    }
+
+    if (flag === '--runs') {
+      config.runs = parsePositiveInteger(value, '--runs');
+    } else if (flag === '--warmup-runs') {
+      config.warmupRuns = parseNonNegativeInteger(value, '--warmup-runs');
+    } else if (flag === '--branching') {
+      config.branching = parsePositiveInteger(value, '--branching');
+    } else if (flag === '--depth') {
+      config.depth = parsePositiveInteger(value, '--depth');
+    } else {
+      config.filesPerFolder = parseNonNegativeInteger(
+        value,
+        '--files-per-folder'
+      );
+    }
+  }
+
+  return config;
+}
+
+function createFixtureBlueprint(
+  branching: number,
+  depth: number,
+  filesPerFolder: number
+): FixtureBlueprint {
+  const items: Record<string, BenchmarkItem> = {
+    root: { id: 'root', name: 'root', isFolder: true },
+  };
+  const children: Record<string, string[]> = {
+    root: [],
+  };
+  const folderIdsByDepth: string[][] = [];
+  const leafIds: string[] = [];
+
+  const buildFolder = (parentId: string, currentDepth: number) => {
+    if (currentDepth >= depth) {
+      return;
+    }
+
+    const nextChildren: string[] = [];
+
+    for (let folderIndex = 0; folderIndex < branching; folderIndex++) {
+      const folderId =
+        parentId === 'root'
+          ? `dir-${currentDepth}-${folderIndex}`
+          : `${parentId}/dir-${currentDepth}-${folderIndex}`;
+      items[folderId] = {
+        id: folderId,
+        name: folderId.slice(folderId.lastIndexOf('/') + 1),
+        isFolder: true,
+      };
+      children[folderId] = [];
+      folderIdsByDepth[currentDepth] ??= [];
+      folderIdsByDepth[currentDepth].push(folderId);
+      nextChildren.push(folderId);
+
+      buildFolder(folderId, currentDepth + 1);
+    }
+
+    for (let fileIndex = 0; fileIndex < filesPerFolder; fileIndex++) {
+      const fileId =
+        parentId === 'root'
+          ? `file-${currentDepth}-${fileIndex}.txt`
+          : `${parentId}/file-${currentDepth}-${fileIndex}.txt`;
+      items[fileId] = {
+        id: fileId,
+        name: fileId.slice(fileId.lastIndexOf('/') + 1),
+        isFolder: false,
+      };
+      leafIds.push(fileId);
+      nextChildren.push(fileId);
+    }
+
+    children[parentId] = nextChildren;
+  };
+
+  buildFolder('root', 0);
+
+  const expandedItems = folderIdsByDepth.flat();
+
+  return {
+    items,
+    children,
+    folderIdsByDepth,
+    leafIds,
+    expandedItems,
+  };
+}
+
+function cloneFixtureState(blueprint: FixtureBlueprint): MutableFixtureState {
+  const items = new Map<string, BenchmarkItem>();
+  const children = new Map<string, string[]>();
+
+  for (const [itemId, item] of Object.entries(blueprint.items)) {
+    items.set(itemId, { ...item });
+  }
+
+  for (const [parentId, childIds] of Object.entries(blueprint.children)) {
+    children.set(parentId, [...childIds]);
+  }
+
+  return { items, children };
+}
+
+function createBenchmarkTree(
+  fixture: MutableFixtureState,
+  expandedItems: readonly string[],
+  initialize = true
+): TreeInstance<BenchmarkItem> {
+  const tree = createTree<BenchmarkItem>({
+    rootItemId: 'root',
+    dataLoader: {
+      getItem: (id) =>
+        fixture.items.get(id) ?? {
+          id,
+          name: id,
+          isFolder: false,
+        },
+      getChildren: (id) => fixture.children.get(id) ?? [],
+    },
+    getItemName: (item) => item.getItemData().name,
+    isItemFolder: (item) => item.getItemData().isFolder,
+    features: [syncDataLoaderFeature],
+    initialState: {
+      expandedItems: [...expandedItems],
+    },
+  });
+
+  tree.setMounted(true);
+  if (initialize) {
+    tree.rebuildTree();
+  }
+
+  return tree;
+}
+
+function resolveTargets(blueprint: FixtureBlueprint): BenchmarkTargets {
+  const getFolder = (depth: number, index: number): string => {
+    const foldersAtDepth = blueprint.folderIdsByDepth[depth] ?? [];
+    const folderId = foldersAtDepth[index] ?? foldersAtDepth[0];
+    if (folderId == null) {
+      throw new Error(`Unable to resolve folder at depth ${depth}`);
+    }
+    return folderId;
+  };
+
+  const pickFolderChild = (
+    parentId: string,
+    exclude: Set<string> = new Set()
+  ) => {
+    const childIds = blueprint.children[parentId] ?? [];
+    for (let index = 0; index < childIds.length; index++) {
+      const childId = childIds[index];
+      if (exclude.has(childId)) {
+        continue;
+      }
+      if (blueprint.items[childId]?.isFolder === true) {
+        return childId;
+      }
+    }
+    return null;
+  };
+
+  const renameItemId =
+    blueprint.leafIds[Math.floor(blueprint.leafIds.length / 2)];
+  const insertParentId = getFolder(
+    Math.min(2, blueprint.folderIdsByDepth.length - 1),
+    0
+  );
+
+  const deleteParentId = getFolder(
+    Math.min(1, blueprint.folderIdsByDepth.length - 1),
+    0
+  );
+  const deleteSubtreeId = pickFolderChild(deleteParentId);
+  if (deleteSubtreeId == null) {
+    throw new Error(`Unable to find subtree candidate under ${deleteParentId}`);
+  }
+
+  const expandCollapseId = getFolder(
+    Math.min(1, blueprint.folderIdsByDepth.length - 1),
+    1
+  );
+
+  const moveSourceParentId = getFolder(
+    Math.min(1, blueprint.folderIdsByDepth.length - 1),
+    2
+  );
+  const moveTargetParentId = getFolder(
+    Math.min(1, blueprint.folderIdsByDepth.length - 1),
+    3
+  );
+  const moveSubtreeId = pickFolderChild(
+    moveSourceParentId,
+    new Set<string>([moveTargetParentId])
+  );
+  if (moveSubtreeId == null) {
+    throw new Error(
+      `Unable to find movable subtree under ${moveSourceParentId}`
+    );
+  }
+
+  return {
+    renameItemId,
+    insertParentId,
+    deleteParentId,
+    deleteSubtreeId,
+    expandCollapseId,
+    moveSourceParentId,
+    moveTargetParentId,
+    moveSubtreeId,
+  };
+}
+
+function createRebuildHelpers(
+  tree: TreeInstance<BenchmarkItem>,
+  mode: RebuildMode
+): {
+  markDirty: (itemId: string) => void;
+  rebuild: () => void;
+  timeRebuild: () => number;
+} {
+  const rebuild = () => {
+    if (mode === 'full') {
+      tree.rebuildTreeFromScratch();
+      return;
+    }
+    tree.rebuildTree();
+  };
+
+  const markDirty = (itemId: string) => {
+    if (mode === 'incremental') {
+      tree.markBranchDirty(itemId, 'children');
+    }
+  };
+
+  const timeRebuild = () => {
+    const start = performance.now();
+    rebuild();
+    return performance.now() - start;
+  };
+
+  return {
+    markDirty,
+    rebuild,
+    timeRebuild,
+  };
+}
+
+function measureScenario(
+  runs: number,
+  warmupRuns: number,
+  createSample: () => number
+): TimingSummary {
+  const samples: number[] = [];
+
+  for (let warmupIndex = 0; warmupIndex < warmupRuns; warmupIndex++) {
+    createSample();
+  }
+
+  for (let runIndex = 0; runIndex < runs; runIndex++) {
+    samples.push(createSample());
+  }
+
+  return summarizeSamples(samples);
+}
+
+function benchmarkInitialIngest(
+  blueprint: FixtureBlueprint,
+  mode: RebuildMode
+): () => number {
+  return () => {
+    const fixture = cloneFixtureState(blueprint);
+    const start = performance.now();
+    const tree = createBenchmarkTree(fixture, blueprint.expandedItems, false);
+
+    if (mode === 'full') {
+      tree.rebuildTreeFromScratch();
+    } else {
+      tree.rebuildTree();
+    }
+
+    return performance.now() - start;
+  };
+}
+
+function benchmarkRenameSingleItem(
+  blueprint: FixtureBlueprint,
+  targets: BenchmarkTargets,
+  mode: RebuildMode
+): () => number {
+  const fixture = cloneFixtureState(blueprint);
+  const tree = createBenchmarkTree(fixture, blueprint.expandedItems);
+  const item = fixture.items.get(targets.renameItemId);
+
+  if (item == null) {
+    throw new Error(`Missing rename target ${targets.renameItemId}`);
+  }
+
+  const { rebuild, timeRebuild } = createRebuildHelpers(tree, mode);
+  const baseName = item.name;
+  let sampleIndex = 0;
+
+  return () => {
+    item.name = `${baseName}-renamed-${sampleIndex}`;
+    sampleIndex += 1;
+
+    const durationMs = timeRebuild();
+
+    item.name = baseName;
+    rebuild();
+
+    return durationMs;
+  };
+}
+
+function benchmarkInsertLeaf(
+  blueprint: FixtureBlueprint,
+  targets: BenchmarkTargets,
+  mode: RebuildMode
+): () => number {
+  const fixture = cloneFixtureState(blueprint);
+  const tree = createBenchmarkTree(fixture, blueprint.expandedItems);
+  const { markDirty, rebuild, timeRebuild } = createRebuildHelpers(tree, mode);
+
+  const insertedLeafId = `${targets.insertParentId}/__bench-inserted-leaf`;
+  fixture.items.set(insertedLeafId, {
+    id: insertedLeafId,
+    name: '__bench-inserted-leaf',
+    isFolder: false,
+  });
+
+  return () => {
+    const parentChildren = fixture.children.get(targets.insertParentId);
+    if (parentChildren == null) {
+      throw new Error(`Missing insert parent ${targets.insertParentId}`);
+    }
+
+    const insertionIndex = Math.floor(parentChildren.length / 2);
+    parentChildren.splice(insertionIndex, 0, insertedLeafId);
+    markDirty(targets.insertParentId);
+
+    const durationMs = timeRebuild();
+
+    const insertedIndex = parentChildren.indexOf(insertedLeafId);
+    parentChildren.splice(insertedIndex, 1);
+    markDirty(targets.insertParentId);
+    rebuild();
+
+    return durationMs;
+  };
+}
+
+function benchmarkDeleteSubtree(
+  blueprint: FixtureBlueprint,
+  targets: BenchmarkTargets,
+  mode: RebuildMode
+): () => number {
+  const fixture = cloneFixtureState(blueprint);
+  const tree = createBenchmarkTree(fixture, blueprint.expandedItems);
+  const { markDirty, rebuild, timeRebuild } = createRebuildHelpers(tree, mode);
+
+  return () => {
+    const parentChildren = fixture.children.get(targets.deleteParentId);
+    if (parentChildren == null) {
+      throw new Error(`Missing delete parent ${targets.deleteParentId}`);
+    }
+
+    const originalIndex = parentChildren.indexOf(targets.deleteSubtreeId);
+    if (originalIndex < 0) {
+      throw new Error(
+        `Subtree ${targets.deleteSubtreeId} is not under ${targets.deleteParentId}`
+      );
+    }
+
+    parentChildren.splice(originalIndex, 1);
+    markDirty(targets.deleteParentId);
+
+    const durationMs = timeRebuild();
+
+    parentChildren.splice(originalIndex, 0, targets.deleteSubtreeId);
+    markDirty(targets.deleteParentId);
+    rebuild();
+
+    return durationMs;
+  };
+}
+
+function benchmarkExpandCollapse(
+  blueprint: FixtureBlueprint,
+  targets: BenchmarkTargets,
+  mode: RebuildMode
+): () => number {
+  const fixture = cloneFixtureState(blueprint);
+  const tree = createBenchmarkTree(fixture, blueprint.expandedItems);
+  const { timeRebuild } = createRebuildHelpers(tree, mode);
+
+  return () => {
+    tree.applySubStateUpdate('expandedItems', (expandedItems) =>
+      expandedItems.filter((itemId) => itemId !== targets.expandCollapseId)
+    );
+    const collapseDurationMs = timeRebuild();
+
+    tree.applySubStateUpdate('expandedItems', (expandedItems) => [
+      ...expandedItems,
+      targets.expandCollapseId,
+    ]);
+    const expandDurationMs = timeRebuild();
+
+    return (collapseDurationMs + expandDurationMs) / 2;
+  };
+}
+
+function benchmarkMoveSubtree(
+  blueprint: FixtureBlueprint,
+  targets: BenchmarkTargets,
+  mode: RebuildMode
+): () => number {
+  const fixture = cloneFixtureState(blueprint);
+  const tree = createBenchmarkTree(fixture, blueprint.expandedItems);
+  const { markDirty, rebuild, timeRebuild } = createRebuildHelpers(tree, mode);
+
+  return () => {
+    const sourceChildren = fixture.children.get(targets.moveSourceParentId);
+    const targetChildren = fixture.children.get(targets.moveTargetParentId);
+
+    if (sourceChildren == null || targetChildren == null) {
+      throw new Error('Unable to resolve move parent children arrays.');
+    }
+
+    const sourceIndex = sourceChildren.indexOf(targets.moveSubtreeId);
+    if (sourceIndex < 0) {
+      throw new Error(
+        `Move subtree ${targets.moveSubtreeId} is not under ${targets.moveSourceParentId}`
+      );
+    }
+
+    sourceChildren.splice(sourceIndex, 1);
+    const targetInsertionIndex = Math.floor(targetChildren.length / 2);
+    targetChildren.splice(targetInsertionIndex, 0, targets.moveSubtreeId);
+
+    markDirty(targets.moveSourceParentId);
+    markDirty(targets.moveTargetParentId);
+    const durationMs = timeRebuild();
+
+    const movedIndexInTarget = targetChildren.indexOf(targets.moveSubtreeId);
+    targetChildren.splice(movedIndexInTarget, 1);
+    sourceChildren.splice(sourceIndex, 0, targets.moveSubtreeId);
+
+    markDirty(targets.moveSourceParentId);
+    markDirty(targets.moveTargetParentId);
+    rebuild();
+
+    return durationMs;
+  };
+}
+
+function runBenchmark(config: BenchmarkConfig): ScenarioSummary[] {
+  const blueprint = createFixtureBlueprint(
+    config.branching,
+    config.depth,
+    config.filesPerFolder
+  );
+  const targets = resolveTargets(blueprint);
+
+  const scenarios: Array<{
+    operation: string;
+    createSample: (mode: RebuildMode) => () => number;
+  }> = [
+    {
+      operation: 'initial-ingest',
+      createSample: (mode) => benchmarkInitialIngest(blueprint, mode),
+    },
+    {
+      operation: 'rename-single-item',
+      createSample: (mode) =>
+        benchmarkRenameSingleItem(blueprint, targets, mode),
+    },
+    {
+      operation: 'insert-leaf',
+      createSample: (mode) => benchmarkInsertLeaf(blueprint, targets, mode),
+    },
+    {
+      operation: 'delete-subtree',
+      createSample: (mode) => benchmarkDeleteSubtree(blueprint, targets, mode),
+    },
+    {
+      operation: 'expand-collapse-medium-subtree',
+      createSample: (mode) => benchmarkExpandCollapse(blueprint, targets, mode),
+    },
+    {
+      operation: 'move-subtree',
+      createSample: (mode) => benchmarkMoveSubtree(blueprint, targets, mode),
+    },
+  ];
+
+  const summaries: ScenarioSummary[] = [];
+
+  for (
+    let scenarioIndex = 0;
+    scenarioIndex < scenarios.length;
+    scenarioIndex++
+  ) {
+    const scenario = scenarios[scenarioIndex];
+
+    const incrementalSummary = measureScenario(
+      config.runs,
+      config.warmupRuns,
+      scenario.createSample('incremental')
+    );
+
+    const fullSummary = measureScenario(
+      config.runs,
+      config.warmupRuns,
+      scenario.createSample('full')
+    );
+
+    summaries.push({
+      operation: scenario.operation,
+      incremental: incrementalSummary,
+      full: fullSummary,
+    });
+  }
+
+  return summaries;
+}
+
+function main() {
+  const config = parseArgs(process.argv.slice(2));
+  const environment = getEnvironment();
+  const summaries = runBenchmark(config);
+
+  if (config.outputJson) {
+    const output: BenchmarkOutput = {
+      benchmark: 'incrementalTreeIndex',
+      environment,
+      config,
+      summaries: summaries.map((summary) => ({
+        operation: summary.operation,
+        incremental: summary.incremental,
+        full: summary.full,
+        speedupMedianX:
+          summary.incremental.medianMs === 0
+            ? Number.POSITIVE_INFINITY
+            : summary.full.medianMs / summary.incremental.medianMs,
+      })),
+    };
+    console.log(JSON.stringify(output, null, 2));
+    return;
+  }
+
+  console.log('incremental tree index benchmark');
+  console.log(
+    `bun=${environment.bunVersion} platform=${environment.platform} arch=${environment.arch}`
+  );
+  console.log(
+    `runsPerOperation=${config.runs} warmupRunsPerOperation=${config.warmupRuns}`
+  );
+  console.log(
+    `branching=${config.branching} depth=${config.depth} filesPerFolder=${config.filesPerFolder}`
+  );
+  console.log('');
+
+  printTable(
+    summaries.map((summary) => {
+      const speedup =
+        summary.incremental.medianMs === 0
+          ? Number.POSITIVE_INFINITY
+          : summary.full.medianMs / summary.incremental.medianMs;
+
+      return {
+        operation: summary.operation,
+        incrementalMedianMs: formatMs(summary.incremental.medianMs),
+        fullMedianMs: formatMs(summary.full.medianMs),
+        speedupMedianX: Number.isFinite(speedup)
+          ? `${speedup.toFixed(2)}x`
+          : 'inf',
+      };
+    }),
+    ['operation', 'incrementalMedianMs', 'fullMedianMs', 'speedupMedianX']
+  );
+}
+
+main();

--- a/packages/trees/scripts/benchmarkModelMutationComplexity.ts
+++ b/packages/trees/scripts/benchmarkModelMutationComplexity.ts
@@ -1,0 +1,428 @@
+import { FileTreeModel } from '../src/model/FileTreeModel';
+import {
+  formatMs,
+  getEnvironment,
+  parseNonNegativeInteger,
+  parsePositiveInteger,
+  printTable,
+  summarizeSamples,
+  type TimingSummary,
+} from './lib/benchmarkUtils';
+
+type FixtureShape = 'wide' | 'deep';
+type ShapeSelection = FixtureShape | 'both';
+
+type MutationOperationName =
+  | 'rename-file'
+  | 'rename-folder'
+  | 'move-file'
+  | 'move-folder'
+  | 'add-path'
+  | 'delete-path';
+
+interface BenchmarkConfig {
+  runs: number;
+  warmupRuns: number;
+  smallNoise: number;
+  largeNoise: number;
+  shape: ShapeSelection;
+  warmPathTree: boolean;
+  outputJson: boolean;
+}
+
+interface CounterCollector {
+  counters: Record<string, number>;
+  instrumentation: {
+    measurePhase: <TValue>(name: string, fn: () => TValue) => TValue;
+    setCounter: (name: string, value: number) => void;
+  };
+}
+
+interface OperationDefinition {
+  name: MutationOperationName;
+  counterName: string;
+  run: (model: FileTreeModel) => { ok: boolean; error?: string };
+}
+
+interface OperationMeasurement {
+  timing: TimingSummary;
+  counter: TimingSummary;
+}
+
+interface OperationRow {
+  shape: FixtureShape;
+  operation: MutationOperationName;
+  counterName: string;
+  smallNoise: number;
+  largeNoise: number;
+  smallTiming: TimingSummary;
+  largeTiming: TimingSummary;
+  smallCounter: TimingSummary;
+  largeCounter: TimingSummary;
+  timingScale: number;
+  counterScale: number;
+}
+
+interface BenchmarkOutput {
+  benchmark: 'modelMutationComplexity';
+  environment: ReturnType<typeof getEnvironment>;
+  config: BenchmarkConfig;
+  rows: OperationRow[];
+}
+
+const DEFAULT_CONFIG: BenchmarkConfig = {
+  runs: 25,
+  warmupRuns: 5,
+  smallNoise: 10,
+  largeNoise: 1500,
+  shape: 'both',
+  warmPathTree: true,
+  outputJson: false,
+};
+
+const OPERATIONS: OperationDefinition[] = [
+  {
+    name: 'rename-file',
+    counterName: 'model.rename.file.remapScannedNodes',
+    run: (model) =>
+      model.renamePath({
+        sourcePath: 'workspace/src/deep/nested/file-a.ts',
+        destinationPath: 'workspace/src/deep/nested/file-a-renamed.ts',
+        isFolder: false,
+      }),
+  },
+  {
+    name: 'rename-folder',
+    counterName: 'model.rename.folder.remapScannedNodes',
+    run: (model) =>
+      model.renamePath({
+        sourcePath: 'workspace/src/deep',
+        destinationPath: 'workspace/src/deep-renamed',
+        isFolder: true,
+      }),
+  },
+  {
+    name: 'move-file',
+    counterName: 'model.move.remapScannedNodes',
+    run: (model) =>
+      model.movePaths({
+        draggedPaths: ['workspace/src/deep/nested/file-a.ts'],
+        targetPath: 'workspace/target',
+      }),
+  },
+  {
+    name: 'move-folder',
+    counterName: 'model.move.remapScannedNodes',
+    run: (model) =>
+      model.movePaths({
+        draggedPaths: ['workspace/src/deep'],
+        targetPath: 'workspace/target',
+      }),
+  },
+  {
+    name: 'add-path',
+    counterName: 'model.rebuildFolders.executedCount',
+    run: (model) =>
+      model.addPaths({
+        paths: ['workspace/src/deep/nested/added.ts'],
+      }),
+  },
+  {
+    name: 'delete-path',
+    counterName: 'model.rebuildFolders.executedCount',
+    run: (model) =>
+      model.deletePaths({
+        paths: ['workspace/src/deep/nested/file-b.ts'],
+      }),
+  },
+];
+
+function printHelpAndExit(): never {
+  console.log('Usage: bun ws trees benchmark:model-mutations -- [options]');
+  console.log('');
+  console.log('Options:');
+  console.log(
+    '  --runs <number>          Measured runs per shape/operation (default: 25)'
+  );
+  console.log(
+    '  --warmup-runs <number>   Warmup runs per shape/operation (default: 5)'
+  );
+  console.log(
+    '  --small-noise <number>   Unrelated fixture size for baseline (default: 10)'
+  );
+  console.log(
+    '  --large-noise <number>   Unrelated fixture size for scale check (default: 1500)'
+  );
+  console.log('  --shape <value>          wide | deep | both (default: both)');
+  console.log(
+    '  --cold-path-tree         Include one-time path-tree creation in mutation timings'
+  );
+  console.log('  --json                   Emit machine-readable JSON output');
+  console.log('  -h, --help               Show this help output');
+  process.exit(0);
+}
+
+function parseShape(value: string): ShapeSelection {
+  if (value === 'wide' || value === 'deep' || value === 'both') {
+    return value;
+  }
+
+  throw new Error(
+    `Invalid --shape value '${value}'. Expected one of: wide, deep, both.`
+  );
+}
+
+function parseArgs(argv: string[]): BenchmarkConfig {
+  const config: BenchmarkConfig = { ...DEFAULT_CONFIG };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const rawArg = argv[index];
+
+    if (rawArg === '--help' || rawArg === '-h') {
+      printHelpAndExit();
+    }
+
+    if (rawArg === '--json') {
+      config.outputJson = true;
+      continue;
+    }
+
+    if (rawArg === '--cold-path-tree') {
+      config.warmPathTree = false;
+      continue;
+    }
+
+    const [flag, inlineValue] = rawArg.split('=', 2);
+    if (
+      flag !== '--runs' &&
+      flag !== '--warmup-runs' &&
+      flag !== '--small-noise' &&
+      flag !== '--large-noise' &&
+      flag !== '--shape'
+    ) {
+      throw new Error(`Unknown argument: ${rawArg}`);
+    }
+
+    const value = inlineValue ?? argv[index + 1];
+    if (value == null) {
+      throw new Error(`Missing value for ${flag}`);
+    }
+    if (inlineValue == null) {
+      index += 1;
+    }
+
+    if (flag === '--runs') {
+      config.runs = parsePositiveInteger(value, '--runs');
+    } else if (flag === '--warmup-runs') {
+      config.warmupRuns = parseNonNegativeInteger(value, '--warmup-runs');
+    } else if (flag === '--small-noise') {
+      config.smallNoise = parseNonNegativeInteger(value, '--small-noise');
+    } else if (flag === '--large-noise') {
+      config.largeNoise = parseNonNegativeInteger(value, '--large-noise');
+    } else {
+      config.shape = parseShape(value);
+    }
+  }
+
+  return config;
+}
+
+function createCounterCollector(): CounterCollector {
+  const counters: Record<string, number> = {};
+
+  return {
+    counters,
+    instrumentation: {
+      measurePhase: (_name, fn) => fn(),
+      setCounter: (name, value) => {
+        counters[name] = value;
+      },
+    },
+  };
+}
+
+function createFixtureFiles(
+  unrelatedFileCount: number,
+  shape: FixtureShape
+): string[] {
+  const files = [
+    'workspace/src/deep/nested/file-a.ts',
+    'workspace/src/deep/nested/file-b.ts',
+    'workspace/src/deep/root-file.ts',
+    'workspace/target/keep.ts',
+  ];
+
+  for (let index = 0; index < unrelatedFileCount; index += 1) {
+    if (shape === 'wide') {
+      files.push(`noise-${index}/file-${index}.ts`);
+      continue;
+    }
+
+    let parentPath = `noise-${index}`;
+    for (let depth = 0; depth < 8; depth += 1) {
+      parentPath = `${parentPath}/segment-${depth}`;
+    }
+    files.push(`${parentPath}/file-${index}.ts`);
+  }
+
+  return files;
+}
+
+function safeScale(large: number, small: number): number {
+  if (small === 0) {
+    return large === 0 ? 1 : Number.POSITIVE_INFINITY;
+  }
+  return large / small;
+}
+
+function primePathTree(model: FileTreeModel): void {
+  model.deletePaths({
+    paths: ['__complexity__/missing-path.ts'],
+  });
+}
+
+function runOperationMeasurement(
+  config: BenchmarkConfig,
+  shape: FixtureShape,
+  unrelatedFileCount: number,
+  operation: OperationDefinition
+): OperationMeasurement {
+  const timingSamples: number[] = [];
+  const counterSamples: number[] = [];
+  const totalRuns = config.runs + config.warmupRuns;
+
+  for (let runIndex = 0; runIndex < totalRuns; runIndex += 1) {
+    const { counters, instrumentation } = createCounterCollector();
+    const model = FileTreeModel.fromFiles(
+      createFixtureFiles(unrelatedFileCount, shape),
+      {
+        sortComparator: false,
+        benchmarkInstrumentation: instrumentation,
+      }
+    );
+
+    if (config.warmPathTree) {
+      primePathTree(model);
+    }
+
+    const startTime = performance.now();
+    const result = operation.run(model);
+    const durationMs = performance.now() - startTime;
+
+    if (result.ok !== true) {
+      const errorMessage = result.error ?? 'Unknown mutation error';
+      throw new Error(
+        `${operation.name} failed for ${shape} fixture (${unrelatedFileCount} unrelated files): ${errorMessage}`
+      );
+    }
+
+    if (runIndex < config.warmupRuns) {
+      continue;
+    }
+
+    timingSamples.push(durationMs);
+    counterSamples.push(counters[operation.counterName] ?? 0);
+  }
+
+  return {
+    timing: summarizeSamples(timingSamples),
+    counter: summarizeSamples(counterSamples),
+  };
+}
+
+function resolveShapes(selection: ShapeSelection): FixtureShape[] {
+  if (selection === 'both') {
+    return ['wide', 'deep'];
+  }
+  return [selection];
+}
+
+function runBenchmark(config: BenchmarkConfig): BenchmarkOutput {
+  const rows: OperationRow[] = [];
+  const shapes = resolveShapes(config.shape);
+
+  for (let shapeIndex = 0; shapeIndex < shapes.length; shapeIndex += 1) {
+    const shape = shapes[shapeIndex];
+
+    for (
+      let operationIndex = 0;
+      operationIndex < OPERATIONS.length;
+      operationIndex += 1
+    ) {
+      const operation = OPERATIONS[operationIndex];
+
+      const small = runOperationMeasurement(
+        config,
+        shape,
+        config.smallNoise,
+        operation
+      );
+      const large = runOperationMeasurement(
+        config,
+        shape,
+        config.largeNoise,
+        operation
+      );
+
+      rows.push({
+        shape,
+        operation: operation.name,
+        counterName: operation.counterName,
+        smallNoise: config.smallNoise,
+        largeNoise: config.largeNoise,
+        smallTiming: small.timing,
+        largeTiming: large.timing,
+        smallCounter: small.counter,
+        largeCounter: large.counter,
+        timingScale: safeScale(large.timing.medianMs, small.timing.medianMs),
+        counterScale: safeScale(large.counter.medianMs, small.counter.medianMs),
+      });
+    }
+  }
+
+  return {
+    benchmark: 'modelMutationComplexity',
+    environment: getEnvironment(),
+    config,
+    rows,
+  };
+}
+
+function printBenchmark(output: BenchmarkOutput): void {
+  const rows = output.rows.map((row) => ({
+    Shape: row.shape,
+    Operation: row.operation,
+    Counter: row.counterName,
+    'Small median (ms)': formatMs(row.smallTiming.medianMs),
+    'Large median (ms)': formatMs(row.largeTiming.medianMs),
+    'Timing scale x': Number.isFinite(row.timingScale)
+      ? row.timingScale.toFixed(2)
+      : 'inf',
+    'Small counter': row.smallCounter.medianMs.toFixed(1),
+    'Large counter': row.largeCounter.medianMs.toFixed(1),
+    'Counter scale x': Number.isFinite(row.counterScale)
+      ? row.counterScale.toFixed(2)
+      : 'inf',
+  }));
+
+  printTable(rows, [
+    'Shape',
+    'Operation',
+    'Counter',
+    'Small median (ms)',
+    'Large median (ms)',
+    'Timing scale x',
+    'Small counter',
+    'Large counter',
+    'Counter scale x',
+  ]);
+}
+
+const config = parseArgs(process.argv.slice(2));
+const output = runBenchmark(config);
+
+if (config.outputJson) {
+  console.log(JSON.stringify(output, null, 2));
+} else {
+  printBenchmark(output);
+}

--- a/packages/trees/scripts/benchmarkVirtualizedFileTreeClientMount.ts
+++ b/packages/trees/scripts/benchmarkVirtualizedFileTreeClientMount.ts
@@ -2,6 +2,7 @@
 import { JSDOM } from 'jsdom';
 import { fileURLToPath } from 'node:url';
 
+import { FileTreeModel } from '../src/model/FileTreeModel';
 import {
   type BenchmarkEnvironment,
   formatMs,
@@ -338,7 +339,9 @@ function createFileTreeOptions(
 ): import('../src/FileTree').FileTreeOptions {
   return {
     id: `benchmark-client-render-${caseConfig.name.replace(/[^A-Za-z0-9_-]/g, '-')}`,
-    initialFiles: caseConfig.files,
+    model: FileTreeModel.fromFiles(caseConfig.files, {
+      sortComparator: false,
+    }),
     flattenEmptyDirectories: true,
     sort: false,
     virtualize: { threshold: 0 },

--- a/packages/trees/scripts/benchmarkVirtualizedFileTreeRender.ts
+++ b/packages/trees/scripts/benchmarkVirtualizedFileTreeRender.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import type { FileTreeOptions, FileTreeStateConfig } from '../src/FileTree';
+import { FileTreeModel } from '../src/model/FileTreeModel';
 import {
   type BenchmarkEnvironment,
   calculateDeltaPercent,
@@ -415,7 +416,9 @@ function createFileTreeOptions(
 ): FileTreeOptions {
   return {
     id: `benchmark-render-${caseConfig.name.replace(/[^A-Za-z0-9_-]/g, '-')}`,
-    initialFiles: caseConfig.files,
+    model: FileTreeModel.fromFiles(caseConfig.files, {
+      sortComparator: false,
+    }),
     flattenEmptyDirectories: true,
     sort: false,
     virtualize: { threshold: 0 },

--- a/packages/trees/scripts/lib/benchmarkVirtualizedRenderRuntime.tsx
+++ b/packages/trees/scripts/lib/benchmarkVirtualizedRenderRuntime.tsx
@@ -219,7 +219,7 @@ function createBenchmarkVirtualizedRoot(
   }: BenchmarkVirtualizedRootProps): JSX.Element {
     'use no memo';
     const {
-      initialFiles: files,
+      model,
       flattenEmptyDirectories,
       fileTreeSearchMode,
       gitStatus,
@@ -228,6 +228,9 @@ function createBenchmarkVirtualizedRoot(
       useLazyDataLoader,
       virtualize,
     } = fileTreeOptions;
+    const files = model.getFiles();
+    const modelVersion = model.getVersion();
+    const syncIndex = model.getSyncIndex();
     const iconRemap = fileTreeOptions.icons?.remap;
 
     const remapIcon = useCallback(
@@ -266,10 +269,13 @@ function createBenchmarkVirtualizedRoot(
       [sortOption]
     );
 
-    const treeData = useMemo(
-      () => runtime.fileListToTree(files, { sortComparator }),
-      [files, sortComparator]
-    );
+    const treeData = useMemo(() => {
+      // Tie recomputation to modelVersion even though the syncIndex Map
+      // identity is stable across model mutations.
+      const snapshotVersion = modelVersion;
+      void snapshotVersion;
+      return Object.fromEntries(syncIndex.tree);
+    }, [modelVersion, syncIndex]);
 
     const { pathToId, idToPath } = useMemo(() => {
       const p2i = new Map<string, string>();

--- a/packages/trees/scripts/profileTreesDevVirtualization.ts
+++ b/packages/trees/scripts/profileTreesDevVirtualization.ts
@@ -4,10 +4,13 @@ import { tmpdir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+type ProfileActionName = 'initial-render' | 'rename-file';
+
 interface ProfileConfig {
   browserUrl: string;
   url: string;
   workloads: string[];
+  actions: ProfileActionName[];
   timeoutMs: number;
   runs: number;
   warmupRuns: number;
@@ -151,6 +154,8 @@ interface HeapSummary {
 
 interface ProfileResult {
   runNumber: number;
+  actionName: ProfileActionName;
+  actionLabel: string;
   browserUrl: string;
   url: string;
   workload: PageWorkloadSummary;
@@ -204,6 +209,7 @@ interface ProfileConfigSummary {
   browserUrl: string;
   url: string;
   workloads: string[];
+  actions: ProfileActionName[];
   timeoutMs: number;
   runs: number;
   warmupRuns: number;
@@ -333,10 +339,19 @@ interface CdpMessage {
   };
 }
 
+interface VirtualizationFixtureApi {
+  runInitialRender: () => Promise<PageRenderSummary>;
+  runRenameFile: () => Promise<PageRenderSummary>;
+}
+
 declare global {
   interface Window {
     __treesDevVirtualizationFixtureReady?: boolean;
-    __treesDevVirtualizationProfile?: PageRenderSummary;
+    __treesDevVirtualizationFixtureApi?: VirtualizationFixtureApi;
+    __treesDevVirtualizationProfile?: {
+      workload?: PageWorkloadSummary;
+      operations?: Partial<Record<ProfileActionName, PageRenderSummary>>;
+    };
   }
 }
 
@@ -345,6 +360,8 @@ const DEFAULT_BROWSER_URL = 'http://127.0.0.1:9222';
 const DEFAULT_URL =
   'http://127.0.0.1:9221/test/e2e/fixtures/virtualization.html';
 const DEFAULT_WORKLOAD_NAME = 'linux-5x';
+const DEFAULT_ACTIONS: ProfileActionName[] = ['initial-render', 'rename-file'];
+const KNOWN_ACTION_NAMES = new Set<ProfileActionName>(DEFAULT_ACTIONS);
 const KNOWN_WORKLOAD_NAMES = new Set([
   'pierre-snapshot',
   'half-linux',
@@ -443,12 +460,12 @@ const AGGREGATE_METRIC_DEFINITIONS: Array<{
 }> = [
   {
     key: 'visibleRowsReadyMs',
-    label: 'Visible rows ready',
+    label: 'Action visible rows ready',
     select: (result) => result.visibleRowsReadyMs,
   },
   {
     key: 'postPaintReadyMs',
-    label: 'Post-paint ready',
+    label: 'Action post-paint ready',
     select: (result) => result.renderDurationMs,
   },
   {
@@ -500,6 +517,9 @@ function printHelpAndExit(): never {
   );
   console.log(
     `  --workload <name>      Fixture workload to run (repeatable, default: ${DEFAULT_WORKLOAD_NAME})`
+  );
+  console.log(
+    `  --action <name>        Profile action to run (repeatable, default: ${DEFAULT_ACTIONS.join(', ')})`
   );
   console.log(
     `  --timeout <ms>         Navigation/render timeout in milliseconds (default: ${DEFAULT_TIMEOUT_MS})`
@@ -573,6 +593,18 @@ function parseWorkloadName(value: string): string {
   );
 }
 
+function parseActionName(value: string): ProfileActionName {
+  if (KNOWN_ACTION_NAMES.has(value as ProfileActionName)) {
+    return value as ProfileActionName;
+  }
+
+  throw new Error(
+    `Invalid --action value '${value}'. Expected one of: ${[
+      ...KNOWN_ACTION_NAMES,
+    ].join(', ')}.`
+  );
+}
+
 function createTraceRunId(): string {
   return `${new Date()
     .toISOString()
@@ -590,7 +622,9 @@ function createDefaultTraceOutputPath(): string {
 function createRunTraceOutputPath(
   traceOutputPath: string,
   workloadName: string,
+  actionName: ProfileActionName,
   workloadCount: number,
+  actionCount: number,
   runNumber: number,
   totalRuns: number
 ): string {
@@ -602,6 +636,15 @@ function createRunTraceOutputPath(
       .replace(/[^a-z0-9]+/g, '-')
       .replace(/^-+|-+$/g, '');
     suffixParts.push(workloadSlug.length > 0 ? workloadSlug : 'workload');
+  }
+
+  if (actionCount > 1 || workloadCount > 1 || totalRuns > 1) {
+    const actionSlug = actionName
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+    suffixParts.push(actionSlug.length > 0 ? actionSlug : 'action');
   }
 
   if (totalRuns > 1) {
@@ -658,6 +701,7 @@ function parseArgs(argv: string[]): ProfileConfig {
     browserUrl: DEFAULT_BROWSER_URL,
     url: DEFAULT_URL,
     workloads: [DEFAULT_WORKLOAD_NAME],
+    actions: [...DEFAULT_ACTIONS],
     timeoutMs: DEFAULT_TIMEOUT_MS,
     runs: DEFAULT_RUN_COUNT,
     warmupRuns: DEFAULT_WARMUP_RUN_COUNT,
@@ -706,6 +750,7 @@ function parseArgs(argv: string[]): ProfileConfig {
       flag === '--browser-url' ||
       flag === '--url' ||
       flag === '--workload' ||
+      flag === '--action' ||
       flag === '--timeout' ||
       flag === '--runs' ||
       flag === '--warmup-runs' ||
@@ -733,6 +778,16 @@ function parseArgs(argv: string[]): ProfileConfig {
           config.workloads = [];
         }
         config.workloads.push(parseWorkloadName(value));
+      } else if (flag === '--action') {
+        if (
+          config.actions.length === DEFAULT_ACTIONS.length &&
+          DEFAULT_ACTIONS.every((action, actionIndex) => {
+            return config.actions[actionIndex] === action;
+          })
+        ) {
+          config.actions = [];
+        }
+        config.actions.push(parseActionName(value));
       } else if (flag === '--timeout') {
         config.timeoutMs = parsePositiveInteger(value, '--timeout');
       } else if (flag === '--runs') {
@@ -753,6 +808,7 @@ function parseArgs(argv: string[]): ProfileConfig {
   }
 
   config.workloads = [...new Set(config.workloads)];
+  config.actions = [...new Set(config.actions)] as ProfileActionName[];
   return config;
 }
 
@@ -896,6 +952,7 @@ function createProfileConfigSummary(
     browserUrl: config.browserUrl,
     url: config.url,
     workloads: [...config.workloads],
+    actions: [...config.actions],
     timeoutMs: config.timeoutMs,
     runs: config.runs,
     warmupRuns: config.warmupRuns,
@@ -2181,11 +2238,28 @@ function formatPhaseWorkload(
       })();
     }
     case 'core.rebuildItemMeta': {
-      return formatWorkloadPair(
-        counters,
-        'workload.visibleItemMeta',
-        'visible items'
-      );
+      return joinWorkloadParts([
+        formatWorkloadPair(
+          counters,
+          'workload.visibleItemMeta',
+          'visible items'
+        ),
+        formatWorkloadPair(
+          counters,
+          'workload.rebuild.fullCount',
+          'full rebuilds'
+        ),
+        formatWorkloadPair(
+          counters,
+          'workload.rebuild.incrementalCount',
+          'incremental rebuilds'
+        ),
+        formatWorkloadPair(
+          counters,
+          'workload.rebuild.noopCount',
+          'noop rebuilds'
+        ),
+      ]);
     }
     case 'fileTree.render.mount': {
       return `${formatCount(renderedItemCount)} visible rows`;
@@ -2493,89 +2567,76 @@ async function closePageTarget(
   ).catch(() => {});
 }
 
-async function waitForProfileSummary(
+function getActionMethodName(actionName: ProfileActionName): string {
+  return actionName === 'rename-file' ? 'runRenameFile' : 'runInitialRender';
+}
+
+function getActionLabel(actionName: ProfileActionName): string {
+  return actionName === 'rename-file' ? 'Rename file' : 'Initial render';
+}
+
+async function runFixtureAction(
   cdp: CdpClient,
-  timeoutMs: number
+  actionName: ProfileActionName
 ): Promise<PageRenderSummary> {
+  const methodName = getActionMethodName(actionName);
   const summary = await evaluateJson<{
     done: boolean;
     profile: PageRenderSummary | null;
+    reason?: string;
   }>(
     cdp,
     `(async () => {
-      const started = performance.now();
-      while (performance.now() - started < ${timeoutMs}) {
-        if (window.__treesDevVirtualizationProfile != null) {
-          return { done: true, profile: window.__treesDevVirtualizationProfile };
-        }
-        await new Promise((resolve) => setTimeout(resolve, 50));
+      const fixtureApi = window.__treesDevVirtualizationFixtureApi;
+      if (fixtureApi == null) {
+        return {
+          done: false,
+          profile: null,
+          reason: 'Missing window.__treesDevVirtualizationFixtureApi',
+        };
       }
-      return {
-        done: false,
-        profile: window.__treesDevVirtualizationProfile ?? null,
-      };
+
+      const operation = fixtureApi['${methodName}'];
+      if (typeof operation !== 'function') {
+        return {
+          done: false,
+          profile: null,
+          reason: 'Missing fixture API method ${methodName}',
+        };
+      }
+
+      try {
+        const profile = await operation();
+        return { done: true, profile };
+      } catch (error) {
+        return {
+          done: false,
+          profile: null,
+          reason: error instanceof Error ? error.message : String(error),
+        };
+      }
     })()`
   );
 
   if (!summary.done || summary.profile == null) {
-    throw new Error('Timed out waiting for the virtualization render summary.');
+    throw new Error(
+      summary.reason ??
+        `Timed out waiting for fixture action ${actionName} summary.`
+    );
   }
 
   return summary.profile;
 }
 
-async function clickRenderButton(cdp: CdpClient): Promise<void> {
-  const result = await evaluateJson<{
-    ok: boolean;
-    reason?: string;
-    x?: number;
-    y?: number;
-  }>(
-    cdp,
-    `(() => {
-      const button = document.querySelector('[data-profile-render-button]');
-      if (!(button instanceof HTMLButtonElement)) {
-        return { ok: false, reason: 'Missing [data-profile-render-button]' };
-      }
-      const rect = button.getBoundingClientRect();
-      return {
-        ok: true,
-        x: rect.left + rect.width / 2,
-        y: rect.top + rect.height / 2,
-      };
-    })()`
-  );
-
-  if (!result.ok || result.x == null || result.y == null) {
-    throw new Error(result.reason ?? 'Failed to click the render button.');
+async function prepareFixtureForAction(
+  cdp: CdpClient,
+  actionName: ProfileActionName
+): Promise<void> {
+  if (actionName === 'initial-render') {
+    return;
   }
 
-  await cdp.send('Input.dispatchMouseEvent', {
-    type: 'mouseMoved',
-    x: result.x,
-    y: result.y,
-    button: 'none',
-    pointerType: 'mouse',
-  });
-  await cdp.send('Input.dispatchMouseEvent', {
-    type: 'mousePressed',
-    x: result.x,
-    y: result.y,
-    button: 'left',
-    buttons: 1,
-    clickCount: 1,
-    pointerType: 'mouse',
-  });
-  await Bun.sleep(16);
-  await cdp.send('Input.dispatchMouseEvent', {
-    type: 'mouseReleased',
-    x: result.x,
-    y: result.y,
-    button: 'left',
-    buttons: 0,
-    clickCount: 1,
-    pointerType: 'mouse',
-  });
+  await runFixtureAction(cdp, 'initial-render');
 }
 
 async function collectProfilingArtifacts(
@@ -2644,13 +2705,16 @@ async function collectProfilingArtifacts(
 async function collectFunctionCallCounts(
   cdp: CdpClient,
   url: string,
+  actionName: ProfileActionName,
   timeoutMs: number
 ): Promise<Map<string, number | null> | null> {
   try {
     await navigateToFixture(cdp, url, timeoutMs);
+    if (actionName !== 'initial-render') {
+      await prepareFixtureForAction(cdp, actionName);
+    }
     await startPreciseCoverage(cdp);
-    await clickRenderButton(cdp);
-    await waitForProfileSummary(cdp, timeoutMs);
+    await runFixtureAction(cdp, actionName);
     const coverage = await stopPreciseCoverage(cdp);
     if (coverage == null) {
       return null;
@@ -2679,6 +2743,7 @@ function writeTraceIfAvailable(
 async function profileVirtualizedRender(
   config: ProfileConfig,
   workloadName: string,
+  actionName: ProfileActionName,
   runNumber: number,
   traceOutputPath: string | null
 ): Promise<ProfileResult> {
@@ -2712,21 +2777,28 @@ async function profileVirtualizedRender(
     await cdp.send('Page.enable');
     await cdp.send('Runtime.enable');
     await navigateToFixture(cdp, profileUrl, config.timeoutMs);
+    await prepareFixtureForAction(cdp, actionName);
 
     const { pageSummary, trace, cpuProfile } = await collectProfilingArtifacts(
       cdp,
       config.timeoutMs,
       async () => {
-        await clickRenderButton(cdp);
-        return await waitForProfileSummary(cdp, config.timeoutMs);
+        return await runFixtureAction(cdp, actionName);
       }
     );
     const callCountsByFunction = config.includeCallCounts
-      ? await collectFunctionCallCounts(cdp, profileUrl, config.timeoutMs)
+      ? await collectFunctionCallCounts(
+          cdp,
+          profileUrl,
+          actionName,
+          config.timeoutMs
+        )
       : null;
 
     return {
       runNumber,
+      actionName,
+      actionLabel: getActionLabel(actionName),
       browserUrl: config.browserUrl,
       url: profileUrl,
       workload: getPageWorkloadSummary(pageSummary, profileUrl),
@@ -2761,15 +2833,20 @@ function printRunHumanSummary(
   totalRuns: number,
   showDominantTraceEvents: boolean
 ): void {
-  const summaryRows = [['Visible rows', String(result.renderedItemCount)]];
+  const actionTimingReadyLabel = `${result.actionLabel} ready`;
+  const actionTimingDoneLabel = `${result.actionLabel} post-paint`;
+  const summaryRows = [
+    ['Action', result.actionLabel],
+    ['Visible rows', String(result.renderedItemCount)],
+  ];
 
   if (result.visibleRowsReadyMs != null) {
     summaryRows.push([
-      'Visible rows ready',
+      actionTimingReadyLabel,
       formatMs(result.visibleRowsReadyMs),
     ]);
   }
-  summaryRows.push(['Post-paint ready', formatMs(result.renderDurationMs)]);
+  summaryRows.push([actionTimingDoneLabel, formatMs(result.renderDurationMs)]);
 
   if (result.trace.available) {
     if (result.trace.clickDispatchMs != null) {
@@ -3011,6 +3088,57 @@ function printAggregateHumanSummary(
   );
 }
 
+function printActionTimingHumanSummary(
+  workloadOutputs: ProfileWorkloadOutput[]
+): void {
+  const rows = workloadOutputs.map((workloadOutput) => {
+    const firstRun = workloadOutput.runs[0];
+    const readyMetric = workloadOutput.summary.metrics.visibleRowsReadyMs;
+    const postPaintMetric = workloadOutput.summary.metrics.postPaintReadyMs;
+    return [
+      firstRun?.workload.label ?? workloadOutput.workload.label,
+      firstRun?.actionLabel ?? 'Unknown action',
+      formatMs(readyMetric.medianMs),
+      formatMs(readyMetric.p95Ms),
+      formatMs(postPaintMetric.medianMs),
+      formatMs(postPaintMetric.p95Ms),
+      `${workloadOutput.runs.length}`,
+    ];
+  });
+
+  if (rows.length === 0) {
+    return;
+  }
+
+  console.log('Action Timing Summary');
+  console.log(
+    createTable(
+      [
+        'Workload',
+        'Action',
+        'Ready median',
+        'Ready P95',
+        'Post-paint median',
+        'Post-paint P95',
+        'Runs',
+      ],
+      rows,
+      {
+        alignments: [
+          'left',
+          'left',
+          'right',
+          'right',
+          'right',
+          'right',
+          'right',
+        ],
+        maxWidths: [28, 18, 14, 14, 18, 14, 8],
+      }
+    )
+  );
+}
+
 function formatSignedNumber(
   value: number | null,
   digits: number,
@@ -3126,6 +3254,13 @@ function createLegacyConfigSummaryFromRuns(
 ): ProfileConfigSummary {
   const firstRun = runs[0];
   const workloadNames = [...new Set(runs.map((run) => run.workload.name))];
+  const actionNames = [
+    ...new Set(
+      runs
+        .map((run) => run.actionName)
+        .filter((action): action is ProfileActionName => action != null)
+    ),
+  ];
   const includeCallCounts = runs.some((run) => {
     return run.cpuProfile.bottomUpFunctions.some((fn) => fn.callCount != null);
   });
@@ -3135,6 +3270,7 @@ function createLegacyConfigSummaryFromRuns(
     url: normalizeComparableUrl(firstRun?.url ?? DEFAULT_URL),
     workloads:
       workloadNames.length > 0 ? workloadNames : [DEFAULT_WORKLOAD_NAME],
+    actions: actionNames.length > 0 ? actionNames : ['initial-render'],
     timeoutMs: DEFAULT_TIMEOUT_MS,
     runs: runs.length,
     warmupRuns: 0,
@@ -3186,6 +3322,14 @@ function normalizeProfileBenchmarkOutput(
       ? (rawValue.config as Partial<ProfileConfigSummary>)
       : {};
 
+    const normalizedActions = Array.isArray(rawConfig.actions)
+      ? rawConfig.actions
+          .map((action) =>
+            typeof action === 'string' ? parseActionName(action) : null
+          )
+          .filter((action): action is ProfileActionName => action != null)
+      : fallbackConfig.actions;
+
     return {
       benchmark: 'virtualizationProfile',
       config: {
@@ -3195,6 +3339,10 @@ function normalizeProfileBenchmarkOutput(
         workloads: workloads.map(
           (workloadOutput) => workloadOutput.workload.name
         ),
+        actions:
+          normalizedActions.length > 0
+            ? normalizedActions
+            : fallbackConfig.actions,
         runs: rawConfig.runs ?? workloads[0].runs.length,
         warmupRuns: rawConfig.warmupRuns ?? fallbackConfig.warmupRuns,
         instrumentationMode:
@@ -3261,6 +3409,18 @@ function assertComparableBenchmarkOutputs(
         'Cannot compare benchmark outputs with different instrumentation modes.',
         `Baseline: ${baseline.config.instrumentationMode}`,
         `Current: ${current.config.instrumentationMode}`,
+      ].join('\n')
+    );
+  }
+
+  const baselineActions = [...baseline.config.actions].sort();
+  const currentActions = [...current.config.actions].sort();
+  if (baselineActions.join(',') !== currentActions.join(',')) {
+    throw new Error(
+      [
+        'Cannot compare benchmark outputs with different action sets.',
+        `Baseline: ${baselineActions.join(', ')}`,
+        `Current: ${currentActions.join(', ')}`,
       ].join('\n')
     );
   }
@@ -3486,6 +3646,7 @@ function printRunsHumanSummary(output: ProfileBenchmarkOutput): void {
     ['Browser', output.config.browserUrl],
     ['URL', output.config.url],
     ['Workloads', output.config.workloads.join(', ')],
+    ['Actions', output.config.actions.join(', ')],
     ['Measured runs/workload', String(output.config.runs)],
     ['Warmup runs/workload', String(output.config.warmupRuns)],
     ['Instrumentation', output.config.instrumentationMode],
@@ -3511,6 +3672,9 @@ function printRunsHumanSummary(output: ProfileBenchmarkOutput): void {
     }
   }
 
+  console.log('');
+  printActionTimingHumanSummary(output.workloads);
+
   if (output.comparison != null) {
     console.log('');
     printComparisonHumanSummary(output.comparison);
@@ -3519,7 +3683,8 @@ function printRunsHumanSummary(output: ProfileBenchmarkOutput): void {
 
 async function runWorkloadProfile(
   config: ProfileConfig,
-  workloadName: string
+  workloadName: string,
+  actionName: ProfileActionName
 ): Promise<ProfileWorkloadOutput> {
   const results: ProfileResult[] = [];
 
@@ -3534,6 +3699,7 @@ async function runWorkloadProfile(
         includeCallCounts: false,
       },
       workloadName,
+      actionName,
       warmupRunNumber,
       null
     );
@@ -3543,20 +3709,31 @@ async function runWorkloadProfile(
     const traceOutputPath = createRunTraceOutputPath(
       config.traceOutputPath,
       workloadName,
+      actionName,
       config.workloads.length,
+      config.actions.length,
       runNumber,
       config.runs
     );
     const result = await profileVirtualizedRender(
       config,
       workloadName,
+      actionName,
       runNumber,
       traceOutputPath
     );
     results.push(result);
   }
 
-  return createWorkloadOutput(results);
+  const workloadOutput = createWorkloadOutput(results);
+  return {
+    ...workloadOutput,
+    workload: {
+      ...workloadOutput.workload,
+      name: `${workloadOutput.workload.name}:${actionName}`,
+      label: `${workloadOutput.workload.label} [${getActionLabel(actionName)}]`,
+    },
+  };
 }
 
 async function main(): Promise<void> {
@@ -3568,7 +3745,11 @@ async function main(): Promise<void> {
 
     const workloads: ProfileWorkloadOutput[] = [];
     for (const workloadName of config.workloads) {
-      workloads.push(await runWorkloadProfile(config, workloadName));
+      for (const actionName of config.actions) {
+        workloads.push(
+          await runWorkloadProfile(config, workloadName, actionName)
+        );
+      }
     }
 
     const output: ProfileBenchmarkOutput = {

--- a/packages/trees/scripts/profileTreesDevVirtualization.ts
+++ b/packages/trees/scripts/profileTreesDevVirtualization.ts
@@ -7,7 +7,14 @@ import { fileURLToPath } from 'node:url';
 type ProfileActionName =
   | 'initial-render'
   | 'rename-file'
-  | 'rename-root-folder';
+  | 'rename-root-folder'
+  | 'add-file-root'
+  | 'add-file-deep'
+  | 'delete-file-deep'
+  | 'delete-root-folder'
+  | 'move-file-to-root'
+  | 'move-folder-to-root'
+  | 'move-root-folder';
 
 interface ProfileConfig {
   browserUrl: string;
@@ -346,6 +353,13 @@ interface VirtualizationFixtureApi {
   runInitialRender: () => Promise<PageRenderSummary>;
   runRenameFile: () => Promise<PageRenderSummary>;
   runRenameRootFolder: () => Promise<PageRenderSummary>;
+  runAddFileRoot: () => Promise<PageRenderSummary>;
+  runAddFileDeep: () => Promise<PageRenderSummary>;
+  runDeleteFileDeep: () => Promise<PageRenderSummary>;
+  runDeleteRootFolder: () => Promise<PageRenderSummary>;
+  runMoveFileToRoot: () => Promise<PageRenderSummary>;
+  runMoveFolderToRoot: () => Promise<PageRenderSummary>;
+  runMoveRootFolder: () => Promise<PageRenderSummary>;
 }
 
 declare global {
@@ -369,6 +383,13 @@ const KNOWN_ACTION_NAMES = new Set<ProfileActionName>([
   'initial-render',
   'rename-file',
   'rename-root-folder',
+  'add-file-root',
+  'add-file-deep',
+  'delete-file-deep',
+  'delete-root-folder',
+  'move-file-to-root',
+  'move-folder-to-root',
+  'move-root-folder',
 ]);
 const KNOWN_WORKLOAD_NAMES = new Set([
   'pierre-snapshot',
@@ -528,6 +549,9 @@ function printHelpAndExit(): never {
   );
   console.log(
     `  --action <name>        Profile action to run (repeatable, default: ${DEFAULT_ACTIONS.join(', ')})`
+  );
+  console.log(
+    '  --all-actions          Run every known profile action (render + all mutation workloads)'
   );
   console.log(
     `  --timeout <ms>         Navigation/render timeout in milliseconds (default: ${DEFAULT_TIMEOUT_MS})`
@@ -740,6 +764,11 @@ function parseArgs(argv: string[]): ProfileConfig {
 
     if (rawArg === '--dominant-trace-events') {
       config.showDominantTraceEvents = true;
+      continue;
+    }
+
+    if (rawArg === '--all-actions') {
+      config.actions = [...KNOWN_ACTION_NAMES];
       continue;
     }
 
@@ -2583,6 +2612,20 @@ function getActionMethodName(actionName: ProfileActionName): string {
       return 'runRenameFile';
     case 'rename-root-folder':
       return 'runRenameRootFolder';
+    case 'add-file-root':
+      return 'runAddFileRoot';
+    case 'add-file-deep':
+      return 'runAddFileDeep';
+    case 'delete-file-deep':
+      return 'runDeleteFileDeep';
+    case 'delete-root-folder':
+      return 'runDeleteRootFolder';
+    case 'move-file-to-root':
+      return 'runMoveFileToRoot';
+    case 'move-folder-to-root':
+      return 'runMoveFolderToRoot';
+    case 'move-root-folder':
+      return 'runMoveRootFolder';
     default:
       return 'runInitialRender';
   }
@@ -2596,6 +2639,20 @@ function getActionLabel(actionName: ProfileActionName): string {
       return 'Rename file';
     case 'rename-root-folder':
       return 'Rename root folder';
+    case 'add-file-root':
+      return 'Add file (root)';
+    case 'add-file-deep':
+      return 'Add file (deep)';
+    case 'delete-file-deep':
+      return 'Delete file (deep)';
+    case 'delete-root-folder':
+      return 'Delete root folder';
+    case 'move-file-to-root':
+      return 'Move file to root';
+    case 'move-folder-to-root':
+      return 'Move folder to root';
+    case 'move-root-folder':
+      return 'Move root folder';
     default:
       return actionName;
   }
@@ -3159,7 +3216,7 @@ function printActionTimingHumanSummary(
           'right',
           'right',
         ],
-        maxWidths: [28, 18, 14, 14, 18, 14, 8],
+        maxWidths: [28, 26, 14, 14, 18, 14, 8],
       }
     )
   );
@@ -3686,7 +3743,7 @@ function printRunsHumanSummary(output: ProfileBenchmarkOutput): void {
   console.log('Benchmark');
   console.log(
     createTable(['Field', 'Value'], runInfoRows, {
-      maxWidths: [22, 96],
+      maxWidths: [22, 140],
     })
   );
 

--- a/packages/trees/scripts/profileTreesDevVirtualization.ts
+++ b/packages/trees/scripts/profileTreesDevVirtualization.ts
@@ -4,7 +4,10 @@ import { tmpdir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-type ProfileActionName = 'initial-render' | 'rename-file';
+type ProfileActionName =
+  | 'initial-render'
+  | 'rename-file'
+  | 'rename-root-folder';
 
 interface ProfileConfig {
   browserUrl: string;
@@ -342,6 +345,7 @@ interface CdpMessage {
 interface VirtualizationFixtureApi {
   runInitialRender: () => Promise<PageRenderSummary>;
   runRenameFile: () => Promise<PageRenderSummary>;
+  runRenameRootFolder: () => Promise<PageRenderSummary>;
 }
 
 declare global {
@@ -361,7 +365,11 @@ const DEFAULT_URL =
   'http://127.0.0.1:9221/test/e2e/fixtures/virtualization.html';
 const DEFAULT_WORKLOAD_NAME = 'linux-5x';
 const DEFAULT_ACTIONS: ProfileActionName[] = ['initial-render', 'rename-file'];
-const KNOWN_ACTION_NAMES = new Set<ProfileActionName>(DEFAULT_ACTIONS);
+const KNOWN_ACTION_NAMES = new Set<ProfileActionName>([
+  'initial-render',
+  'rename-file',
+  'rename-root-folder',
+]);
 const KNOWN_WORKLOAD_NAMES = new Set([
   'pierre-snapshot',
   'half-linux',
@@ -2568,11 +2576,29 @@ async function closePageTarget(
 }
 
 function getActionMethodName(actionName: ProfileActionName): string {
-  return actionName === 'rename-file' ? 'runRenameFile' : 'runInitialRender';
+  switch (actionName) {
+    case 'initial-render':
+      return 'runInitialRender';
+    case 'rename-file':
+      return 'runRenameFile';
+    case 'rename-root-folder':
+      return 'runRenameRootFolder';
+    default:
+      return 'runInitialRender';
+  }
 }
 
 function getActionLabel(actionName: ProfileActionName): string {
-  return actionName === 'rename-file' ? 'Rename file' : 'Initial render';
+  switch (actionName) {
+    case 'initial-render':
+      return 'Initial render';
+    case 'rename-file':
+      return 'Rename file';
+    case 'rename-root-folder':
+      return 'Rename root folder';
+    default:
+      return actionName;
+  }
 }
 
 async function runFixtureAction(

--- a/packages/trees/src/FileTree.ts
+++ b/packages/trees/src/FileTree.ts
@@ -290,6 +290,8 @@ export class FileTree {
       },
     };
 
+    this.model.prepareMutationIndexes();
+
     this.model.subscribe((mutation) => {
       this.handleModelMutation(mutation);
     });

--- a/packages/trees/src/FileTree.ts
+++ b/packages/trees/src/FileTree.ts
@@ -115,6 +115,15 @@ export interface FileTreeCallbacks {
   onExpandedItemsChange?: (items: string[]) => void;
   onSelectedItemsChange?: (items: string[]) => void;
   onSelection?: (items: FileTreeSelectionItem[]) => void;
+  /**
+   * Preferred model-mutation callback. Receives semantic changesets plus an
+   * on-demand snapshot accessor.
+   */
+  onModelChange?: (
+    changeSet: FileTreeChangeSet,
+    context: FileTreeChangeContext
+  ) => void;
+  /** @deprecated Use onModelChange instead. */
   onFilesChange?: (
     changeSet: FileTreeChangeSet,
     context: FileTreeChangeContext
@@ -183,6 +192,15 @@ export interface FileTreeStateConfig {
   onExpandedItemsChange?: (items: string[]) => void;
   onSelectedItemsChange?: (items: string[]) => void;
   onSelection?: (items: FileTreeSelectionItem[]) => void;
+  /**
+   * Preferred model-mutation callback. Receives semantic changesets plus an
+   * on-demand snapshot accessor.
+   */
+  onModelChange?: (
+    changeSet: FileTreeChangeSet,
+    context: FileTreeChangeContext
+  ) => void;
+  /** @deprecated Use onModelChange instead. */
   onFilesChange?: (
     changeSet: FileTreeChangeSet,
     context: FileTreeChangeContext
@@ -257,6 +275,7 @@ export class FileTree {
         onExpandedItemsChange: stateConfig.onExpandedItemsChange,
         onSelectedItemsChange: stateConfig.onSelectedItemsChange,
         onSelection: stateConfig.onSelection,
+        onModelChange: stateConfig.onModelChange,
         onFilesChange: stateConfig.onFilesChange,
         onContextMenuOpen: stateConfig.onContextMenuOpen,
         onContextMenuClose: stateConfig.onContextMenuClose,
@@ -480,10 +499,14 @@ export class FileTree {
 
   private handleModelMutation(mutation: FileTreeModelMutation): void {
     this.options.model = this.model;
-    this.callbacksRef.current.onFilesChange?.(mutation, {
+    const changeContext: FileTreeChangeContext = {
       model: this.model,
       getFiles: () => this.model.getFiles(),
-    });
+    };
+    const onModelMutationChange =
+      this.callbacksRef.current.onModelChange ??
+      this.callbacksRef.current.onFilesChange;
+    onModelMutationChange?.(mutation, changeContext);
 
     const handle = this.handleRef.current;
     if (handle == null) {
@@ -571,6 +594,9 @@ export class FileTree {
     }
     if (state?.onSelection !== undefined) {
       this.callbacksRef.current.onSelection = state.onSelection;
+    }
+    if (state?.onModelChange !== undefined) {
+      this.callbacksRef.current.onModelChange = state.onModelChange;
     }
     if (state?.onFilesChange !== undefined) {
       this.callbacksRef.current.onFilesChange = state.onFilesChange;

--- a/packages/trees/src/FileTree.ts
+++ b/packages/trees/src/FileTree.ts
@@ -11,6 +11,10 @@ import {
   inheritBenchmarkInstrumentation,
   withBenchmarkPhase,
 } from './internal/benchmarkInstrumentation';
+import {
+  FileTreeModel,
+  type FileTreeModelMutation,
+} from './model/FileTreeModel';
 import { SVGSpriteSheet } from './sprite';
 import type {
   ContextMenuItem,
@@ -32,7 +36,10 @@ import {
   preactRenderRoot,
   preactUnmountRoot,
 } from './utils/preactRenderer';
-import type { ChildrenComparator } from './utils/sortChildren';
+import type {
+  ChildrenComparator,
+  ChildrenSortOption,
+} from './utils/sortChildren';
 
 export type { GitStatusEntry } from './types';
 
@@ -66,6 +73,11 @@ export type FileTreeRenameEvent = {
   sourcePath: string;
   destinationPath: string;
   isFolder: boolean;
+};
+
+export type FileTreeMovePathsRequest = {
+  draggedPaths: string[];
+  targetPath: string;
 };
 
 export interface FileTreeRenamingConfig {
@@ -102,10 +114,6 @@ export interface FileTreeCallbacks {
     context: ContextMenuOpenContext
   ) => void;
   onContextMenuClose?: () => void;
-  /** Internal: called when a DnD move produces a new file list. */
-  _onDragMoveFiles?: (newFiles: string[]) => void;
-  /** Internal: called when a rename produces a new file list. */
-  _onRenameFiles?: (newFiles: string[]) => void;
 }
 
 type RemappedIcon =
@@ -127,7 +135,7 @@ export interface FileTreeOptions {
   flattenEmptyDirectories?: boolean;
   gitStatus?: GitStatusEntry[];
   id?: string;
-  initialFiles: string[];
+  model: FileTreeModel;
   /** Paths that cannot be dragged (e.g. ['package.json']). Uses same path form as the tree (no f:: prefix). */
   lockedPaths?: string[];
   /** Return true to overwrite the destination file when a DnD move collides. */
@@ -160,7 +168,6 @@ export interface FileTreeStateConfig {
   // Controlled state (applied every render, overrides internal state)
   expandedItems?: string[];
   selectedItems?: string[];
-  files?: string[];
 
   // State change callbacks
   onExpandedItemsChange?: (items: string[]) => void;
@@ -180,6 +187,18 @@ export const isRenamingEnabled = (
   renaming: FileTreeOptions['renaming'] | undefined
 ): boolean => renaming != null && renaming !== false;
 
+function resolveSortComparator(
+  sortOption: FileTreeOptions['sort']
+): ChildrenSortOption | undefined {
+  if (sortOption === false) {
+    return false;
+  }
+  if (sortOption != null && typeof sortOption === 'object') {
+    return sortOption.comparator;
+  }
+  return undefined;
+}
+
 export class FileTree {
   static LoadedCustomComponent: boolean = FileTreeContainerLoaded;
 
@@ -194,6 +213,7 @@ export class FileTree {
 
   /** Populated by FileTree, read by the Preact Root for callbacks. */
   readonly callbacksRef: { current: FileTreeCallbacks };
+  readonly model: FileTreeModel;
 
   private expandPathsCache: Map<string, string[]> = new Map();
   private expandPathsCacheFor: PathToIdLookup | null = null;
@@ -208,6 +228,17 @@ export class FileTree {
       this.fileTreeContainer = document.createElement(FILE_TREE_TAG_NAME);
     }
     this.__id = options.id ?? `ft_${isBrowser ? 'brw' : 'srv'}_${++instanceId}`;
+
+    const modelSortComparator = resolveSortComparator(options.sort);
+
+    this.model = options.model;
+    this.model.setSortComparator(modelSortComparator);
+
+    this.options = inheritBenchmarkInstrumentation(options, {
+      ...options,
+      model: this.model,
+    });
+
     this.callbacksRef = {
       current: {
         onExpandedItemsChange: stateConfig.onExpandedItemsChange,
@@ -216,15 +247,12 @@ export class FileTree {
         onFilesChange: stateConfig.onFilesChange,
         onContextMenuOpen: stateConfig.onContextMenuOpen,
         onContextMenuClose: stateConfig.onContextMenuClose,
-        _onDragMoveFiles:
-          options.dragAndDrop === true
-            ? (newFiles) => this.setFiles(newFiles)
-            : undefined,
-        _onRenameFiles: isRenamingEnabled(options.renaming)
-          ? (newFiles) => this.setFiles(newFiles)
-          : undefined,
       },
     };
+
+    this.model.subscribe((mutation) => {
+      this.handleModelMutation(mutation);
+    });
   }
 
   // --- State setters (imperative) ---
@@ -437,20 +465,78 @@ export class FileTree {
 
   // --- Heavier updates (re-render) ---
 
-  setFiles(files: string[]): void {
-    if (this.options.initialFiles === files) {
+  private handleModelMutation(mutation: FileTreeModelMutation): void {
+    const files = this.model.getFiles();
+    this.options.model = this.model;
+    this.callbacksRef.current.onFilesChange?.(files);
+
+    const handle = this.handleRef.current;
+    if (handle == null) {
+      if (this.divWrapper != null) {
+        this.rerender();
+      }
       return;
     }
-    this.options = inheritBenchmarkInstrumentation(this.options, {
-      ...this.options,
-      initialFiles: files,
+
+    if (mutation.kind === 'rename-path') {
+      handle.tree.markBranchDirty(mutation.parentId, 'children');
+      handle.tree.rebuildTree();
+      return;
+    }
+
+    if (mutation.kind === 'move-paths') {
+      if (mutation.affectedParentIds.length === 0) {
+        handle.tree.markBranchDirty(
+          handle.tree.getConfig().rootItemId,
+          'children'
+        );
+      } else {
+        for (
+          let index = 0;
+          index < mutation.affectedParentIds.length;
+          index += 1
+        ) {
+          handle.tree.markBranchDirty(
+            mutation.affectedParentIds[index],
+            'children'
+          );
+        }
+      }
+      handle.tree.rebuildTree();
+      return;
+    }
+
+    handle.tree.rebuildTreeFromScratch();
+  }
+
+  renamePath(event: FileTreeRenameEvent): void {
+    const result = this.model.renamePath({
+      sourcePath: event.sourcePath,
+      destinationPath: event.destinationPath,
+      isFolder: event.isFolder,
     });
-    this.callbacksRef.current.onFilesChange?.(files);
-    this.rerender();
+
+    if (!result.ok) {
+      const renamingConfig =
+        this.options.renaming != null &&
+        this.options.renaming !== true &&
+        this.options.renaming !== false
+          ? this.options.renaming
+          : undefined;
+      renamingConfig?.onError?.(result.error);
+    }
+  }
+
+  movePaths(request: FileTreeMovePathsRequest): void {
+    this.model.movePaths({
+      draggedPaths: request.draggedPaths,
+      targetPath: request.targetPath,
+      onCollision: this.options.onCollision,
+    });
   }
 
   getFiles(): string[] {
-    return this.options.initialFiles;
+    return this.model.getFiles();
   }
 
   setOptions(
@@ -458,24 +544,6 @@ export class FileTree {
     state?: Partial<FileTreeStateConfig>
   ): void {
     const hadContextMenu = this.callbacksRef.current.onContextMenuOpen != null;
-
-    if (options.dragAndDrop === false) {
-      this.callbacksRef.current._onDragMoveFiles = undefined;
-    } else if (
-      options.dragAndDrop === true &&
-      this.callbacksRef.current._onDragMoveFiles == null
-    ) {
-      this.callbacksRef.current._onDragMoveFiles = (newFiles) =>
-        this.setFiles(newFiles);
-    }
-    if ('renaming' in options) {
-      if (!isRenamingEnabled(options.renaming)) {
-        this.callbacksRef.current._onRenameFiles = undefined;
-      } else {
-        this.callbacksRef.current._onRenameFiles ??= (newFiles) =>
-          this.setFiles(newFiles);
-      }
-    }
 
     // Update callbacks without re-rendering
     if (state?.onExpandedItemsChange !== undefined) {
@@ -499,12 +567,23 @@ export class FileTree {
       this.callbacksRef.current.onContextMenuClose = state.onContextMenuClose;
     }
 
+    const { model: nextModel, ...restOptions } = options;
+
+    if (nextModel != null && nextModel !== this.model) {
+      throw new Error(
+        'FileTree.setOptions cannot swap model instances. Create a new FileTree instead.'
+      );
+    }
+
+    if ('sort' in options) {
+      this.model.setSortComparator(resolveSortComparator(options.sort));
+    }
+
     // Check if structural props changed (require re-render)
     const structuralKeys = [
       'dragAndDrop',
       'fileTreeSearchMode',
       'gitStatus',
-      'initialFiles',
       'icons',
       'flattenEmptyDirectories',
       'lockedPaths',
@@ -517,19 +596,16 @@ export class FileTree {
     ] as const;
     let needsRerender = false;
     for (const key of structuralKeys) {
-      if (key in options) {
+      if (key in restOptions) {
         needsRerender = true;
         break;
       }
     }
 
-    const nextFiles = state?.files;
-    const stateFilesChanged =
-      nextFiles !== undefined && this.options.initialFiles !== nextFiles;
     this.options = inheritBenchmarkInstrumentation(this.options, {
       ...this.options,
-      ...options,
-      ...(nextFiles !== undefined && { initialFiles: nextFiles }),
+      ...restOptions,
+      model: this.model,
     });
     if (state != null) {
       this.stateConfig = inheritBenchmarkInstrumentation(this.options, {
@@ -543,10 +619,7 @@ export class FileTree {
       needsRerender = true;
     }
 
-    if (needsRerender || stateFilesChanged) {
-      if (stateFilesChanged && nextFiles !== undefined) {
-        this.callbacksRef.current.onFilesChange?.(nextFiles);
-      }
+    if (needsRerender) {
       this.rerender();
     } else {
       // State-only changes - use imperative methods

--- a/packages/trees/src/FileTree.ts
+++ b/packages/trees/src/FileTree.ts
@@ -525,7 +525,9 @@ export class FileTree {
     }
 
     if (mutation.kind === 'rename-path') {
-      handle.tree.markBranchDirty(mutation.parentId, 'children');
+      if (mutation.childrenOrderChanged) {
+        handle.tree.markBranchDirty(mutation.parentId, 'children');
+      }
       handle.tree.rebuildTree();
       return;
     }

--- a/packages/trees/src/FileTree.ts
+++ b/packages/trees/src/FileTree.ts
@@ -104,11 +104,21 @@ export interface FileTreeHandle {
   closeContextMenu?: () => void;
 }
 
+export type FileTreeChangeSet = FileTreeModelMutation;
+
+export interface FileTreeChangeContext {
+  model: FileTreeModel;
+  getFiles: () => string[];
+}
+
 export interface FileTreeCallbacks {
   onExpandedItemsChange?: (items: string[]) => void;
   onSelectedItemsChange?: (items: string[]) => void;
   onSelection?: (items: FileTreeSelectionItem[]) => void;
-  onFilesChange?: (files: string[]) => void;
+  onFilesChange?: (
+    changeSet: FileTreeChangeSet,
+    context: FileTreeChangeContext
+  ) => void;
   onContextMenuOpen?: (
     item: ContextMenuItem,
     context: ContextMenuOpenContext
@@ -173,7 +183,10 @@ export interface FileTreeStateConfig {
   onExpandedItemsChange?: (items: string[]) => void;
   onSelectedItemsChange?: (items: string[]) => void;
   onSelection?: (items: FileTreeSelectionItem[]) => void;
-  onFilesChange?: (files: string[]) => void;
+  onFilesChange?: (
+    changeSet: FileTreeChangeSet,
+    context: FileTreeChangeContext
+  ) => void;
   onContextMenuOpen?: (
     item: ContextMenuItem,
     context: ContextMenuOpenContext
@@ -466,9 +479,11 @@ export class FileTree {
   // --- Heavier updates (re-render) ---
 
   private handleModelMutation(mutation: FileTreeModelMutation): void {
-    const files = this.model.getFiles();
     this.options.model = this.model;
-    this.callbacksRef.current.onFilesChange?.(files);
+    this.callbacksRef.current.onFilesChange?.(mutation, {
+      model: this.model,
+      getFiles: () => this.model.getFiles(),
+    });
 
     const handle = this.handleRef.current;
     if (handle == null) {

--- a/packages/trees/src/FileTree.ts
+++ b/packages/trees/src/FileTree.ts
@@ -80,6 +80,14 @@ export type FileTreeMovePathsRequest = {
   targetPath: string;
 };
 
+export type FileTreeAddPathsRequest = {
+  paths: string[];
+};
+
+export type FileTreeDeletePathsRequest = {
+  paths: string[];
+};
+
 export interface FileTreeRenamingConfig {
   canRename?: (item: FileTreeRenamingItem) => boolean;
   onError?: (error: string) => void;
@@ -522,7 +530,11 @@ export class FileTree {
       return;
     }
 
-    if (mutation.kind === 'move-paths') {
+    if (
+      mutation.kind === 'move-paths' ||
+      mutation.kind === 'add-paths' ||
+      mutation.kind === 'delete-paths'
+    ) {
       if (mutation.affectedParentIds.length === 0) {
         handle.tree.markBranchDirty(
           handle.tree.getConfig().rootItemId,
@@ -571,6 +583,14 @@ export class FileTree {
       targetPath: request.targetPath,
       onCollision: this.options.onCollision,
     });
+  }
+
+  addPaths(request: FileTreeAddPathsRequest): void {
+    this.model.addPaths({ paths: request.paths });
+  }
+
+  deletePaths(request: FileTreeDeletePathsRequest): void {
+    this.model.deletePaths({ paths: request.paths });
   }
 
   getFiles(): string[] {

--- a/packages/trees/src/components/Root.tsx
+++ b/packages/trees/src/components/Root.tsx
@@ -175,26 +175,13 @@ export function Root({
       return syncIndex.pathToId;
     });
   }, [benchmarkInstrumentation, syncIndex]);
-  const idToPathSnapshot = useMemo(() => {
-    // Tie snapshot invalidation to modelVersion even though the syncIndex Map
-    // identity is stable across model mutations.
-    const snapshotVersion = modelVersion;
-    void snapshotVersion;
-
-    const snapshot = new Map<string, string>();
-    for (const [id, node] of syncIndex.tree) {
-      snapshot.set(id, node.path);
-    }
-    return snapshot;
-  }, [modelVersion, syncIndex]);
-
-  const idToPath = useMemo<IdToPathLookup>(
-    () => ({
-      get: (id: string) => idToPathSnapshot.get(id),
-      has: (id: string) => idToPathSnapshot.has(id),
-    }),
-    [idToPathSnapshot]
-  );
+  const idToPath = useMemo<IdToPathLookup>(() => {
+    // Keep lookup identity tied to model version so dependent caches can reset,
+    // while avoiding an O(N) id->path snapshot rebuild on every mutation.
+    const currentVersion = modelVersion;
+    void currentVersion;
+    return model.getIdToPathLookup();
+  }, [model, modelVersion]);
 
   const ancestorChainsCacheRef = useRef<Map<string, string[]>>(new Map());
   const prevIdToPathForCacheRef = useRef(idToPath);

--- a/packages/trees/src/components/Root.tsx
+++ b/packages/trees/src/components/Root.tsx
@@ -1,12 +1,6 @@
 /** @jsxImportSource preact */
 import type { JSX } from 'preact';
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-} from 'preact/hooks';
+import { useCallback, useLayoutEffect, useMemo, useRef } from 'preact/hooks';
 
 import {
   CONTEXT_MENU_SLOT_NAME,
@@ -53,16 +47,13 @@ import { generateLazyDataLoader } from '../loader/lazy';
 import { generateSyncDataLoaderFromIndex } from '../loader/sync';
 import type { SVGSpriteNames } from '../sprite';
 import type { FileTreeNode } from '../types';
-import { computeNewFilesAfterDrop } from '../utils/computeNewFilesAfterDrop';
-import { buildFileListSyncIndex } from '../utils/fileListToTree';
+import type { FileListSyncIndex } from '../utils/fileListToTree';
 import { getGitStatusSignature } from '../utils/getGitStatusSignature';
 import { getSelectionPath } from '../utils/getSelectionPath';
 import type { IdToPathLookup } from '../utils/pathLookups';
-import { renameFileTreePaths } from '../utils/renameFileTreePaths';
 import type { ChildrenSortOption } from '../utils/sortChildren';
 import { useContextMenuController } from './hooks/useContextMenuController';
 import {
-  getFilesSignature,
   type PendingDropTarget,
   type PendingRenameExpandedRemap,
   type PendingRenameFocusRestore,
@@ -104,7 +95,7 @@ export function Root({
 }: FileTreeRootProps): JSX.Element {
   'use no memo';
   const {
-    initialFiles: files,
+    model,
     flattenEmptyDirectories,
     fileTreeSearchMode,
     gitStatus,
@@ -170,19 +161,9 @@ export function Root({
     [sortOption]
   );
 
-  const syncIndex = useMemo(
-    () =>
-      withBenchmarkPhase(benchmarkInstrumentation, 'root.fileListToTree', () =>
-        buildFileListSyncIndex(
-          files,
-          attachBenchmarkInstrumentation(
-            { sortComparator },
-            benchmarkInstrumentation
-          )
-        )
-      ),
-    [benchmarkInstrumentation, files, sortComparator]
-  );
+  const files = model.getFiles();
+  const modelVersion = model.getVersion();
+  const syncIndex: FileListSyncIndex = model.getSyncIndex();
 
   const pathToId = useMemo(() => {
     return withBenchmarkPhase(benchmarkInstrumentation, 'root.pathToId', () => {
@@ -194,12 +175,25 @@ export function Root({
       return syncIndex.pathToId;
     });
   }, [benchmarkInstrumentation, syncIndex]);
+  const idToPathSnapshot = useMemo(() => {
+    // Tie snapshot invalidation to modelVersion even though the syncIndex Map
+    // identity is stable across model mutations.
+    const snapshotVersion = modelVersion;
+    void snapshotVersion;
+
+    const snapshot = new Map<string, string>();
+    for (const [id, node] of syncIndex.tree) {
+      snapshot.set(id, node.path);
+    }
+    return snapshot;
+  }, [modelVersion, syncIndex]);
+
   const idToPath = useMemo<IdToPathLookup>(
     () => ({
-      get: (id: string) => syncIndex.tree.get(id)?.path,
-      has: (id: string) => syncIndex.tree.has(id),
+      get: (id: string) => idToPathSnapshot.get(id),
+      has: (id: string) => idToPathSnapshot.has(id),
     }),
-    [syncIndex]
+    [idToPathSnapshot]
   );
 
   const ancestorChainsCacheRef = useRef<Map<string, string[]>>(new Map());
@@ -216,11 +210,12 @@ export function Root({
     benchmarkInstrumentation,
   });
 
+  const lazyFileInput = useLazyDataLoader === true ? files : null;
   const dataLoader = useMemo(
     () =>
       withBenchmarkPhase(benchmarkInstrumentation, 'root.dataLoader', () =>
         useLazyDataLoader === true
-          ? generateLazyDataLoader(files, {
+          ? generateLazyDataLoader(lazyFileInput ?? [], {
               flattenEmptyDirectories,
               sortComparator,
             })
@@ -230,8 +225,8 @@ export function Root({
       ),
     [
       benchmarkInstrumentation,
-      files,
       flattenEmptyDirectories,
+      lazyFileInput,
       sortComparator,
       syncIndex,
       useLazyDataLoader,
@@ -263,10 +258,6 @@ export function Root({
     base.push(propMemoizationFeature);
     return base;
   }, [isDnD, renamingEnabled]);
-
-  // Keep a ref to current files so onDrop doesn't capture stale values
-  const filesRef = useRef(files);
-  filesRef.current = files;
 
   // Ref populated after useTree — allows hooks called before useTree to
   // access the tree instance at event-handler time (not render time).
@@ -306,30 +297,28 @@ export function Root({
         flattenedDropSubfolderIdRef.current = null;
       }
 
-      const newFiles = computeNewFilesAfterDrop(
-        filesRef.current,
+      const result = model.movePaths({
         draggedPaths,
         targetPath,
-        { onCollision }
-      );
+        onCollision,
+      });
+      if (!result.ok) {
+        pendingDropTargetExpandRef.current = null;
+        return;
+      }
 
-      // Store the drop target path (stripped of f:: prefix) so the migration
-      // effect can expand it alongside the preserved expansion state, but only
-      // if this exact file result is later applied.
-      if (targetPath !== 'root') {
+      if (targetPath !== 'root' && result.mutation != null) {
         pendingDropTargetExpandRef.current = {
           path: targetPath.startsWith(FLATTENED_PREFIX)
             ? targetPath.slice(FLATTENED_PREFIX.length)
             : targetPath,
-          expectedFilesSignature: getFilesSignature(newFiles),
+          expectedVersion: result.mutation.version,
         };
       } else {
         pendingDropTargetExpandRef.current = null;
       }
-
-      callbacksRef?.current._onDragMoveFiles?.(newFiles);
     },
-    [callbacksRef, onCollision, idToPath, flattenedDropSubfolderIdRef]
+    [model, onCollision, idToPath, flattenedDropSubfolderIdRef]
   );
 
   // Track search state via ref so the canDrag callback (evaluated at event
@@ -407,43 +396,78 @@ export function Root({
         },
         onRename: (item: ItemInstance<FileTreeNode>, nextBasename: string) => {
           const data = item.getItemData();
-          const result = renameFileTreePaths({
-            files: filesRef.current,
-            path: getSelectionPath(data.path),
+          const sourcePath = getSelectionPath(data.path);
+          const trimmedBasename = nextBasename.trim();
+
+          if (trimmedBasename.length === 0) {
+            renamingConfig?.onError?.('Name cannot be empty.');
+            return;
+          }
+          if (trimmedBasename.includes('/')) {
+            renamingConfig?.onError?.('Name cannot include "/".');
+            return;
+          }
+
+          const separatorIndex = sourcePath.lastIndexOf('/');
+          const parentPath =
+            separatorIndex < 0 ? '' : sourcePath.slice(0, separatorIndex);
+          const currentBasename =
+            separatorIndex < 0
+              ? sourcePath
+              : sourcePath.slice(separatorIndex + 1);
+          if (currentBasename === trimmedBasename) {
+            pendingRenameExpandedRemapRef.current = null;
+            pendingRenameFocusRestoreRef.current = null;
+            return;
+          }
+
+          const destinationPath =
+            parentPath.length > 0
+              ? `${parentPath}/${trimmedBasename}`
+              : trimmedBasename;
+          const result = model.renamePath({
+            sourcePath,
+            destinationPath,
             isFolder: data.children?.direct != null,
-            nextBasename,
           });
-          if ('error' in result) {
+          if (!result.ok) {
+            pendingRenameExpandedRemapRef.current = null;
+            pendingRenameFocusRestoreRef.current = null;
             renamingConfig?.onError?.(result.error);
             return;
           }
-          if (result.isFolder && result.sourcePath !== result.destinationPath) {
+
+          const mutation = result.mutation;
+          if (mutation == null) {
+            pendingRenameExpandedRemapRef.current = null;
+            pendingRenameFocusRestoreRef.current = null;
+            return;
+          }
+
+          if (mutation.isFolder) {
             pendingRenameExpandedRemapRef.current = {
-              sourcePath: result.sourcePath,
-              destinationPath: result.destinationPath,
+              sourcePath: mutation.sourcePath,
+              destinationPath: mutation.destinationPath,
             };
           } else {
             pendingRenameExpandedRemapRef.current = null;
           }
-          if (result.sourcePath !== result.destinationPath) {
-            pendingRenameFocusRestoreRef.current = {
-              destinationPath: result.destinationPath,
-              expectedFilesSignature: getFilesSignature(result.nextFiles),
-            };
-          } else {
-            pendingRenameFocusRestoreRef.current = null;
-          }
-          if (result.sourcePath === result.destinationPath) {
-            return;
-          }
+          pendingRenameFocusRestoreRef.current = {
+            destinationPath: mutation.destinationPath,
+            expectedVersion: mutation.version,
+          };
+
           renamingConfig?.onRename?.({
-            sourcePath: result.sourcePath,
-            destinationPath: result.destinationPath,
-            isFolder: result.isFolder,
+            sourcePath: mutation.sourcePath,
+            destinationPath: mutation.destinationPath,
+            isFolder: mutation.isFolder,
           });
-          if (result.nextFiles !== filesRef.current) {
-            callbacksRef?.current._onRenameFiles?.(result.nextFiles);
-          }
+
+          // Stable model IDs keep the renamed item identity unchanged.
+          // Pin focus back to that ID so rename flows don't depend on
+          // path-based remap bookkeeping.
+          tree.applySubStateUpdate('focusedItem', () => item.getId());
+          tree.updateDomFocus();
         },
       }),
       ...(isDnD && {
@@ -477,7 +501,7 @@ export function Root({
   // --- Expansion migration ---
   useExpansionMigration({
     tree,
-    files,
+    structureVersion: modelVersion,
     pathToId,
     idToPath,
     flattenEmptyDirectories,
@@ -528,7 +552,7 @@ export function Root({
     tree,
     isContextMenuEnabled,
     callbacksRef,
-    files,
+    structureVersion: modelVersion,
     idToPath,
   });
   contextMenuRequestHandlerRef.current = (request: ContextMenuRequest) => {
@@ -538,8 +562,9 @@ export function Root({
   const focusedItemId = tree.getState().focusedItem ?? null;
   const hasFocusedItem = focusedItemId != null;
 
-  // Populate handleRef so the FileTree class can call tree methods directly
-  useEffect(() => {
+  // Populate handleRef so the FileTree class can call tree methods directly.
+  // useLayoutEffect makes the imperative handle available before paint.
+  useLayoutEffect(() => {
     if (handleRef == null) return;
     handleRef.current = {
       tree,

--- a/packages/trees/src/components/Root.tsx
+++ b/packages/trees/src/components/Root.tsx
@@ -80,10 +80,30 @@ const EMPTY_ANCESTORS: string[] = [];
 // Reuses the last rebuild's visible ID list so virtualized rendering can size
 // and slice the tree without forcing core to instantiate every visible item.
 function getVisibleItemIds(tree: TreeInstance<FileTreeNode>): string[] {
-  return (
-    tree.getDataRef<TreeDataRef>().current.visibleItemIds ??
-    tree.getItems().map((item) => item.getId())
-  );
+  const treeDataRef = tree.getDataRef<TreeDataRef>().current;
+  if (treeDataRef.visibleItemIds != null) {
+    return treeDataRef.visibleItemIds;
+  }
+
+  const visibleItemCount =
+    treeDataRef.visibleItemCount ?? tree.getVisibleItemCount();
+  const visibleItemIds = new Array<string>(visibleItemCount);
+  let resolvedCount = 0;
+
+  for (let index = 0; index < visibleItemCount; index += 1) {
+    const itemId = tree.getVisibleItemIdAt(index);
+    if (itemId == null) {
+      break;
+    }
+    visibleItemIds[index] = itemId;
+    resolvedCount += 1;
+  }
+
+  if (resolvedCount !== visibleItemCount) {
+    visibleItemIds.length = resolvedCount;
+  }
+
+  return visibleItemIds;
 }
 
 export function Root({
@@ -657,20 +677,25 @@ export function Root({
       {(() => {
         const visibleIdSet = getSearchVisibleIdSet(tree);
         const gitStatusMap = getGitStatusMap(tree);
-        const allItemIds = getVisibleItemIds(tree);
-        const itemIds =
-          visibleIdSet != null
-            ? allItemIds.filter((itemId) => visibleIdSet.has(itemId))
-            : allItemIds;
+        let allItemIds: string[] | null = null;
+        let filteredItemIds: string[] | null = null;
+        if (visibleIdSet != null) {
+          allItemIds = getVisibleItemIds(tree);
+          filteredItemIds = allItemIds.filter((itemId) =>
+            visibleIdSet.has(itemId)
+          );
+        }
+        const itemCount = filteredItemIds?.length ?? tree.getVisibleItemCount();
+
         setBenchmarkCounter(
           benchmarkInstrumentation,
           'workload.visibleItemIds',
-          allItemIds.length
+          allItemIds?.length ?? itemCount
         );
         setBenchmarkCounter(
           benchmarkInstrumentation,
           'workload.renderItemIds',
-          itemIds.length
+          itemCount
         );
         const draggedItemIdSet = isDnD
           ? new Set(
@@ -680,8 +705,15 @@ export function Root({
             )
           : null;
 
+        const getItemIdAtIndex = (index: number): string | undefined => {
+          if (filteredItemIds != null) {
+            return filteredItemIds[index];
+          }
+          return tree.getVisibleItemIdAt(index);
+        };
+
         const renderItemAtIndex = (index: number) => {
-          const itemId = itemIds[index];
+          const itemId = getItemIdAtIndex(index);
           if (itemId == null) {
             return null;
           }
@@ -767,15 +799,19 @@ export function Root({
 
         if (
           shouldVirtualize &&
-          itemIds.length > 0 &&
-          itemIds.length >= virtualizeThreshold
+          itemCount > 0 &&
+          itemCount >= virtualizeThreshold
         ) {
           const focusedIndex =
-            focusedItemId != null ? itemIds.indexOf(focusedItemId) : null;
+            focusedItemId != null
+              ? filteredItemIds != null
+                ? filteredItemIds.indexOf(focusedItemId)
+                : tree.getItemInstance(focusedItemId).getItemMeta().index
+              : null;
           return (
             <div data-file-tree-virtualized-scroll="true">
               <VirtualizedList
-                itemCount={itemIds.length}
+                itemCount={itemCount}
                 renderItem={renderItemAtIndex}
                 scrollToIndex={
                   focusedIndex != null && focusedIndex >= 0
@@ -789,9 +825,17 @@ export function Root({
           );
         }
 
+        const renderedItems: JSX.Element[] = [];
+        for (let index = 0; index < itemCount; index += 1) {
+          const renderedItem = renderItemAtIndex(index);
+          if (renderedItem != null) {
+            renderedItems.push(renderedItem);
+          }
+        }
+
         return (
           <>
-            {itemIds.map((_, i) => renderItemAtIndex(i))}
+            {renderedItems}
             {contextMenuTrigger}
           </>
         );

--- a/packages/trees/src/components/Root.tsx
+++ b/packages/trees/src/components/Root.tsx
@@ -161,7 +161,6 @@ export function Root({
     [sortOption]
   );
 
-  const files = model.getFiles();
   const modelVersion = model.getVersion();
   const syncIndex: FileListSyncIndex = model.getSyncIndex();
 
@@ -197,7 +196,7 @@ export function Root({
     benchmarkInstrumentation,
   });
 
-  const lazyFileInput = useLazyDataLoader === true ? files : null;
+  const lazyFileInput = useLazyDataLoader === true ? model.getFiles() : null;
   const dataLoader = useMemo(
     () =>
       withBenchmarkPhase(benchmarkInstrumentation, 'root.dataLoader', () =>

--- a/packages/trees/src/components/hooks/useContextMenuController.ts
+++ b/packages/trees/src/components/hooks/useContextMenuController.ts
@@ -24,7 +24,7 @@ export interface UseContextMenuControllerArgs {
   tree: TreeInstance<FileTreeNode>;
   isContextMenuEnabled: boolean;
   callbacksRef?: { current: FileTreeCallbacks };
-  files: string[];
+  structureVersion: number;
   idToPath: Pick<Map<string, string>, 'get' | 'has'>;
 }
 
@@ -53,7 +53,7 @@ export function useContextMenuController({
   tree,
   isContextMenuEnabled,
   callbacksRef,
-  files,
+  structureVersion,
   idToPath,
 }: UseContextMenuControllerArgs): UseContextMenuControllerResult {
   'use no memo';
@@ -530,12 +530,19 @@ export function useContextMenuController({
     closeContextMenu();
   }, [closeContextMenu, contextMenuItemId, isContextMenuEnabled]);
 
-  const prevContextMenuStructureRef = useRef({ files, idToPath });
+  const prevContextMenuStructureRef = useRef({
+    structureVersion,
+    idToPath,
+  });
   useEffect(() => {
     const previous = prevContextMenuStructureRef.current;
-    prevContextMenuStructureRef.current = { files, idToPath };
+    prevContextMenuStructureRef.current = {
+      structureVersion,
+      idToPath,
+    };
     const structureChanged =
-      previous.files !== files || previous.idToPath !== idToPath;
+      previous.structureVersion !== structureVersion ||
+      previous.idToPath !== idToPath;
     if (
       !isContextMenuEnabled ||
       contextMenuItemId == null ||
@@ -547,7 +554,7 @@ export function useContextMenuController({
   }, [
     closeContextMenu,
     contextMenuItemId,
-    files,
+    structureVersion,
     idToPath,
     isContextMenuEnabled,
   ]);

--- a/packages/trees/src/components/hooks/useExpansionMigration.ts
+++ b/packages/trees/src/components/hooks/useExpansionMigration.ts
@@ -31,7 +31,7 @@ function resolvePathToRenderedId(
 
 export interface PendingDropTarget {
   path: string;
-  expectedFilesSignature: string;
+  expectedVersion: number;
 }
 
 export interface PendingRenameExpandedRemap {
@@ -41,12 +41,12 @@ export interface PendingRenameExpandedRemap {
 
 export interface PendingRenameFocusRestore {
   destinationPath: string;
-  expectedFilesSignature: string;
+  expectedVersion: number;
 }
 
 export interface UseExpansionMigrationArgs {
   tree: TreeInstance<FileTreeNode>;
-  files: string[];
+  structureVersion: number;
   pathToId: PathToIdLookup;
   idToPath: IdToPathLookup;
   flattenEmptyDirectories: boolean | undefined;
@@ -73,7 +73,7 @@ export interface UseExpansionMigrationArgs {
  */
 export function useExpansionMigration({
   tree,
-  files,
+  structureVersion,
   pathToId,
   idToPath,
   flattenEmptyDirectories,
@@ -85,13 +85,17 @@ export function useExpansionMigration({
   // Keep the previous idToPath so we can translate stale expanded IDs -> paths
   // when files change (DnD or controlled update).
   const prevIdToPathRef = useRef<IdToPathLookup>(idToPath);
+  const prevStructureVersionRef = useRef(structureVersion);
 
   // Detect stale expanded IDs when the file list changes. Flattened chains
   // may break or form, causing node IDs to change. We snapshot the expanded
   // paths using the OLD idToPath so the effect can re-map them to new IDs.
   // This covers both DnD drops and controlled file updates.
   const pendingExpandMigrationRef = useRef<string[] | null>(null);
-  if (prevIdToPathRef.current !== idToPath) {
+  if (
+    prevIdToPathRef.current !== idToPath ||
+    prevStructureVersionRef.current !== structureVersion
+  ) {
     const currentExpandedIds = tree.getState().expandedItems ?? [];
     const hasStaleIds = currentExpandedIds.some(
       (id: string) => !idToPath.has(id)
@@ -115,6 +119,7 @@ export function useExpansionMigration({
     }
   }
   prevIdToPathRef.current = idToPath;
+  prevStructureVersionRef.current = structureVersion;
 
   // Migrate expanded state after file list changes.
   // When the file list changes (DnD drop or controlled update), flattened
@@ -122,18 +127,17 @@ export function useExpansionMigration({
   // previously-expanded paths to new IDs and optionally expands a drop target
   // when the applied files match a pending drop result.
   useEffect(() => {
-    const filesSignature = getFilesSignature(files);
     const previousPaths = pendingExpandMigrationRef.current;
     const pendingDropTarget = pendingDropTargetExpandRef.current;
     const pendingRenameFocus = pendingRenameFocusRestoreRef.current;
     const dropTarget =
       pendingDropTarget != null &&
-      pendingDropTarget.expectedFilesSignature === filesSignature
+      pendingDropTarget.expectedVersion === structureVersion
         ? pendingDropTarget.path
         : null;
     const renameFocusPath =
       pendingRenameFocus != null &&
-      pendingRenameFocus.expectedFilesSignature === filesSignature
+      pendingRenameFocus.expectedVersion === structureVersion
         ? pendingRenameFocus.destinationPath
         : null;
     pendingExpandMigrationRef.current = null;
@@ -191,7 +195,7 @@ export function useExpansionMigration({
       }
     }
   }, [
-    files,
+    structureVersion,
     pathToId,
     tree,
     flattenEmptyDirectories,

--- a/packages/trees/src/components/hooks/useTree.ts
+++ b/packages/trees/src/components/hooks/useTree.ts
@@ -50,7 +50,7 @@ export const useTree = <T>(config: TreeConfig<T>): TreeInstance<T> => {
     },
   }));
 
-  // Rebuild when the dataLoader changes (e.g. files were updated via setFiles).
+  // Rebuild when the dataLoader identity changes (e.g. loader mode/config swap).
   // Skip the initial render — the constructor already calls rebuildTree().
   const prevDataLoaderRef = useRef(config.dataLoader);
   if (prevDataLoaderRef.current !== config.dataLoader) {

--- a/packages/trees/src/core/INCREMENTAL_TREE_INDEX.md
+++ b/packages/trees/src/core/INCREMENTAL_TREE_INDEX.md
@@ -78,3 +78,36 @@ can refresh just the affected branch once data arrives.
    reindexing).
 3. Optional subtree size / descendant caches for even faster range operations.
 4. More aggressive dirty-root coalescing for complex batch moves.
+
+## v2 model direction (in progress)
+
+The next major step is to make the canonical model fully **ID/parent-pointer
+first**, while keeping path-based APIs as a projection layer.
+
+Planned properties:
+
+- Node identity is stable and path-independent.
+- After the initial model build, common edits (`add`, `delete`, `rename`,
+  `move`) should update local node links/child lists instead of rebuilding a
+  full file snapshot.
+- External mutation notifications should be **changesets**, not mandatory full
+  `files[]` snapshots.
+
+### SSR-stable IDs
+
+Initial IDs should be deterministic from server input so SSR hydration can match
+model identities. Path-derived hashing is acceptable as the bootstrap key
+source, while post-hydration mutations keep IDs stable even if paths change.
+
+### Why we are not introducing ropes/B+ trees yet
+
+The current block index already provides good locality with simpler
+implementation costs. A rope/B+ visible-order structure is a follow-on step for
+very large range edits (especially root-level subtree moves), once the model
+layer is fully local-mutation-first.
+
+Expected follow-on benefits when introduced:
+
+- lower-cost giant visible-range splices,
+- better asymptotic behavior for very large trees,
+- improved worst-case root-level structural edits.

--- a/packages/trees/src/core/INCREMENTAL_TREE_INDEX.md
+++ b/packages/trees/src/core/INCREMENTAL_TREE_INDEX.md
@@ -1,0 +1,80 @@
+# Incremental tree index design (v1)
+
+The tree core now maintains an **incremental internal index** instead of fully
+rebuilding flattened metadata from a DFS traversal on every `rebuildTree()`.
+
+## Invariants
+
+- `nodes: Map<id, InternalTreeNode>` is the canonical node store.
+  - Every known node tracks `id`, `parentId`, `children`, `level`, `expanded`,
+    `orderKey`, `posInSet`, `setSize`, and child load state.
+- Visible order is stored explicitly in a block-based ordered index.
+- `visibleMetaById` stores ARIA-related metadata for visible nodes: `parentId`,
+  `level`, `posInSet`, `setSize`.
+- `visible` + `visibleMetaById` are always updated together.
+- Unknown or non-visible items fall back to a safe `ItemMeta` sentinel
+  (`index: -1`, `level: -1`, etc.).
+
+## Ordered-index choice
+
+v1 uses a **chunked block index** (`VisibleBlockIndex`) instead of a flat array:
+
+- IDs are stored in fixed-size blocks (default 128 IDs per block).
+- Local inserts/removes mutate one/few blocks, then recompute block starts.
+- `itemId -> { block, offset }` locations provide O(1)-ish index lookups.
+- Prefix starts are maintained per block, avoiding per-mutation O(N) array
+  shifting for the whole visible list.
+
+This gives B+-tree-like locality and mutation behavior with simpler JS/TS
+implementation complexity.
+
+## Key scheme
+
+Sibling order is explicit via a gap-based `orderKey` per child
+(`(index + 1) * ORDER_KEY_GAP` in v1).
+
+- Order is no longer derived from traversal as source-of-truth.
+- Reindexing is limited to the affected sibling list (branch-local), never a
+  global renumber across the full tree.
+- This leaves a clear seam for denser fractional-key strategies later if needed.
+
+## Incremental operations in v1
+
+Fully incremental / branch-local in v1:
+
+- Expand / collapse (visible range insert/remove under the toggled node)
+- Branch child updates via `markBranchDirty(..., 'children')`
+  - insert leaf/folder
+  - delete leaf/subtree
+  - sibling reorder
+  - move subtree (when source/target parents are marked dirty)
+- Metadata-only updates can skip structural rebuild (`setState` re-render path)
+
+`rebuildTree()` now performs:
+
+1. expansion diff (collapse/remove then expand/insert),
+2. dirty-branch refreshes,
+3. no-op when neither structure nor visibility changed.
+
+## Partial recompute paths retained
+
+- `rebuildTreeFromScratch()` is retained as a recovery/benchmark hook.
+- Data-loader identity changes currently force a full rebuild in v1.
+  - This is correctness-first and keeps stale-cache risk low.
+  - Future optimization: loader-aware structural diffing for immutable loader
+    replacement workflows.
+
+## Async-ready branch states
+
+Nodes track child load state (`unknown | loading | loaded | invalidated`).
+`markBranchDirty(id, 'invalidated')` is supported so async child invalidation
+can refresh just the affected branch once data arrives.
+
+## Future optimization targets
+
+1. Data-loader replacement diffing (avoid forced full rebuilds on immutable
+   loader swaps with small structural deltas).
+2. Richer order-key insertion strategy (fractional keys without sibling
+   reindexing).
+3. Optional subtree size / descendant caches for even faster range operations.
+4. More aggressive dirty-root coalescing for complex batch moves.

--- a/packages/trees/src/core/INCREMENTAL_TREE_INDEX.md
+++ b/packages/trees/src/core/INCREMENTAL_TREE_INDEX.md
@@ -17,6 +17,32 @@ rebuilding flattened metadata from a DFS traversal on every `rebuildTree()`.
 
 ## Ordered-index choice
 
+### Lock-in snapshot (current branch shape)
+
+The current mutation-fast shape we are converging on is:
+
+- **Model graph is ID/parent-pointer first** (`FileTreeModel` +
+  `MutablePathTree`)
+  - stable IDs are decoupled from path strings,
+  - path lookups are projection helpers (`pathToId` / `idToPath`),
+  - path-tree mutations (`add/delete/move/rename`) rewire pointers locally.
+- **Core visible order is index-first** (`IncrementalTreeIndex`)
+  - `nodes` keeps structural metadata,
+  - `visible` (`VisibleBlockIndex`) is the mutable ordered visible sequence,
+  - `visibleMetaById` keeps per-visible-node ARIA/index metadata.
+- **Mutation notifications are changesets**
+  - runtime marks only affected parents dirty,
+  - rebuild performs branch-local refreshes instead of full traversal.
+
+Important implementation detail we now rely on for large subtree moves:
+
+- Visible block insertion avoids argument-spread splice (`splice(...ids)`) for
+  large fragments, because JS argument limits can trigger stack overflows. We
+  build a merged block array (`head + inserted + tail`) and then split.
+
+This keeps root-structural edits incremental and avoids fallback-to-full rebuild
+on very large insert fragments.
+
 v1 uses a **chunked block index** (`VisibleBlockIndex`) instead of a flat array:
 
 - IDs are stored in fixed-size blocks (default 128 IDs per block).

--- a/packages/trees/src/core/create-tree.ts
+++ b/packages/trees/src/core/create-tree.ts
@@ -1,7 +1,6 @@
 import type { TreeDataRef } from '../features/main/types';
 import { treeFeature } from '../features/tree/feature';
 import type { ItemMeta } from '../features/tree/types';
-import { buildPackedVisibleItemMeta } from '../features/tree/visibleItemMeta';
 import {
   getBenchmarkInstrumentation,
   setBenchmarkCounter,
@@ -9,6 +8,10 @@ import {
 } from '../internal/benchmarkInstrumentation';
 /* oxlint-disable typescript-eslint/no-unsafe-return, typescript-eslint/strict-boolean-expressions */
 import { buildStaticInstance } from './build-static-instance';
+import {
+  IncrementalTreeIndex,
+  type IncrementalTreeRebuildResult,
+} from './incremental-tree-index';
 import {
   type FeatureImplementation,
   type HotkeysConfig,
@@ -66,29 +69,20 @@ const compareFeatures =
 const sortFeatures = (features: FeatureImplementation[] = []) =>
   exhaustiveSort(features, compareFeatures(features));
 
-interface PackedItemMetaStore {
-  cache: Array<ItemMeta | undefined>;
-  indexById: Record<string, number | undefined>;
-  levels: number[];
-  parentIds: string[];
-  posInSet: number[];
-  setSizes: number[];
-}
-
-function createPackedItemMetaStore(): PackedItemMetaStore {
-  return {
-    cache: [],
-    indexById: Object.create(null) as Record<string, number | undefined>,
-    levels: [],
-    parentIds: [],
-    posInSet: [],
-    setSizes: [],
-  };
-}
-
 function createFallbackItemMeta(itemId: string): ItemMeta {
   return {
     itemId,
+    parentId: null,
+    level: -1,
+    index: -1,
+    posInSet: 0,
+    setSize: 1,
+  };
+}
+
+function createRootItemMeta(rootItemId: string): ItemMeta {
+  return {
+    itemId: rootItemId,
     parentId: null,
     level: -1,
     index: -1,
@@ -140,10 +134,15 @@ export const createTree = <T>(
   const itemElementsMap: Record<string, HTMLElement | undefined | null> = {};
   // oxlint-disable-next-line typescript-eslint/no-explicit-any
   const itemDataRefs: Record<string, { current: any }> = {};
-  let itemMetaStore = createPackedItemMetaStore();
-  let rootItemMeta: ItemMeta = createFallbackItemMeta(initialConfig.rootItemId);
+  const itemMetaCache = new Map<string, ItemMeta>();
+  let rootItemMeta: ItemMeta = createRootItemMeta(initialConfig.rootItemId);
 
   const hotkeyPresets = {} as HotkeysConfig<T>;
+
+  const treeIndex = new IncrementalTreeIndex({
+    retrieveChildrenIds: (itemId) => treeInstance.retrieveChildrenIds(itemId),
+    getLoadingChildrenIds: () => state.loadingItemChildrens,
+  });
 
   // Builds and caches a single item instance the first time a caller actually
   // needs it. This lets virtualized renders size/slice the visible tree using
@@ -185,41 +184,55 @@ export const createTree = <T>(
     itemInstancesMap[config.rootItemId] = rootInstance;
   };
 
-  const rebuildItemMeta = () => {
-    withBenchmarkPhase(benchmarkInstrumentation, 'core.rebuildItemMeta', () => {
-      itemInstances = null;
-      itemMetaStore = createPackedItemMetaStore();
-      rootItemMeta = {
-        itemId: config.rootItemId,
-        index: -1,
-        parentId: null!,
-        level: -1,
-        posInSet: 0,
-        setSize: 1,
-      };
+  const invalidateVisibleCaches = () => {
+    itemInstances = null;
+    itemMetaCache.clear();
+  };
 
+  const syncVisibleIdsToDataRef = () => {
+    visibleItemIds = treeIndex.getVisibleItemIds();
+    const ref = treeDataRef.current as TreeDataRef;
+    ref.visibleItemIds = visibleItemIds;
+    setBenchmarkCounter(
+      benchmarkInstrumentation,
+      'workload.visibleItemMeta',
+      visibleItemIds.length
+    );
+  };
+
+  const rebuildItemMeta = (forceFull = false) => {
+    withBenchmarkPhase(benchmarkInstrumentation, 'core.rebuildItemMeta', () => {
+      let rebuildResult: IncrementalTreeRebuildResult;
+
+      try {
+        rebuildResult = treeIndex.rebuild({
+          rootId: config.rootItemId,
+          expandedItems: state.expandedItems,
+          dataLoaderIdentity: config.dataLoader,
+          forceFull,
+        });
+      } catch {
+        rebuildResult = treeIndex.rebuild({
+          rootId: config.rootItemId,
+          expandedItems: state.expandedItems,
+          dataLoaderIdentity: config.dataLoader,
+          forceFull: true,
+        });
+      }
+
+      rootItemMeta = createRootItemMeta(config.rootItemId);
       rebuildRootItemInstance();
 
-      // FileTree does not expose generic core feature overrides, so the hot
-      // rebuild path intentionally bypasses `tree.getItemsMeta()` and uses the
-      // packed traversal directly. If FileTree needs alternate visible-item
-      // derivation later, add a dedicated fast path here instead of routing
-      // every rebuild through the generic feature hook.
-      const packedVisibleMeta = buildPackedVisibleItemMeta(treeInstance);
-      itemMetaStore.indexById = packedVisibleMeta.indexById;
-      itemMetaStore.parentIds = packedVisibleMeta.parentIds;
-      itemMetaStore.levels = packedVisibleMeta.levels;
-      itemMetaStore.setSizes = packedVisibleMeta.setSizes;
-      itemMetaStore.posInSet = packedVisibleMeta.posInSet;
-      itemMetaStore.cache = new Array(packedVisibleMeta.visibleItemIds.length);
+      if (rebuildResult.visibleChanged) {
+        invalidateVisibleCaches();
+      }
 
-      visibleItemIds = packedVisibleMeta.visibleItemIds;
-      (treeDataRef.current as TreeDataRef).visibleItemIds = visibleItemIds;
-      setBenchmarkCounter(
-        benchmarkInstrumentation,
-        'workload.visibleItemMeta',
-        visibleItemIds.length
-      );
+      const ref = treeDataRef.current as TreeDataRef;
+      ref.lastRebuildMode = rebuildResult.mode;
+      ref.rebuildModeCounts ??= { full: 0, incremental: 0, noop: 0 };
+      ref.rebuildModeCounts[rebuildResult.mode] += 1;
+
+      syncVisibleIdsToDataRef();
       rebuildScheduled = false;
     });
   };
@@ -229,6 +242,22 @@ export const createTree = <T>(
     for (const feature of additionalFeatures) {
       fn(feature);
     }
+  };
+
+  const runRebuild = (forceFull = false) => {
+    const ref = treeDataRef.current as TreeDataRef;
+    const run = () => {
+      rebuildItemMeta(forceFull);
+      config.setState?.(state);
+    };
+
+    if (ref.isMounted === true) {
+      run();
+      return;
+    }
+
+    ref.waitingForMount ??= [];
+    ref.waitingForMount.push(run);
   };
 
   const mainFeature: FeatureImplementation<T> = {
@@ -269,21 +298,15 @@ export const createTree = <T>(
           ref.waitingForMount.push(apply);
         }
       },
-      rebuildTree: () => {
-        const ref = treeDataRef.current as TreeDataRef;
-        if (ref.isMounted === true) {
-          rebuildItemMeta();
-          config.setState?.(state);
-        } else {
-          ref.waitingForMount ??= [];
-          ref.waitingForMount.push(() => {
-            rebuildItemMeta();
-            config.setState?.(state);
-          });
-        }
+      rebuildTree: () => runRebuild(false),
+      rebuildTreeFromScratch: () => runRebuild(true),
+      markBranchDirty: (_opts, itemId, reason = 'children') => {
+        treeIndex.markBranchDirty(itemId, reason);
       },
       scheduleRebuildTree: () => {
         rebuildScheduled = true;
+        const ref = treeDataRef.current as TreeDataRef;
+        ref.visibleItemIds = undefined;
       },
       getConfig: () => config,
       setConfig: (_, updater) => {
@@ -297,8 +320,8 @@ export const createTree = <T>(
         if (newConfig.state != null) {
           state = { ...state, ...newConfig.state };
         }
+
         if (hasChangedExpandedItems === true) {
-          // if expanded items where changed from the outside
           rebuildItemMeta();
           config.setState?.(state);
         }
@@ -352,30 +375,36 @@ export const createTree = <T>(
       getElement: ({ itemId }) => itemElementsMap[itemId],
       getDataRef: ({ itemId }) => (itemDataRefs[itemId] ??= { current: {} }),
       getItemMeta: ({ itemId }) => {
+        if (rebuildScheduled) {
+          rebuildItemMeta();
+        }
+
         if (itemId === rootItemMeta.itemId) {
           return rootItemMeta;
         }
 
-        const index = itemMetaStore.indexById[itemId];
-        if (index === undefined) {
+        const visibleIndex = treeIndex.getVisibleIndex(itemId);
+        const visibleMeta = treeIndex.getVisibleMeta(itemId);
+        if (visibleIndex == null || visibleMeta == null) {
           return createFallbackItemMeta(itemId);
         }
 
-        const cached = itemMetaStore.cache[index];
-        if (cached != null) {
-          return cached;
+        const cachedMeta = itemMetaCache.get(itemId);
+        if (cachedMeta != null && cachedMeta.index === visibleIndex) {
+          return cachedMeta;
         }
 
-        const meta: ItemMeta = {
+        const itemMeta: ItemMeta = {
           itemId,
-          parentId: itemMetaStore.parentIds[index] ?? null,
-          level: itemMetaStore.levels[index] ?? -1,
-          index,
-          posInSet: itemMetaStore.posInSet[index] ?? 0,
-          setSize: itemMetaStore.setSizes[index] ?? 1,
+          parentId: visibleMeta.parentId,
+          level: visibleMeta.level,
+          index: visibleIndex,
+          posInSet: visibleMeta.posInSet,
+          setSize: visibleMeta.setSize,
         };
-        itemMetaStore.cache[index] = meta;
-        return meta;
+
+        itemMetaCache.set(itemId, itemMeta);
+        return itemMeta;
       },
     },
   };

--- a/packages/trees/src/core/create-tree.ts
+++ b/packages/trees/src/core/create-tree.ts
@@ -129,7 +129,7 @@ export const createTree = <T>(
 
   let rebuildScheduled = false;
   const itemInstancesMap: Record<string, ItemInstance<T>> = {};
-  let visibleItemIds: string[] = [];
+  let visibleItemIds: string[] | null = null;
   let itemInstances: ItemInstance<T>[] | null = null;
   const itemElementsMap: Record<string, HTMLElement | undefined | null> = {};
   // oxlint-disable-next-line typescript-eslint/no-explicit-any
@@ -186,17 +186,24 @@ export const createTree = <T>(
 
   const invalidateVisibleCaches = () => {
     itemInstances = null;
+    visibleItemIds = null;
     itemMetaCache.clear();
   };
 
+  const getVisibleItemIdsSnapshot = (): string[] => {
+    visibleItemIds ??= treeIndex.getVisibleItemIds();
+    return visibleItemIds;
+  };
+
   const syncVisibleIdsToDataRef = () => {
-    visibleItemIds = treeIndex.getVisibleItemIds();
+    const visibleItemCount = treeIndex.getVisibleCount();
     const ref = treeDataRef.current as TreeDataRef;
-    ref.visibleItemIds = visibleItemIds;
+    ref.visibleItemIds = undefined;
+    ref.visibleItemCount = visibleItemCount;
     setBenchmarkCounter(
       benchmarkInstrumentation,
       'workload.visibleItemMeta',
-      visibleItemIds.length
+      visibleItemCount
     );
   };
 
@@ -307,6 +314,7 @@ export const createTree = <T>(
         rebuildScheduled = true;
         const ref = treeDataRef.current as TreeDataRef;
         ref.visibleItemIds = undefined;
+        ref.visibleItemCount = undefined;
       },
       getConfig: () => config,
       setConfig: (_, updater) => {
@@ -329,10 +337,19 @@ export const createTree = <T>(
       getItemInstance: (_opts, itemId) => getOrCreateItemInstance(itemId),
       getItems: () => {
         if (rebuildScheduled) rebuildItemMeta();
-        itemInstances ??= visibleItemIds.map((itemId) =>
+        const currentVisibleIds = getVisibleItemIdsSnapshot();
+        itemInstances ??= currentVisibleIds.map((itemId) =>
           getOrCreateItemInstance(itemId)
         );
         return itemInstances;
+      },
+      getVisibleItemCount: () => {
+        if (rebuildScheduled) rebuildItemMeta();
+        return treeIndex.getVisibleCount();
+      },
+      getVisibleItemIdAt: (_opts, index) => {
+        if (rebuildScheduled) rebuildItemMeta();
+        return treeIndex.getVisibleItemIdAt(index);
       },
       registerElement: (_opts, element) => {
         if (treeElement === element) {

--- a/packages/trees/src/core/incremental-tree-index.ts
+++ b/packages/trees/src/core/incremental-tree-index.ts
@@ -1,0 +1,1015 @@
+import type { ItemMeta } from '../features/tree/types';
+
+const ORDER_KEY_GAP = 1024;
+const VISIBLE_BLOCK_SIZE = 128;
+
+type ChildrenLoadState = 'unknown' | 'loading' | 'loaded' | 'invalidated';
+
+interface InternalTreeNode {
+  id: string;
+  parentId: string | null;
+  children: string[];
+  orderKey: number;
+  level: number;
+  expanded: boolean;
+  posInSet: number;
+  setSize: number;
+  childrenState: ChildrenLoadState;
+}
+
+interface VisibleItemMetaRecord {
+  parentId: string;
+  level: number;
+  posInSet: number;
+  setSize: number;
+}
+
+interface VisibleBlock {
+  ids: string[];
+  start: number;
+}
+
+interface VisibleLocation {
+  block: VisibleBlock;
+  offset: number;
+}
+
+export interface IncrementalTreeIndexAdapter {
+  retrieveChildrenIds: (itemId: string) => string[] | undefined;
+  getLoadingChildrenIds: () => readonly string[] | undefined;
+}
+
+export interface IncrementalTreeRebuildInput {
+  rootId: string;
+  expandedItems: readonly string[];
+  dataLoaderIdentity: unknown;
+  forceFull?: boolean;
+}
+
+export interface IncrementalTreeRebuildResult {
+  mode: 'full' | 'incremental' | 'noop';
+  visibleChanged: boolean;
+}
+
+function areIdArraysEqual(left: readonly string[], right: readonly string[]) {
+  if (left === right) {
+    return true;
+  }
+
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  for (let index = 0; index < left.length; index++) {
+    if (left[index] !== right[index]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function normalizeChildren(
+  children: readonly string[],
+  parentId: string
+): string[] {
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+
+  for (let index = 0; index < children.length; index++) {
+    const childId = children[index];
+    if (childId === parentId || seen.has(childId)) {
+      continue;
+    }
+    seen.add(childId);
+    normalized.push(childId);
+  }
+
+  return normalized;
+}
+
+class VisibleBlockIndex {
+  private readonly blocks: VisibleBlock[] = [];
+  private readonly locationById = new Map<string, VisibleLocation>();
+  private readonly blockSize: number;
+  private size = 0;
+
+  constructor(blockSize: number) {
+    this.blockSize = Math.max(16, blockSize);
+  }
+
+  get length() {
+    return this.size;
+  }
+
+  clear() {
+    this.blocks.length = 0;
+    this.locationById.clear();
+    this.size = 0;
+  }
+
+  toArray(): string[] {
+    if (this.size === 0) {
+      return [];
+    }
+
+    const ids = new Array<string>(this.size);
+    let nextIndex = 0;
+
+    for (let blockIndex = 0; blockIndex < this.blocks.length; blockIndex++) {
+      const block = this.blocks[blockIndex];
+      for (let offset = 0; offset < block.ids.length; offset++) {
+        ids[nextIndex] = block.ids[offset];
+        nextIndex += 1;
+      }
+    }
+
+    return ids;
+  }
+
+  replaceAll(ids: readonly string[]) {
+    this.clear();
+
+    if (ids.length === 0) {
+      return;
+    }
+
+    let start = 0;
+    for (let index = 0; index < ids.length; index += this.blockSize) {
+      const blockIds = ids.slice(index, index + this.blockSize);
+      const block: VisibleBlock = {
+        ids: blockIds,
+        start,
+      };
+      this.blocks.push(block);
+      this.rebuildLocationsForBlock(block);
+      start += blockIds.length;
+    }
+
+    this.size = ids.length;
+  }
+
+  getIndex(itemId: string): number | undefined {
+    const location = this.locationById.get(itemId);
+    if (location == null) {
+      return undefined;
+    }
+
+    return location.block.start + location.offset;
+  }
+
+  getIdAt(index: number): string | undefined {
+    if (index < 0 || index >= this.size) {
+      return undefined;
+    }
+
+    let low = 0;
+    let high = this.blocks.length - 1;
+
+    while (low <= high) {
+      const middle = (low + high) >>> 1;
+      const block = this.blocks[middle];
+      const blockStart = block.start;
+      const blockEnd = blockStart + block.ids.length;
+
+      if (index < blockStart) {
+        high = middle - 1;
+      } else if (index >= blockEnd) {
+        low = middle + 1;
+      } else {
+        return block.ids[index - blockStart];
+      }
+    }
+
+    return undefined;
+  }
+
+  insertAt(index: number, ids: readonly string[]) {
+    if (ids.length === 0) {
+      return;
+    }
+
+    const normalizedIndex = Math.max(0, Math.min(index, this.size));
+
+    if (this.blocks.length === 0) {
+      this.replaceAll(ids);
+      return;
+    }
+
+    const { blockIndex, offset } = this.findBlockAtIndex(normalizedIndex);
+    const initialBlock = this.blocks[blockIndex];
+    initialBlock.ids.splice(offset, 0, ...ids);
+
+    const changedBlocks = new Set<number>([blockIndex]);
+    this.splitOversizedBlocks(blockIndex, changedBlocks);
+
+    this.size += ids.length;
+
+    const firstChangedIndex = Math.min(...changedBlocks);
+    this.recomputeStarts(firstChangedIndex);
+
+    for (const changedBlockIndex of changedBlocks) {
+      const block = this.blocks[changedBlockIndex];
+      if (block != null) {
+        this.rebuildLocationsForBlock(block);
+      }
+    }
+  }
+
+  removeRange(index: number, count: number): string[] {
+    if (count <= 0 || this.size === 0) {
+      return [];
+    }
+
+    const startIndex = Math.max(0, Math.min(index, this.size));
+    if (startIndex >= this.size) {
+      return [];
+    }
+
+    let remaining = Math.min(count, this.size - startIndex);
+    const removedIds: string[] = [];
+    let firstChangedIndex: number | null = null;
+
+    while (remaining > 0) {
+      const { blockIndex, offset } = this.findBlockAtIndex(startIndex);
+      const block = this.blocks[blockIndex];
+      if (block == null) {
+        break;
+      }
+
+      const removableCount = Math.min(remaining, block.ids.length - offset);
+      const removed = block.ids.splice(offset, removableCount);
+
+      for (
+        let removedIndex = 0;
+        removedIndex < removed.length;
+        removedIndex++
+      ) {
+        const removedId = removed[removedIndex];
+        this.locationById.delete(removedId);
+        removedIds.push(removedId);
+      }
+
+      if (firstChangedIndex == null || blockIndex < firstChangedIndex) {
+        firstChangedIndex = blockIndex;
+      }
+
+      if (block.ids.length === 0) {
+        this.blocks.splice(blockIndex, 1);
+      } else {
+        this.rebuildLocationsForBlock(block);
+      }
+
+      remaining -= removableCount;
+    }
+
+    if (removedIds.length === 0) {
+      return removedIds;
+    }
+
+    this.size -= removedIds.length;
+
+    if (this.blocks.length === 0) {
+      return removedIds;
+    }
+
+    const mergeStart = Math.max(0, (firstChangedIndex ?? 0) - 1);
+    this.mergeSmallNeighborBlocks(mergeStart);
+    this.recomputeStarts(mergeStart);
+
+    return removedIds;
+  }
+
+  private findBlockAtIndex(index: number): {
+    blockIndex: number;
+    offset: number;
+  } {
+    if (this.blocks.length === 0) {
+      return { blockIndex: 0, offset: 0 };
+    }
+
+    if (index >= this.size) {
+      const lastIndex = this.blocks.length - 1;
+      const lastBlock = this.blocks[lastIndex];
+      return {
+        blockIndex: lastIndex,
+        offset: lastBlock.ids.length,
+      };
+    }
+
+    let low = 0;
+    let high = this.blocks.length - 1;
+
+    while (low <= high) {
+      const middle = (low + high) >>> 1;
+      const block = this.blocks[middle];
+      const blockStart = block.start;
+      const blockEnd = blockStart + block.ids.length;
+
+      if (index < blockStart) {
+        high = middle - 1;
+      } else if (index >= blockEnd) {
+        low = middle + 1;
+      } else {
+        return {
+          blockIndex: middle,
+          offset: index - blockStart,
+        };
+      }
+    }
+
+    const fallbackIndex = Math.max(0, Math.min(low, this.blocks.length - 1));
+    return {
+      blockIndex: fallbackIndex,
+      offset: 0,
+    };
+  }
+
+  private splitOversizedBlocks(
+    startBlockIndex: number,
+    changedBlocks: Set<number>
+  ) {
+    let blockIndex = startBlockIndex;
+
+    while (blockIndex < this.blocks.length) {
+      const block = this.blocks[blockIndex];
+      if (block == null || block.ids.length <= this.blockSize) {
+        break;
+      }
+
+      const splitIndex = Math.ceil(block.ids.length / 2);
+      const tail = block.ids.splice(splitIndex);
+      const nextBlock: VisibleBlock = {
+        ids: tail,
+        start: 0,
+      };
+
+      this.blocks.splice(blockIndex + 1, 0, nextBlock);
+      changedBlocks.add(blockIndex);
+      changedBlocks.add(blockIndex + 1);
+
+      blockIndex += 1;
+    }
+  }
+
+  private mergeSmallNeighborBlocks(startBlockIndex: number) {
+    let index = startBlockIndex;
+
+    while (index < this.blocks.length - 1) {
+      const current = this.blocks[index];
+      const next = this.blocks[index + 1];
+
+      if (current.ids.length + next.ids.length > this.blockSize) {
+        index += 1;
+        continue;
+      }
+
+      current.ids.push(...next.ids);
+      this.blocks.splice(index + 1, 1);
+      this.rebuildLocationsForBlock(current);
+    }
+  }
+
+  private recomputeStarts(startBlockIndex: number) {
+    if (this.blocks.length === 0) {
+      return;
+    }
+
+    const normalizedStartIndex = Math.max(
+      0,
+      Math.min(startBlockIndex, this.blocks.length - 1)
+    );
+
+    let start =
+      normalizedStartIndex === 0
+        ? 0
+        : this.blocks[normalizedStartIndex - 1].start +
+          this.blocks[normalizedStartIndex - 1].ids.length;
+
+    for (
+      let blockIndex = normalizedStartIndex;
+      blockIndex < this.blocks.length;
+      blockIndex++
+    ) {
+      const block = this.blocks[blockIndex];
+      block.start = start;
+      start += block.ids.length;
+    }
+  }
+
+  private rebuildLocationsForBlock(block: VisibleBlock) {
+    for (let offset = 0; offset < block.ids.length; offset++) {
+      const itemId = block.ids[offset];
+      this.locationById.set(itemId, { block, offset });
+    }
+  }
+}
+
+interface VisibleFragment {
+  ids: string[];
+  meta: VisibleItemMetaRecord[];
+}
+
+// Maintains a canonical node store plus a block-based visible-order index so
+// local edits can update only the affected visible branch instead of
+// recomputing the entire flattened tree.
+export class IncrementalTreeIndex {
+  private readonly adapter: IncrementalTreeIndexAdapter;
+
+  private readonly nodes = new Map<string, InternalTreeNode>();
+  private readonly visible = new VisibleBlockIndex(VISIBLE_BLOCK_SIZE);
+  private readonly visibleMetaById = new Map<string, VisibleItemMetaRecord>();
+  private readonly dirtyParents = new Set<string>();
+  private readonly childrenSnapshotCache = new Map<string, string[]>();
+
+  private expandedItemIds = new Set<string>();
+  private rootId: string | null = null;
+  private dataLoaderIdentity: unknown = null;
+
+  private visibleIdsCache: string[] | null = null;
+  private visibleMetaSnapshotCache: ItemMeta[] | null = null;
+
+  constructor(adapter: IncrementalTreeIndexAdapter) {
+    this.adapter = adapter;
+  }
+
+  getVisibleItemIds(): string[] {
+    this.visibleIdsCache ??= this.visible.toArray();
+    return this.visibleIdsCache;
+  }
+
+  getVisibleIndex(itemId: string): number | undefined {
+    return this.visible.getIndex(itemId);
+  }
+
+  getVisibleMeta(itemId: string): VisibleItemMetaRecord | undefined {
+    return this.visibleMetaById.get(itemId);
+  }
+
+  getVisibleMetaSnapshot(): ItemMeta[] {
+    this.visibleMetaSnapshotCache ??= this.buildVisibleMetaSnapshot();
+    return this.visibleMetaSnapshotCache;
+  }
+
+  markBranchDirty(
+    itemId: string,
+    reason: 'children' | 'invalidated' = 'children'
+  ) {
+    const node = this.ensureNode(itemId);
+    if (reason === 'invalidated') {
+      node.childrenState = 'invalidated';
+    }
+    this.dirtyParents.add(itemId);
+  }
+
+  rebuild(input: IncrementalTreeRebuildInput): IncrementalTreeRebuildResult {
+    const nextExpanded = new Set(input.expandedItems);
+
+    this.childrenSnapshotCache.clear();
+
+    const needsFullRebuild =
+      input.forceFull === true ||
+      this.rootId !== input.rootId ||
+      this.dataLoaderIdentity !== input.dataLoaderIdentity ||
+      !this.nodes.has(input.rootId);
+
+    if (needsFullRebuild) {
+      this.fullRebuild(input.rootId, nextExpanded, input.dataLoaderIdentity);
+      return {
+        mode: 'full',
+        visibleChanged: true,
+      };
+    }
+
+    let visibleChanged = false;
+
+    const collapsedIds: string[] = [];
+    for (const itemId of this.expandedItemIds) {
+      if (!nextExpanded.has(itemId)) {
+        collapsedIds.push(itemId);
+      }
+    }
+
+    for (let index = 0; index < collapsedIds.length; index++) {
+      const collapsedItemId = collapsedIds[index];
+      if (this.collapseVisibleNode(collapsedItemId)) {
+        visibleChanged = true;
+      }
+      const node = this.nodes.get(collapsedItemId);
+      if (node != null) {
+        node.expanded = false;
+      }
+    }
+
+    const dirtyRoots = this.getMinimalDirtyParents(input.rootId);
+    for (let index = 0; index < dirtyRoots.length; index++) {
+      const dirtyRootId = dirtyRoots[index];
+      if (this.refreshVisibleBranch(dirtyRootId, nextExpanded, input.rootId)) {
+        visibleChanged = true;
+      }
+    }
+
+    const expandedIds: string[] = [];
+    for (const itemId of nextExpanded) {
+      if (!this.expandedItemIds.has(itemId)) {
+        expandedIds.push(itemId);
+      }
+    }
+
+    for (let index = 0; index < expandedIds.length; index++) {
+      const expandedItemId = expandedIds[index];
+      const node = this.ensureNode(expandedItemId);
+      node.expanded = true;
+
+      if (this.expandVisibleNode(expandedItemId, nextExpanded)) {
+        visibleChanged = true;
+      }
+    }
+
+    this.expandedItemIds = nextExpanded;
+    this.rootId = input.rootId;
+    this.dataLoaderIdentity = input.dataLoaderIdentity;
+    this.dirtyParents.clear();
+
+    if (visibleChanged) {
+      this.invalidateVisibleCaches();
+    }
+
+    return {
+      mode: visibleChanged ? 'incremental' : 'noop',
+      visibleChanged,
+    };
+  }
+
+  private fullRebuild(
+    rootId: string,
+    expandedItems: Set<string>,
+    dataLoaderIdentity: unknown
+  ) {
+    this.nodes.clear();
+    this.visible.clear();
+    this.visibleMetaById.clear();
+    this.dirtyParents.clear();
+
+    const rootNode = this.ensureNode(rootId, null, -1);
+    rootNode.expanded = true;
+
+    const fragment = this.collectVisibleChildren(
+      rootId,
+      -1,
+      expandedItems,
+      false
+    );
+    this.visible.replaceAll(fragment.ids);
+
+    for (let index = 0; index < fragment.ids.length; index++) {
+      const itemId = fragment.ids[index];
+      const meta = fragment.meta[index];
+      this.visibleMetaById.set(itemId, meta);
+    }
+
+    this.expandedItemIds = expandedItems;
+    this.rootId = rootId;
+    this.dataLoaderIdentity = dataLoaderIdentity;
+    this.invalidateVisibleCaches();
+  }
+
+  private collapseVisibleNode(itemId: string): boolean {
+    const visibleIndex = this.visible.getIndex(itemId);
+    const visibleMeta = this.visibleMetaById.get(itemId);
+
+    if (visibleIndex == null || visibleMeta == null) {
+      return false;
+    }
+
+    const removedIds = this.removeVisibleDescendants(
+      visibleIndex,
+      visibleMeta.level
+    );
+
+    return removedIds.length > 0;
+  }
+
+  private expandVisibleNode(
+    itemId: string,
+    expandedItems: Set<string>
+  ): boolean {
+    const visibleIndex = this.visible.getIndex(itemId);
+    const visibleMeta = this.visibleMetaById.get(itemId);
+
+    if (visibleIndex == null || visibleMeta == null) {
+      return false;
+    }
+
+    if (this.hasVisibleDescendants(visibleIndex, visibleMeta.level)) {
+      return false;
+    }
+
+    const fragment = this.collectVisibleChildren(
+      itemId,
+      visibleMeta.level,
+      expandedItems
+    );
+
+    if (fragment.ids.length === 0) {
+      return false;
+    }
+
+    this.visible.insertAt(visibleIndex + 1, fragment.ids);
+
+    for (let index = 0; index < fragment.ids.length; index++) {
+      const fragmentId = fragment.ids[index];
+      this.visibleMetaById.set(fragmentId, fragment.meta[index]);
+    }
+
+    return true;
+  }
+
+  private refreshVisibleBranch(
+    parentId: string,
+    expandedItems: Set<string>,
+    rootId: string
+  ): boolean {
+    const parentNode = this.ensureNode(
+      parentId,
+      parentId === rootId ? null : undefined,
+      parentId === rootId ? -1 : undefined
+    );
+    parentNode.expanded = parentId === rootId || expandedItems.has(parentId);
+
+    this.readAndSyncChildren(parentId, expandedItems);
+
+    if (parentId === rootId) {
+      this.visible.clear();
+      this.visibleMetaById.clear();
+
+      const fragment = this.collectVisibleChildren(
+        rootId,
+        -1,
+        expandedItems,
+        false
+      );
+      this.visible.replaceAll(fragment.ids);
+
+      for (let index = 0; index < fragment.ids.length; index++) {
+        const fragmentId = fragment.ids[index];
+        this.visibleMetaById.set(fragmentId, fragment.meta[index]);
+      }
+
+      return true;
+    }
+
+    const parentVisibleIndex = this.visible.getIndex(parentId);
+    const parentVisibleMeta = this.visibleMetaById.get(parentId);
+
+    if (parentVisibleIndex == null || parentVisibleMeta == null) {
+      return false;
+    }
+
+    const removedIds = this.removeVisibleDescendants(
+      parentVisibleIndex,
+      parentVisibleMeta.level
+    );
+
+    if (!expandedItems.has(parentId)) {
+      return removedIds.length > 0;
+    }
+
+    const fragment = this.collectVisibleChildren(
+      parentId,
+      parentVisibleMeta.level,
+      expandedItems
+    );
+
+    if (fragment.ids.length > 0) {
+      this.visible.insertAt(parentVisibleIndex + 1, fragment.ids);
+      for (let index = 0; index < fragment.ids.length; index++) {
+        const fragmentId = fragment.ids[index];
+        this.visibleMetaById.set(fragmentId, fragment.meta[index]);
+      }
+    }
+
+    return removedIds.length > 0 || fragment.ids.length > 0;
+  }
+
+  private removeVisibleDescendants(
+    parentIndex: number,
+    parentLevel: number
+  ): string[] {
+    let nextIndex = parentIndex + 1;
+    let removeCount = 0;
+
+    while (nextIndex < this.visible.length) {
+      const visibleId = this.visible.getIdAt(nextIndex);
+      if (visibleId == null) {
+        break;
+      }
+
+      const visibleMeta = this.visibleMetaById.get(visibleId);
+      if (visibleMeta == null || visibleMeta.level <= parentLevel) {
+        break;
+      }
+
+      removeCount += 1;
+      nextIndex += 1;
+    }
+
+    if (removeCount === 0) {
+      return [];
+    }
+
+    const removedIds = this.visible.removeRange(parentIndex + 1, removeCount);
+
+    for (let index = 0; index < removedIds.length; index++) {
+      const removedId = removedIds[index];
+      this.visibleMetaById.delete(removedId);
+    }
+
+    return removedIds;
+  }
+
+  private hasVisibleDescendants(itemIndex: number, itemLevel: number): boolean {
+    const nextVisibleId = this.visible.getIdAt(itemIndex + 1);
+    if (nextVisibleId == null) {
+      return false;
+    }
+
+    const nextMeta = this.visibleMetaById.get(nextVisibleId);
+    if (nextMeta == null) {
+      return false;
+    }
+
+    return nextMeta.level > itemLevel;
+  }
+
+  private collectVisibleChildren(
+    parentId: string,
+    parentLevel: number,
+    expandedItems = this.expandedItemIds,
+    checkExistingVisible = true
+  ): VisibleFragment {
+    const fragment: VisibleFragment = {
+      ids: [],
+      meta: [],
+    };
+
+    const ancestorSet = new Set<string>([parentId]);
+    const fragmentIdSet = new Set<string>();
+
+    this.appendVisibleChildren(
+      parentId,
+      parentLevel,
+      expandedItems,
+      ancestorSet,
+      fragmentIdSet,
+      fragment,
+      checkExistingVisible
+    );
+
+    return fragment;
+  }
+
+  // Traverses a branch in pre-order and appends only the visible nodes for the
+  // current expanded-item set. The caller supplies reusable output arrays so we
+  // avoid repeated allocations while mutating local branches.
+  private appendVisibleChildren(
+    parentId: string,
+    parentLevel: number,
+    expandedItems: Set<string>,
+    ancestorSet: Set<string>,
+    fragmentIdSet: Set<string>,
+    fragment: VisibleFragment,
+    checkExistingVisible: boolean
+  ) {
+    const children = this.readAndSyncChildren(parentId, expandedItems);
+    const setSize = children.length;
+
+    for (let childIndex = 0; childIndex < children.length; childIndex++) {
+      const childId = children[childIndex];
+
+      if (
+        ancestorSet.has(childId) ||
+        fragmentIdSet.has(childId) ||
+        (checkExistingVisible && this.visible.getIndex(childId) != null)
+      ) {
+        continue;
+      }
+
+      const childLevel = parentLevel + 1;
+      const childNode = this.ensureNode(childId, parentId, childLevel);
+      childNode.expanded = expandedItems.has(childId);
+      childNode.posInSet = childIndex;
+      childNode.setSize = setSize;
+
+      fragment.ids.push(childId);
+      fragment.meta.push({
+        parentId,
+        level: childLevel,
+        posInSet: childIndex,
+        setSize,
+      });
+      fragmentIdSet.add(childId);
+
+      if (!childNode.expanded) {
+        continue;
+      }
+
+      ancestorSet.add(childId);
+      this.appendVisibleChildren(
+        childId,
+        childLevel,
+        expandedItems,
+        ancestorSet,
+        fragmentIdSet,
+        fragment,
+        checkExistingVisible
+      );
+      ancestorSet.delete(childId);
+    }
+  }
+
+  private readAndSyncChildren(
+    parentId: string,
+    expandedItems: Set<string>
+  ): string[] {
+    const cachedChildren = this.childrenSnapshotCache.get(parentId);
+    const children =
+      cachedChildren ??
+      normalizeChildren(this.safeRetrieveChildren(parentId), parentId);
+
+    if (cachedChildren == null) {
+      this.childrenSnapshotCache.set(parentId, children);
+    }
+
+    this.syncChildren(parentId, children, expandedItems);
+    return this.nodes.get(parentId)?.children ?? [];
+  }
+
+  private safeRetrieveChildren(parentId: string): string[] {
+    try {
+      return this.adapter.retrieveChildrenIds(parentId) ?? [];
+    } catch {
+      return [];
+    }
+  }
+
+  private syncChildren(
+    parentId: string,
+    nextChildrenIds: readonly string[],
+    expandedItems: Set<string>
+  ) {
+    const parentNode = this.ensureNode(parentId);
+    const currentChildren = parentNode.children;
+
+    const loadingChildren = this.adapter.getLoadingChildrenIds();
+    parentNode.childrenState =
+      loadingChildren?.includes(parentId) === true ? 'loading' : 'loaded';
+
+    if (!areIdArraysEqual(currentChildren, nextChildrenIds)) {
+      const nextChildrenSet = new Set<string>(nextChildrenIds);
+      for (let index = 0; index < currentChildren.length; index++) {
+        const previousChildId = currentChildren[index];
+        if (!nextChildrenSet.has(previousChildId)) {
+          const previousChild = this.nodes.get(previousChildId);
+          if (previousChild?.parentId === parentId) {
+            previousChild.parentId = null;
+          }
+        }
+      }
+
+      parentNode.children = [...nextChildrenIds];
+    }
+
+    const setSize = parentNode.children.length;
+
+    for (
+      let childIndex = 0;
+      childIndex < parentNode.children.length;
+      childIndex++
+    ) {
+      const childId = parentNode.children[childIndex];
+      const childNode = this.ensureNode(
+        childId,
+        parentId,
+        parentNode.level + 1
+      );
+
+      childNode.parentId = parentId;
+      childNode.level = parentNode.level + 1;
+      childNode.orderKey = (childIndex + 1) * ORDER_KEY_GAP;
+      childNode.posInSet = childIndex;
+      childNode.setSize = setSize;
+      childNode.expanded = expandedItems.has(childId);
+    }
+  }
+
+  private ensureNode(
+    itemId: string,
+    parentId: string | null | undefined = undefined,
+    level: number | undefined = undefined
+  ): InternalTreeNode {
+    const existingNode = this.nodes.get(itemId);
+    if (existingNode != null) {
+      if (parentId !== undefined) {
+        existingNode.parentId = parentId;
+      }
+      if (level != null) {
+        existingNode.level = level;
+      }
+      return existingNode;
+    }
+
+    const createdNode: InternalTreeNode = {
+      id: itemId,
+      parentId: parentId ?? null,
+      children: [],
+      orderKey: 0,
+      level: level ?? 0,
+      expanded: this.expandedItemIds.has(itemId),
+      posInSet: 0,
+      setSize: 1,
+      childrenState: 'unknown',
+    };
+
+    this.nodes.set(itemId, createdNode);
+    return createdNode;
+  }
+
+  private getMinimalDirtyParents(rootId: string): string[] {
+    if (this.dirtyParents.size === 0) {
+      return [];
+    }
+
+    const dirtyIds = [...this.dirtyParents];
+    dirtyIds.sort(
+      (leftId, rightId) =>
+        this.getNodeLevel(leftId) - this.getNodeLevel(rightId)
+    );
+
+    const selectedIds: string[] = [];
+    const selectedSet = new Set<string>();
+
+    for (let index = 0; index < dirtyIds.length; index++) {
+      const dirtyId = dirtyIds[index];
+
+      if (dirtyId === rootId) {
+        return [rootId];
+      }
+
+      let ancestorId = this.nodes.get(dirtyId)?.parentId ?? null;
+      let shouldSkip = false;
+
+      while (ancestorId != null) {
+        if (selectedSet.has(ancestorId)) {
+          shouldSkip = true;
+          break;
+        }
+        ancestorId = this.nodes.get(ancestorId)?.parentId ?? null;
+      }
+
+      if (shouldSkip) {
+        continue;
+      }
+
+      selectedSet.add(dirtyId);
+      selectedIds.push(dirtyId);
+    }
+
+    return selectedIds;
+  }
+
+  private getNodeLevel(itemId: string): number {
+    const node = this.nodes.get(itemId);
+    if (node == null) {
+      return Number.MAX_SAFE_INTEGER;
+    }
+
+    return node.level;
+  }
+
+  private buildVisibleMetaSnapshot(): ItemMeta[] {
+    const visibleIds = this.getVisibleItemIds();
+    const metaSnapshot = new Array<ItemMeta>(visibleIds.length);
+
+    for (let index = 0; index < visibleIds.length; index++) {
+      const itemId = visibleIds[index];
+      const visibleMeta = this.visibleMetaById.get(itemId);
+
+      metaSnapshot[index] = {
+        itemId,
+        parentId: visibleMeta?.parentId ?? null,
+        level: visibleMeta?.level ?? -1,
+        index,
+        posInSet: visibleMeta?.posInSet ?? 0,
+        setSize: visibleMeta?.setSize ?? 1,
+      };
+    }
+
+    return metaSnapshot;
+  }
+
+  private invalidateVisibleCaches() {
+    this.visibleIdsCache = null;
+    this.visibleMetaSnapshotCache = null;
+  }
+}

--- a/packages/trees/src/core/incremental-tree-index.ts
+++ b/packages/trees/src/core/incremental-tree-index.ts
@@ -198,7 +198,9 @@ class VisibleBlockIndex {
 
     const { blockIndex, offset } = this.findBlockAtIndex(normalizedIndex);
     const initialBlock = this.blocks[blockIndex];
-    initialBlock.ids.splice(offset, 0, ...ids);
+    const blockHead = initialBlock.ids.slice(0, offset);
+    const blockTail = initialBlock.ids.slice(offset);
+    initialBlock.ids = blockHead.concat(ids, blockTail);
 
     const changedBlocks = new Set<number>([blockIndex]);
     this.splitOversizedBlocks(blockIndex, changedBlocks);
@@ -438,6 +440,14 @@ export class IncrementalTreeIndex {
     return this.visibleIdsCache;
   }
 
+  getVisibleCount(): number {
+    return this.visible.length;
+  }
+
+  getVisibleItemIdAt(index: number): string | undefined {
+    return this.visible.getIdAt(index);
+  }
+
   getVisibleIndex(itemId: string): number | undefined {
     return this.visible.getIndex(itemId);
   }
@@ -637,9 +647,20 @@ export class IncrementalTreeIndex {
     );
     parentNode.expanded = parentId === rootId || expandedItems.has(parentId);
 
+    const previousChildren = parentNode.children.slice();
     this.readAndSyncChildren(parentId, expandedItems);
 
     if (parentId === rootId) {
+      const rootRefreshResult = this.tryRefreshRootVisibleBranch(
+        rootId,
+        previousChildren,
+        parentNode.children,
+        expandedItems
+      );
+      if (rootRefreshResult != null) {
+        return rootRefreshResult;
+      }
+
       this.visible.clear();
       this.visibleMetaById.clear();
 
@@ -690,6 +711,213 @@ export class IncrementalTreeIndex {
     }
 
     return removedIds.length > 0 || fragment.ids.length > 0;
+  }
+
+  private tryRefreshRootVisibleBranch(
+    rootId: string,
+    previousChildren: readonly string[],
+    nextChildren: readonly string[],
+    expandedItems: Set<string>
+  ): boolean | null {
+    if (areIdArraysEqual(previousChildren, nextChildren)) {
+      return null;
+    }
+
+    let prefixLength = 0;
+    const minLength = Math.min(previousChildren.length, nextChildren.length);
+    while (
+      prefixLength < minLength &&
+      previousChildren[prefixLength] === nextChildren[prefixLength]
+    ) {
+      prefixLength += 1;
+    }
+
+    let previousSuffixIndex = previousChildren.length - 1;
+    let nextSuffixIndex = nextChildren.length - 1;
+    while (
+      previousSuffixIndex >= prefixLength &&
+      nextSuffixIndex >= prefixLength &&
+      previousChildren[previousSuffixIndex] === nextChildren[nextSuffixIndex]
+    ) {
+      previousSuffixIndex -= 1;
+      nextSuffixIndex -= 1;
+    }
+
+    const removedCount = Math.max(0, previousSuffixIndex - prefixLength + 1);
+    const insertedCount = Math.max(0, nextSuffixIndex - prefixLength + 1);
+
+    let visibleChanged = false;
+
+    if (removedCount > 0) {
+      const removedChildren = previousChildren.slice(
+        prefixLength,
+        prefixLength + removedCount
+      );
+      for (let index = removedChildren.length - 1; index >= 0; index--) {
+        const removedChildId = removedChildren[index];
+        const removedVisibleMeta = this.visibleMetaById.get(removedChildId);
+        if (
+          removedVisibleMeta == null ||
+          removedVisibleMeta.parentId !== rootId ||
+          removedVisibleMeta.level !== 0
+        ) {
+          continue;
+        }
+
+        const removedVisibleIndex = this.visible.getIndex(removedChildId);
+        if (removedVisibleIndex == null) {
+          continue;
+        }
+
+        const removedIds = this.removeVisibleSubtree(removedVisibleIndex, 0);
+        if (removedIds.length > 0) {
+          visibleChanged = true;
+        }
+      }
+    }
+
+    if (insertedCount > 0) {
+      const insertionAnchorId = nextChildren[prefixLength + insertedCount];
+      const insertIndex =
+        insertionAnchorId == null
+          ? this.visible.length
+          : (this.visible.getIndex(insertionAnchorId) ?? this.visible.length);
+
+      const fragment = this.collectVisibleRootInsertedChildren(
+        rootId,
+        nextChildren,
+        prefixLength,
+        prefixLength + insertedCount,
+        expandedItems
+      );
+
+      if (fragment.ids.length > 0) {
+        this.visible.insertAt(insertIndex, fragment.ids);
+        for (let index = 0; index < fragment.ids.length; index++) {
+          const fragmentId = fragment.ids[index];
+          this.visibleMetaById.set(fragmentId, fragment.meta[index]);
+        }
+        visibleChanged = true;
+      }
+    }
+
+    if (!visibleChanged) {
+      this.updateRootChildrenVisibleMeta(rootId, nextChildren);
+      return false;
+    }
+
+    this.updateRootChildrenVisibleMeta(rootId, nextChildren);
+    return true;
+  }
+
+  private collectVisibleRootInsertedChildren(
+    rootId: string,
+    rootChildren: readonly string[],
+    startIndex: number,
+    endIndexExclusive: number,
+    expandedItems: Set<string>
+  ): VisibleFragment {
+    const fragment: VisibleFragment = {
+      ids: [],
+      meta: [],
+    };
+
+    const ancestorSet = new Set<string>();
+    const fragmentIdSet = new Set<string>();
+    const setSize = rootChildren.length;
+
+    for (
+      let childIndex = startIndex;
+      childIndex < endIndexExclusive;
+      childIndex++
+    ) {
+      const childId = rootChildren[childIndex];
+      if (childId == null || fragmentIdSet.has(childId)) {
+        continue;
+      }
+
+      const childNode = this.ensureNode(childId, rootId, 0);
+      childNode.parentId = rootId;
+      childNode.level = 0;
+      childNode.expanded = expandedItems.has(childId);
+      childNode.posInSet = childIndex;
+      childNode.setSize = setSize;
+
+      fragment.ids.push(childId);
+      fragment.meta.push({
+        parentId: rootId,
+        level: 0,
+        posInSet: childIndex,
+        setSize,
+      });
+      fragmentIdSet.add(childId);
+
+      if (!childNode.expanded) {
+        continue;
+      }
+
+      ancestorSet.add(childId);
+      this.appendVisibleChildren(
+        childId,
+        0,
+        expandedItems,
+        ancestorSet,
+        fragmentIdSet,
+        fragment,
+        false
+      );
+      ancestorSet.delete(childId);
+    }
+
+    return fragment;
+  }
+
+  private updateRootChildrenVisibleMeta(
+    rootId: string,
+    rootChildren: readonly string[]
+  ): void {
+    const setSize = rootChildren.length;
+
+    for (let childIndex = 0; childIndex < rootChildren.length; childIndex++) {
+      const childId = rootChildren[childIndex];
+      const visibleMeta = this.visibleMetaById.get(childId);
+      if (visibleMeta == null) {
+        continue;
+      }
+
+      visibleMeta.parentId = rootId;
+      visibleMeta.level = 0;
+      visibleMeta.posInSet = childIndex;
+      visibleMeta.setSize = setSize;
+    }
+  }
+
+  private removeVisibleSubtree(
+    startIndex: number,
+    rootLevel: number
+  ): string[] {
+    let removeCount = 1;
+
+    while (startIndex + removeCount < this.visible.length) {
+      const visibleId = this.visible.getIdAt(startIndex + removeCount);
+      if (visibleId == null) {
+        break;
+      }
+
+      const visibleMeta = this.visibleMetaById.get(visibleId);
+      if (visibleMeta == null || visibleMeta.level <= rootLevel) {
+        break;
+      }
+
+      removeCount += 1;
+    }
+
+    const removedIds = this.visible.removeRange(startIndex, removeCount);
+    for (let index = 0; index < removedIds.length; index++) {
+      this.visibleMetaById.delete(removedIds[index]);
+    }
+
+    return removedIds;
   }
 
   private removeVisibleDescendants(
@@ -779,8 +1007,14 @@ export class IncrementalTreeIndex {
     ancestorSet: Set<string>,
     fragmentIdSet: Set<string>,
     fragment: VisibleFragment,
-    checkExistingVisible: boolean
+    checkExistingVisible: boolean,
+    recursionDepth = 0
   ) {
+    if (recursionDepth > 2048) {
+      throw new Error(
+        `appendVisibleChildren exceeded recursion depth at ${parentId}`
+      );
+    }
     const children = this.readAndSyncChildren(parentId, expandedItems);
     const setSize = children.length;
 
@@ -822,7 +1056,8 @@ export class IncrementalTreeIndex {
         ancestorSet,
         fragmentIdSet,
         fragment,
-        checkExistingVisible
+        checkExistingVisible,
+        recursionDepth + 1
       );
       ancestorSet.delete(childId);
     }
@@ -941,6 +1176,8 @@ export class IncrementalTreeIndex {
     }
 
     const dirtyIds = [...this.dirtyParents];
+    const hasRoot = this.dirtyParents.has(rootId);
+
     dirtyIds.sort(
       (leftId, rightId) =>
         this.getNodeLevel(leftId) - this.getNodeLevel(rightId)
@@ -953,14 +1190,14 @@ export class IncrementalTreeIndex {
       const dirtyId = dirtyIds[index];
 
       if (dirtyId === rootId) {
-        return [rootId];
+        continue;
       }
 
       let ancestorId = this.nodes.get(dirtyId)?.parentId ?? null;
       let shouldSkip = false;
 
       while (ancestorId != null) {
-        if (selectedSet.has(ancestorId)) {
+        if (ancestorId !== rootId && selectedSet.has(ancestorId)) {
           shouldSkip = true;
           break;
         }
@@ -973,6 +1210,10 @@ export class IncrementalTreeIndex {
 
       selectedSet.add(dirtyId);
       selectedIds.push(dirtyId);
+    }
+
+    if (hasRoot) {
+      selectedIds.unshift(rootId);
     }
 
     return selectedIds;

--- a/packages/trees/src/core/utilities/insert-items-at-target.ts
+++ b/packages/trees/src/core/utilities/insert-items-at-target.ts
@@ -18,10 +18,18 @@ export const insertItemsAtTarget = async <T>(
   if (!('childIndex' in target)) {
     const newChildren = [...oldChildrenIds, ...itemIds];
     await onChangeChildren(target.item, newChildren);
-    if ('updateCachedChildrenIds' in target.item) {
-      target.item.updateCachedChildrenIds(newChildren);
+
+    const maybeAsyncItem = target.item as ItemInstance<T> & {
+      updateCachedChildrenIds?: (childrenIds: string[]) => void;
+    };
+    if (typeof maybeAsyncItem.updateCachedChildrenIds === 'function') {
+      maybeAsyncItem.updateCachedChildrenIds(newChildren);
+      return;
     }
-    target.item.getTree().rebuildTree();
+
+    const tree = target.item.getTree();
+    tree.markBranchDirty(target.item.getId(), 'children');
+    tree.rebuildTree();
     return;
   }
 
@@ -34,8 +42,15 @@ export const insertItemsAtTarget = async <T>(
 
   await onChangeChildren(target.item, newChildren);
 
-  if ('updateCachedChildrenIds' in target.item) {
-    target.item.updateCachedChildrenIds(newChildren);
+  const maybeAsyncItem = target.item as ItemInstance<T> & {
+    updateCachedChildrenIds?: (childrenIds: string[]) => void;
+  };
+  if (typeof maybeAsyncItem.updateCachedChildrenIds === 'function') {
+    maybeAsyncItem.updateCachedChildrenIds(newChildren);
+    return;
   }
-  target.item.getTree().rebuildTree();
+
+  const tree = target.item.getTree();
+  tree.markBranchDirty(target.item.getId(), 'children');
+  tree.rebuildTree();
 };

--- a/packages/trees/src/core/utilities/remove-items-from-parents.ts
+++ b/packages/trees/src/core/utilities/remove-items-from-parents.ts
@@ -13,6 +13,8 @@ export const removeItemsFromParents = async <T>(
     ...new Set(movedItems.map((item) => item.getParent())),
   ];
 
+  let handledRebuildViaItemUpdater = false;
+
   for (const parent of uniqueParents) {
     const siblings = parent?.getChildren();
     if (siblings != null && parent != null) {
@@ -20,11 +22,20 @@ export const removeItemsFromParents = async <T>(
         .filter((sibling) => !movedItemsIds.includes(sibling.getId()))
         .map((i) => i.getId());
       await onChangeChildren(parent, newChildren);
-      if ('updateCachedChildrenIds' in parent) {
-        parent.updateCachedChildrenIds(newChildren);
+
+      const maybeAsyncParent = parent as ItemInstance<T> & {
+        updateCachedChildrenIds?: (childrenIds: string[]) => void;
+      };
+      if (typeof maybeAsyncParent.updateCachedChildrenIds === 'function') {
+        maybeAsyncParent.updateCachedChildrenIds(newChildren);
+        handledRebuildViaItemUpdater = true;
+      } else {
+        movedItems[0].getTree().markBranchDirty(parent.getId(), 'children');
       }
     }
   }
 
-  movedItems[0].getTree().rebuildTree();
+  if (!handledRebuildViaItemUpdater) {
+    movedItems[0].getTree().rebuildTree();
+  }
 };

--- a/packages/trees/src/features/async-data-loader/feature.ts
+++ b/packages/trees/src/features/async-data-loader/feature.ts
@@ -77,6 +77,7 @@ const loadChildrenIds = async <T>(tree: TreeInstance<T>, itemId: string) => {
     });
 
     config.onLoadedChildren?.(itemId, childrenIds);
+    tree.markBranchDirty(itemId, 'children');
     tree.rebuildTree();
     tree.applySubStateUpdate('loadingItemData', (loadingItemData) =>
       loadingItemData.filter((id) => !childrenIds.includes(id))
@@ -85,6 +86,7 @@ const loadChildrenIds = async <T>(tree: TreeInstance<T>, itemId: string) => {
     childrenIds = await config.dataLoader.getChildren(itemId);
     dataRef.current.childrenIds[itemId] = childrenIds;
     config.onLoadedChildren?.(itemId, childrenIds);
+    tree.markBranchDirty(itemId, 'children');
     tree.rebuildTree();
   }
 
@@ -193,12 +195,13 @@ export const asyncDataLoaderFeature: FeatureImplementation = {
     updateCachedChildrenIds: ({ tree, itemId }, childrenIds) => {
       const dataRef = tree.getDataRef<AsyncDataLoaderDataRef>();
       dataRef.current.childrenIds[itemId] = childrenIds;
+      tree.markBranchDirty(itemId, 'children');
       tree.rebuildTree();
     },
     updateCachedData: ({ tree, itemId }, data) => {
       const dataRef = tree.getDataRef<AsyncDataLoaderDataRef>();
       dataRef.current.itemData[itemId] = data;
-      tree.rebuildTree();
+      tree.setState((previousState) => previousState);
     },
     hasLoadedData: ({ tree, itemId }) => {
       const dataRef = tree.getDataRef<AsyncDataLoaderDataRef>();

--- a/packages/trees/src/features/main/types.ts
+++ b/packages/trees/src/features/main/types.ts
@@ -19,6 +19,9 @@ export interface TreeDataRef {
    * item instance up front.
    */
   visibleItemIds?: string[];
+  /** Internal rebuild telemetry for profiling/debugging incremental behavior. */
+  lastRebuildMode?: 'full' | 'incremental' | 'noop';
+  rebuildModeCounts?: Record<'full' | 'incremental' | 'noop', number>;
 }
 
 export type InstanceTypeMap = {
@@ -66,6 +69,20 @@ export type MainFeatureDef<T = any> = {
     /* @internal */
     getHotkeyPresets: () => HotkeysConfig<T>;
     rebuildTree: () => void;
+    /**
+     * Forces a full rebuild of internal tree indexes.
+     * @internal Recovery/benchmark hook. Prefer `rebuildTree()` for normal use.
+     */
+    rebuildTreeFromScratch: () => void;
+    /**
+     * Marks a branch as structurally dirty so the next rebuild can refresh only
+     * the affected subtree instead of re-walking the full visible tree.
+     * @internal
+     */
+    markBranchDirty: (
+      itemId: string,
+      reason?: 'children' | 'invalidated'
+    ) => void;
     /** @deprecated Experimental feature, might get removed or changed in the future. */
     scheduleRebuildTree: () => void;
     /** @internal */

--- a/packages/trees/src/features/main/types.ts
+++ b/packages/trees/src/features/main/types.ts
@@ -19,6 +19,10 @@ export interface TreeDataRef {
    * item instance up front.
    */
   visibleItemIds?: string[];
+  /**
+   * Visible row count from the latest rebuild.
+   */
+  visibleItemCount?: number;
   /** Internal rebuild telemetry for profiling/debugging incremental behavior. */
   lastRebuildMode?: 'full' | 'incremental' | 'noop';
   rebuildModeCounts?: Record<'full' | 'incremental' | 'noop', number>;
@@ -62,6 +66,10 @@ export type MainFeatureDef<T = any> = {
     getConfig: () => TreeConfig<T>;
     getItemInstance: (itemId: string) => ItemInstance<T>;
     getItems: () => ItemInstance<T>[];
+    /** @internal */
+    getVisibleItemCount: () => number;
+    /** @internal */
+    getVisibleItemIdAt: (index: number) => string | undefined;
     registerElement: (element: HTMLElement | null) => void;
     getElement: () => HTMLElement | undefined | null;
     /** @internal */

--- a/packages/trees/src/features/tree/feature.ts
+++ b/packages/trees/src/features/tree/feature.ts
@@ -27,9 +27,30 @@ export const treeFeature: FeatureImplementation<any> = {
   treeInstance: {
     getItemsMeta: ({ tree }) => {
       const dataRef = tree.getDataRef<TreeDataRef>();
+      const cachedVisibleIds = dataRef.current.visibleItemIds;
       const visibleIds =
-        dataRef.current.visibleItemIds ??
-        tree.getItems().map((item) => item.getId());
+        cachedVisibleIds ??
+        (() => {
+          const visibleCount =
+            dataRef.current.visibleItemCount ?? tree.getVisibleItemCount();
+          const ids = new Array<string>(visibleCount);
+          let resolvedCount = 0;
+
+          for (let index = 0; index < visibleCount; index += 1) {
+            const visibleId = tree.getVisibleItemIdAt(index);
+            if (visibleId == null) {
+              break;
+            }
+            ids[index] = visibleId;
+            resolvedCount += 1;
+          }
+
+          if (resolvedCount !== visibleCount) {
+            ids.length = resolvedCount;
+          }
+
+          return ids;
+        })();
       return visibleIds.map((itemId) =>
         tree.getItemInstance(itemId).getItemMeta()
       );

--- a/packages/trees/src/features/tree/feature.ts
+++ b/packages/trees/src/features/tree/feature.ts
@@ -1,7 +1,7 @@
 /* oxlint-disable typescript-eslint/no-unsafe-return, typescript-eslint/strict-boolean-expressions */
 import type { FeatureImplementation } from '../../core/types/core';
 import { makeStateUpdater, poll } from '../../core/utils';
-import { collectVisibleItemMeta } from './visibleItemMeta';
+import type { TreeDataRef } from '../main/types';
 
 // oxlint-disable-next-line typescript-eslint/no-explicit-any
 export const treeFeature: FeatureImplementation<any> = {
@@ -25,7 +25,15 @@ export const treeFeature: FeatureImplementation<any> = {
   },
 
   treeInstance: {
-    getItemsMeta: ({ tree }) => collectVisibleItemMeta(tree),
+    getItemsMeta: ({ tree }) => {
+      const dataRef = tree.getDataRef<TreeDataRef>();
+      const visibleIds =
+        dataRef.current.visibleItemIds ??
+        tree.getItems().map((item) => item.getId());
+      return visibleIds.map((itemId) =>
+        tree.getItemInstance(itemId).getItemMeta()
+      );
+    },
 
     getFocusedItem: ({ tree }) => {
       const focusedItemId = tree.getState().focusedItem;

--- a/packages/trees/src/index.ts
+++ b/packages/trees/src/index.ts
@@ -1,5 +1,6 @@
 export * from './constants';
 export * from './FileTree';
+export * from './model';
 export { generateLazyDataLoader } from './loader/lazy';
 export { generateSyncDataLoader } from './loader/sync';
 export type { DataLoaderOptions, TreeDataLoader } from './loader/types';

--- a/packages/trees/src/loader/sync.ts
+++ b/packages/trees/src/loader/sync.ts
@@ -48,7 +48,16 @@ export function generateSyncDataLoaderFromIndex(
       if (item == null) {
         throw new Error(`generateSyncDataLoaderFromIndex: unknown id ${id}`);
       }
-      return item;
+
+      const resolvedPath = index.idToPath?.get(id);
+      if (resolvedPath == null || resolvedPath === item.path) {
+        return item;
+      }
+
+      return {
+        ...item,
+        path: resolvedPath,
+      };
     },
     getChildren: (id: string) => {
       const children = index.tree.get(id)?.children;

--- a/packages/trees/src/model/FileTreeModel.ts
+++ b/packages/trees/src/model/FileTreeModel.ts
@@ -129,47 +129,6 @@ function getPathDepth(path: string): number {
   return depth;
 }
 
-/**
- * Applies a precomputed file origin->destination mapping to a mutable path
- * tree. Returns false if we hit an unexpected inconsistency and need to fall
- * back to rebuilding the tree from a snapshot.
- */
-function applyMappedFilesToPathTree(
-  pathTree: MutablePathTree,
-  currentFiles: string[],
-  finalPathByOrigin: Map<string, string | null>
-): boolean {
-  for (let index = 0; index < currentFiles.length; index += 1) {
-    const origin = currentFiles[index];
-    if (finalPathByOrigin.get(origin) != null) {
-      continue;
-    }
-    pathTree.deleteFilePath(origin);
-  }
-
-  for (let index = 0; index < currentFiles.length; index += 1) {
-    const origin = currentFiles[index];
-    const destination = finalPathByOrigin.get(origin);
-    if (destination == null || destination === origin) {
-      continue;
-    }
-
-    const { parentPath, baseName } = splitPath(destination);
-    const moveResult = pathTree.movePath(
-      origin,
-      parentPath === '' ? ROOT_ID : parentPath,
-      baseName,
-      'file'
-    );
-
-    if (moveResult !== 'ok') {
-      return false;
-    }
-  }
-
-  return true;
-}
-
 interface PlannedMoveRule {
   sourcePath: string;
   destinationPath: string;
@@ -403,6 +362,10 @@ export class FileTreeModel {
   private readonly fileIndexByPath = new Map<string, number>();
   private readonly flattenedRefCountById = new Map<string, number>();
   private readonly flattenedIdsPendingPrune = new Set<string>();
+  private readonly directChildIndexByFolderId = new Map<
+    string,
+    Map<string, number>
+  >();
   private readonly benchmarkInstrumentation: BenchmarkInstrumentation | null;
   private pathTree: MutablePathTree | null = null;
   private version = 0;
@@ -445,21 +408,29 @@ export class FileTreeModel {
     }
 
     this.tree.clear();
+    this.directChildIndexByFolderId.clear();
     for (const [id, node] of builtIndex.tree) {
       this.tree.set(id, node);
+      const directChildren = node.children?.direct;
+      if (directChildren != null) {
+        const directChildIndexMap = new Map<string, number>();
+        for (let index = 0; index < directChildren.length; index += 1) {
+          directChildIndexMap.set(directChildren[index], index);
+        }
+        this.directChildIndexByFolderId.set(id, directChildIndexMap);
+      }
     }
 
     this.files = builtIndex.files;
-    this.fileIndexByPath.clear();
-    for (let index = 0; index < this.files.length; index += 1) {
-      this.fileIndexByPath.set(this.files[index], index);
-    }
+    this.rebuildFileIndexByPath(this.files);
+    this.setModelCounter('model.snapshot.fileCount', this.files.length);
     this.nextNodeId = builtIndex.nextNodeId;
 
     this.rebuildFlattenedReferenceCounts();
 
     if (options.syncPathTree !== false && this.pathTree != null) {
       this.pathTree.replaceAll(this.files);
+      this.adoptPathTreeFilesReference(this.pathTree);
     }
   }
 
@@ -605,29 +576,70 @@ export class FileTreeModel {
     return [...affectedParentIdsSet];
   }
 
-  private getOrCreatePathTree(): MutablePathTree {
-    this.pathTree ??= MutablePathTree.fromFiles(this.files);
-    return this.pathTree;
-  }
-
-  private replaceFilesSnapshot(files: string[]): void {
-    this.files = files;
+  private rebuildFileIndexByPath(files: readonly string[]): void {
     this.fileIndexByPath.clear();
     for (let index = 0; index < files.length; index += 1) {
       this.fileIndexByPath.set(files[index], index);
     }
-    this.setModelCounter('model.snapshot.fileCount', files.length);
   }
 
-  private addAncestorFoldersForPath(path: string, out: Set<string>): void {
-    let currentPath = path.length === 0 ? ROOT_ID : path;
-    while (true) {
-      out.add(currentPath);
-      if (currentPath === ROOT_ID) {
-        return;
-      }
-      currentPath = getParentPath(currentPath);
+  private adoptPathTreeFilesReference(pathTree: MutablePathTree): void {
+    this.files = pathTree.getFilesReference();
+    this.fileIndexByPath.clear();
+    this.setModelCounter('model.snapshot.fileCount', this.files.length);
+  }
+
+  private getOrCreatePathTree(): MutablePathTree {
+    if (this.pathTree == null) {
+      this.pathTree = MutablePathTree.fromFiles(this.files);
+      this.adoptPathTreeFilesReference(this.pathTree);
     }
+    return this.pathTree;
+  }
+
+  private areIdArraysEqual(
+    left: readonly string[],
+    right: readonly string[]
+  ): boolean {
+    if (left.length !== right.length) {
+      return false;
+    }
+
+    for (let index = 0; index < left.length; index += 1) {
+      if (left[index] !== right[index]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private setDirectChildIndexCache(
+    folderId: string,
+    directChildIds: readonly string[]
+  ): void {
+    const directChildIndexMap = new Map<string, number>();
+    for (let index = 0; index < directChildIds.length; index += 1) {
+      directChildIndexMap.set(directChildIds[index], index);
+    }
+    this.directChildIndexByFolderId.set(folderId, directChildIndexMap);
+  }
+
+  private getDirectChildIndex(
+    folderId: string,
+    childId: string,
+    directChildIds: readonly string[]
+  ): number {
+    let directChildIndexMap = this.directChildIndexByFolderId.get(folderId);
+    if (directChildIndexMap == null) {
+      this.setDirectChildIndexCache(folderId, directChildIds);
+      directChildIndexMap = this.directChildIndexByFolderId.get(folderId);
+      if (directChildIndexMap == null) {
+        return -1;
+      }
+    }
+
+    return directChildIndexMap.get(childId) ?? -1;
   }
 
   private allocateStableIdForPath(path: string): string {
@@ -677,6 +689,7 @@ export class FileTreeModel {
     }
 
     this.tree.delete(id);
+    this.directChildIndexByFolderId.delete(id);
   }
 
   /**
@@ -983,6 +996,42 @@ export class FileTreeModel {
     const rebuiltFolders = new Set<string>();
     const rebuildingFolders = new Set<string>();
     const flattenedEndpointCache = new Map<string, string | null>();
+    const dirtyChildrenByFolderPath = new Map<string, Set<string>>();
+
+    const markDirtyChild = (folderPath: string, childPath: string): void => {
+      const normalizedFolderPath =
+        folderPath.length === 0 ? ROOT_ID : folderPath;
+      const normalizedChildPath = childPath.length === 0 ? ROOT_ID : childPath;
+      const existing = dirtyChildrenByFolderPath.get(normalizedFolderPath);
+      if (existing != null) {
+        existing.add(normalizedChildPath);
+        return;
+      }
+      dirtyChildrenByFolderPath.set(
+        normalizedFolderPath,
+        new Set([normalizedChildPath])
+      );
+    };
+
+    for (const folderPath of folderPaths) {
+      const normalizedFolderPath =
+        folderPath.length === 0 ? ROOT_ID : folderPath;
+      if (normalizedFolderPath === ROOT_ID) {
+        continue;
+      }
+      markDirtyChild(getParentPath(normalizedFolderPath), normalizedFolderPath);
+    }
+
+    const isLocallyAffectedFolder = (path: string): boolean => {
+      let currentPath = path;
+      while (currentPath !== ROOT_ID) {
+        if (folderPaths.has(currentPath)) {
+          return true;
+        }
+        currentPath = getParentPath(currentPath);
+      }
+      return false;
+    };
 
     const rebuildFolder = (folderPath: string): void => {
       const normalizedFolderPath =
@@ -999,6 +1048,7 @@ export class FileTreeModel {
         normalizedFolderPath !== ROOT_ID &&
         !pathTree.hasFolder(normalizedFolderPath)
       ) {
+        let removedFolder = false;
         const missingFolderId = this.pathToIdMap.get(normalizedFolderPath);
         if (missingFolderId != null) {
           const subtreePrefix = `${normalizedFolderPath}/`;
@@ -1011,8 +1061,15 @@ export class FileTreeModel {
               rawPath.startsWith(subtreePrefix)
             );
           });
+          removedFolder = true;
         }
+
         rebuiltFolders.add(normalizedFolderPath);
+        if (removedFolder) {
+          const parentPath = getParentPath(normalizedFolderPath);
+          markDirtyChild(parentPath, normalizedFolderPath);
+          rebuildFolder(parentPath);
+        }
         return;
       }
 
@@ -1023,58 +1080,111 @@ export class FileTreeModel {
           ? ROOT_ID
           : this.ensureStableIdForPath(normalizedFolderPath);
       const previousNode = this.tree.get(folderId);
-      const previousDirectChildren =
-        previousNode?.children?.direct?.slice() ?? [];
-      const previousFlattenedChildren =
-        previousNode?.children?.flattened?.slice() ?? [];
-
-      const directChildren = pathTree.getDirectChildren(normalizedFolderPath);
-      this.sortPathTreeChildren(directChildren, pathTree);
-
-      const directChildIds = new Array<string>(directChildren.length);
-      for (let index = 0; index < directChildren.length; index += 1) {
-        const child = directChildren[index];
-        const childId = this.ensureStableIdForPath(child.path);
-        directChildIds[index] = childId;
-
-        const existingNode = this.tree.get(childId);
-        if (child.kind === 'folder') {
-          if (existingNode?.children == null) {
-            this.tree.set(childId, {
-              name: getLeafName(child.path),
-              path: child.path,
-              children: { direct: [] },
-            });
-          } else {
-            existingNode.path = child.path;
-            existingNode.name = getLeafName(child.path);
-          }
-        } else {
-          this.tree.set(childId, {
-            name: getLeafName(child.path),
-            path: child.path,
-          });
+      const previousDirectChildren = previousNode?.children?.direct ?? [];
+      const previousFlattenedChildren = previousNode?.children?.flattened ?? [];
+      const previousHadSingleFolderChild =
+        previousDirectChildren.length === 1 &&
+        this.tree.get(previousDirectChildren[0])?.children?.direct != null;
+      const previousFlattenedByStartId = new Map<string, string>();
+      for (
+        let index = 0;
+        index < previousFlattenedChildren.length;
+        index += 1
+      ) {
+        const previousFlattenedId = previousFlattenedChildren[index];
+        const flattenedNode = this.tree.get(previousFlattenedId);
+        const flattenedStartId = flattenedNode?.flattens?.[0];
+        if (flattenedStartId != null) {
+          previousFlattenedByStartId.set(flattenedStartId, previousFlattenedId);
         }
       }
 
-      if (previousDirectChildren.length > 0) {
-        const nextDirectSet = new Set(directChildIds);
+      const dirtyChildPaths =
+        dirtyChildrenByFolderPath.get(normalizedFolderPath);
+
+      let directChildren: Array<{
+        path: string;
+        kind: 'folder' | 'file';
+      }> | null = null;
+      let directChildIds: string[];
+
+      let canReuseDirectChildren =
+        previousNode != null &&
+        pathTree.getDirectChildCount(normalizedFolderPath) ===
+          previousDirectChildren.length;
+
+      if (canReuseDirectChildren) {
         for (let index = 0; index < previousDirectChildren.length; index += 1) {
           const previousChildId = previousDirectChildren[index];
-          if (nextDirectSet.has(previousChildId)) {
-            continue;
-          }
-
           const previousChildPath = this.idToPathMap.get(previousChildId);
-          if (previousChildPath == null) {
-            continue;
+          if (
+            previousChildPath == null ||
+            getParentPath(previousChildPath) !== normalizedFolderPath ||
+            !pathTree.hasPath(previousChildPath)
+          ) {
+            canReuseDirectChildren = false;
+            break;
           }
+        }
+      }
 
-          if (pathTree.hasPath(previousChildPath)) {
-            continue;
+      if (canReuseDirectChildren) {
+        directChildIds = previousDirectChildren;
+      } else {
+        directChildren = pathTree.getDirectChildren(normalizedFolderPath);
+        this.sortPathTreeChildren(directChildren, pathTree);
+
+        directChildIds = new Array<string>(directChildren.length);
+        for (let index = 0; index < directChildren.length; index += 1) {
+          const child = directChildren[index];
+          const childId = this.ensureStableIdForPath(child.path);
+          directChildIds[index] = childId;
+
+          const existingNode = this.tree.get(childId);
+          if (child.kind === 'folder') {
+            if (existingNode?.children == null) {
+              this.tree.set(childId, {
+                name: getLeafName(child.path),
+                path: child.path,
+                children: { direct: [] },
+              });
+              this.setDirectChildIndexCache(childId, []);
+            } else {
+              existingNode.path = child.path;
+              existingNode.name = getLeafName(child.path);
+            }
+          } else {
+            this.tree.set(childId, {
+              name: getLeafName(child.path),
+              path: child.path,
+            });
+            this.directChildIndexByFolderId.delete(childId);
           }
+        }
 
-          this.removeSubtreeById(previousChildId);
+        if (previousDirectChildren.length > 0) {
+          const nextDirectSet = new Set(directChildIds);
+          for (
+            let index = 0;
+            index < previousDirectChildren.length;
+            index += 1
+          ) {
+            const previousChildId = previousDirectChildren[index];
+            if (nextDirectSet.has(previousChildId)) {
+              continue;
+            }
+
+            const previousChildPath = this.idToPathMap.get(previousChildId);
+            if (previousChildPath == null) {
+              continue;
+            }
+
+            if (pathTree.hasPath(previousChildPath)) {
+              continue;
+            }
+
+            this.removeSubtreeById(previousChildId);
+          }
         }
       }
 
@@ -1146,21 +1256,84 @@ export class FileTreeModel {
       };
 
       let flattenedChildIds: string[] | undefined;
-      for (let index = 0; index < directChildren.length; index += 1) {
-        const child = directChildren[index];
-
-        if (child.kind === 'folder') {
-          const endpointPath = resolveEndpoint(child.path);
-          if (endpointPath != null) {
-            const flattenedId = ensureFlattenedNode(child.path, endpointPath);
-            flattenedChildIds ??= directChildIds.slice(0, index);
-            flattenedChildIds.push(flattenedId);
-            continue;
-          }
+      if (canReuseDirectChildren) {
+        if (previousFlattenedChildren.length > 0) {
+          flattenedChildIds = previousFlattenedChildren.slice();
         }
 
-        if (flattenedChildIds != null) {
-          flattenedChildIds.push(directChildIds[index]);
+        if (dirtyChildPaths != null && dirtyChildPaths.size > 0) {
+          for (const dirtyChildPath of dirtyChildPaths) {
+            const dirtyChildId = this.pathToIdMap.get(dirtyChildPath);
+            if (dirtyChildId == null) {
+              continue;
+            }
+
+            const childIndex = this.getDirectChildIndex(
+              folderId,
+              dirtyChildId,
+              directChildIds
+            );
+            if (childIndex < 0) {
+              continue;
+            }
+
+            let nextChildEntryId = dirtyChildId;
+            if (pathTree.hasFolder(dirtyChildPath)) {
+              const endpointPath = resolveEndpoint(dirtyChildPath);
+              if (endpointPath != null) {
+                nextChildEntryId = ensureFlattenedNode(
+                  dirtyChildPath,
+                  endpointPath
+                );
+              }
+            }
+
+            const currentChildEntryId =
+              flattenedChildIds?.[childIndex] ?? directChildIds[childIndex];
+            if (nextChildEntryId === currentChildEntryId) {
+              continue;
+            }
+
+            flattenedChildIds ??= directChildIds.slice();
+            flattenedChildIds[childIndex] = nextChildEntryId;
+          }
+        }
+      } else {
+        if (directChildren == null) {
+          throw new Error(
+            'FileTreeModel: expected direct children for non-reused folder rebuild.'
+          );
+        }
+
+        for (let index = 0; index < directChildren.length; index += 1) {
+          const child = directChildren[index];
+
+          if (child.kind === 'folder') {
+            const endpointPath = resolveEndpoint(child.path);
+            if (endpointPath != null) {
+              const childId = directChildIds[index];
+              const reusableFlattenedId =
+                previousFlattenedByStartId.get(childId) ?? null;
+
+              if (
+                reusableFlattenedId != null &&
+                !isLocallyAffectedFolder(child.path)
+              ) {
+                flattenedChildIds ??= directChildIds.slice(0, index);
+                flattenedChildIds.push(reusableFlattenedId);
+                continue;
+              }
+
+              const flattenedId = ensureFlattenedNode(child.path, endpointPath);
+              flattenedChildIds ??= directChildIds.slice(0, index);
+              flattenedChildIds.push(flattenedId);
+              continue;
+            }
+          }
+
+          if (flattenedChildIds != null) {
+            flattenedChildIds.push(directChildIds[index]);
+          }
         }
       }
 
@@ -1177,6 +1350,7 @@ export class FileTreeModel {
           }),
         },
       });
+      this.setDirectChildIndexCache(folderId, directChildIds);
 
       const previousFlattenedSet = new Set(previousFlattenedChildren);
       const nextFlattenedSet = new Set(flattenedChildIds ?? []);
@@ -1192,8 +1366,42 @@ export class FileTreeModel {
         }
       }
 
+      const nextFlattenedChildren = flattenedChildIds ?? [];
+      const folderChildrenChanged =
+        previousNode == null ||
+        !this.areIdArraysEqual(previousDirectChildren, directChildIds) ||
+        !this.areIdArraysEqual(
+          previousFlattenedChildren,
+          nextFlattenedChildren
+        );
+      let nextHasSingleFolderChild = false;
+      if (canReuseDirectChildren) {
+        if (directChildIds.length === 1) {
+          const onlyChildPath = this.idToPathMap.get(directChildIds[0]);
+          nextHasSingleFolderChild =
+            onlyChildPath != null && pathTree.hasFolder(onlyChildPath);
+        }
+      } else {
+        nextHasSingleFolderChild =
+          directChildren != null &&
+          directChildren.length === 1 &&
+          directChildren[0]?.kind === 'folder';
+      }
+      const shouldPropagateToParent =
+        normalizedFolderPath !== ROOT_ID &&
+        folderChildrenChanged &&
+        (previousNode == null ||
+          previousHadSingleFolderChild ||
+          nextHasSingleFolderChild);
+
       rebuildingFolders.delete(normalizedFolderPath);
       rebuiltFolders.add(normalizedFolderPath);
+
+      if (shouldPropagateToParent) {
+        const parentPath = getParentPath(normalizedFolderPath);
+        markDirtyChild(parentPath, normalizedFolderPath);
+        rebuildFolder(parentPath);
+      }
     };
 
     for (const folderPath of folderPaths) {
@@ -1271,8 +1479,7 @@ export class FileTreeModel {
     const targetPrefix =
       normalizedTarget === ROOT_ID ? '' : `${normalizedTarget}/`;
 
-    const currentFiles = this.files;
-    if (draggedPaths.length === 0 || currentFiles.length === 0) {
+    if (draggedPaths.length === 0 || this.files.length === 0) {
       return { ok: true, mutation: null };
     }
 
@@ -1314,9 +1521,8 @@ export class FileTreeModel {
       selectedFiles.add(item.path);
     }
 
-    const moveRules: PlannedMoveRule[] = [];
-    const folderDestinations = new Map<string, string>();
-    const proposedDestinationByOrigin = new Map<string, string>();
+    const fileRules: PlannedMoveRule[] = [];
+    const folderRules: PlannedMoveRule[] = [];
 
     for (const selectedFile of selectedFiles) {
       const destinationPath = `${targetPrefix}${getLeafName(selectedFile)}`;
@@ -1324,14 +1530,14 @@ export class FileTreeModel {
         continue;
       }
 
-      proposedDestinationByOrigin.set(selectedFile, destinationPath);
-      moveRules.push({
+      fileRules.push({
         sourcePath: selectedFile,
         destinationPath,
         isFolder: false,
       });
     }
 
+    const folderDestinations = new Map<string, string>();
     for (const selectedFolder of selectedFolders) {
       if (
         normalizedTarget === selectedFolder ||
@@ -1346,153 +1552,178 @@ export class FileTreeModel {
       }
 
       folderDestinations.set(selectedFolder, destinationPath);
-      moveRules.push({
+      folderRules.push({
         sourcePath: selectedFolder,
         destinationPath,
         isFolder: true,
       });
     }
 
-    for (const [
-      selectedFolder,
-      selectedFolderDestination,
-    ] of folderDestinations) {
-      const descendantFiles = pathTree.getDescendantFilePaths(selectedFolder);
-      for (let index = 0; index < descendantFiles.length; index += 1) {
-        const originPath = descendantFiles[index];
-        const destinationPath = `${selectedFolderDestination}${originPath.slice(selectedFolder.length)}`;
-        if (destinationPath === originPath) {
+    const plannedActions: Array<{
+      originPath: string;
+      destinationPath: string;
+      sourceIndex: number;
+      folderSourcePath: string | null;
+    }> = [];
+    const plannedOrigins = new Set<string>();
+
+    for (let index = 0; index < fileRules.length; index += 1) {
+      const rule = fileRules[index];
+      const sourceIndex = pathTree.getFileIndex(rule.sourcePath);
+      if (sourceIndex == null) {
+        continue;
+      }
+      plannedActions.push({
+        originPath: rule.sourcePath,
+        destinationPath: rule.destinationPath,
+        sourceIndex,
+        folderSourcePath: null,
+      });
+      plannedOrigins.add(rule.sourcePath);
+    }
+
+    for (let index = 0; index < folderRules.length; index += 1) {
+      const rule = folderRules[index];
+      const descendants = pathTree.getDescendantFilePaths(rule.sourcePath);
+      for (
+        let descendantIndex = 0;
+        descendantIndex < descendants.length;
+        descendantIndex += 1
+      ) {
+        const originPath = descendants[descendantIndex];
+        const destinationPath = `${rule.destinationPath}${originPath.slice(rule.sourcePath.length)}`;
+        if (destinationPath === originPath || plannedOrigins.has(originPath)) {
           continue;
         }
-        proposedDestinationByOrigin.set(originPath, destinationPath);
+
+        const sourceIndex = pathTree.getFileIndex(originPath);
+        if (sourceIndex == null) {
+          continue;
+        }
+
+        plannedActions.push({
+          originPath,
+          destinationPath,
+          sourceIndex,
+          folderSourcePath: rule.sourcePath,
+        });
+        plannedOrigins.add(originPath);
       }
+    }
+
+    plannedActions.sort((left, right) => left.sourceIndex - right.sourceIndex);
+    if (plannedActions.length === 0) {
+      return { ok: true, mutation: null };
     }
 
     const finalPathByOrigin = new Map<string, string | null>();
-    const occupantByDestination = new Map<string, string>();
-    for (let index = 0; index < currentFiles.length; index += 1) {
-      const filePath = currentFiles[index];
-      finalPathByOrigin.set(filePath, filePath);
-      occupantByDestination.set(filePath, filePath);
+    const originByCurrentPath = new Map<string, string>();
+    for (let index = 0; index < plannedActions.length; index += 1) {
+      const originPath = plannedActions[index].originPath;
+      if (finalPathByOrigin.has(originPath)) {
+        continue;
+      }
+      finalPathByOrigin.set(originPath, originPath);
+      originByCurrentPath.set(originPath, originPath);
     }
 
-    for (let index = 0; index < currentFiles.length; index += 1) {
-      const originPath = currentFiles[index];
-      const destinationPath = proposedDestinationByOrigin.get(originPath);
-      if (destinationPath == null) {
-        continue;
-      }
+    const removedFilePaths: string[] = [];
+    const movedFileDestinationByOrigin = new Map<string, string>();
+    const activeFolderSources = new Set<string>();
 
+    for (let index = 0; index < plannedActions.length; index += 1) {
+      const action = plannedActions[index];
+      const originPath = action.originPath;
       const currentPath = finalPathByOrigin.get(originPath);
-      if (currentPath == null || currentPath === destinationPath) {
+
+      if (currentPath == null || currentPath === action.destinationPath) {
+        continue;
+      }
+      if (!pathTree.hasFile(currentPath)) {
+        finalPathByOrigin.set(originPath, null);
+        originByCurrentPath.delete(currentPath);
+        movedFileDestinationByOrigin.delete(originPath);
         continue;
       }
 
-      const existingOccupant = occupantByDestination.get(destinationPath);
-      if (existingOccupant != null && existingOccupant !== originPath) {
+      if (
+        pathTree.hasFile(action.destinationPath) &&
+        action.destinationPath !== currentPath
+      ) {
         const allowOverwrite =
           onCollision?.({
             origin: originPath,
-            destination: destinationPath,
+            destination: action.destinationPath,
           }) === true;
         if (!allowOverwrite) {
           continue;
         }
 
-        const existingPath = finalPathByOrigin.get(existingOccupant);
-        if (existingPath != null) {
-          occupantByDestination.delete(existingPath);
+        pathTree.deleteFilePath(action.destinationPath);
+
+        const removedMovingOrigin = originByCurrentPath.get(
+          action.destinationPath
+        );
+        if (removedMovingOrigin != null) {
+          finalPathByOrigin.set(removedMovingOrigin, null);
+          movedFileDestinationByOrigin.delete(removedMovingOrigin);
+          originByCurrentPath.delete(action.destinationPath);
+          removedFilePaths.push(removedMovingOrigin);
+        } else {
+          removedFilePaths.push(action.destinationPath);
         }
-        finalPathByOrigin.set(existingOccupant, null);
       }
 
-      occupantByDestination.delete(currentPath);
-      occupantByDestination.set(destinationPath, originPath);
-      finalPathByOrigin.set(originPath, destinationPath);
-    }
-
-    const nextFiles: string[] = [];
-    const removedFilePaths: string[] = [];
-    for (let index = 0; index < currentFiles.length; index += 1) {
-      const filePath = currentFiles[index];
-      const nextPath = finalPathByOrigin.get(filePath);
-      if (nextPath != null) {
-        nextFiles.push(nextPath);
+      const { parentPath, baseName } = splitPath(action.destinationPath);
+      const moveResult = pathTree.movePath(
+        currentPath,
+        parentPath === '' ? ROOT_ID : parentPath,
+        baseName,
+        'file'
+      );
+      if (moveResult !== 'ok') {
         continue;
       }
-      removedFilePaths.push(filePath);
+
+      finalPathByOrigin.set(originPath, action.destinationPath);
+      movedFileDestinationByOrigin.set(originPath, action.destinationPath);
+      originByCurrentPath.delete(currentPath);
+      originByCurrentPath.set(action.destinationPath, originPath);
+      if (action.folderSourcePath != null) {
+        activeFolderSources.add(action.folderSourcePath);
+      }
     }
 
     if (
-      nextFiles.length === currentFiles.length &&
-      nextFiles.every((path, index) => path === currentFiles[index])
+      movedFileDestinationByOrigin.size === 0 &&
+      removedFilePaths.length === 0
     ) {
       return { ok: true, mutation: null };
     }
 
-    const movedFolderRuleBySource = new Map<string, PlannedMoveRule>();
-    for (let index = 0; index < moveRules.length; index += 1) {
-      const rule = moveRules[index];
-      if (rule.isFolder) {
-        movedFolderRuleBySource.set(rule.sourcePath, rule);
-      }
-    }
-
-    const activeFolderSources = new Set<string>();
-    for (const [sourcePath, rule] of movedFolderRuleBySource) {
-      const descendants = pathTree.getDescendantFilePaths(sourcePath);
-      for (let index = 0; index < descendants.length; index += 1) {
-        const nextPath = finalPathByOrigin.get(descendants[index]);
-        if (
-          nextPath != null &&
-          nextPath.startsWith(`${rule.destinationPath}/`)
-        ) {
-          activeFolderSources.add(sourcePath);
-          break;
-        }
-      }
-    }
-
-    const remapRules = moveRules
+    const remapRules = [...fileRules, ...folderRules]
       .filter((rule) => {
         if (!rule.isFolder) {
           return (
-            finalPathByOrigin.get(rule.sourcePath) === rule.destinationPath
+            movedFileDestinationByOrigin.get(rule.sourcePath) ===
+            rule.destinationPath
           );
         }
         return activeFolderSources.has(rule.sourcePath);
       })
       .sort((left, right) => right.sourcePath.length - left.sourcePath.length);
 
-    const pathTreeApplied = applyMappedFilesToPathTree(
-      pathTree,
-      currentFiles,
-      finalPathByOrigin
-    );
-    if (!pathTreeApplied) {
-      pathTree.replaceAll(nextFiles);
-    }
-
     this.applyPathRemapRules(remapRules);
-    this.replaceFilesSnapshot(nextFiles);
+    this.adoptPathTreeFilesReference(pathTree);
 
     const affectedFolderPaths = new Set<string>();
     for (let index = 0; index < remapRules.length; index += 1) {
       const rule = remapRules[index];
-      this.addAncestorFoldersForPath(
-        getParentPath(rule.sourcePath),
-        affectedFolderPaths
-      );
-      this.addAncestorFoldersForPath(
-        getParentPath(rule.destinationPath),
-        affectedFolderPaths
-      );
+      affectedFolderPaths.add(getParentPath(rule.sourcePath));
+      affectedFolderPaths.add(getParentPath(rule.destinationPath));
     }
     for (let index = 0; index < removedFilePaths.length; index += 1) {
-      this.addAncestorFoldersForPath(
-        getParentPath(removedFilePaths[index]),
-        affectedFolderPaths
-      );
+      affectedFolderPaths.add(getParentPath(removedFilePaths[index]));
     }
     if (affectedFolderPaths.size === 0) {
       affectedFolderPaths.add(ROOT_ID);
@@ -1567,14 +1798,11 @@ export class FileTreeModel {
       return { ok: true, mutation: null };
     }
 
-    this.replaceFilesSnapshot(pathTree.cloneFiles());
+    this.adoptPathTreeFilesReference(pathTree);
 
     const affectedFolderPaths = new Set<string>();
     for (let index = 0; index < addedPaths.length; index += 1) {
-      this.addAncestorFoldersForPath(
-        getParentPath(addedPaths[index]),
-        affectedFolderPaths
-      );
+      affectedFolderPaths.add(getParentPath(addedPaths[index]));
     }
     if (affectedFolderPaths.size === 0) {
       affectedFolderPaths.add(ROOT_ID);
@@ -1638,14 +1866,7 @@ export class FileTreeModel {
       }
     }
 
-    const deletedPaths: string[] = [];
-
-    for (let index = 0; index < selectedFiles.length; index += 1) {
-      const path = selectedFiles[index];
-      if (pathTree.deleteFilePath(path)) {
-        deletedPaths.push(path);
-      }
-    }
+    const deletedPaths = pathTree.deleteFilePaths(selectedFiles);
 
     for (const path of selectedFolders) {
       if (pathTree.deleteFolderPath(path)) {
@@ -1657,14 +1878,11 @@ export class FileTreeModel {
       return { ok: true, mutation: null };
     }
 
-    this.replaceFilesSnapshot(pathTree.cloneFiles());
+    this.adoptPathTreeFilesReference(pathTree);
 
     const affectedFolderPaths = new Set<string>();
     for (let index = 0; index < deletedPaths.length; index += 1) {
-      this.addAncestorFoldersForPath(
-        getParentPath(deletedPaths[index]),
-        affectedFolderPaths
-      );
+      affectedFolderPaths.add(getParentPath(deletedPaths[index]));
     }
     if (affectedFolderPaths.size === 0) {
       affectedFolderPaths.add(ROOT_ID);
@@ -1751,11 +1969,11 @@ export class FileTreeModel {
 
     const parentPath = getParentPath(normalizedSourcePath);
     const parentId = this.pathToIdMap.get(parentPath) ?? ROOT_ID;
-    const pathTree = this.pathTree;
+    const existingPathTree = this.pathTree;
 
     if (!nodeIsFolder) {
-      if (pathTree != null) {
-        const renameResult = pathTree.renamePath(
+      if (existingPathTree != null) {
+        const renameResult = existingPathTree.renamePath(
           normalizedSourcePath,
           normalizedDestinationPath,
           'file'
@@ -1792,6 +2010,10 @@ export class FileTreeModel {
         this.files[sourceIndex] = normalizedDestinationPath;
         this.fileIndexByPath.delete(normalizedSourcePath);
         this.fileIndexByPath.set(normalizedDestinationPath, sourceIndex);
+      }
+
+      if (existingPathTree != null) {
+        this.adoptPathTreeFilesReference(existingPathTree);
       }
 
       this.sortChildren(parentId);
@@ -1851,30 +2073,29 @@ export class FileTreeModel {
       }
     }
 
-    if (pathTree != null) {
-      const folderRenameResult = pathTree.renamePath(
-        normalizedSourcePath,
-        normalizedDestinationPath,
-        'folder'
-      );
-      if (folderRenameResult === 'missing') {
-        return {
-          ok: false,
-          error: 'Could not find the selected folder to rename.',
-        };
-      }
-      if (folderRenameResult === 'collision') {
-        return {
-          ok: false,
-          error: `"${normalizedDestinationPath}" already exists.`,
-        };
-      }
-      if (folderRenameResult === 'invalid') {
-        return {
-          ok: false,
-          error: 'Could not rename the selected folder.',
-        };
-      }
+    const pathTreeForFolder = this.getOrCreatePathTree();
+    const folderRenameResult = pathTreeForFolder.renamePath(
+      normalizedSourcePath,
+      normalizedDestinationPath,
+      'folder'
+    );
+    if (folderRenameResult === 'missing') {
+      return {
+        ok: false,
+        error: 'Could not find the selected folder to rename.',
+      };
+    }
+    if (folderRenameResult === 'collision') {
+      return {
+        ok: false,
+        error: `"${normalizedDestinationPath}" already exists.`,
+      };
+    }
+    if (folderRenameResult === 'invalid') {
+      return {
+        ok: false,
+        error: 'Could not rename the selected folder.',
+      };
     }
 
     for (const { oldPath } of pathUpdates) {
@@ -1892,20 +2113,7 @@ export class FileTreeModel {
       }
     }
 
-    const sourcePrefix = `${normalizedSourcePath}/`;
-    const remappedFiles = new Array<string>(this.files.length);
-    for (let index = 0; index < this.files.length; index += 1) {
-      const filePath = this.files[index];
-      remappedFiles[index] =
-        filePath === normalizedSourcePath || filePath.startsWith(sourcePrefix)
-          ? `${normalizedDestinationPath}${filePath.slice(normalizedSourcePath.length)}`
-          : filePath;
-    }
-    this.files = remappedFiles;
-    this.fileIndexByPath.clear();
-    for (let index = 0; index < remappedFiles.length; index += 1) {
-      this.fileIndexByPath.set(remappedFiles[index], index);
-    }
+    this.adoptPathTreeFilesReference(pathTreeForFolder);
 
     this.sortChildren(parentId);
 

--- a/packages/trees/src/model/FileTreeModel.ts
+++ b/packages/trees/src/model/FileTreeModel.ts
@@ -385,6 +385,8 @@ export class FileTreeModel {
   private readonly benchmarkInstrumentation: BenchmarkInstrumentation | null;
   private pathTree: MutablePathTree | null = null;
   private pathTreeCreationCount = 0;
+  private pathPrefixRemapMaterializationCount = 0;
+  private fileIndexRebuildCount = 0;
   private version = 0;
   private nextNodeId = 1;
   private sortComparator: ChildrenSortOption;
@@ -685,6 +687,12 @@ export class FileTreeModel {
       return;
     }
 
+    this.pathPrefixRemapMaterializationCount += 1;
+    this.setModelCounter(
+      'model.pathPrefixRemaps.materializedCount',
+      this.pathPrefixRemapMaterializationCount
+    );
+
     const nextPathToId = new Map<string, string>();
 
     for (const [canonicalPath, id] of this.pathToIdMap) {
@@ -733,13 +741,18 @@ export class FileTreeModel {
     for (let index = 0; index < files.length; index += 1) {
       this.fileIndexByPath.set(files[index], index);
     }
+
+    this.fileIndexRebuildCount += 1;
+    this.setModelCounter(
+      'model.snapshot.fileIndexRebuildCount',
+      this.fileIndexRebuildCount
+    );
   }
 
   private adoptPathTreeFilesReference(pathTree: MutablePathTree): void {
     this.pathTree = pathTree;
     this.filesPendingPathTreeSync = true;
     this.pendingFileSnapshotPrefixRemaps.length = 0;
-    this.pendingPathPrefixRemaps.length = 0;
     this.fileIndexByPath.clear();
   }
 
@@ -751,7 +764,6 @@ export class FileTreeModel {
     this.files = this.pathTree.getFilesReference();
     this.filesPendingPathTreeSync = false;
     this.pendingFileSnapshotPrefixRemaps.length = 0;
-    this.pendingPathPrefixRemaps.length = 0;
     this.fileIndexByPath.clear();
     this.setModelCounter('model.snapshot.fileCount', this.files.length);
   }
@@ -784,14 +796,13 @@ export class FileTreeModel {
       sourcePath,
       destinationPath,
     });
-    this.fileIndexByPath.clear();
   }
 
   /**
    * Applies deferred folder-prefix remaps to the dense files[] snapshot.
    *
-   * This lets folder rename/move stay cheap on the hot path and only pays the
-   * O(fileCount) rewrite cost when a caller actually needs the full snapshot.
+   * This keeps folder rename/move cheap on the hot path and only pays the
+   * O(fileCount) rewrite when a caller asks for a full files[] snapshot.
    */
   private applyPendingFileSnapshotPrefixRemaps(): void {
     const remapRules = this.pendingFileSnapshotPrefixRemaps;
@@ -799,33 +810,66 @@ export class FileTreeModel {
       return;
     }
 
-    for (let fileIndex = 0; fileIndex < this.files.length; fileIndex += 1) {
-      let currentPath = this.files[fileIndex];
+    const preparedRules = remapRules.map((rule) => ({
+      sourcePath: rule.sourcePath,
+      sourcePathWithSlash: `${rule.sourcePath}/`,
+      sourcePathLength: rule.sourcePath.length,
+      destinationPath: rule.destinationPath,
+    }));
 
-      for (let ruleIndex = 0; ruleIndex < remapRules.length; ruleIndex += 1) {
-        const rule = remapRules[ruleIndex];
-        const sourcePath = rule.sourcePath;
+    const originalPathByTouchedIndex = new Map<number, string>();
+
+    for (let fileIndex = 0; fileIndex < this.files.length; fileIndex += 1) {
+      const originalPath = this.files[fileIndex];
+      let currentPath = originalPath;
+
+      for (
+        let ruleIndex = 0;
+        ruleIndex < preparedRules.length;
+        ruleIndex += 1
+      ) {
+        const rule = preparedRules[ruleIndex];
         if (
-          currentPath !== sourcePath &&
-          !currentPath.startsWith(`${sourcePath}/`)
+          currentPath !== rule.sourcePath &&
+          !currentPath.startsWith(rule.sourcePathWithSlash)
         ) {
           continue;
         }
 
-        currentPath = `${rule.destinationPath}${currentPath.slice(sourcePath.length)}`;
+        currentPath = `${rule.destinationPath}${currentPath.slice(rule.sourcePathLength)}`;
       }
 
-      this.files[fileIndex] = currentPath;
+      if (currentPath !== originalPath) {
+        originalPathByTouchedIndex.set(fileIndex, originalPath);
+        this.files[fileIndex] = currentPath;
+      }
     }
 
     remapRules.length = 0;
-    this.rebuildFileIndexByPath(this.files);
+
+    if (
+      originalPathByTouchedIndex.size === 0 ||
+      this.fileIndexByPath.size === 0
+    ) {
+      return;
+    }
+
+    if (originalPathByTouchedIndex.size > 4096) {
+      this.fileIndexByPath.clear();
+      return;
+    }
+
+    for (const originalPath of originalPathByTouchedIndex.values()) {
+      this.fileIndexByPath.delete(originalPath);
+    }
+    for (const fileIndex of originalPathByTouchedIndex.keys()) {
+      this.fileIndexByPath.set(this.files[fileIndex], fileIndex);
+    }
   }
 
   private getOrCreatePathTree(): MutablePathTree {
     if (this.pathTree == null) {
       this.applyPendingFileSnapshotPrefixRemaps();
-      this.materializePendingPathPrefixRemaps();
       this.pathTree = MutablePathTree.fromFiles(this.files);
       this.filesPendingPathTreeSync = false;
       this.fileIndexByPath.clear();
@@ -899,14 +943,20 @@ export class FileTreeModel {
   }
 
   private ensureStableIdForPath(path: string): string {
-    const existingId = this.pathToIdMap.get(path);
+    const existingId = this.resolveIdForPath(path);
     if (existingId != null) {
       return existingId;
     }
 
-    const allocatedId = this.allocateStableIdForPath(path);
-    this.pathToIdMap.set(path, allocatedId);
-    this.idToPathMap.set(allocatedId, path);
+    const canonicalPath = this.remapPathBackward(path);
+    const canonicalExistingId = this.pathToIdMap.get(canonicalPath);
+    if (canonicalExistingId != null) {
+      return canonicalExistingId;
+    }
+
+    const allocatedId = this.allocateStableIdForPath(canonicalPath);
+    this.pathToIdMap.set(canonicalPath, allocatedId);
+    this.idToPathMap.set(allocatedId, canonicalPath);
     return allocatedId;
   }
 
@@ -957,7 +1007,7 @@ export class FileTreeModel {
       }
       visited.add(id);
 
-      const nodePath = this.idToPathMap.get(id);
+      const nodePath = this.getResolvedPathForId(id);
       if (
         shouldRemovePath != null &&
         nodePath != null &&
@@ -996,7 +1046,7 @@ export class FileTreeModel {
     updates: Array<{ id: string; oldPath: string; newPath: string }>;
     scannedNodeCount: number;
   } {
-    const sourceId = this.pathToIdMap.get(sourcePath);
+    const sourceId = this.resolveIdForPath(sourcePath);
     if (sourceId == null) {
       return { updates: [], scannedNodeCount: 0 };
     }
@@ -1016,39 +1066,55 @@ export class FileTreeModel {
       scannedNodeCount += 1;
 
       const node = this.tree.get(id);
-      const oldPath = this.idToPathMap.get(id);
+      const canonicalPath = this.idToPathMap.get(id);
+      const resolvedPath =
+        canonicalPath == null
+          ? undefined
+          : this.remapPathForward(canonicalPath);
       const remappedPath =
-        oldPath == null
+        resolvedPath == null
           ? null
-          : remapPathWithPrefix(oldPath, sourcePath, destinationPath);
+          : remapPathWithPrefix(resolvedPath, sourcePath, destinationPath);
 
       if (
-        oldPath != null &&
+        canonicalPath != null &&
+        resolvedPath != null &&
         remappedPath != null &&
-        remappedPath !== oldPath &&
+        remappedPath !== resolvedPath &&
         !updatedIds.has(id)
       ) {
-        updates.push({ id, oldPath, newPath: remappedPath });
+        updates.push({
+          id,
+          oldPath: canonicalPath,
+          newPath: this.remapPathBackward(remappedPath),
+        });
         updatedIds.add(id);
       }
 
       if (
-        oldPath != null &&
+        canonicalPath != null &&
+        resolvedPath != null &&
         remappedPath != null &&
-        remappedPath !== oldPath &&
+        remappedPath !== resolvedPath &&
         node?.children?.direct != null &&
-        !oldPath.startsWith(FLATTENED_PREFIX)
+        !resolvedPath.startsWith(FLATTENED_PREFIX)
       ) {
-        const flattenedAliasPath = `${FLATTENED_PREFIX}${oldPath}`;
-        const flattenedAliasId = this.pathToIdMap.get(flattenedAliasPath);
+        const flattenedAliasPath = `${FLATTENED_PREFIX}${resolvedPath}`;
+        const flattenedAliasId = this.resolveIdForPath(flattenedAliasPath);
         if (flattenedAliasId != null && !updatedIds.has(flattenedAliasId)) {
-          updates.push({
-            id: flattenedAliasId,
-            oldPath: flattenedAliasPath,
-            newPath: `${FLATTENED_PREFIX}${remappedPath}`,
-          });
-          updatedIds.add(flattenedAliasId);
-          scannedNodeCount += 1;
+          const flattenedAliasCanonicalPath =
+            this.idToPathMap.get(flattenedAliasId);
+          if (flattenedAliasCanonicalPath != null) {
+            updates.push({
+              id: flattenedAliasId,
+              oldPath: flattenedAliasCanonicalPath,
+              newPath: this.remapPathBackward(
+                `${FLATTENED_PREFIX}${remappedPath}`
+              ),
+            });
+            updatedIds.add(flattenedAliasId);
+            scannedNodeCount += 1;
+          }
         }
       }
 
@@ -1104,8 +1170,13 @@ export class FileTreeModel {
         continue;
       }
 
-      const id = this.pathToIdMap.get(rule.sourcePath);
+      const id = this.resolveIdForPath(rule.sourcePath);
       if (id == null || updatedIds.has(id)) {
+        continue;
+      }
+
+      const canonicalSourcePath = this.idToPathMap.get(id);
+      if (canonicalSourcePath == null) {
         continue;
       }
 
@@ -1113,8 +1184,8 @@ export class FileTreeModel {
       updatedIds.add(id);
       updates.push({
         id,
-        oldPath: rule.sourcePath,
-        newPath: rule.destinationPath,
+        oldPath: canonicalSourcePath,
+        newPath: this.remapPathBackward(rule.destinationPath),
       });
     }
 
@@ -1290,7 +1361,7 @@ export class FileTreeModel {
         !pathTree.hasFolder(normalizedFolderPath)
       ) {
         let removedFolder = false;
-        const missingFolderId = this.pathToIdMap.get(normalizedFolderPath);
+        const missingFolderId = this.resolveIdForPath(normalizedFolderPath);
         if (missingFolderId != null) {
           const subtreePrefix = `${normalizedFolderPath}/`;
           this.removeSubtreeById(missingFolderId, (path) => {
@@ -1357,7 +1428,7 @@ export class FileTreeModel {
       if (canReuseDirectChildren) {
         for (let index = 0; index < previousDirectChildren.length; index += 1) {
           const previousChildId = previousDirectChildren[index];
-          const previousChildPath = this.idToPathMap.get(previousChildId);
+          const previousChildPath = this.getResolvedPathForId(previousChildId);
           if (
             previousChildPath == null ||
             getParentPath(previousChildPath) !== normalizedFolderPath ||
@@ -1415,7 +1486,8 @@ export class FileTreeModel {
               continue;
             }
 
-            const previousChildPath = this.idToPathMap.get(previousChildId);
+            const previousChildPath =
+              this.getResolvedPathForId(previousChildId);
             if (previousChildPath == null) {
               continue;
             }
@@ -1448,7 +1520,7 @@ export class FileTreeModel {
         const flattenedPath = `${FLATTENED_PREFIX}${endpointPath}`;
         const flattenedId = this.ensureStableIdForPath(flattenedPath);
 
-        const endpointId = this.pathToIdMap.get(endpointPath);
+        const endpointId = this.resolveIdForPath(endpointPath);
         const endpointNode =
           endpointId != null ? this.tree.get(endpointId) : undefined;
         const endpointChildren = endpointNode?.children;
@@ -1504,7 +1576,7 @@ export class FileTreeModel {
 
         if (dirtyChildPaths != null && dirtyChildPaths.size > 0) {
           for (const dirtyChildPath of dirtyChildPaths) {
-            const dirtyChildId = this.pathToIdMap.get(dirtyChildPath);
+            const dirtyChildId = this.resolveIdForPath(dirtyChildPath);
             if (dirtyChildId == null) {
               continue;
             }
@@ -1618,7 +1690,7 @@ export class FileTreeModel {
       let nextHasSingleFolderChild = false;
       if (canReuseDirectChildren) {
         if (directChildIds.length === 1) {
-          const onlyChildPath = this.idToPathMap.get(directChildIds[0]);
+          const onlyChildPath = this.getResolvedPathForId(directChildIds[0]);
           nextHasSingleFolderChild =
             onlyChildPath != null && pathTree.hasFolder(onlyChildPath);
         }
@@ -1666,6 +1738,16 @@ export class FileTreeModel {
     return this.version;
   }
 
+  /**
+   * Prepares mutable indexes used by structural mutations (add/delete/move).
+   *
+   * This lets callers shift one-time index construction cost out of a hot
+   * interaction path (for example: prime during initial mount, then mutate).
+   */
+  prepareMutationIndexes(): void {
+    this.getOrCreatePathTree();
+  }
+
   getFiles(): string[] {
     this.syncFilesSnapshotFromPathTree();
     this.applyPendingFileSnapshotPrefixRemaps();
@@ -1700,6 +1782,7 @@ export class FileTreeModel {
   }
 
   replaceAll(files: string[]): void {
+    this.materializePendingPathPrefixRemaps();
     const builtIndex = buildStableIndexFromFiles(
       files,
       this.sortComparator,
@@ -1709,6 +1792,205 @@ export class FileTreeModel {
     );
     this.applyBuiltIndex(builtIndex);
     this.emitMutation({ kind: 'replace-all' });
+  }
+
+  /**
+   * Rebinds a single source path to a destination path while preserving its
+   * stable ID. Used for direct file moves where no subtree-wide remap is needed.
+   */
+  private remapDirectPath(
+    sourcePath: string,
+    destinationPath: string
+  ): boolean {
+    const sourceId = this.resolveIdForPath(sourcePath);
+    if (sourceId == null) {
+      return false;
+    }
+
+    const existingDestinationId = this.resolveIdForPath(destinationPath);
+    if (existingDestinationId != null && existingDestinationId !== sourceId) {
+      return false;
+    }
+
+    const canonicalSourcePath = this.remapPathBackward(sourcePath);
+    const canonicalDestinationPath = this.remapPathBackward(destinationPath);
+
+    this.pathToIdMap.delete(canonicalSourcePath);
+    this.pathToIdMap.set(canonicalDestinationPath, sourceId);
+    this.idToPathMap.set(sourceId, canonicalDestinationPath);
+
+    const node = this.tree.get(sourceId);
+    if (node != null) {
+      node.path = canonicalDestinationPath;
+      node.name = getLeafName(destinationPath);
+    }
+
+    return true;
+  }
+
+  private hasFastMoveCollision(
+    pathTree: MutablePathTree,
+    fileRules: readonly PlannedMoveRule[],
+    folderRules: readonly PlannedMoveRule[]
+  ): boolean {
+    const sourcePaths = new Set<string>();
+    for (let index = 0; index < fileRules.length; index += 1) {
+      sourcePaths.add(fileRules[index].sourcePath);
+    }
+    for (let index = 0; index < folderRules.length; index += 1) {
+      sourcePaths.add(folderRules[index].sourcePath);
+    }
+
+    const destinationPaths = new Set<string>();
+    const allRules = [...fileRules, ...folderRules];
+
+    for (let index = 0; index < allRules.length; index += 1) {
+      const rule = allRules[index];
+      if (destinationPaths.has(rule.destinationPath)) {
+        return true;
+      }
+      destinationPaths.add(rule.destinationPath);
+
+      if (sourcePaths.has(rule.destinationPath)) {
+        return true;
+      }
+
+      if (
+        pathTree.hasPath(rule.destinationPath) &&
+        !sourcePaths.has(rule.destinationPath)
+      ) {
+        return true;
+      }
+
+      const destinationParentPath = getParentPath(rule.destinationPath);
+      if (
+        destinationParentPath !== ROOT_ID &&
+        pathTree.hasFile(destinationParentPath)
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Fast-path move application for collision-free operations.
+   *
+   * This avoids per-descendant remap scans by queuing folder prefix remaps and
+   * only rebinding direct file paths that actually moved.
+   */
+  private tryApplyCollisionFreeMoveRules(
+    pathTree: MutablePathTree,
+    fileRules: readonly PlannedMoveRule[],
+    folderRules: readonly PlannedMoveRule[]
+  ): FileTreeModelMoveResult | null {
+    if (fileRules.length === 0 && folderRules.length === 0) {
+      return { ok: true, mutation: null };
+    }
+
+    if (this.hasFastMoveCollision(pathTree, fileRules, folderRules)) {
+      return null;
+    }
+
+    const movedRules: PlannedMoveRule[] = [];
+
+    for (let index = 0; index < fileRules.length; index += 1) {
+      const rule = fileRules[index];
+      const { parentPath, baseName } = splitPath(rule.destinationPath);
+      const moveResult = pathTree.movePath(
+        rule.sourcePath,
+        parentPath === '' ? ROOT_ID : parentPath,
+        baseName,
+        'file'
+      );
+      if (moveResult !== 'ok') {
+        return null;
+      }
+
+      if (!this.remapDirectPath(rule.sourcePath, rule.destinationPath)) {
+        return null;
+      }
+
+      movedRules.push(rule);
+    }
+
+    for (let index = 0; index < folderRules.length; index += 1) {
+      const rule = folderRules[index];
+      const { parentPath, baseName } = splitPath(rule.destinationPath);
+      const moveResult = pathTree.movePath(
+        rule.sourcePath,
+        parentPath === '' ? ROOT_ID : parentPath,
+        baseName,
+        'folder'
+      );
+      if (moveResult !== 'ok') {
+        return null;
+      }
+
+      const folderId = this.resolveIdForPath(rule.sourcePath);
+      if (folderId != null) {
+        const folderNode = this.tree.get(folderId);
+        if (folderNode != null) {
+          folderNode.name = getLeafName(rule.destinationPath);
+        }
+      }
+
+      this.queuePathPrefixRemap(rule.sourcePath, rule.destinationPath);
+      movedRules.push(rule);
+    }
+
+    if (movedRules.length === 0) {
+      return { ok: true, mutation: null };
+    }
+
+    this.setModelCounter('model.move.remapScannedNodes', movedRules.length);
+    this.setModelCounter('model.move.remapUpdatedNodes', movedRules.length);
+
+    this.adoptPathTreeFilesReference(pathTree);
+
+    const affectedFolderPaths = new Set<string>();
+    const affectedParentIdsSet = new Set<string>();
+
+    for (let index = 0; index < movedRules.length; index += 1) {
+      const rule = movedRules[index];
+      const sourceParentPath = getParentPath(rule.sourcePath);
+      const destinationParentPath = getParentPath(rule.destinationPath);
+
+      affectedFolderPaths.add(sourceParentPath);
+      affectedFolderPaths.add(destinationParentPath);
+
+      affectedParentIdsSet.add(this.resolveAncestorId(sourceParentPath));
+      affectedParentIdsSet.add(this.resolveAncestorId(destinationParentPath));
+    }
+
+    if (affectedFolderPaths.size === 0) {
+      affectedFolderPaths.add(ROOT_ID);
+    }
+
+    this.rebuildFolderNodesFromPathTree(pathTree, affectedFolderPaths);
+    this.prunePendingFlattenedNodes();
+
+    const movedPaths = movedRules.map((rule) => ({
+      sourcePath: rule.sourcePath,
+      destinationPath: rule.destinationPath,
+      isFolder: rule.isFolder,
+    }));
+
+    const mutation = {
+      kind: 'move-paths' as const,
+      movedPaths,
+      affectedParentIds: [...affectedParentIdsSet],
+    };
+    this.emitMutation(mutation);
+
+    return {
+      ok: true,
+      mutation: {
+        ...mutation,
+        version: this.version,
+      },
+    };
   }
 
   movePaths({
@@ -1782,7 +2064,6 @@ export class FileTreeModel {
       });
     }
 
-    const folderDestinations = new Map<string, string>();
     for (const selectedFolder of selectedFolders) {
       if (
         normalizedTarget === selectedFolder ||
@@ -1796,12 +2077,20 @@ export class FileTreeModel {
         continue;
       }
 
-      folderDestinations.set(selectedFolder, destinationPath);
       folderRules.push({
         sourcePath: selectedFolder,
         destinationPath,
         isFolder: true,
       });
+    }
+
+    const fastPathResult = this.tryApplyCollisionFreeMoveRules(
+      pathTree,
+      fileRules,
+      folderRules
+    );
+    if (fastPathResult != null) {
+      return fastPathResult;
     }
 
     const plannedActions: Array<{
@@ -2297,126 +2586,49 @@ export class FileTreeModel {
       };
     }
 
-    if (this.pathTree == null) {
-      this.queueFileSnapshotPrefixRemap(
+    if (this.pathTree != null) {
+      const folderRenameResult = this.pathTree.renamePath(
         normalizedSourcePath,
-        normalizedDestinationPath
+        normalizedDestinationPath,
+        'folder'
       );
-      this.queuePathPrefixRemap(
-        normalizedSourcePath,
-        normalizedDestinationPath
-      );
-
-      node.name = getLeafName(normalizedDestinationPath);
-
-      this.sortChildren(parentId);
-      const childrenOrderChanged = this.didParentChildrenOrderChange(
-        parentId,
-        parentChildrenBeforeSort
-      );
-      this.setModelCounter('model.rename.folder.remapScannedNodes', 1);
-      this.setModelCounter('model.rename.folder.remapUpdatedNodes', 1);
-
-      const mutation = {
-        kind: 'rename-path' as const,
-        sourcePath: normalizedSourcePath,
-        destinationPath: normalizedDestinationPath,
-        isFolder: true,
-        parentId,
-        nodeId,
-        childrenOrderChanged,
-      };
-      this.emitMutation(mutation);
-      return {
-        ok: true,
-        mutation: { ...mutation, version: this.version },
-      };
-    }
-
-    const {
-      updates: pathUpdates,
-      scannedNodeCount: folderRenameScannedNodeCount,
-    } = this.collectSubtreePathUpdates(
-      normalizedSourcePath,
-      normalizedDestinationPath
-    );
-    this.setModelCounter(
-      'model.rename.folder.remapScannedNodes',
-      folderRenameScannedNodeCount
-    );
-    this.setModelCounter(
-      'model.rename.folder.remapUpdatedNodes',
-      pathUpdates.length
-    );
-
-    if (pathUpdates.length === 0) {
-      return {
-        ok: false,
-        error: 'Could not find the selected folder to rename.',
-      };
-    }
-
-    const updatedPathSet = new Set(pathUpdates.map((entry) => entry.oldPath));
-    for (const { id, newPath } of pathUpdates) {
-      const existingId = this.resolveIdForPath(newPath);
-      if (
-        existingId != null &&
-        existingId !== id &&
-        !updatedPathSet.has(newPath)
-      ) {
+      if (folderRenameResult === 'missing') {
+        return {
+          ok: false,
+          error: 'Could not find the selected folder to rename.',
+        };
+      }
+      if (folderRenameResult === 'collision') {
         return {
           ok: false,
           error: `"${normalizedDestinationPath}" already exists.`,
         };
       }
-    }
-
-    const folderRenameResult = this.pathTree.renamePath(
-      normalizedSourcePath,
-      normalizedDestinationPath,
-      'folder'
-    );
-    if (folderRenameResult === 'missing') {
-      return {
-        ok: false,
-        error: 'Could not find the selected folder to rename.',
-      };
-    }
-    if (folderRenameResult === 'collision') {
-      return {
-        ok: false,
-        error: `"${normalizedDestinationPath}" already exists.`,
-      };
-    }
-    if (folderRenameResult === 'invalid') {
-      return {
-        ok: false,
-        error: 'Could not rename the selected folder.',
-      };
-    }
-
-    for (const { oldPath } of pathUpdates) {
-      this.pathToIdMap.delete(oldPath);
-    }
-    for (const { id, newPath } of pathUpdates) {
-      this.pathToIdMap.set(newPath, id);
-      this.idToPathMap.set(id, newPath);
-      const item = this.tree.get(id);
-      if (item != null) {
-        item.path = newPath;
-        if (id === nodeId) {
-          item.name = getLeafName(newPath);
-        }
+      if (folderRenameResult === 'invalid') {
+        return {
+          ok: false,
+          error: 'Could not rename the selected folder.',
+        };
       }
+
+      this.adoptPathTreeFilesReference(this.pathTree);
+    } else {
+      this.queueFileSnapshotPrefixRemap(
+        normalizedSourcePath,
+        normalizedDestinationPath
+      );
     }
 
-    this.adoptPathTreeFilesReference(this.pathTree);
+    this.queuePathPrefixRemap(normalizedSourcePath, normalizedDestinationPath);
+    node.name = getLeafName(normalizedDestinationPath);
 
     this.sortChildren(parentId);
     const childrenOrderChanged = this.didParentChildrenOrderChange(
       parentId,
       parentChildrenBeforeSort
     );
+    this.setModelCounter('model.rename.folder.remapScannedNodes', 1);
+    this.setModelCounter('model.rename.folder.remapUpdatedNodes', 1);
 
     const mutation = {
       kind: 'rename-path' as const,

--- a/packages/trees/src/model/FileTreeModel.ts
+++ b/packages/trees/src/model/FileTreeModel.ts
@@ -17,6 +17,36 @@ import {
 const ROOT_ID = 'root';
 const FLATTENED_PREFIX_LENGTH = FLATTENED_PREFIX.length;
 
+function hashPathToStableSuffix(path: string): string {
+  let hash = 2166136261;
+  for (let index = 0; index < path.length; index += 1) {
+    hash ^= path.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function allocateDeterministicNodeId(
+  path: string,
+  usedIds: Set<string>
+): string {
+  const baseId = `p_${hashPathToStableSuffix(path)}`;
+  if (!usedIds.has(baseId)) {
+    usedIds.add(baseId);
+    return baseId;
+  }
+
+  let suffix = 2;
+  let candidate = `${baseId}_${suffix}`;
+  while (usedIds.has(candidate)) {
+    suffix += 1;
+    candidate = `${baseId}_${suffix}`;
+  }
+
+  usedIds.add(candidate);
+  return candidate;
+}
+
 function getParentPath(path: string): string {
   const separatorIndex = path.lastIndexOf('/');
   return separatorIndex < 0 ? ROOT_ID : path.slice(0, separatorIndex);
@@ -256,14 +286,8 @@ function buildStableIndexFromFiles(
       continue;
     }
 
-    let allocatedId: string;
-    do {
-      allocatedId = `n_${nextNodeId}`;
-      nextNodeId += 1;
-    } while (usedIds.has(allocatedId));
-
+    const allocatedId = allocateDeterministicNodeId(path, usedIds);
     pathToIdMap.set(path, allocatedId);
-    usedIds.add(allocatedId);
   }
 
   const idToPathMap = new Map<string, string>();

--- a/packages/trees/src/model/FileTreeModel.ts
+++ b/packages/trees/src/model/FileTreeModel.ts
@@ -2,12 +2,14 @@ import { FLATTENED_PREFIX } from '../constants';
 import {
   attachBenchmarkInstrumentation,
   type BenchmarkInstrumentation,
+  setBenchmarkCounter,
 } from '../internal/benchmarkInstrumentation';
 import type { FileTreeNode } from '../types';
 import {
   buildFileListSyncIndex,
   type FileListSyncIndex,
 } from '../utils/fileListToTree';
+import { MutablePathTree } from '../utils/mutablePathTree';
 import {
   createMapPathToIdLookup,
   type IdToPathLookup,
@@ -106,66 +108,72 @@ function hasSelectedFolderAncestor(
   return false;
 }
 
-function buildFolderSet(files: string[]): Set<string> {
-  const folders = new Set<string>();
-  for (const file of files) {
-    let slash = file.lastIndexOf('/');
-    while (slash !== -1) {
-      folders.add(file.slice(0, slash));
-      slash = file.lastIndexOf('/', slash - 1);
-    }
+function splitPath(path: string): { parentPath: string; baseName: string } {
+  const separatorIndex = path.lastIndexOf('/');
+  if (separatorIndex < 0) {
+    return { parentPath: '', baseName: path };
   }
-  return folders;
+  return {
+    parentPath: path.slice(0, separatorIndex),
+    baseName: path.slice(separatorIndex + 1),
+  };
 }
 
-function getSelectedFolderForFile(
-  file: string,
-  selectedFolders: Set<string>
-): string | undefined {
-  let slash = file.lastIndexOf('/');
-  while (slash !== -1) {
-    const folder = file.slice(0, slash);
-    if (selectedFolders.has(folder)) {
-      return folder;
+function getPathDepth(path: string): number {
+  let depth = 1;
+  for (let index = 0; index < path.length; index += 1) {
+    if (path.charCodeAt(index) === 47) {
+      depth += 1;
     }
-    slash = folder.lastIndexOf('/');
   }
-  return undefined;
+  return depth;
+}
+
+/**
+ * Applies a precomputed file origin->destination mapping to a mutable path
+ * tree. Returns false if we hit an unexpected inconsistency and need to fall
+ * back to rebuilding the tree from a snapshot.
+ */
+function applyMappedFilesToPathTree(
+  pathTree: MutablePathTree,
+  currentFiles: string[],
+  finalPathByOrigin: Map<string, string | null>
+): boolean {
+  for (let index = 0; index < currentFiles.length; index += 1) {
+    const origin = currentFiles[index];
+    if (finalPathByOrigin.get(origin) != null) {
+      continue;
+    }
+    pathTree.deleteFilePath(origin);
+  }
+
+  for (let index = 0; index < currentFiles.length; index += 1) {
+    const origin = currentFiles[index];
+    const destination = finalPathByOrigin.get(origin);
+    if (destination == null || destination === origin) {
+      continue;
+    }
+
+    const { parentPath, baseName } = splitPath(destination);
+    const moveResult = pathTree.movePath(
+      origin,
+      parentPath === '' ? ROOT_ID : parentPath,
+      baseName,
+      'file'
+    );
+
+    if (moveResult !== 'ok') {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 interface PlannedMoveRule {
   sourcePath: string;
   destinationPath: string;
   isFolder: boolean;
-}
-
-function remapPathWithRules(
-  path: string,
-  rules: readonly PlannedMoveRule[]
-): string | null {
-  for (let index = 0; index < rules.length; index += 1) {
-    const rule = rules[index];
-    if (!rule.isFolder) {
-      if (path === rule.sourcePath) {
-        return rule.destinationPath;
-      }
-      if (path === `${FLATTENED_PREFIX}${rule.sourcePath}`) {
-        return `${FLATTENED_PREFIX}${rule.destinationPath}`;
-      }
-      continue;
-    }
-
-    const remapped = remapPathWithPrefix(
-      path,
-      rule.sourcePath,
-      rule.destinationPath
-    );
-    if (remapped != null) {
-      return remapped;
-    }
-  }
-
-  return null;
 }
 
 export interface FileTreeModelRenameRequest {
@@ -181,6 +189,14 @@ export interface FileTreeModelMoveRequest {
     origin: string | null;
     destination: string;
   }) => boolean;
+}
+
+export interface FileTreeModelAddPathsRequest {
+  paths: string[];
+}
+
+export interface FileTreeModelDeletePathsRequest {
+  paths: string[];
 }
 
 export type FileTreeModelMutation =
@@ -206,6 +222,18 @@ export type FileTreeModelMutation =
       }>;
       affectedParentIds: readonly string[];
       version: number;
+    }
+  | {
+      kind: 'add-paths';
+      addedPaths: readonly string[];
+      affectedParentIds: readonly string[];
+      version: number;
+    }
+  | {
+      kind: 'delete-paths';
+      deletedPaths: readonly string[];
+      affectedParentIds: readonly string[];
+      version: number;
     };
 
 export type FileTreeModelRenameResult =
@@ -219,6 +247,20 @@ export type FileTreeModelMoveResult =
   | {
       ok: true;
       mutation: Extract<FileTreeModelMutation, { kind: 'move-paths' }> | null;
+    }
+  | { ok: false; error: string };
+
+export type FileTreeModelAddPathsResult =
+  | {
+      ok: true;
+      mutation: Extract<FileTreeModelMutation, { kind: 'add-paths' }> | null;
+    }
+  | { ok: false; error: string };
+
+export type FileTreeModelDeletePathsResult =
+  | {
+      ok: true;
+      mutation: Extract<FileTreeModelMutation, { kind: 'delete-paths' }> | null;
     }
   | { ok: false; error: string };
 
@@ -359,6 +401,10 @@ export class FileTreeModel {
 
   private files: string[] = [];
   private readonly fileIndexByPath = new Map<string, number>();
+  private readonly flattenedRefCountById = new Map<string, number>();
+  private readonly flattenedIdsPendingPrune = new Set<string>();
+  private readonly benchmarkInstrumentation: BenchmarkInstrumentation | null;
+  private pathTree: MutablePathTree | null = null;
   private version = 0;
   private nextNodeId = 1;
   private sortComparator: ChildrenSortOption;
@@ -372,17 +418,22 @@ export class FileTreeModel {
 
   constructor(files: string[], options: FileTreeModelOptions = {}) {
     this.sortComparator = options.sortComparator ?? defaultChildrenComparator;
+    this.benchmarkInstrumentation = options.benchmarkInstrumentation ?? null;
+
     const builtIndex = buildStableIndexFromFiles(
       files,
       this.sortComparator,
-      options.benchmarkInstrumentation,
+      this.benchmarkInstrumentation,
       null,
       this.nextNodeId
     );
     this.applyBuiltIndex(builtIndex);
   }
 
-  private applyBuiltIndex(builtIndex: BuiltStableIndex): void {
+  private applyBuiltIndex(
+    builtIndex: BuiltStableIndex,
+    options: { syncPathTree?: boolean } = {}
+  ): void {
     this.pathToIdMap.clear();
     for (const [path, id] of builtIndex.pathToIdMap) {
       this.pathToIdMap.set(path, id);
@@ -404,6 +455,93 @@ export class FileTreeModel {
       this.fileIndexByPath.set(this.files[index], index);
     }
     this.nextNodeId = builtIndex.nextNodeId;
+
+    this.rebuildFlattenedReferenceCounts();
+
+    if (options.syncPathTree !== false && this.pathTree != null) {
+      this.pathTree.replaceAll(this.files);
+    }
+  }
+
+  private isFlattenedPath(path: string | undefined): boolean {
+    return path?.startsWith(FLATTENED_PREFIX) === true;
+  }
+
+  private rebuildFlattenedReferenceCounts(): void {
+    this.flattenedRefCountById.clear();
+    this.flattenedIdsPendingPrune.clear();
+
+    for (const node of this.tree.values()) {
+      const flattenedChildren = node.children?.flattened;
+      if (flattenedChildren == null) {
+        continue;
+      }
+
+      for (let index = 0; index < flattenedChildren.length; index += 1) {
+        const childId = flattenedChildren[index];
+        if (!this.isFlattenedPath(this.idToPathMap.get(childId))) {
+          continue;
+        }
+        this.flattenedRefCountById.set(
+          childId,
+          (this.flattenedRefCountById.get(childId) ?? 0) + 1
+        );
+      }
+    }
+  }
+
+  private incrementFlattenedReference(id: string): void {
+    if (!this.isFlattenedPath(this.idToPathMap.get(id))) {
+      return;
+    }
+
+    this.flattenedRefCountById.set(
+      id,
+      (this.flattenedRefCountById.get(id) ?? 0) + 1
+    );
+    this.flattenedIdsPendingPrune.delete(id);
+  }
+
+  private decrementFlattenedReference(id: string): void {
+    if (!this.isFlattenedPath(this.idToPathMap.get(id))) {
+      return;
+    }
+
+    const previousCount = this.flattenedRefCountById.get(id);
+    if (previousCount == null) {
+      return;
+    }
+
+    if (previousCount <= 1) {
+      this.flattenedRefCountById.delete(id);
+      this.flattenedIdsPendingPrune.add(id);
+      return;
+    }
+
+    this.flattenedRefCountById.set(id, previousCount - 1);
+  }
+
+  private prunePendingFlattenedNodes(): void {
+    while (this.flattenedIdsPendingPrune.size > 0) {
+      const iterator = this.flattenedIdsPendingPrune.values().next();
+      if (iterator.done === true) {
+        return;
+      }
+
+      const flattenedId = iterator.value;
+      this.flattenedIdsPendingPrune.delete(flattenedId);
+
+      if (this.flattenedRefCountById.has(flattenedId)) {
+        continue;
+      }
+
+      const flattenedPath = this.idToPathMap.get(flattenedId);
+      if (!this.isFlattenedPath(flattenedPath)) {
+        continue;
+      }
+
+      this.removePathById(flattenedId);
+    }
   }
 
   private emitMutation(mutation: Omit<FileTreeModelMutation, 'version'>): void {
@@ -415,6 +553,10 @@ export class FileTreeModel {
     for (const listener of this.listeners) {
       listener(mutationWithVersion);
     }
+  }
+
+  private setModelCounter(name: string, value: number): void {
+    setBenchmarkCounter(this.benchmarkInstrumentation, name, value);
   }
 
   private sortChildren(parentId: string): void {
@@ -438,6 +580,630 @@ export class FileTreeModel {
     if (parentNode.children.flattened != null) {
       parentNode.children.flattened.sort(compareByPath);
     }
+  }
+
+  private resolveAncestorId(path: string): string {
+    let candidatePath = path;
+    while (true) {
+      const candidateId = this.pathToIdMap.get(candidatePath);
+      if (candidateId != null) {
+        return candidateId;
+      }
+      if (candidatePath === ROOT_ID) {
+        return ROOT_ID;
+      }
+      candidatePath = getParentPath(candidatePath);
+    }
+  }
+
+  private resolveAncestorIdsForPaths(paths: readonly string[]): string[] {
+    const affectedParentIdsSet = new Set<string>();
+    for (let index = 0; index < paths.length; index += 1) {
+      const path = paths[index];
+      affectedParentIdsSet.add(this.resolveAncestorId(getParentPath(path)));
+    }
+    return [...affectedParentIdsSet];
+  }
+
+  private getOrCreatePathTree(): MutablePathTree {
+    this.pathTree ??= MutablePathTree.fromFiles(this.files);
+    return this.pathTree;
+  }
+
+  private replaceFilesSnapshot(files: string[]): void {
+    this.files = files;
+    this.fileIndexByPath.clear();
+    for (let index = 0; index < files.length; index += 1) {
+      this.fileIndexByPath.set(files[index], index);
+    }
+    this.setModelCounter('model.snapshot.fileCount', files.length);
+  }
+
+  private addAncestorFoldersForPath(path: string, out: Set<string>): void {
+    let currentPath = path.length === 0 ? ROOT_ID : path;
+    while (true) {
+      out.add(currentPath);
+      if (currentPath === ROOT_ID) {
+        return;
+      }
+      currentPath = getParentPath(currentPath);
+    }
+  }
+
+  private allocateStableIdForPath(path: string): string {
+    const baseId = `p_${hashPathToStableSuffix(path)}`;
+    if (!this.idToPathMap.has(baseId)) {
+      return baseId;
+    }
+
+    let suffix = 2;
+    let candidate = `${baseId}_${suffix}`;
+    while (this.idToPathMap.has(candidate)) {
+      suffix += 1;
+      candidate = `${baseId}_${suffix}`;
+    }
+    return candidate;
+  }
+
+  private ensureStableIdForPath(path: string): string {
+    const existingId = this.pathToIdMap.get(path);
+    if (existingId != null) {
+      return existingId;
+    }
+
+    const allocatedId = this.allocateStableIdForPath(path);
+    this.pathToIdMap.set(path, allocatedId);
+    this.idToPathMap.set(allocatedId, path);
+    return allocatedId;
+  }
+
+  private removePathById(id: string): void {
+    const node = this.tree.get(id);
+    const flattenedChildren = node?.children?.flattened;
+    if (flattenedChildren != null) {
+      for (let index = 0; index < flattenedChildren.length; index += 1) {
+        this.decrementFlattenedReference(flattenedChildren[index]);
+      }
+    }
+
+    const path = this.idToPathMap.get(id);
+    if (path != null) {
+      this.idToPathMap.delete(id);
+      this.pathToIdMap.delete(path);
+      if (this.isFlattenedPath(path)) {
+        this.flattenedRefCountById.delete(id);
+        this.flattenedIdsPendingPrune.delete(id);
+      }
+    }
+
+    this.tree.delete(id);
+  }
+
+  /**
+   * Removes a node and every descendant reachable via direct/flattened links.
+   *
+   * The optional predicate lets callers keep nodes that were reparented and
+   * still live elsewhere in the current path mapping.
+   */
+  private removeSubtreeById(
+    rootId: string,
+    shouldRemovePath?: (path: string) => boolean
+  ): void {
+    if (rootId === ROOT_ID) {
+      return;
+    }
+
+    const stack = [rootId];
+    const visited = new Set<string>();
+
+    while (stack.length > 0) {
+      const id = stack.pop()!;
+      if (id === ROOT_ID || visited.has(id)) {
+        continue;
+      }
+      visited.add(id);
+
+      const nodePath = this.idToPathMap.get(id);
+      if (
+        shouldRemovePath != null &&
+        nodePath != null &&
+        !shouldRemovePath(nodePath)
+      ) {
+        continue;
+      }
+
+      const node = this.tree.get(id);
+      const directChildren = node?.children?.direct;
+      if (directChildren != null) {
+        for (let index = 0; index < directChildren.length; index += 1) {
+          stack.push(directChildren[index]);
+        }
+      }
+
+      const flattenedChildren = node?.children?.flattened;
+      if (flattenedChildren != null) {
+        for (let index = 0; index < flattenedChildren.length; index += 1) {
+          stack.push(flattenedChildren[index]);
+        }
+      }
+
+      this.removePathById(id);
+    }
+  }
+
+  /**
+   * Collects path remaps by traversing only the folder subtree being moved.
+   * This avoids scanning unrelated entries in the model-wide path map.
+   */
+  private collectSubtreePathUpdates(
+    sourcePath: string,
+    destinationPath: string
+  ): {
+    updates: Array<{ id: string; oldPath: string; newPath: string }>;
+    scannedNodeCount: number;
+  } {
+    const sourceId = this.pathToIdMap.get(sourcePath);
+    if (sourceId == null) {
+      return { updates: [], scannedNodeCount: 0 };
+    }
+
+    const updates: Array<{ id: string; oldPath: string; newPath: string }> = [];
+    const updatedIds = new Set<string>();
+    const visited = new Set<string>();
+    const stack = [sourceId];
+    let scannedNodeCount = 0;
+
+    while (stack.length > 0) {
+      const id = stack.pop()!;
+      if (visited.has(id)) {
+        continue;
+      }
+      visited.add(id);
+      scannedNodeCount += 1;
+
+      const node = this.tree.get(id);
+      const oldPath = this.idToPathMap.get(id);
+      const remappedPath =
+        oldPath == null
+          ? null
+          : remapPathWithPrefix(oldPath, sourcePath, destinationPath);
+
+      if (
+        oldPath != null &&
+        remappedPath != null &&
+        remappedPath !== oldPath &&
+        !updatedIds.has(id)
+      ) {
+        updates.push({ id, oldPath, newPath: remappedPath });
+        updatedIds.add(id);
+      }
+
+      if (
+        oldPath != null &&
+        remappedPath != null &&
+        remappedPath !== oldPath &&
+        node?.children?.direct != null &&
+        !oldPath.startsWith(FLATTENED_PREFIX)
+      ) {
+        const flattenedAliasPath = `${FLATTENED_PREFIX}${oldPath}`;
+        const flattenedAliasId = this.pathToIdMap.get(flattenedAliasPath);
+        if (flattenedAliasId != null && !updatedIds.has(flattenedAliasId)) {
+          updates.push({
+            id: flattenedAliasId,
+            oldPath: flattenedAliasPath,
+            newPath: `${FLATTENED_PREFIX}${remappedPath}`,
+          });
+          updatedIds.add(flattenedAliasId);
+          scannedNodeCount += 1;
+        }
+      }
+
+      const directChildren = node?.children?.direct;
+      if (directChildren != null) {
+        for (let index = 0; index < directChildren.length; index += 1) {
+          stack.push(directChildren[index]);
+        }
+      }
+
+      const flattenedChildren = node?.children?.flattened;
+      if (flattenedChildren != null) {
+        for (let index = 0; index < flattenedChildren.length; index += 1) {
+          stack.push(flattenedChildren[index]);
+        }
+      }
+    }
+
+    return { updates, scannedNodeCount };
+  }
+
+  private applyPathRemapRules(rules: readonly PlannedMoveRule[]): void {
+    if (rules.length === 0) {
+      return;
+    }
+
+    const updates: Array<{ id: string; oldPath: string; newPath: string }> = [];
+    const updatedIds = new Set<string>();
+    let scannedNodeCount = 0;
+
+    for (let index = 0; index < rules.length; index += 1) {
+      const rule = rules[index];
+
+      if (rule.isFolder) {
+        const folderUpdates = this.collectSubtreePathUpdates(
+          rule.sourcePath,
+          rule.destinationPath
+        );
+        scannedNodeCount += folderUpdates.scannedNodeCount;
+
+        for (
+          let updateIndex = 0;
+          updateIndex < folderUpdates.updates.length;
+          updateIndex += 1
+        ) {
+          const update = folderUpdates.updates[updateIndex];
+          if (updatedIds.has(update.id)) {
+            continue;
+          }
+          updatedIds.add(update.id);
+          updates.push(update);
+        }
+        continue;
+      }
+
+      const id = this.pathToIdMap.get(rule.sourcePath);
+      if (id == null || updatedIds.has(id)) {
+        continue;
+      }
+
+      scannedNodeCount += 1;
+      updatedIds.add(id);
+      updates.push({
+        id,
+        oldPath: rule.sourcePath,
+        newPath: rule.destinationPath,
+      });
+    }
+
+    this.setModelCounter('model.move.remapScannedNodes', scannedNodeCount);
+    this.setModelCounter('model.move.remapUpdatedNodes', updates.length);
+
+    if (updates.length === 0) {
+      return;
+    }
+
+    const remappedSourcePaths = new Set(
+      updates.map((update) => update.oldPath)
+    );
+    for (let index = 0; index < updates.length; index += 1) {
+      const update = updates[index];
+      const existingId = this.pathToIdMap.get(update.newPath);
+      if (
+        existingId != null &&
+        existingId !== update.id &&
+        !remappedSourcePaths.has(update.newPath)
+      ) {
+        this.removePathById(existingId);
+      }
+    }
+
+    for (let index = 0; index < updates.length; index += 1) {
+      this.pathToIdMap.delete(updates[index].oldPath);
+    }
+
+    for (let index = 0; index < updates.length; index += 1) {
+      const update = updates[index];
+      this.pathToIdMap.set(update.newPath, update.id);
+      this.idToPathMap.set(update.id, update.newPath);
+      const node = this.tree.get(update.id);
+      if (node != null) {
+        node.path = update.newPath;
+      }
+    }
+  }
+
+  private sortPathTreeChildren(
+    children: Array<{ path: string; kind: 'folder' | 'file' }>,
+    pathTree: MutablePathTree
+  ): void {
+    if (this.sortComparator === false) {
+      return;
+    }
+
+    const comparator = this.sortComparator ?? defaultChildrenComparator;
+    children.sort((left, right) =>
+      comparator(left.path, right.path, (path) => pathTree.hasFolder(path))
+    );
+  }
+
+  private getFlattenedEndpoint(
+    pathTree: MutablePathTree,
+    startPath: string
+  ): string | null {
+    let current = startPath;
+    let endpoint: string | null = null;
+
+    while (true) {
+      const directChildren = pathTree.getDirectChildren(current);
+      if (directChildren.length !== 1) {
+        break;
+      }
+
+      const onlyChild = directChildren[0];
+      if (onlyChild.kind !== 'folder') {
+        break;
+      }
+
+      endpoint = onlyChild.path;
+      current = onlyChild.path;
+    }
+
+    return endpoint;
+  }
+
+  private collectFlattenedFolderChain(
+    pathTree: MutablePathTree,
+    startPath: string,
+    endpointPath: string
+  ): string[] {
+    const folders: string[] = [startPath];
+    let current = startPath;
+
+    while (current !== endpointPath) {
+      const directChildren = pathTree.getDirectChildren(current);
+      if (directChildren.length !== 1 || directChildren[0].kind !== 'folder') {
+        break;
+      }
+      current = directChildren[0].path;
+      folders.push(current);
+    }
+
+    return folders;
+  }
+
+  private buildFlattenedDisplayName(
+    startPath: string,
+    endpointPath: string
+  ): string {
+    const startName = getLeafName(startPath);
+    const relativeSuffix = endpointPath.slice(startPath.length + 1);
+    return relativeSuffix.length > 0
+      ? `${startName}/${relativeSuffix}`
+      : startName;
+  }
+
+  private rebuildFolderNodesFromPathTree(
+    pathTree: MutablePathTree,
+    folderPaths: ReadonlySet<string>
+  ): void {
+    this.setModelCounter(
+      'model.rebuildFolders.requestedCount',
+      folderPaths.size
+    );
+
+    const rebuiltFolders = new Set<string>();
+    const rebuildingFolders = new Set<string>();
+    const flattenedEndpointCache = new Map<string, string | null>();
+
+    const rebuildFolder = (folderPath: string): void => {
+      const normalizedFolderPath =
+        folderPath.length === 0 ? ROOT_ID : folderPath;
+
+      if (rebuiltFolders.has(normalizedFolderPath)) {
+        return;
+      }
+      if (rebuildingFolders.has(normalizedFolderPath)) {
+        return;
+      }
+
+      if (
+        normalizedFolderPath !== ROOT_ID &&
+        !pathTree.hasFolder(normalizedFolderPath)
+      ) {
+        const missingFolderId = this.pathToIdMap.get(normalizedFolderPath);
+        if (missingFolderId != null) {
+          const subtreePrefix = `${normalizedFolderPath}/`;
+          this.removeSubtreeById(missingFolderId, (path) => {
+            const rawPath = path.startsWith(FLATTENED_PREFIX)
+              ? path.slice(FLATTENED_PREFIX_LENGTH)
+              : path;
+            return (
+              rawPath === normalizedFolderPath ||
+              rawPath.startsWith(subtreePrefix)
+            );
+          });
+        }
+        rebuiltFolders.add(normalizedFolderPath);
+        return;
+      }
+
+      rebuildingFolders.add(normalizedFolderPath);
+
+      const folderId =
+        normalizedFolderPath === ROOT_ID
+          ? ROOT_ID
+          : this.ensureStableIdForPath(normalizedFolderPath);
+      const previousNode = this.tree.get(folderId);
+      const previousDirectChildren =
+        previousNode?.children?.direct?.slice() ?? [];
+      const previousFlattenedChildren =
+        previousNode?.children?.flattened?.slice() ?? [];
+
+      const directChildren = pathTree.getDirectChildren(normalizedFolderPath);
+      this.sortPathTreeChildren(directChildren, pathTree);
+
+      const directChildIds = new Array<string>(directChildren.length);
+      for (let index = 0; index < directChildren.length; index += 1) {
+        const child = directChildren[index];
+        const childId = this.ensureStableIdForPath(child.path);
+        directChildIds[index] = childId;
+
+        const existingNode = this.tree.get(childId);
+        if (child.kind === 'folder') {
+          if (existingNode?.children == null) {
+            this.tree.set(childId, {
+              name: getLeafName(child.path),
+              path: child.path,
+              children: { direct: [] },
+            });
+          } else {
+            existingNode.path = child.path;
+            existingNode.name = getLeafName(child.path);
+          }
+        } else {
+          this.tree.set(childId, {
+            name: getLeafName(child.path),
+            path: child.path,
+          });
+        }
+      }
+
+      if (previousDirectChildren.length > 0) {
+        const nextDirectSet = new Set(directChildIds);
+        for (let index = 0; index < previousDirectChildren.length; index += 1) {
+          const previousChildId = previousDirectChildren[index];
+          if (nextDirectSet.has(previousChildId)) {
+            continue;
+          }
+
+          const previousChildPath = this.idToPathMap.get(previousChildId);
+          if (previousChildPath == null) {
+            continue;
+          }
+
+          if (pathTree.hasPath(previousChildPath)) {
+            continue;
+          }
+
+          this.removeSubtreeById(previousChildId);
+        }
+      }
+
+      const resolveEndpoint = (path: string): string | null => {
+        if (flattenedEndpointCache.has(path)) {
+          return flattenedEndpointCache.get(path) ?? null;
+        }
+
+        const endpoint = this.getFlattenedEndpoint(pathTree, path);
+        flattenedEndpointCache.set(path, endpoint);
+        return endpoint;
+      };
+
+      const ensureFlattenedNode = (
+        startPath: string,
+        endpointPath: string
+      ): string => {
+        rebuildFolder(endpointPath);
+
+        const flattenedPath = `${FLATTENED_PREFIX}${endpointPath}`;
+        const flattenedId = this.ensureStableIdForPath(flattenedPath);
+
+        const endpointId = this.pathToIdMap.get(endpointPath);
+        const endpointNode =
+          endpointId != null ? this.tree.get(endpointId) : undefined;
+        const endpointChildren = endpointNode?.children;
+        const previousFlattenedChildren =
+          this.tree.get(flattenedId)?.children?.flattened?.slice() ?? [];
+
+        const flattenedFolders = this.collectFlattenedFolderChain(
+          pathTree,
+          startPath,
+          endpointPath
+        );
+        const flattens = new Array<string>(flattenedFolders.length);
+        for (let index = 0; index < flattenedFolders.length; index += 1) {
+          flattens[index] = this.ensureStableIdForPath(flattenedFolders[index]);
+        }
+
+        const nextFlattenedChildren = endpointChildren?.flattened?.slice();
+        const flattenedNode: FileTreeNode = {
+          name: this.buildFlattenedDisplayName(startPath, endpointPath),
+          path: flattenedPath,
+          flattens,
+          children: {
+            direct: endpointChildren?.direct?.slice() ?? [],
+            ...(nextFlattenedChildren != null && {
+              flattened: nextFlattenedChildren,
+            }),
+          },
+        };
+
+        this.tree.set(flattenedId, flattenedNode);
+
+        const previousFlattenedSet = new Set(previousFlattenedChildren);
+        const nextFlattenedSet = new Set(nextFlattenedChildren ?? []);
+        for (const childId of previousFlattenedSet) {
+          if (!nextFlattenedSet.has(childId)) {
+            this.decrementFlattenedReference(childId);
+          }
+        }
+        for (const childId of nextFlattenedSet) {
+          if (!previousFlattenedSet.has(childId)) {
+            this.incrementFlattenedReference(childId);
+          }
+        }
+
+        return flattenedId;
+      };
+
+      let flattenedChildIds: string[] | undefined;
+      for (let index = 0; index < directChildren.length; index += 1) {
+        const child = directChildren[index];
+
+        if (child.kind === 'folder') {
+          const endpointPath = resolveEndpoint(child.path);
+          if (endpointPath != null) {
+            const flattenedId = ensureFlattenedNode(child.path, endpointPath);
+            flattenedChildIds ??= directChildIds.slice(0, index);
+            flattenedChildIds.push(flattenedId);
+            continue;
+          }
+        }
+
+        if (flattenedChildIds != null) {
+          flattenedChildIds.push(directChildIds[index]);
+        }
+      }
+
+      this.tree.set(folderId, {
+        name:
+          normalizedFolderPath === ROOT_ID
+            ? ROOT_ID
+            : getLeafName(normalizedFolderPath),
+        path: normalizedFolderPath,
+        children: {
+          direct: directChildIds,
+          ...(flattenedChildIds != null && {
+            flattened: flattenedChildIds,
+          }),
+        },
+      });
+
+      const previousFlattenedSet = new Set(previousFlattenedChildren);
+      const nextFlattenedSet = new Set(flattenedChildIds ?? []);
+
+      for (const flattenedId of previousFlattenedSet) {
+        if (!nextFlattenedSet.has(flattenedId)) {
+          this.decrementFlattenedReference(flattenedId);
+        }
+      }
+      for (const flattenedId of nextFlattenedSet) {
+        if (!previousFlattenedSet.has(flattenedId)) {
+          this.incrementFlattenedReference(flattenedId);
+        }
+      }
+
+      rebuildingFolders.delete(normalizedFolderPath);
+      rebuiltFolders.add(normalizedFolderPath);
+    };
+
+    for (const folderPath of folderPaths) {
+      rebuildFolder(folderPath);
+    }
+
+    this.setModelCounter(
+      'model.rebuildFolders.executedCount',
+      rebuiltFolders.size
+    );
   }
 
   subscribe(listener: (mutation: FileTreeModelMutation) => void): () => void {
@@ -510,8 +1276,7 @@ export class FileTreeModel {
       return { ok: true, mutation: null };
     }
 
-    const currentFileSet = new Set(currentFiles);
-    const folderSet = buildFolderSet(currentFiles);
+    const pathTree = this.getOrCreatePathTree();
 
     const normalizedDragged = [...new Set(draggedPaths.map(normalizeTreePath))]
       .map((path) => path.trim())
@@ -521,12 +1286,17 @@ export class FileTreeModel {
     }
 
     const orderedDragged = normalizedDragged
+      .filter((path) => pathTree.hasPath(path))
       .map((path) => ({
         path,
-        kind: folderSet.has(path) ? 'folder' : 'file',
-        depth: path.split('/').length,
+        kind: pathTree.hasFolder(path) ? 'folder' : 'file',
+        depth: getPathDepth(path),
       }))
       .sort((left, right) => left.depth - right.depth);
+
+    if (orderedDragged.length === 0) {
+      return { ok: true, mutation: null };
+    }
 
     const selectedFolders = new Set<string>();
     const selectedFiles = new Set<string>();
@@ -535,17 +1305,33 @@ export class FileTreeModel {
       if (hasSelectedFolderAncestor(item.path, selectedFolders)) {
         continue;
       }
+
       if (item.kind === 'folder') {
         selectedFolders.add(item.path);
         continue;
       }
-      if (currentFileSet.has(item.path)) {
-        selectedFiles.add(item.path);
-      }
+
+      selectedFiles.add(item.path);
     }
 
     const moveRules: PlannedMoveRule[] = [];
     const folderDestinations = new Map<string, string>();
+    const proposedDestinationByOrigin = new Map<string, string>();
+
+    for (const selectedFile of selectedFiles) {
+      const destinationPath = `${targetPrefix}${getLeafName(selectedFile)}`;
+      if (destinationPath === selectedFile) {
+        continue;
+      }
+
+      proposedDestinationByOrigin.set(selectedFile, destinationPath);
+      moveRules.push({
+        sourcePath: selectedFile,
+        destinationPath,
+        isFolder: false,
+      });
+    }
+
     for (const selectedFolder of selectedFolders) {
       if (
         normalizedTarget === selectedFolder ||
@@ -553,10 +1339,12 @@ export class FileTreeModel {
       ) {
         continue;
       }
+
       const destinationPath = `${targetPrefix}${getLeafName(selectedFolder)}`;
       if (destinationPath === selectedFolder) {
         continue;
       }
+
       folderDestinations.set(selectedFolder, destinationPath);
       moveRules.push({
         sourcePath: selectedFolder,
@@ -565,46 +1353,18 @@ export class FileTreeModel {
       });
     }
 
-    const proposedDestinationByOrigin = new Map<string, string>();
-    for (let index = 0; index < currentFiles.length; index += 1) {
-      const filePath = currentFiles[index];
-
-      if (selectedFiles.has(filePath)) {
-        const destinationPath = `${targetPrefix}${getLeafName(filePath)}`;
-        if (destinationPath !== filePath) {
-          proposedDestinationByOrigin.set(filePath, destinationPath);
-          moveRules.push({
-            sourcePath: filePath,
-            destinationPath,
-            isFolder: false,
-          });
+    for (const [
+      selectedFolder,
+      selectedFolderDestination,
+    ] of folderDestinations) {
+      const descendantFiles = pathTree.getDescendantFilePaths(selectedFolder);
+      for (let index = 0; index < descendantFiles.length; index += 1) {
+        const originPath = descendantFiles[index];
+        const destinationPath = `${selectedFolderDestination}${originPath.slice(selectedFolder.length)}`;
+        if (destinationPath === originPath) {
+          continue;
         }
-        continue;
-      }
-
-      const selectedFolder = getSelectedFolderForFile(
-        filePath,
-        selectedFolders
-      );
-      if (selectedFolder == null) {
-        continue;
-      }
-
-      if (
-        normalizedTarget === selectedFolder ||
-        isPathDescendant(normalizedTarget, selectedFolder)
-      ) {
-        continue;
-      }
-
-      const selectedFolderDestination = folderDestinations.get(selectedFolder);
-      if (selectedFolderDestination == null) {
-        continue;
-      }
-
-      const destinationPath = `${selectedFolderDestination}${filePath.slice(selectedFolder.length)}`;
-      if (destinationPath !== filePath) {
-        proposedDestinationByOrigin.set(filePath, destinationPath);
+        proposedDestinationByOrigin.set(originPath, destinationPath);
       }
     }
 
@@ -652,12 +1412,15 @@ export class FileTreeModel {
     }
 
     const nextFiles: string[] = [];
+    const removedFilePaths: string[] = [];
     for (let index = 0; index < currentFiles.length; index += 1) {
       const filePath = currentFiles[index];
       const nextPath = finalPathByOrigin.get(filePath);
       if (nextPath != null) {
         nextFiles.push(nextPath);
+        continue;
       }
+      removedFilePaths.push(filePath);
     }
 
     if (
@@ -670,36 +1433,22 @@ export class FileTreeModel {
     const movedFolderRuleBySource = new Map<string, PlannedMoveRule>();
     for (let index = 0; index < moveRules.length; index += 1) {
       const rule = moveRules[index];
-      if (rule?.isFolder) {
+      if (rule.isFolder) {
         movedFolderRuleBySource.set(rule.sourcePath, rule);
       }
     }
 
     const activeFolderSources = new Set<string>();
-    if (movedFolderRuleBySource.size > 0) {
-      for (const [originPath, nextPath] of finalPathByOrigin) {
-        if (nextPath == null) {
-          continue;
-        }
-
-        const selectedFolder = getSelectedFolderForFile(
-          originPath,
-          selectedFolders
-        );
-        if (selectedFolder == null) {
-          continue;
-        }
-
-        const folderRule = movedFolderRuleBySource.get(selectedFolder);
-        if (folderRule == null) {
-          continue;
-        }
-
+    for (const [sourcePath, rule] of movedFolderRuleBySource) {
+      const descendants = pathTree.getDescendantFilePaths(sourcePath);
+      for (let index = 0; index < descendants.length; index += 1) {
+        const nextPath = finalPathByOrigin.get(descendants[index]);
         if (
-          nextPath === folderRule.destinationPath ||
-          nextPath.startsWith(`${folderRule.destinationPath}/`)
+          nextPath != null &&
+          nextPath.startsWith(`${rule.destinationPath}/`)
         ) {
-          activeFolderSources.add(selectedFolder);
+          activeFolderSources.add(sourcePath);
+          break;
         }
       }
     }
@@ -715,43 +1464,56 @@ export class FileTreeModel {
       })
       .sort((left, right) => right.sourcePath.length - left.sourcePath.length);
 
-    const remappedPathToId = new Map<string, string>();
-    for (const [path, id] of this.pathToIdMap) {
-      const remappedPath = remapPathWithRules(path, remapRules) ?? path;
-      remappedPathToId.set(remappedPath, id);
+    const pathTreeApplied = applyMappedFilesToPathTree(
+      pathTree,
+      currentFiles,
+      finalPathByOrigin
+    );
+    if (!pathTreeApplied) {
+      pathTree.replaceAll(nextFiles);
     }
 
-    const builtIndex = buildStableIndexFromFiles(
-      nextFiles,
-      this.sortComparator,
-      null,
-      remappedPathToId,
-      this.nextNodeId
-    );
-    this.applyBuiltIndex(builtIndex);
+    this.applyPathRemapRules(remapRules);
+    this.replaceFilesSnapshot(nextFiles);
+
+    const affectedFolderPaths = new Set<string>();
+    for (let index = 0; index < remapRules.length; index += 1) {
+      const rule = remapRules[index];
+      this.addAncestorFoldersForPath(
+        getParentPath(rule.sourcePath),
+        affectedFolderPaths
+      );
+      this.addAncestorFoldersForPath(
+        getParentPath(rule.destinationPath),
+        affectedFolderPaths
+      );
+    }
+    for (let index = 0; index < removedFilePaths.length; index += 1) {
+      this.addAncestorFoldersForPath(
+        getParentPath(removedFilePaths[index]),
+        affectedFolderPaths
+      );
+    }
+    if (affectedFolderPaths.size === 0) {
+      affectedFolderPaths.add(ROOT_ID);
+    }
+
+    this.rebuildFolderNodesFromPathTree(pathTree, affectedFolderPaths);
+    this.prunePendingFlattenedNodes();
 
     const affectedParentIdsSet = new Set<string>();
-    const resolveAncestorId = (path: string): string => {
-      let candidatePath = path;
-      while (true) {
-        const candidateId = this.pathToIdMap.get(candidatePath);
-        if (candidateId != null) {
-          return candidateId;
-        }
-        if (candidatePath === ROOT_ID) {
-          return ROOT_ID;
-        }
-        candidatePath = getParentPath(candidatePath);
-      }
-    };
-
     for (let index = 0; index < remapRules.length; index += 1) {
       const rule = remapRules[index];
       affectedParentIdsSet.add(
-        resolveAncestorId(getParentPath(rule.sourcePath))
+        this.resolveAncestorId(getParentPath(rule.sourcePath))
       );
       affectedParentIdsSet.add(
-        resolveAncestorId(getParentPath(rule.destinationPath))
+        this.resolveAncestorId(getParentPath(rule.destinationPath))
+      );
+    }
+    for (let index = 0; index < removedFilePaths.length; index += 1) {
+      affectedParentIdsSet.add(
+        this.resolveAncestorId(getParentPath(removedFilePaths[index]))
       );
     }
 
@@ -765,6 +1527,156 @@ export class FileTreeModel {
       kind: 'move-paths' as const,
       movedPaths,
       affectedParentIds: [...affectedParentIdsSet],
+    };
+    this.emitMutation(mutation);
+
+    return {
+      ok: true,
+      mutation: {
+        ...mutation,
+        version: this.version,
+      },
+    };
+  }
+
+  addPaths({
+    paths,
+  }: FileTreeModelAddPathsRequest): FileTreeModelAddPathsResult {
+    if (paths.length === 0) {
+      return { ok: true, mutation: null };
+    }
+
+    const normalizedPaths = [...new Set(paths.map(normalizeTreePath))]
+      .map((path) => path.trim())
+      .filter((path) => path.length > 0);
+    if (normalizedPaths.length === 0) {
+      return { ok: true, mutation: null };
+    }
+
+    const pathTree = this.getOrCreatePathTree();
+
+    const addedPaths: string[] = [];
+    for (let index = 0; index < normalizedPaths.length; index += 1) {
+      const path = normalizedPaths[index];
+      if (pathTree.addFilePath(path)) {
+        addedPaths.push(path);
+      }
+    }
+
+    if (addedPaths.length === 0) {
+      return { ok: true, mutation: null };
+    }
+
+    this.replaceFilesSnapshot(pathTree.cloneFiles());
+
+    const affectedFolderPaths = new Set<string>();
+    for (let index = 0; index < addedPaths.length; index += 1) {
+      this.addAncestorFoldersForPath(
+        getParentPath(addedPaths[index]),
+        affectedFolderPaths
+      );
+    }
+    if (affectedFolderPaths.size === 0) {
+      affectedFolderPaths.add(ROOT_ID);
+    }
+
+    this.rebuildFolderNodesFromPathTree(pathTree, affectedFolderPaths);
+    this.prunePendingFlattenedNodes();
+
+    const mutation = {
+      kind: 'add-paths' as const,
+      addedPaths,
+      affectedParentIds: this.resolveAncestorIdsForPaths(addedPaths),
+    };
+    this.emitMutation(mutation);
+
+    return {
+      ok: true,
+      mutation: {
+        ...mutation,
+        version: this.version,
+      },
+    };
+  }
+
+  deletePaths({
+    paths,
+  }: FileTreeModelDeletePathsRequest): FileTreeModelDeletePathsResult {
+    if (paths.length === 0) {
+      return { ok: true, mutation: null };
+    }
+
+    const normalizedPaths = [...new Set(paths.map(normalizeTreePath))]
+      .map((path) => path.trim())
+      .filter((path) => path.length > 0);
+    if (normalizedPaths.length === 0) {
+      return { ok: true, mutation: null };
+    }
+
+    const pathTree = this.getOrCreatePathTree();
+
+    const orderedPaths = normalizedPaths
+      .map((path) => ({ path, depth: getPathDepth(path) }))
+      .sort((left, right) => left.depth - right.depth);
+
+    const selectedFolders = new Set<string>();
+    const selectedFiles: string[] = [];
+
+    for (let index = 0; index < orderedPaths.length; index += 1) {
+      const path = orderedPaths[index].path;
+      if (hasSelectedFolderAncestor(path, selectedFolders)) {
+        continue;
+      }
+
+      if (pathTree.hasFolder(path)) {
+        selectedFolders.add(path);
+        continue;
+      }
+
+      if (pathTree.hasFile(path)) {
+        selectedFiles.push(path);
+      }
+    }
+
+    const deletedPaths: string[] = [];
+
+    for (let index = 0; index < selectedFiles.length; index += 1) {
+      const path = selectedFiles[index];
+      if (pathTree.deleteFilePath(path)) {
+        deletedPaths.push(path);
+      }
+    }
+
+    for (const path of selectedFolders) {
+      if (pathTree.deleteFolderPath(path)) {
+        deletedPaths.push(path);
+      }
+    }
+
+    if (deletedPaths.length === 0) {
+      return { ok: true, mutation: null };
+    }
+
+    this.replaceFilesSnapshot(pathTree.cloneFiles());
+
+    const affectedFolderPaths = new Set<string>();
+    for (let index = 0; index < deletedPaths.length; index += 1) {
+      this.addAncestorFoldersForPath(
+        getParentPath(deletedPaths[index]),
+        affectedFolderPaths
+      );
+    }
+    if (affectedFolderPaths.size === 0) {
+      affectedFolderPaths.add(ROOT_ID);
+    }
+
+    this.rebuildFolderNodesFromPathTree(pathTree, affectedFolderPaths);
+    this.prunePendingFlattenedNodes();
+
+    const mutation = {
+      kind: 'delete-paths' as const,
+      deletedPaths,
+      affectedParentIds: this.resolveAncestorIdsForPaths(deletedPaths),
     };
     this.emitMutation(mutation);
 
@@ -839,8 +1751,35 @@ export class FileTreeModel {
 
     const parentPath = getParentPath(normalizedSourcePath);
     const parentId = this.pathToIdMap.get(parentPath) ?? ROOT_ID;
+    const pathTree = this.pathTree;
 
     if (!nodeIsFolder) {
+      if (pathTree != null) {
+        const renameResult = pathTree.renamePath(
+          normalizedSourcePath,
+          normalizedDestinationPath,
+          'file'
+        );
+        if (renameResult === 'missing') {
+          return {
+            ok: false,
+            error: 'Could not find the selected file to rename.',
+          };
+        }
+        if (renameResult === 'collision') {
+          return {
+            ok: false,
+            error: `"${normalizedDestinationPath}" already exists.`,
+          };
+        }
+        if (renameResult === 'invalid') {
+          return {
+            ok: false,
+            error: 'Could not rename the selected file.',
+          };
+        }
+      }
+
       this.pathToIdMap.delete(normalizedSourcePath);
       this.pathToIdMap.set(normalizedDestinationPath, nodeId);
       this.idToPathMap.set(nodeId, normalizedDestinationPath);
@@ -856,6 +1795,8 @@ export class FileTreeModel {
       }
 
       this.sortChildren(parentId);
+      this.setModelCounter('model.rename.file.remapScannedNodes', 1);
+      this.setModelCounter('model.rename.file.remapUpdatedNodes', 1);
 
       const mutation = {
         kind: 'rename-path' as const,
@@ -872,19 +1813,21 @@ export class FileTreeModel {
       };
     }
 
-    const pathUpdates: Array<{ id: string; oldPath: string; newPath: string }> =
-      [];
-    for (const [path, id] of this.pathToIdMap) {
-      const remappedPath = remapPathWithPrefix(
-        path,
-        normalizedSourcePath,
-        normalizedDestinationPath
-      );
-      if (remappedPath == null) {
-        continue;
-      }
-      pathUpdates.push({ id, oldPath: path, newPath: remappedPath });
-    }
+    const {
+      updates: pathUpdates,
+      scannedNodeCount: folderRenameScannedNodeCount,
+    } = this.collectSubtreePathUpdates(
+      normalizedSourcePath,
+      normalizedDestinationPath
+    );
+    this.setModelCounter(
+      'model.rename.folder.remapScannedNodes',
+      folderRenameScannedNodeCount
+    );
+    this.setModelCounter(
+      'model.rename.folder.remapUpdatedNodes',
+      pathUpdates.length
+    );
 
     if (pathUpdates.length === 0) {
       return {
@@ -904,6 +1847,32 @@ export class FileTreeModel {
         return {
           ok: false,
           error: `"${normalizedDestinationPath}" already exists.`,
+        };
+      }
+    }
+
+    if (pathTree != null) {
+      const folderRenameResult = pathTree.renamePath(
+        normalizedSourcePath,
+        normalizedDestinationPath,
+        'folder'
+      );
+      if (folderRenameResult === 'missing') {
+        return {
+          ok: false,
+          error: 'Could not find the selected folder to rename.',
+        };
+      }
+      if (folderRenameResult === 'collision') {
+        return {
+          ok: false,
+          error: `"${normalizedDestinationPath}" already exists.`,
+        };
+      }
+      if (folderRenameResult === 'invalid') {
+        return {
+          ok: false,
+          error: 'Could not rename the selected folder.',
         };
       }
     }

--- a/packages/trees/src/model/FileTreeModel.ts
+++ b/packages/trees/src/model/FileTreeModel.ts
@@ -11,7 +11,7 @@ import {
 } from '../utils/fileListToTree';
 import { MutablePathTree } from '../utils/mutablePathTree';
 import {
-  createMapPathToIdLookup,
+  createDynamicPathToIdLookup,
   type IdToPathLookup,
 } from '../utils/pathLookups';
 import {
@@ -170,6 +170,7 @@ export type FileTreeModelMutation =
       isFolder: boolean;
       parentId: string;
       nodeId: string;
+      childrenOrderChanged: boolean;
       version: number;
     }
   | {
@@ -348,18 +349,33 @@ export class FileTreeModel {
   private readonly pathToIdMap = new Map<string, string>();
   private readonly idToPathMap = new Map<string, string>();
   private readonly tree = new Map<string, FileTreeNode>();
-  private readonly pathToIdLookup = createMapPathToIdLookup(this.pathToIdMap);
+  private readonly pendingPathPrefixRemaps: Array<{
+    sourcePath: string;
+    destinationPath: string;
+  }> = [];
+  private readonly pathToIdLookup = createDynamicPathToIdLookup({
+    size: () => this.pathToIdMap.size,
+    get: (path) => this.resolveIdForPath(path),
+    has: (path) => this.resolveIdForPath(path) != null,
+    keys: () => this.getCurrentPathKeys(),
+  });
   private readonly idToPathLookup: IdToPathLookup = {
-    get: (id: string) => this.idToPathMap.get(id),
+    get: (id: string) => this.getResolvedPathForId(id),
     has: (id: string) => this.idToPathMap.has(id),
   };
   private readonly syncIndex: FileListSyncIndex = {
     pathToId: this.pathToIdLookup,
     tree: this.tree,
+    idToPath: this.idToPathLookup,
   };
 
   private files: string[] = [];
+  private filesPendingPathTreeSync = false;
   private readonly fileIndexByPath = new Map<string, number>();
+  private readonly pendingFileSnapshotPrefixRemaps: Array<{
+    sourcePath: string;
+    destinationPath: string;
+  }> = [];
   private readonly flattenedRefCountById = new Map<string, number>();
   private readonly flattenedIdsPendingPrune = new Set<string>();
   private readonly directChildIndexByFolderId = new Map<
@@ -368,6 +384,7 @@ export class FileTreeModel {
   >();
   private readonly benchmarkInstrumentation: BenchmarkInstrumentation | null;
   private pathTree: MutablePathTree | null = null;
+  private pathTreeCreationCount = 0;
   private version = 0;
   private nextNodeId = 1;
   private sortComparator: ChildrenSortOption;
@@ -422,6 +439,9 @@ export class FileTreeModel {
     }
 
     this.files = builtIndex.files;
+    this.filesPendingPathTreeSync = false;
+    this.pendingFileSnapshotPrefixRemaps.length = 0;
+    this.pendingPathPrefixRemaps.length = 0;
     this.rebuildFileIndexByPath(this.files);
     this.setModelCounter('model.snapshot.fileCount', this.files.length);
     this.nextNodeId = builtIndex.nextNodeId;
@@ -538,12 +558,12 @@ export class FileTreeModel {
 
     const comparator = this.sortComparator ?? defaultChildrenComparator;
     const isFolderPath = (path: string) => {
-      const id = this.pathToIdMap.get(path);
+      const id = this.resolveIdForPath(path);
       return id != null && this.tree.get(id)?.children?.direct != null;
     };
     const compareByPath = (leftId: string, rightId: string) => {
-      const leftPath = this.idToPathMap.get(leftId) ?? leftId;
-      const rightPath = this.idToPathMap.get(rightId) ?? rightId;
+      const leftPath = this.getResolvedPathForId(leftId) ?? leftId;
+      const rightPath = this.getResolvedPathForId(rightId) ?? rightId;
       return comparator(leftPath, rightPath, isFolderPath);
     };
 
@@ -553,10 +573,142 @@ export class FileTreeModel {
     }
   }
 
+  private captureParentChildrenSnapshot(parentId: string): {
+    direct: string[];
+    flattened: string[] | null;
+  } {
+    const parentChildren = this.tree.get(parentId)?.children;
+    return {
+      direct: parentChildren?.direct.slice() ?? [],
+      flattened: parentChildren?.flattened?.slice() ?? null,
+    };
+  }
+
+  private didParentChildrenOrderChange(
+    parentId: string,
+    before: { direct: readonly string[]; flattened: readonly string[] | null }
+  ): boolean {
+    const afterChildren = this.tree.get(parentId)?.children;
+    const afterDirect = afterChildren?.direct ?? [];
+    const afterFlattened = afterChildren?.flattened ?? null;
+
+    if (!this.areIdArraysEqual(before.direct, afterDirect)) {
+      return true;
+    }
+
+    if (before.flattened == null || afterFlattened == null) {
+      return before.flattened !== afterFlattened;
+    }
+
+    return !this.areIdArraysEqual(before.flattened, afterFlattened);
+  }
+
+  private remapPathForward(path: string): string {
+    let remappedPath = path;
+
+    for (
+      let index = 0;
+      index < this.pendingPathPrefixRemaps.length;
+      index += 1
+    ) {
+      const rule = this.pendingPathPrefixRemaps[index];
+      const nextPath = remapPathWithPrefix(
+        remappedPath,
+        rule.sourcePath,
+        rule.destinationPath
+      );
+      if (nextPath != null) {
+        remappedPath = nextPath;
+      }
+    }
+
+    return remappedPath;
+  }
+
+  private remapPathBackward(path: string): string {
+    let canonicalPath = path;
+
+    for (
+      let index = this.pendingPathPrefixRemaps.length - 1;
+      index >= 0;
+      index -= 1
+    ) {
+      const rule = this.pendingPathPrefixRemaps[index];
+      const previousPath = remapPathWithPrefix(
+        canonicalPath,
+        rule.destinationPath,
+        rule.sourcePath
+      );
+      if (previousPath != null) {
+        canonicalPath = previousPath;
+      }
+    }
+
+    return canonicalPath;
+  }
+
+  private getResolvedPathForId(id: string): string | undefined {
+    const canonicalPath = this.idToPathMap.get(id);
+    if (canonicalPath == null) {
+      return undefined;
+    }
+
+    return this.remapPathForward(canonicalPath);
+  }
+
+  private resolveIdForPath(path: string): string | undefined {
+    const canonicalPath = this.remapPathBackward(path);
+    const id = this.pathToIdMap.get(canonicalPath);
+    if (id == null) {
+      return undefined;
+    }
+
+    const resolvedPath = this.remapPathForward(canonicalPath);
+    return resolvedPath === path ? id : undefined;
+  }
+
+  private *getCurrentPathKeys(): IterableIterator<string> {
+    for (const canonicalPath of this.pathToIdMap.keys()) {
+      yield this.remapPathForward(canonicalPath);
+    }
+  }
+
+  private queuePathPrefixRemap(
+    sourcePath: string,
+    destinationPath: string
+  ): void {
+    this.pendingPathPrefixRemaps.push({ sourcePath, destinationPath });
+  }
+
+  private materializePendingPathPrefixRemaps(): void {
+    if (this.pendingPathPrefixRemaps.length === 0) {
+      return;
+    }
+
+    const nextPathToId = new Map<string, string>();
+
+    for (const [canonicalPath, id] of this.pathToIdMap) {
+      const remappedPath = this.remapPathForward(canonicalPath);
+      nextPathToId.set(remappedPath, id);
+      this.idToPathMap.set(id, remappedPath);
+      const node = this.tree.get(id);
+      if (node != null) {
+        node.path = remappedPath;
+      }
+    }
+
+    this.pathToIdMap.clear();
+    for (const [path, id] of nextPathToId) {
+      this.pathToIdMap.set(path, id);
+    }
+
+    this.pendingPathPrefixRemaps.length = 0;
+  }
+
   private resolveAncestorId(path: string): string {
     let candidatePath = path;
     while (true) {
-      const candidateId = this.pathToIdMap.get(candidatePath);
+      const candidateId = this.resolveIdForPath(candidatePath);
       if (candidateId != null) {
         return candidateId;
       }
@@ -584,15 +736,104 @@ export class FileTreeModel {
   }
 
   private adoptPathTreeFilesReference(pathTree: MutablePathTree): void {
-    this.files = pathTree.getFilesReference();
+    this.pathTree = pathTree;
+    this.filesPendingPathTreeSync = true;
+    this.pendingFileSnapshotPrefixRemaps.length = 0;
+    this.pendingPathPrefixRemaps.length = 0;
+    this.fileIndexByPath.clear();
+  }
+
+  private syncFilesSnapshotFromPathTree(): void {
+    if (!this.filesPendingPathTreeSync || this.pathTree == null) {
+      return;
+    }
+
+    this.files = this.pathTree.getFilesReference();
+    this.filesPendingPathTreeSync = false;
+    this.pendingFileSnapshotPrefixRemaps.length = 0;
+    this.pendingPathPrefixRemaps.length = 0;
     this.fileIndexByPath.clear();
     this.setModelCounter('model.snapshot.fileCount', this.files.length);
   }
 
+  private getKnownFileCount(): number {
+    if (this.pathTree != null) {
+      return this.pathTree.getFileCount();
+    }
+
+    return this.files.length;
+  }
+
+  private getFileIndexFromSnapshot(path: string): number {
+    this.applyPendingFileSnapshotPrefixRemaps();
+
+    const knownIndex = this.fileIndexByPath.get(path);
+    if (knownIndex != null) {
+      return knownIndex;
+    }
+
+    this.rebuildFileIndexByPath(this.files);
+    return this.fileIndexByPath.get(path) ?? -1;
+  }
+
+  private queueFileSnapshotPrefixRemap(
+    sourcePath: string,
+    destinationPath: string
+  ): void {
+    this.pendingFileSnapshotPrefixRemaps.push({
+      sourcePath,
+      destinationPath,
+    });
+    this.fileIndexByPath.clear();
+  }
+
+  /**
+   * Applies deferred folder-prefix remaps to the dense files[] snapshot.
+   *
+   * This lets folder rename/move stay cheap on the hot path and only pays the
+   * O(fileCount) rewrite cost when a caller actually needs the full snapshot.
+   */
+  private applyPendingFileSnapshotPrefixRemaps(): void {
+    const remapRules = this.pendingFileSnapshotPrefixRemaps;
+    if (remapRules.length === 0) {
+      return;
+    }
+
+    for (let fileIndex = 0; fileIndex < this.files.length; fileIndex += 1) {
+      let currentPath = this.files[fileIndex];
+
+      for (let ruleIndex = 0; ruleIndex < remapRules.length; ruleIndex += 1) {
+        const rule = remapRules[ruleIndex];
+        const sourcePath = rule.sourcePath;
+        if (
+          currentPath !== sourcePath &&
+          !currentPath.startsWith(`${sourcePath}/`)
+        ) {
+          continue;
+        }
+
+        currentPath = `${rule.destinationPath}${currentPath.slice(sourcePath.length)}`;
+      }
+
+      this.files[fileIndex] = currentPath;
+    }
+
+    remapRules.length = 0;
+    this.rebuildFileIndexByPath(this.files);
+  }
+
   private getOrCreatePathTree(): MutablePathTree {
     if (this.pathTree == null) {
+      this.applyPendingFileSnapshotPrefixRemaps();
+      this.materializePendingPathPrefixRemaps();
       this.pathTree = MutablePathTree.fromFiles(this.files);
-      this.adoptPathTreeFilesReference(this.pathTree);
+      this.filesPendingPathTreeSync = false;
+      this.fileIndexByPath.clear();
+      this.pathTreeCreationCount += 1;
+      this.setModelCounter(
+        'model.pathTree.createdCount',
+        this.pathTreeCreationCount
+      );
     }
     return this.pathTree;
   }
@@ -1426,6 +1667,8 @@ export class FileTreeModel {
   }
 
   getFiles(): string[] {
+    this.syncFilesSnapshotFromPathTree();
+    this.applyPendingFileSnapshotPrefixRemaps();
     return this.files;
   }
 
@@ -1434,7 +1677,7 @@ export class FileTreeModel {
   }
 
   getPathForId(id: string): string | undefined {
-    return this.idToPathMap.get(id);
+    return this.getResolvedPathForId(id);
   }
 
   hasId(id: string): boolean {
@@ -1451,6 +1694,8 @@ export class FileTreeModel {
       return;
     }
     this.sortComparator = nextComparator;
+    this.syncFilesSnapshotFromPathTree();
+    this.applyPendingFileSnapshotPrefixRemaps();
     this.replaceAll(this.files);
   }
 
@@ -1479,7 +1724,7 @@ export class FileTreeModel {
     const targetPrefix =
       normalizedTarget === ROOT_ID ? '' : `${normalizedTarget}/`;
 
-    if (draggedPaths.length === 0 || this.files.length === 0) {
+    if (draggedPaths.length === 0 || this.getKnownFileCount() === 0) {
       return { ok: true, mutation: null };
     }
 
@@ -1936,7 +2181,12 @@ export class FileTreeModel {
       };
     }
 
-    const nodeId = this.pathToIdMap.get(normalizedSourcePath);
+    const canonicalSourcePath = this.remapPathBackward(normalizedSourcePath);
+    const canonicalDestinationPath = this.remapPathBackward(
+      normalizedDestinationPath
+    );
+
+    const nodeId = this.resolveIdForPath(normalizedSourcePath);
     if (nodeId == null) {
       return {
         ok: false,
@@ -1944,7 +2194,10 @@ export class FileTreeModel {
       };
     }
 
-    if (this.pathToIdMap.has(normalizedDestinationPath)) {
+    const existingDestinationId = this.resolveIdForPath(
+      normalizedDestinationPath
+    );
+    if (existingDestinationId != null && existingDestinationId !== nodeId) {
       return {
         ok: false,
         error: `"${normalizedDestinationPath}" already exists.`,
@@ -1968,12 +2221,13 @@ export class FileTreeModel {
     }
 
     const parentPath = getParentPath(normalizedSourcePath);
-    const parentId = this.pathToIdMap.get(parentPath) ?? ROOT_ID;
-    const existingPathTree = this.pathTree;
+    const parentId = this.resolveIdForPath(parentPath) ?? ROOT_ID;
+    const parentChildrenBeforeSort =
+      this.captureParentChildrenSnapshot(parentId);
 
     if (!nodeIsFolder) {
-      if (existingPathTree != null) {
-        const renameResult = existingPathTree.renamePath(
+      if (this.pathTree != null) {
+        const renameResult = this.pathTree.renamePath(
           normalizedSourcePath,
           normalizedDestinationPath,
           'file'
@@ -1996,27 +2250,34 @@ export class FileTreeModel {
             error: 'Could not rename the selected file.',
           };
         }
-      }
 
-      this.pathToIdMap.delete(normalizedSourcePath);
-      this.pathToIdMap.set(normalizedDestinationPath, nodeId);
-      this.idToPathMap.set(nodeId, normalizedDestinationPath);
+        this.adoptPathTreeFilesReference(this.pathTree);
+      } else {
+        const sourceIndex = this.getFileIndexFromSnapshot(normalizedSourcePath);
+        if (sourceIndex < 0) {
+          return {
+            ok: false,
+            error: 'Could not find the selected file to rename.',
+          };
+        }
 
-      node.path = normalizedDestinationPath;
-      node.name = getLeafName(normalizedDestinationPath);
-
-      const sourceIndex = this.fileIndexByPath.get(normalizedSourcePath);
-      if (sourceIndex != null) {
         this.files[sourceIndex] = normalizedDestinationPath;
         this.fileIndexByPath.delete(normalizedSourcePath);
         this.fileIndexByPath.set(normalizedDestinationPath, sourceIndex);
       }
 
-      if (existingPathTree != null) {
-        this.adoptPathTreeFilesReference(existingPathTree);
-      }
+      this.pathToIdMap.delete(canonicalSourcePath);
+      this.pathToIdMap.set(canonicalDestinationPath, nodeId);
+      this.idToPathMap.set(nodeId, canonicalDestinationPath);
+
+      node.path = canonicalDestinationPath;
+      node.name = getLeafName(normalizedDestinationPath);
 
       this.sortChildren(parentId);
+      const childrenOrderChanged = this.didParentChildrenOrderChange(
+        parentId,
+        parentChildrenBeforeSort
+      );
       this.setModelCounter('model.rename.file.remapScannedNodes', 1);
       this.setModelCounter('model.rename.file.remapUpdatedNodes', 1);
 
@@ -2027,6 +2288,43 @@ export class FileTreeModel {
         isFolder: false,
         parentId,
         nodeId,
+        childrenOrderChanged,
+      };
+      this.emitMutation(mutation);
+      return {
+        ok: true,
+        mutation: { ...mutation, version: this.version },
+      };
+    }
+
+    if (this.pathTree == null) {
+      this.queueFileSnapshotPrefixRemap(
+        normalizedSourcePath,
+        normalizedDestinationPath
+      );
+      this.queuePathPrefixRemap(
+        normalizedSourcePath,
+        normalizedDestinationPath
+      );
+
+      node.name = getLeafName(normalizedDestinationPath);
+
+      this.sortChildren(parentId);
+      const childrenOrderChanged = this.didParentChildrenOrderChange(
+        parentId,
+        parentChildrenBeforeSort
+      );
+      this.setModelCounter('model.rename.folder.remapScannedNodes', 1);
+      this.setModelCounter('model.rename.folder.remapUpdatedNodes', 1);
+
+      const mutation = {
+        kind: 'rename-path' as const,
+        sourcePath: normalizedSourcePath,
+        destinationPath: normalizedDestinationPath,
+        isFolder: true,
+        parentId,
+        nodeId,
+        childrenOrderChanged,
       };
       this.emitMutation(mutation);
       return {
@@ -2060,7 +2358,7 @@ export class FileTreeModel {
 
     const updatedPathSet = new Set(pathUpdates.map((entry) => entry.oldPath));
     for (const { id, newPath } of pathUpdates) {
-      const existingId = this.pathToIdMap.get(newPath);
+      const existingId = this.resolveIdForPath(newPath);
       if (
         existingId != null &&
         existingId !== id &&
@@ -2073,8 +2371,7 @@ export class FileTreeModel {
       }
     }
 
-    const pathTreeForFolder = this.getOrCreatePathTree();
-    const folderRenameResult = pathTreeForFolder.renamePath(
+    const folderRenameResult = this.pathTree.renamePath(
       normalizedSourcePath,
       normalizedDestinationPath,
       'folder'
@@ -2113,9 +2410,13 @@ export class FileTreeModel {
       }
     }
 
-    this.adoptPathTreeFilesReference(pathTreeForFolder);
+    this.adoptPathTreeFilesReference(this.pathTree);
 
     this.sortChildren(parentId);
+    const childrenOrderChanged = this.didParentChildrenOrderChange(
+      parentId,
+      parentChildrenBeforeSort
+    );
 
     const mutation = {
       kind: 'rename-path' as const,
@@ -2124,6 +2425,7 @@ export class FileTreeModel {
       isFolder: true,
       parentId,
       nodeId,
+      childrenOrderChanged,
     };
     this.emitMutation(mutation);
     return {

--- a/packages/trees/src/model/FileTreeModel.ts
+++ b/packages/trees/src/model/FileTreeModel.ts
@@ -1,0 +1,907 @@
+import { FLATTENED_PREFIX } from '../constants';
+import {
+  attachBenchmarkInstrumentation,
+  type BenchmarkInstrumentation,
+} from '../internal/benchmarkInstrumentation';
+import type { FileTreeNode } from '../types';
+import {
+  buildFileListSyncIndex,
+  type FileListSyncIndex,
+} from '../utils/fileListToTree';
+import { createMapPathToIdLookup } from '../utils/pathLookups';
+import {
+  type ChildrenSortOption,
+  defaultChildrenComparator,
+} from '../utils/sortChildren';
+
+const ROOT_ID = 'root';
+const FLATTENED_PREFIX_LENGTH = FLATTENED_PREFIX.length;
+
+function getParentPath(path: string): string {
+  const separatorIndex = path.lastIndexOf('/');
+  return separatorIndex < 0 ? ROOT_ID : path.slice(0, separatorIndex);
+}
+
+function getLeafName(path: string): string {
+  const separatorIndex = path.lastIndexOf('/');
+  return separatorIndex < 0 ? path : path.slice(separatorIndex + 1);
+}
+
+function remapPathWithPrefix(
+  path: string,
+  sourcePath: string,
+  destinationPath: string
+): string | null {
+  const isFlattened =
+    path.length >= FLATTENED_PREFIX_LENGTH &&
+    path.charCodeAt(0) === 102 &&
+    path.charCodeAt(1) === 58 &&
+    path.charCodeAt(2) === 58;
+  const rawPath = isFlattened ? path.slice(FLATTENED_PREFIX_LENGTH) : path;
+  if (rawPath !== sourcePath && !rawPath.startsWith(`${sourcePath}/`)) {
+    return null;
+  }
+
+  const remappedRawPath = `${destinationPath}${rawPath.slice(sourcePath.length)}`;
+  return isFlattened
+    ? `${FLATTENED_PREFIX}${remappedRawPath}`
+    : remappedRawPath;
+}
+
+function normalizeTreePath(path: string): string {
+  return path.startsWith(FLATTENED_PREFIX)
+    ? path.slice(FLATTENED_PREFIX_LENGTH)
+    : path;
+}
+
+function isPathDescendant(path: string, ancestor: string): boolean {
+  return path.startsWith(`${ancestor}/`);
+}
+
+function hasSelectedFolderAncestor(
+  path: string,
+  selectedFolders: Set<string>
+): boolean {
+  let slash = path.lastIndexOf('/');
+  while (slash !== -1) {
+    const parent = path.slice(0, slash);
+    if (selectedFolders.has(parent)) {
+      return true;
+    }
+    slash = parent.lastIndexOf('/');
+  }
+  return false;
+}
+
+function buildFolderSet(files: string[]): Set<string> {
+  const folders = new Set<string>();
+  for (const file of files) {
+    let slash = file.lastIndexOf('/');
+    while (slash !== -1) {
+      folders.add(file.slice(0, slash));
+      slash = file.lastIndexOf('/', slash - 1);
+    }
+  }
+  return folders;
+}
+
+function getSelectedFolderForFile(
+  file: string,
+  selectedFolders: Set<string>
+): string | undefined {
+  let slash = file.lastIndexOf('/');
+  while (slash !== -1) {
+    const folder = file.slice(0, slash);
+    if (selectedFolders.has(folder)) {
+      return folder;
+    }
+    slash = folder.lastIndexOf('/');
+  }
+  return undefined;
+}
+
+interface PlannedMoveRule {
+  sourcePath: string;
+  destinationPath: string;
+  isFolder: boolean;
+}
+
+function remapPathWithRules(
+  path: string,
+  rules: readonly PlannedMoveRule[]
+): string | null {
+  for (let index = 0; index < rules.length; index += 1) {
+    const rule = rules[index];
+    if (!rule.isFolder) {
+      if (path === rule.sourcePath) {
+        return rule.destinationPath;
+      }
+      if (path === `${FLATTENED_PREFIX}${rule.sourcePath}`) {
+        return `${FLATTENED_PREFIX}${rule.destinationPath}`;
+      }
+      continue;
+    }
+
+    const remapped = remapPathWithPrefix(
+      path,
+      rule.sourcePath,
+      rule.destinationPath
+    );
+    if (remapped != null) {
+      return remapped;
+    }
+  }
+
+  return null;
+}
+
+export interface FileTreeModelRenameRequest {
+  sourcePath: string;
+  destinationPath: string;
+  isFolder?: boolean;
+}
+
+export interface FileTreeModelMoveRequest {
+  draggedPaths: string[];
+  targetPath: string;
+  onCollision?: (collision: {
+    origin: string | null;
+    destination: string;
+  }) => boolean;
+}
+
+export type FileTreeModelMutation =
+  | {
+      kind: 'replace-all';
+      version: number;
+    }
+  | {
+      kind: 'rename-path';
+      sourcePath: string;
+      destinationPath: string;
+      isFolder: boolean;
+      parentId: string;
+      nodeId: string;
+      version: number;
+    }
+  | {
+      kind: 'move-paths';
+      movedPaths: ReadonlyArray<{
+        sourcePath: string;
+        destinationPath: string;
+        isFolder: boolean;
+      }>;
+      affectedParentIds: readonly string[];
+      version: number;
+    };
+
+export type FileTreeModelRenameResult =
+  | {
+      ok: true;
+      mutation: Extract<FileTreeModelMutation, { kind: 'rename-path' }> | null;
+    }
+  | { ok: false; error: string };
+
+export type FileTreeModelMoveResult =
+  | {
+      ok: true;
+      mutation: Extract<FileTreeModelMutation, { kind: 'move-paths' }> | null;
+    }
+  | { ok: false; error: string };
+
+export interface FileTreeModelOptions {
+  sortComparator?: ChildrenSortOption;
+  benchmarkInstrumentation?: BenchmarkInstrumentation | null;
+}
+
+interface BuiltStableIndex {
+  files: string[];
+  pathToIdMap: Map<string, string>;
+  idToPathMap: Map<string, string>;
+  tree: Map<string, FileTreeNode>;
+  nextNodeId: number;
+}
+
+function mapPathArrayToStableIds(
+  paths: string[],
+  pathToIdMap: Map<string, string>
+): string[] {
+  const mapped = new Array<string>(paths.length);
+  for (let index = 0; index < paths.length; index += 1) {
+    const stableId = pathToIdMap.get(paths[index]);
+    if (stableId == null) {
+      throw new Error(
+        `FileTreeModel: missing stable ID for path ${paths[index]}`
+      );
+    }
+    mapped[index] = stableId;
+  }
+  return mapped;
+}
+
+function buildStableIndexFromFiles(
+  files: string[],
+  sortComparator: ChildrenSortOption,
+  benchmarkInstrumentation: BenchmarkInstrumentation | null | undefined,
+  existingPathToIdMap: Map<string, string> | null,
+  startingNodeId: number
+): BuiltStableIndex {
+  const rawIndex = buildFileListSyncIndex(
+    files,
+    attachBenchmarkInstrumentation(
+      { sortComparator },
+      benchmarkInstrumentation ?? null
+    )
+  );
+  const rawTree = rawIndex.tree;
+
+  let nextNodeId = startingNodeId;
+  const usedIds = new Set<string>([ROOT_ID]);
+  const pathToIdMap = new Map<string, string>();
+
+  for (const path of rawTree.keys()) {
+    if (path === ROOT_ID) {
+      pathToIdMap.set(path, ROOT_ID);
+      continue;
+    }
+
+    const reusableId = existingPathToIdMap?.get(path);
+    if (
+      reusableId != null &&
+      reusableId !== ROOT_ID &&
+      !usedIds.has(reusableId)
+    ) {
+      pathToIdMap.set(path, reusableId);
+      usedIds.add(reusableId);
+      continue;
+    }
+
+    let allocatedId: string;
+    do {
+      allocatedId = `n_${nextNodeId}`;
+      nextNodeId += 1;
+    } while (usedIds.has(allocatedId));
+
+    pathToIdMap.set(path, allocatedId);
+    usedIds.add(allocatedId);
+  }
+
+  const idToPathMap = new Map<string, string>();
+  for (const [path, id] of pathToIdMap) {
+    idToPathMap.set(id, path);
+  }
+
+  const tree = new Map<string, FileTreeNode>();
+  for (const [path, node] of rawTree) {
+    const stableId = pathToIdMap.get(path);
+    if (stableId == null) {
+      throw new Error(`FileTreeModel: failed to allocate ID for ${path}`);
+    }
+
+    const directChildren = node.children?.direct;
+    const flattenedChildren = node.children?.flattened;
+    const flattens = node.flattens;
+
+    const stableNode: FileTreeNode = {
+      ...node,
+      ...(directChildren != null && {
+        children: {
+          direct: mapPathArrayToStableIds(directChildren, pathToIdMap),
+          ...(flattenedChildren != null && {
+            flattened: mapPathArrayToStableIds(flattenedChildren, pathToIdMap),
+          }),
+        },
+      }),
+      ...(flattens != null && {
+        flattens: mapPathArrayToStableIds(flattens, pathToIdMap),
+      }),
+    };
+
+    tree.set(stableId, stableNode);
+  }
+
+  return {
+    files: [...files],
+    pathToIdMap,
+    idToPathMap,
+    tree,
+    nextNodeId,
+  };
+}
+
+/**
+ * Mutable tree model with stable node IDs (decoupled from path strings).
+ * FileTree instances subscribe to model mutations and rebuild affected branches.
+ */
+export class FileTreeModel {
+  private readonly listeners = new Set<
+    (mutation: FileTreeModelMutation) => void
+  >();
+  private readonly pathToIdMap = new Map<string, string>();
+  private readonly idToPathMap = new Map<string, string>();
+  private readonly tree = new Map<string, FileTreeNode>();
+  private readonly pathToIdLookup = createMapPathToIdLookup(this.pathToIdMap);
+  private readonly syncIndex: FileListSyncIndex = {
+    pathToId: this.pathToIdLookup,
+    tree: this.tree,
+  };
+
+  private files: string[] = [];
+  private version = 0;
+  private nextNodeId = 1;
+  private sortComparator: ChildrenSortOption;
+
+  static fromFiles(
+    files: string[],
+    options: FileTreeModelOptions = {}
+  ): FileTreeModel {
+    return new FileTreeModel(files, options);
+  }
+
+  constructor(files: string[], options: FileTreeModelOptions = {}) {
+    this.sortComparator = options.sortComparator ?? defaultChildrenComparator;
+    const builtIndex = buildStableIndexFromFiles(
+      files,
+      this.sortComparator,
+      options.benchmarkInstrumentation,
+      null,
+      this.nextNodeId
+    );
+    this.applyBuiltIndex(builtIndex);
+  }
+
+  private applyBuiltIndex(builtIndex: BuiltStableIndex): void {
+    this.pathToIdMap.clear();
+    for (const [path, id] of builtIndex.pathToIdMap) {
+      this.pathToIdMap.set(path, id);
+    }
+
+    this.idToPathMap.clear();
+    for (const [id, path] of builtIndex.idToPathMap) {
+      this.idToPathMap.set(id, path);
+    }
+
+    this.tree.clear();
+    for (const [id, node] of builtIndex.tree) {
+      this.tree.set(id, node);
+    }
+
+    this.files = builtIndex.files;
+    this.nextNodeId = builtIndex.nextNodeId;
+  }
+
+  private emitMutation(mutation: Omit<FileTreeModelMutation, 'version'>): void {
+    this.version += 1;
+    const mutationWithVersion = {
+      ...mutation,
+      version: this.version,
+    } as FileTreeModelMutation;
+    for (const listener of this.listeners) {
+      listener(mutationWithVersion);
+    }
+  }
+
+  private sortChildren(parentId: string): void {
+    const parentNode = this.tree.get(parentId);
+    if (parentNode?.children == null || this.sortComparator === false) {
+      return;
+    }
+
+    const comparator = this.sortComparator ?? defaultChildrenComparator;
+    const isFolderPath = (path: string) => {
+      const id = this.pathToIdMap.get(path);
+      return id != null && this.tree.get(id)?.children?.direct != null;
+    };
+    const compareByPath = (leftId: string, rightId: string) => {
+      const leftPath = this.idToPathMap.get(leftId) ?? leftId;
+      const rightPath = this.idToPathMap.get(rightId) ?? rightId;
+      return comparator(leftPath, rightPath, isFolderPath);
+    };
+
+    parentNode.children.direct.sort(compareByPath);
+    if (parentNode.children.flattened != null) {
+      parentNode.children.flattened.sort(compareByPath);
+    }
+  }
+
+  subscribe(listener: (mutation: FileTreeModelMutation) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  getVersion(): number {
+    return this.version;
+  }
+
+  getFiles(): string[] {
+    return this.files;
+  }
+
+  getSyncIndex(): FileListSyncIndex {
+    return this.syncIndex;
+  }
+
+  getPathForId(id: string): string | undefined {
+    return this.idToPathMap.get(id);
+  }
+
+  setSortComparator(sortComparator: ChildrenSortOption | undefined): void {
+    const nextComparator = sortComparator ?? defaultChildrenComparator;
+    if (this.sortComparator === nextComparator) {
+      return;
+    }
+    this.sortComparator = nextComparator;
+    this.replaceAll(this.files);
+  }
+
+  replaceAll(files: string[]): void {
+    const builtIndex = buildStableIndexFromFiles(
+      files,
+      this.sortComparator,
+      null,
+      this.pathToIdMap,
+      this.nextNodeId
+    );
+    this.applyBuiltIndex(builtIndex);
+    this.emitMutation({ kind: 'replace-all' });
+  }
+
+  movePaths({
+    draggedPaths,
+    targetPath,
+    onCollision,
+  }: FileTreeModelMoveRequest): FileTreeModelMoveResult {
+    const normalizedTarget = normalizeTreePath(targetPath.trim());
+    if (normalizedTarget.length === 0) {
+      return { ok: false, error: 'Target path cannot be empty.' };
+    }
+
+    const targetPrefix =
+      normalizedTarget === ROOT_ID ? '' : `${normalizedTarget}/`;
+
+    const currentFiles = this.files;
+    if (draggedPaths.length === 0 || currentFiles.length === 0) {
+      return { ok: true, mutation: null };
+    }
+
+    const currentFileSet = new Set(currentFiles);
+    const folderSet = buildFolderSet(currentFiles);
+
+    const normalizedDragged = [...new Set(draggedPaths.map(normalizeTreePath))]
+      .map((path) => path.trim())
+      .filter((path) => path.length > 0);
+    if (normalizedDragged.length === 0) {
+      return { ok: true, mutation: null };
+    }
+
+    const orderedDragged = normalizedDragged
+      .map((path) => ({
+        path,
+        kind: folderSet.has(path) ? 'folder' : 'file',
+        depth: path.split('/').length,
+      }))
+      .sort((left, right) => left.depth - right.depth);
+
+    const selectedFolders = new Set<string>();
+    const selectedFiles = new Set<string>();
+    for (let index = 0; index < orderedDragged.length; index += 1) {
+      const item = orderedDragged[index];
+      if (hasSelectedFolderAncestor(item.path, selectedFolders)) {
+        continue;
+      }
+      if (item.kind === 'folder') {
+        selectedFolders.add(item.path);
+        continue;
+      }
+      if (currentFileSet.has(item.path)) {
+        selectedFiles.add(item.path);
+      }
+    }
+
+    const moveRules: PlannedMoveRule[] = [];
+    const folderDestinations = new Map<string, string>();
+    for (const selectedFolder of selectedFolders) {
+      if (
+        normalizedTarget === selectedFolder ||
+        isPathDescendant(normalizedTarget, selectedFolder)
+      ) {
+        continue;
+      }
+      const destinationPath = `${targetPrefix}${getLeafName(selectedFolder)}`;
+      if (destinationPath === selectedFolder) {
+        continue;
+      }
+      folderDestinations.set(selectedFolder, destinationPath);
+      moveRules.push({
+        sourcePath: selectedFolder,
+        destinationPath,
+        isFolder: true,
+      });
+    }
+
+    const proposedDestinationByOrigin = new Map<string, string>();
+    for (let index = 0; index < currentFiles.length; index += 1) {
+      const filePath = currentFiles[index];
+
+      if (selectedFiles.has(filePath)) {
+        const destinationPath = `${targetPrefix}${getLeafName(filePath)}`;
+        if (destinationPath !== filePath) {
+          proposedDestinationByOrigin.set(filePath, destinationPath);
+          moveRules.push({
+            sourcePath: filePath,
+            destinationPath,
+            isFolder: false,
+          });
+        }
+        continue;
+      }
+
+      const selectedFolder = getSelectedFolderForFile(
+        filePath,
+        selectedFolders
+      );
+      if (selectedFolder == null) {
+        continue;
+      }
+
+      if (
+        normalizedTarget === selectedFolder ||
+        isPathDescendant(normalizedTarget, selectedFolder)
+      ) {
+        continue;
+      }
+
+      const selectedFolderDestination = folderDestinations.get(selectedFolder);
+      if (selectedFolderDestination == null) {
+        continue;
+      }
+
+      const destinationPath = `${selectedFolderDestination}${filePath.slice(selectedFolder.length)}`;
+      if (destinationPath !== filePath) {
+        proposedDestinationByOrigin.set(filePath, destinationPath);
+      }
+    }
+
+    const finalPathByOrigin = new Map<string, string | null>();
+    const occupantByDestination = new Map<string, string>();
+    for (let index = 0; index < currentFiles.length; index += 1) {
+      const filePath = currentFiles[index];
+      finalPathByOrigin.set(filePath, filePath);
+      occupantByDestination.set(filePath, filePath);
+    }
+
+    for (let index = 0; index < currentFiles.length; index += 1) {
+      const originPath = currentFiles[index];
+      const destinationPath = proposedDestinationByOrigin.get(originPath);
+      if (destinationPath == null) {
+        continue;
+      }
+
+      const currentPath = finalPathByOrigin.get(originPath);
+      if (currentPath == null || currentPath === destinationPath) {
+        continue;
+      }
+
+      const existingOccupant = occupantByDestination.get(destinationPath);
+      if (existingOccupant != null && existingOccupant !== originPath) {
+        const allowOverwrite =
+          onCollision?.({
+            origin: originPath,
+            destination: destinationPath,
+          }) === true;
+        if (!allowOverwrite) {
+          continue;
+        }
+
+        const existingPath = finalPathByOrigin.get(existingOccupant);
+        if (existingPath != null) {
+          occupantByDestination.delete(existingPath);
+        }
+        finalPathByOrigin.set(existingOccupant, null);
+      }
+
+      occupantByDestination.delete(currentPath);
+      occupantByDestination.set(destinationPath, originPath);
+      finalPathByOrigin.set(originPath, destinationPath);
+    }
+
+    const nextFiles: string[] = [];
+    for (let index = 0; index < currentFiles.length; index += 1) {
+      const filePath = currentFiles[index];
+      const nextPath = finalPathByOrigin.get(filePath);
+      if (nextPath != null) {
+        nextFiles.push(nextPath);
+      }
+    }
+
+    if (
+      nextFiles.length === currentFiles.length &&
+      nextFiles.every((path, index) => path === currentFiles[index])
+    ) {
+      return { ok: true, mutation: null };
+    }
+
+    const movedFolderRuleBySource = new Map<string, PlannedMoveRule>();
+    for (let index = 0; index < moveRules.length; index += 1) {
+      const rule = moveRules[index];
+      if (rule?.isFolder) {
+        movedFolderRuleBySource.set(rule.sourcePath, rule);
+      }
+    }
+
+    const activeFolderSources = new Set<string>();
+    if (movedFolderRuleBySource.size > 0) {
+      for (const [originPath, nextPath] of finalPathByOrigin) {
+        if (nextPath == null) {
+          continue;
+        }
+
+        const selectedFolder = getSelectedFolderForFile(
+          originPath,
+          selectedFolders
+        );
+        if (selectedFolder == null) {
+          continue;
+        }
+
+        const folderRule = movedFolderRuleBySource.get(selectedFolder);
+        if (folderRule == null) {
+          continue;
+        }
+
+        if (
+          nextPath === folderRule.destinationPath ||
+          nextPath.startsWith(`${folderRule.destinationPath}/`)
+        ) {
+          activeFolderSources.add(selectedFolder);
+        }
+      }
+    }
+
+    const remapRules = moveRules
+      .filter((rule) => {
+        if (!rule.isFolder) {
+          return (
+            finalPathByOrigin.get(rule.sourcePath) === rule.destinationPath
+          );
+        }
+        return activeFolderSources.has(rule.sourcePath);
+      })
+      .sort((left, right) => right.sourcePath.length - left.sourcePath.length);
+
+    const remappedPathToId = new Map<string, string>();
+    for (const [path, id] of this.pathToIdMap) {
+      const remappedPath = remapPathWithRules(path, remapRules) ?? path;
+      remappedPathToId.set(remappedPath, id);
+    }
+
+    const builtIndex = buildStableIndexFromFiles(
+      nextFiles,
+      this.sortComparator,
+      null,
+      remappedPathToId,
+      this.nextNodeId
+    );
+    this.applyBuiltIndex(builtIndex);
+
+    const affectedParentIdsSet = new Set<string>();
+    const resolveAncestorId = (path: string): string => {
+      let candidatePath = path;
+      while (true) {
+        const candidateId = this.pathToIdMap.get(candidatePath);
+        if (candidateId != null) {
+          return candidateId;
+        }
+        if (candidatePath === ROOT_ID) {
+          return ROOT_ID;
+        }
+        candidatePath = getParentPath(candidatePath);
+      }
+    };
+
+    for (let index = 0; index < remapRules.length; index += 1) {
+      const rule = remapRules[index];
+      affectedParentIdsSet.add(
+        resolveAncestorId(getParentPath(rule.sourcePath))
+      );
+      affectedParentIdsSet.add(
+        resolveAncestorId(getParentPath(rule.destinationPath))
+      );
+    }
+
+    const movedPaths = remapRules.map((rule) => ({
+      sourcePath: rule.sourcePath,
+      destinationPath: rule.destinationPath,
+      isFolder: rule.isFolder,
+    }));
+
+    const mutation = {
+      kind: 'move-paths' as const,
+      movedPaths,
+      affectedParentIds: [...affectedParentIdsSet],
+    };
+    this.emitMutation(mutation);
+
+    return {
+      ok: true,
+      mutation: {
+        ...mutation,
+        version: this.version,
+      },
+    };
+  }
+
+  renamePath({
+    sourcePath,
+    destinationPath,
+    isFolder,
+  }: FileTreeModelRenameRequest): FileTreeModelRenameResult {
+    const normalizedSourcePath = sourcePath.trim();
+    const normalizedDestinationPath = destinationPath.trim();
+
+    if (
+      normalizedSourcePath.length === 0 ||
+      normalizedDestinationPath.length === 0
+    ) {
+      return { ok: false, error: 'Path cannot be empty.' };
+    }
+
+    if (normalizedSourcePath === normalizedDestinationPath) {
+      return { ok: true, mutation: null };
+    }
+
+    if (
+      getParentPath(normalizedSourcePath) !==
+      getParentPath(normalizedDestinationPath)
+    ) {
+      return {
+        ok: false,
+        error: 'renamePath currently supports same-parent renames only.',
+      };
+    }
+
+    const nodeId = this.pathToIdMap.get(normalizedSourcePath);
+    if (nodeId == null) {
+      return {
+        ok: false,
+        error: 'Could not find the selected path to rename.',
+      };
+    }
+
+    if (this.pathToIdMap.has(normalizedDestinationPath)) {
+      return {
+        ok: false,
+        error: `"${normalizedDestinationPath}" already exists.`,
+      };
+    }
+
+    const node = this.tree.get(nodeId);
+    if (node == null) {
+      return {
+        ok: false,
+        error: 'Could not find the selected path to rename.',
+      };
+    }
+
+    const nodeIsFolder = node.children?.direct != null;
+    if (isFolder != null && nodeIsFolder !== isFolder) {
+      return {
+        ok: false,
+        error: 'Rename target type does not match model data.',
+      };
+    }
+
+    const parentPath = getParentPath(normalizedSourcePath);
+    const parentId = this.pathToIdMap.get(parentPath) ?? ROOT_ID;
+
+    if (!nodeIsFolder) {
+      this.pathToIdMap.delete(normalizedSourcePath);
+      this.pathToIdMap.set(normalizedDestinationPath, nodeId);
+      this.idToPathMap.set(nodeId, normalizedDestinationPath);
+
+      node.path = normalizedDestinationPath;
+      node.name = getLeafName(normalizedDestinationPath);
+
+      const sourceIndex = this.files.indexOf(normalizedSourcePath);
+      if (sourceIndex >= 0) {
+        this.files[sourceIndex] = normalizedDestinationPath;
+      }
+
+      this.sortChildren(parentId);
+
+      const mutation = {
+        kind: 'rename-path' as const,
+        sourcePath: normalizedSourcePath,
+        destinationPath: normalizedDestinationPath,
+        isFolder: false,
+        parentId,
+        nodeId,
+      };
+      this.emitMutation(mutation);
+      return {
+        ok: true,
+        mutation: { ...mutation, version: this.version },
+      };
+    }
+
+    const pathUpdates: Array<{ id: string; oldPath: string; newPath: string }> =
+      [];
+    for (const [path, id] of this.pathToIdMap) {
+      const remappedPath = remapPathWithPrefix(
+        path,
+        normalizedSourcePath,
+        normalizedDestinationPath
+      );
+      if (remappedPath == null) {
+        continue;
+      }
+      pathUpdates.push({ id, oldPath: path, newPath: remappedPath });
+    }
+
+    if (pathUpdates.length === 0) {
+      return {
+        ok: false,
+        error: 'Could not find the selected folder to rename.',
+      };
+    }
+
+    const updatedPathSet = new Set(pathUpdates.map((entry) => entry.oldPath));
+    for (const { id, newPath } of pathUpdates) {
+      const existingId = this.pathToIdMap.get(newPath);
+      if (
+        existingId != null &&
+        existingId !== id &&
+        !updatedPathSet.has(newPath)
+      ) {
+        return {
+          ok: false,
+          error: `"${normalizedDestinationPath}" already exists.`,
+        };
+      }
+    }
+
+    for (const { oldPath } of pathUpdates) {
+      this.pathToIdMap.delete(oldPath);
+    }
+    for (const { id, newPath } of pathUpdates) {
+      this.pathToIdMap.set(newPath, id);
+      this.idToPathMap.set(id, newPath);
+      const item = this.tree.get(id);
+      if (item != null) {
+        item.path = newPath;
+        if (id === nodeId) {
+          item.name = getLeafName(newPath);
+        }
+      }
+    }
+
+    const sourcePrefix = `${normalizedSourcePath}/`;
+    const remappedFiles = new Array<string>(this.files.length);
+    for (let index = 0; index < this.files.length; index += 1) {
+      const filePath = this.files[index];
+      remappedFiles[index] =
+        filePath === normalizedSourcePath || filePath.startsWith(sourcePrefix)
+          ? `${normalizedDestinationPath}${filePath.slice(normalizedSourcePath.length)}`
+          : filePath;
+    }
+    this.files = remappedFiles;
+
+    this.sortChildren(parentId);
+
+    const mutation = {
+      kind: 'rename-path' as const,
+      sourcePath: normalizedSourcePath,
+      destinationPath: normalizedDestinationPath,
+      isFolder: true,
+      parentId,
+      nodeId,
+    };
+    this.emitMutation(mutation);
+    return {
+      ok: true,
+      mutation: { ...mutation, version: this.version },
+    };
+  }
+}

--- a/packages/trees/src/model/FileTreeModel.ts
+++ b/packages/trees/src/model/FileTreeModel.ts
@@ -8,7 +8,10 @@ import {
   buildFileListSyncIndex,
   type FileListSyncIndex,
 } from '../utils/fileListToTree';
-import { createMapPathToIdLookup } from '../utils/pathLookups';
+import {
+  createMapPathToIdLookup,
+  type IdToPathLookup,
+} from '../utils/pathLookups';
 import {
   type ChildrenSortOption,
   defaultChildrenComparator,
@@ -345,12 +348,17 @@ export class FileTreeModel {
   private readonly idToPathMap = new Map<string, string>();
   private readonly tree = new Map<string, FileTreeNode>();
   private readonly pathToIdLookup = createMapPathToIdLookup(this.pathToIdMap);
+  private readonly idToPathLookup: IdToPathLookup = {
+    get: (id: string) => this.idToPathMap.get(id),
+    has: (id: string) => this.idToPathMap.has(id),
+  };
   private readonly syncIndex: FileListSyncIndex = {
     pathToId: this.pathToIdLookup,
     tree: this.tree,
   };
 
   private files: string[] = [];
+  private readonly fileIndexByPath = new Map<string, number>();
   private version = 0;
   private nextNodeId = 1;
   private sortComparator: ChildrenSortOption;
@@ -391,6 +399,10 @@ export class FileTreeModel {
     }
 
     this.files = builtIndex.files;
+    this.fileIndexByPath.clear();
+    for (let index = 0; index < this.files.length; index += 1) {
+      this.fileIndexByPath.set(this.files[index], index);
+    }
     this.nextNodeId = builtIndex.nextNodeId;
   }
 
@@ -449,6 +461,14 @@ export class FileTreeModel {
 
   getPathForId(id: string): string | undefined {
     return this.idToPathMap.get(id);
+  }
+
+  hasId(id: string): boolean {
+    return this.idToPathMap.has(id);
+  }
+
+  getIdToPathLookup(): IdToPathLookup {
+    return this.idToPathLookup;
   }
 
   setSortComparator(sortComparator: ChildrenSortOption | undefined): void {
@@ -828,9 +848,11 @@ export class FileTreeModel {
       node.path = normalizedDestinationPath;
       node.name = getLeafName(normalizedDestinationPath);
 
-      const sourceIndex = this.files.indexOf(normalizedSourcePath);
-      if (sourceIndex >= 0) {
+      const sourceIndex = this.fileIndexByPath.get(normalizedSourcePath);
+      if (sourceIndex != null) {
         this.files[sourceIndex] = normalizedDestinationPath;
+        this.fileIndexByPath.delete(normalizedSourcePath);
+        this.fileIndexByPath.set(normalizedDestinationPath, sourceIndex);
       }
 
       this.sortChildren(parentId);
@@ -911,6 +933,10 @@ export class FileTreeModel {
           : filePath;
     }
     this.files = remappedFiles;
+    this.fileIndexByPath.clear();
+    for (let index = 0; index < remappedFiles.length; index += 1) {
+      this.fileIndexByPath.set(remappedFiles[index], index);
+    }
 
     this.sortChildren(parentId);
 

--- a/packages/trees/src/model/MODEL_ARCHITECTURE.md
+++ b/packages/trees/src/model/MODEL_ARCHITECTURE.md
@@ -1,0 +1,309 @@
+# File Tree Model Architecture (Mutation-First)
+
+This document describes the internal data-structure shape we converged on for
+large-tree mutation performance.
+
+The goal is to give a new agent enough detail to recreate the approach from
+scratch, even if APIs change.
+
+---
+
+## 1) Optimization target
+
+Primary target:
+
+- Keep **localized mutations** cheap (`rename`, `add`, `delete`, `move`) in very
+  large trees.
+
+Secondary target:
+
+- Keep root-structural edits (`move-root-folder`, `delete-root-folder`) stable
+  and incremental (no hangs, no fallback full rebuilds in normal paths).
+
+Non-goal during this phase:
+
+- Initial render speed (important, but explicitly deprioritized relative to
+  mutation latency).
+
+---
+
+## 2) Architectural shape (3 layers)
+
+We use three cooperating structures:
+
+1. **Canonical model graph (ID-first)**
+2. **Mutable path mutation engine (parent-pointer path tree)**
+3. **Incremental visible-order index (block index)**
+
+This separation is deliberate:
+
+- the model handles semantic correctness and stable identity,
+- the path tree handles path-native mutation mechanics cheaply,
+- the visible index handles UI-visible order/meta updates incrementally.
+
+---
+
+## 3) Canonical model graph (ID-first)
+
+Core stores:
+
+- `tree: Map<id, node>`
+- `pathToIdMap: Map<path, id>`
+- `idToPathMap: Map<id, path>`
+
+Typical node shape:
+
+```ts
+type Node = {
+  name: string;
+  path: string; // canonical path projection
+  children?: {
+    direct: string[]; // child IDs
+    flattened?: string[]; // child IDs in flatten projection
+  };
+  flattens?: string[]; // IDs of folders represented by a flattened node
+};
+```
+
+### Why this shape
+
+- Stable IDs decouple identity from path churn.
+- Path API remains user-facing while internals remain ID-first.
+- Enables local rewiring instead of global rebuilds for most edits.
+
+### Key design detail: deterministic bootstrap IDs
+
+Initial IDs are deterministic from path hash (`p_<hash>` + collision suffix) so
+SSR/hydration stays stable.
+
+---
+
+## 4) Path mutation engine: parent-pointer tree
+
+`MutablePathTree` is a mutable filesystem trie with parent pointers.
+
+### Node shape
+
+- Folder nodes: `children: Map<segment, node>`
+- File nodes:
+  - parent pointer + name
+  - linked-list pointers (`previous`, `next`)
+  - stable insertion token (`order`)
+
+### Why
+
+- Folder move/rename is pointer rewiring, not descendant path rewriting.
+- `files[]` snapshot can be rebuilt lazily from file linked list.
+- Preserves insertion order naturally without array-wide shifts.
+
+### Tradeoff
+
+- Path strings become derived state.
+- Requires careful invalidation/materialization boundaries.
+
+---
+
+## 5) Deferred path remap overlay
+
+Folder rename/move is often handled by queuing prefix remaps instead of eagerly
+rewriting every descendant path.
+
+Core mechanism:
+
+- `pendingPathPrefixRemaps: [{ sourcePath, destinationPath }]`
+- `id -> path`: apply remaps **forward**
+- `path -> id`: map path **backward** to canonical path, then verify round-trip
+
+Related snapshot optimization:
+
+- `pendingFileSnapshotPrefixRemaps` lets us defer expensive `files[]` rewrite
+  until snapshot access is requested.
+
+### Why
+
+- Keeps hot mutation path cheap for large subtree renames/moves.
+
+### Hard part
+
+- Correctness under overlapping remaps and mixed lookup directions.
+
+---
+
+## 6) Local folder rebuild strategy
+
+After mutation, we rebuild only affected folders (plus minimal propagated
+ancestors), not the full model.
+
+Key helper concept:
+
+- `rebuildFolderNodesFromPathTree(affectedFolderPaths)`
+
+What it does:
+
+- Reuses previous child arrays when still valid.
+- Recomputes direct children only when needed.
+- Rebuilds flatten projections only where necessary.
+- Tracks flattened node lifecycle via ref-count (`increment/decrement`).
+- Propagates parent rebuild only when child shape changes imply parent flatten
+  semantics may have changed.
+
+Auxiliary cache:
+
+- `directChildIndexByFolderId` avoids repeated linear scans for child index
+  lookups during patching.
+
+---
+
+## 7) Mutation protocol (changesets, not snapshots)
+
+Mutations emit semantic changesets:
+
+- `rename-path`
+- `move-paths`
+- `add-paths`
+- `delete-paths`
+
+Each includes `affectedParentIds` (or equivalent localized invalidation
+payload).
+
+Runtime/view layer consumes this and marks only those branches dirty.
+
+### Why
+
+- This is incremental view maintenance: mutate model once, update only impacted
+  view branches.
+
+### Tradeoff
+
+- If invalidation sets are incomplete, stale UI/meta bugs can occur.
+
+---
+
+## 8) Incremental visible-order index (UI side)
+
+The model is not the visible list.
+Visible order is maintained by an incremental index.
+
+Core pieces:
+
+- `nodes: Map<id, InternalTreeNode>` with parent/level/expanded metadata
+- `visibleMetaById: Map<id, { parentId, level, posInSet, setSize }>`
+- `visible: VisibleBlockIndex`
+
+`VisibleBlockIndex` stores IDs in chunks (block size ~128) and supports local
+insert/remove with per-ID location map.
+
+This is similar to an unrolled list / B+-tree leaf layer specialized for
+visible preorder mutation.
+
+### Critical implementation lesson
+
+For large inserts, avoid `splice(offset, 0, ...largeArray)`.
+Use block merge (`head + inserted + tail`) to avoid JS argument-stack limits.
+
+That single detail prevented stack overflows and full-rebuild fallback during
+large root-folder moves.
+
+---
+
+## 9) Root-specific fast path
+
+Root structural changes are common and expensive in huge fixtures.
+
+We use a root-child diff path to avoid always rebuilding the whole visible
+sequence:
+
+- detect changed middle segment via prefix/suffix match,
+- remove only affected root-visible subtrees,
+- insert only affected root-visible fragment,
+- repair root child visible metadata.
+
+Guardrails ensure we only remove nodes still attached as root children
+(`parentId === root` + `level === 0`).
+
+---
+
+## 10) Tensions and hard problems
+
+### A) ID-first internals vs path-first UX
+
+Users express mutations in paths; internals want stable IDs.
+Maintaining both with deferred remaps is inherently complex.
+
+### B) Flattening semantics
+
+Flattened folder nodes are synthetic and topology-dependent.
+Small local edits can cause broad flatten identity/projection churn.
+
+### C) Root structural operations
+
+Even with good structure, moving a huge expanded subtree is still expensive
+because visible preorder truly changes a lot.
+
+### D) Collision + batch move semantics
+
+Multi-source move planning must handle:
+
+- source/destination overlaps,
+- destination collisions,
+- nested folder selections,
+- deterministic ordering.
+
+### E) Lazy/deferred state complexity
+
+Deferral improves performance but multiplies invalidation edges:
+
+- remap chains,
+- snapshot materialization,
+- cache reuse boundaries.
+
+---
+
+## 11) How this maps to known structures
+
+We are effectively combining:
+
+- **Filesystem trie** (path segments) + parent-pointer rewiring
+- **Bi-map projection layer** (`path <-> id`) with deferred transforms
+- **Unrolled sequence blocks** for mutable visible order
+- **Incremental view maintenance** via explicit mutation changesets
+
+Differences from textbook forms:
+
+- flatten projection (`flattened`, `flattens`) is domain-specific,
+- path remap overlay is a practical optimization layer over the canonical graph,
+- root-visible branch diffing is specialized for UI-tree workloads.
+
+---
+
+## 12) Where theoretical gains remain
+
+1. **Order-statistic tree / rope / B+ tree** for visible sequence
+   - Better worst-case root-range splices.
+2. **Subtree visible counts / interval indexing**
+   - Faster subtree boundary calculations.
+3. **Prefix-remap compaction** (e.g. trie/transducer)
+   - Lower lookup cost under long remap chains.
+4. **Explicit mutation transactions**
+   - Batch invalidation/materialization once per logical action.
+5. **Stronger invariant checks in debug mode**
+   - Catch subtle stale-state bugs earlier.
+
+---
+
+## 13) Rebuild-from-scratch recipe
+
+If implementing a standalone model library with this shape:
+
+1. Build deterministic stable IDs and canonical `tree + path/id` maps.
+2. Add parent-pointer mutable path tree for mutation mechanics.
+3. Add deferred path-prefix remap overlay (forward/backward resolution).
+4. Implement local folder rebuild + flatten projection lifecycle/ref-count.
+5. Emit mutation changesets with affected parent IDs.
+6. Maintain a separate incremental visible-order structure (block index).
+7. Add root-specialized structural diff path.
+8. Add stress tests for root moves, flatten churn, collision handling, and
+   no-fallback incremental behavior.
+
+This gives the same mutation-first complexity profile we optimized for in this
+branch.

--- a/packages/trees/src/model/index.ts
+++ b/packages/trees/src/model/index.ts
@@ -1,0 +1,1 @@
+export * from './FileTreeModel';

--- a/packages/trees/src/react/FileTree.tsx
+++ b/packages/trees/src/react/FileTree.tsx
@@ -11,6 +11,8 @@ import {
   HEADER_SLOT_NAME,
 } from '../constants';
 import type {
+  FileTreeChangeContext,
+  FileTreeChangeSet,
   FileTreeOptions,
   FileTreeSelectionItem,
   GitStatusEntry,
@@ -82,7 +84,10 @@ export interface FileTreeProps {
    */
   containerId?: string;
 
-  onFilesChange?: (files: string[]) => void;
+  onFilesChange?: (
+    changeSet: FileTreeChangeSet,
+    context: FileTreeChangeContext
+  ) => void;
 
   // Default (uncontrolled) state
   initialExpandedItems?: string[];

--- a/packages/trees/src/react/FileTree.tsx
+++ b/packages/trees/src/react/FileTree.tsx
@@ -15,6 +15,7 @@ import type {
   FileTreeSelectionItem,
   GitStatusEntry,
 } from '../FileTree';
+import type { FileTreeModel } from '../model/FileTreeModel';
 import type { ContextMenuItem, ContextMenuOpenContext } from '../types';
 import { useFileTreeInstance } from './utils/useFileTreeInstance';
 
@@ -69,7 +70,8 @@ export function templateRender(
 }
 
 export interface FileTreeProps {
-  options: Omit<FileTreeOptions, 'initialFiles'>;
+  model: FileTreeModel;
+  options: Omit<FileTreeOptions, 'model'>;
   className?: string;
   style?: React.CSSProperties;
   prerenderedHTML?: string;
@@ -80,11 +82,6 @@ export interface FileTreeProps {
    */
   containerId?: string;
 
-  // Default (uncontrolled) files
-  initialFiles?: string[];
-
-  // Controlled files
-  files?: string[];
   onFilesChange?: (files: string[]) => void;
 
   // Default (uncontrolled) state
@@ -118,13 +115,12 @@ export interface FileTreeProps {
 }
 
 export function FileTree({
+  model,
   options,
   className,
   style,
   prerenderedHTML,
   containerId,
-  initialFiles,
-  files,
   onFilesChange,
   initialExpandedItems,
   initialSelectedItems,
@@ -180,9 +176,8 @@ export function FileTree({
     activeContextMenuContext
   );
   const { ref } = useFileTreeInstance({
+    model,
     options,
-    initialFiles,
-    files,
     onFilesChange,
     initialExpandedItems,
     initialSelectedItems,

--- a/packages/trees/src/react/FileTree.tsx
+++ b/packages/trees/src/react/FileTree.tsx
@@ -84,6 +84,11 @@ export interface FileTreeProps {
    */
   containerId?: string;
 
+  onModelChange?: (
+    changeSet: FileTreeChangeSet,
+    context: FileTreeChangeContext
+  ) => void;
+  /** @deprecated Use onModelChange instead. */
   onFilesChange?: (
     changeSet: FileTreeChangeSet,
     context: FileTreeChangeContext
@@ -126,6 +131,7 @@ export function FileTree({
   style,
   prerenderedHTML,
   containerId,
+  onModelChange,
   onFilesChange,
   initialExpandedItems,
   initialSelectedItems,
@@ -183,6 +189,7 @@ export function FileTree({
   const { ref } = useFileTreeInstance({
     model,
     options,
+    onModelChange,
     onFilesChange,
     initialExpandedItems,
     initialSelectedItems,

--- a/packages/trees/src/react/utils/useFileTreeInstance.ts
+++ b/packages/trees/src/react/utils/useFileTreeInstance.ts
@@ -2,24 +2,20 @@ import { useCallback, useEffect, useRef } from 'react';
 
 import {
   FileTree,
-  type FileTreeCallbacks,
   type FileTreeOptions,
   type FileTreeSelectionItem,
   type FileTreeStateConfig,
   type GitStatusEntry,
-  isRenamingEnabled,
 } from '../../FileTree';
+import type { FileTreeModel } from '../../model/FileTreeModel';
 import type { ContextMenuItem, ContextMenuOpenContext } from '../../types';
 import { getGitStatusSignature } from '../../utils/getGitStatusSignature';
 
 interface UseFileTreeInstanceProps {
-  options: Omit<FileTreeOptions, 'initialFiles'>;
+  model: FileTreeModel;
+  options: Omit<FileTreeOptions, 'model'>;
 
-  // Default (uncontrolled) files
-  initialFiles?: string[];
-
-  // Controlled files
-  files?: string[];
+  // State callbacks
   onFilesChange?: (files: string[]) => void;
 
   // Default (uncontrolled) state
@@ -50,9 +46,8 @@ interface UseFileTreeInstanceReturn {
 }
 
 export function useFileTreeInstance({
+  model,
   options,
-  initialFiles,
-  files,
   onFilesChange,
   initialExpandedItems,
   initialSelectedItems,
@@ -74,17 +69,17 @@ export function useFileTreeInstance({
   // them at creation time without including them as useMemo deps.
   const statePropsRef = useRef<
     FileTreeStateConfig & {
-      initialFiles?: string[];
       gitStatus?: GitStatusEntry[];
       onContextMenuOpen?: (
         item: ContextMenuItem,
         context: ContextMenuOpenContext
       ) => void;
       onContextMenuClose?: () => void;
+      model: FileTreeModel;
+      onFilesChange?: (files: string[]) => void;
     }
   >({
-    files,
-    initialFiles,
+    model,
     onFilesChange,
     expandedItems,
     selectedItems,
@@ -99,8 +94,7 @@ export function useFileTreeInstance({
     onContextMenuClose,
   });
   statePropsRef.current = {
-    files,
-    initialFiles,
+    model,
     onFilesChange,
     expandedItems,
     selectedItems,
@@ -115,14 +109,13 @@ export function useFileTreeInstance({
     onContextMenuClose,
   };
 
-  // Ref callback that handles mount/unmount and re-runs when options change.
-  // By including options in the dependency array, the callback identity changes
-  // when structural options change, causing React to call cleanup then re-invoke with the
-  // same DOM node - allowing us to detect and handle options changes.
-  //
   // React 19: Return cleanup function, called when ref changes or element unmounts.
   const ref = useCallback(
     (fileTreeContainer: HTMLElement | null) => {
+      // Model identity must remain a callback dependency so React can recreate
+      // the imperative instance when callers swap models.
+      void model;
+
       if (fileTreeContainer == null) {
         instanceRef.current?.cleanUp();
         instanceRef.current = null;
@@ -160,27 +153,19 @@ export function useFileTreeInstance({
 
       const createInstance = (existingId?: string): FileTree => {
         const sp = statePropsRef.current;
-        const optionsWithFiles = options as FileTreeOptions;
         syncedGitStatusSignatureRef.current = getGitStatusSignature(
           sp.gitStatus
         );
         return new FileTree(
           {
             ...options,
-            initialFiles:
-              sp.initialFiles ??
-              sp.files ??
-              optionsWithFiles.initialFiles ??
-              [],
+            model: sp.model,
             id: existingId,
             ...(sp.gitStatus != null && { gitStatus: sp.gitStatus }),
           },
           {
-            // Use controlled values as initial state, but do NOT pass them as
-            // controlled `expandedItems`/`selectedItems` — those bake into
-            // config.state in the Preact Root and override imperative updates.
-            // Subsequent controlled updates flow via the useEffect below calling
-            // setExpandedItems/setSelectedItems imperatively.
+            // Controlled values are seeded as initial state once, then synced
+            // imperatively by effects below.
             initialExpandedItems: sp.initialExpandedItems ?? sp.expandedItems,
             initialSelectedItems: sp.initialSelectedItems ?? sp.selectedItems,
             initialSearchQuery: sp.initialSearchQuery,
@@ -194,58 +179,29 @@ export function useFileTreeInstance({
         );
       };
 
-      const setupControlledDnD = (inst: FileTree): void => {
-        const sp = statePropsRef.current;
-        if (sp.files === undefined) return;
-        const controlledCallbacks: Partial<FileTreeCallbacks> = {
-          ...(options.dragAndDrop === true && {
-            _onDragMoveFiles: (newFiles: string[]) => {
-              sp.onFilesChange?.(newFiles);
-            },
-          }),
-          ...(isRenamingEnabled(options.renaming) && {
-            _onRenameFiles: (newFiles: string[]) => {
-              sp.onFilesChange?.(newFiles);
-            },
-          }),
-        };
-        if (Object.keys(controlledCallbacks).length > 0) {
-          inst.setCallbacks(controlledCallbacks);
-        }
-      };
-
       const existingFileTreeId = getExistingFileTreeId();
 
-      // Check if this is a re-run due to options change (same container, but new callback identity)
       const isOptionsChange =
         containerRef.current === fileTreeContainer &&
         instanceRef.current != null;
 
       if (isOptionsChange) {
-        // Options changed - clean up and re-create instance
         instanceRef.current?.cleanUp();
         clearExistingFileTree();
         instanceRef.current = createInstance(existingFileTreeId);
-        setupControlledDnD(instanceRef.current);
         void instanceRef.current.render({ fileTreeContainer });
       } else {
-        // Initial mount
         containerRef.current = fileTreeContainer;
 
-        // If markup already exists in the shadow root (typically via SSR
-        // declarative shadow DOM), hydrate it.
         const hasPrerenderedContent = existingFileTreeId != null;
 
         instanceRef.current = createInstance(existingFileTreeId);
-        setupControlledDnD(instanceRef.current);
 
         if (hasPrerenderedContent) {
-          // SSR: hydrate the prerendered HTML
           void instanceRef.current.hydrate({
             fileTreeContainer,
           });
         } else {
-          // CSR: render from scratch
           void instanceRef.current.render({ fileTreeContainer });
         }
       }
@@ -256,15 +212,8 @@ export function useFileTreeInstance({
         containerRef.current = null;
       };
     },
-    [options]
+    [model, options]
   );
-
-  // Sync controlled files imperatively (no tree recreation)
-  useEffect(() => {
-    if (files !== undefined && instanceRef.current != null) {
-      instanceRef.current.setFiles(files);
-    }
-  }, [files]);
 
   // Sync controlled expanded items imperatively (no tree recreation)
   useEffect(() => {
@@ -282,7 +231,6 @@ export function useFileTreeInstance({
 
   const gitStatusSignature = getGitStatusSignature(gitStatus);
 
-  // Sync controlled git status
   useEffect(() => {
     const instance = instanceRef.current;
     if (instance == null) return;
@@ -293,7 +241,6 @@ export function useFileTreeInstance({
     instance.setGitStatus(gitStatus);
   }, [gitStatus, gitStatusSignature]);
 
-  // Update callbacks without re-rendering Preact
   useEffect(() => {
     instanceRef.current?.setCallbacks({
       onExpandedItemsChange,
@@ -302,20 +249,6 @@ export function useFileTreeInstance({
       onFilesChange,
       onContextMenuOpen,
       onContextMenuClose,
-      // In controlled DnD mode, override to only fire onFilesChange
-      // without calling setFiles() directly, letting the parent decide.
-      ...(files !== undefined &&
-        options.dragAndDrop === true && {
-          _onDragMoveFiles: (newFiles) => {
-            onFilesChange?.(newFiles);
-          },
-        }),
-      ...(files !== undefined &&
-        isRenamingEnabled(options.renaming) && {
-          _onRenameFiles: (newFiles: string[]) => {
-            onFilesChange?.(newFiles);
-          },
-        }),
     });
   }, [
     onExpandedItemsChange,
@@ -324,9 +257,6 @@ export function useFileTreeInstance({
     onFilesChange,
     onContextMenuOpen,
     onContextMenuClose,
-    files,
-    options.dragAndDrop,
-    options.renaming,
   ]);
 
   return { ref };

--- a/packages/trees/src/react/utils/useFileTreeInstance.ts
+++ b/packages/trees/src/react/utils/useFileTreeInstance.ts
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useRef } from 'react';
 
 import {
   FileTree,
+  type FileTreeChangeContext,
+  type FileTreeChangeSet,
   type FileTreeOptions,
   type FileTreeSelectionItem,
   type FileTreeStateConfig,
@@ -16,7 +18,10 @@ interface UseFileTreeInstanceProps {
   options: Omit<FileTreeOptions, 'model'>;
 
   // State callbacks
-  onFilesChange?: (files: string[]) => void;
+  onFilesChange?: (
+    changeSet: FileTreeChangeSet,
+    context: FileTreeChangeContext
+  ) => void;
 
   // Default (uncontrolled) state
   initialExpandedItems?: string[];
@@ -76,7 +81,10 @@ export function useFileTreeInstance({
       ) => void;
       onContextMenuClose?: () => void;
       model: FileTreeModel;
-      onFilesChange?: (files: string[]) => void;
+      onFilesChange?: (
+        changeSet: FileTreeChangeSet,
+        context: FileTreeChangeContext
+      ) => void;
     }
   >({
     model,

--- a/packages/trees/src/react/utils/useFileTreeInstance.ts
+++ b/packages/trees/src/react/utils/useFileTreeInstance.ts
@@ -18,6 +18,10 @@ interface UseFileTreeInstanceProps {
   options: Omit<FileTreeOptions, 'model'>;
 
   // State callbacks
+  onModelChange?: (
+    changeSet: FileTreeChangeSet,
+    context: FileTreeChangeContext
+  ) => void;
   onFilesChange?: (
     changeSet: FileTreeChangeSet,
     context: FileTreeChangeContext
@@ -53,6 +57,7 @@ interface UseFileTreeInstanceReturn {
 export function useFileTreeInstance({
   model,
   options,
+  onModelChange,
   onFilesChange,
   initialExpandedItems,
   initialSelectedItems,
@@ -81,6 +86,10 @@ export function useFileTreeInstance({
       ) => void;
       onContextMenuClose?: () => void;
       model: FileTreeModel;
+      onModelChange?: (
+        changeSet: FileTreeChangeSet,
+        context: FileTreeChangeContext
+      ) => void;
       onFilesChange?: (
         changeSet: FileTreeChangeSet,
         context: FileTreeChangeContext
@@ -88,6 +97,7 @@ export function useFileTreeInstance({
     }
   >({
     model,
+    onModelChange,
     onFilesChange,
     expandedItems,
     selectedItems,
@@ -103,6 +113,7 @@ export function useFileTreeInstance({
   });
   statePropsRef.current = {
     model,
+    onModelChange,
     onFilesChange,
     expandedItems,
     selectedItems,
@@ -180,6 +191,7 @@ export function useFileTreeInstance({
             onExpandedItemsChange: sp.onExpandedItemsChange,
             onSelectedItemsChange: sp.onSelectedItemsChange,
             onSelection: sp.onSelection,
+            onModelChange: sp.onModelChange,
             onFilesChange: sp.onFilesChange,
             onContextMenuOpen: sp.onContextMenuOpen,
             onContextMenuClose: sp.onContextMenuClose,
@@ -254,6 +266,7 @@ export function useFileTreeInstance({
       onExpandedItemsChange,
       onSelectedItemsChange,
       onSelection,
+      onModelChange,
       onFilesChange,
       onContextMenuOpen,
       onContextMenuClose,
@@ -262,6 +275,7 @@ export function useFileTreeInstance({
     onExpandedItemsChange,
     onSelectedItemsChange,
     onSelection,
+    onModelChange,
     onFilesChange,
     onContextMenuOpen,
     onContextMenuClose,

--- a/packages/trees/src/utils/computeNewFilesAfterDrop.ts
+++ b/packages/trees/src/utils/computeNewFilesAfterDrop.ts
@@ -1,4 +1,5 @@
 import { FLATTENED_PREFIX } from '../constants';
+import { MutablePathTree } from './mutablePathTree';
 
 export interface DropCollision {
   origin: string | null;
@@ -7,6 +8,10 @@ export interface DropCollision {
 
 export interface ComputeDropOptions {
   onCollision?: (collision: DropCollision) => boolean;
+  /** Optional persistent path tree to reuse across drag operations. */
+  pathTree?: MutablePathTree;
+  /** Mutate the provided path tree in place when true. */
+  mutatePathTree?: boolean;
 }
 
 const normalizePath = (path: string): string =>
@@ -21,6 +26,16 @@ const getBasename = (path: string): string => {
 
 const isDescendantOf = (path: string, ancestor: string): boolean =>
   path.startsWith(`${ancestor}/`);
+
+const getPathDepth = (path: string): number => {
+  let depth = 1;
+  for (let index = 0; index < path.length; index += 1) {
+    if (path.charCodeAt(index) === 47) {
+      depth += 1;
+    }
+  }
+  return depth;
+};
 
 const hasSelectedFolderAncestor = (
   path: string,
@@ -37,41 +52,59 @@ const hasSelectedFolderAncestor = (
   return false;
 };
 
-const buildFolderSet = (files: string[]): Set<string> => {
-  const folders = new Set<string>();
-  for (const file of files) {
-    let slash = file.lastIndexOf('/');
-    while (slash !== -1) {
-      folders.add(file.slice(0, slash));
-      slash = file.lastIndexOf('/', slash - 1);
-    }
+const splitPath = (path: string): { parentPath: string; baseName: string } => {
+  const separatorIndex = path.lastIndexOf('/');
+  if (separatorIndex < 0) {
+    return { parentPath: '', baseName: path };
   }
-  return folders;
-};
-
-const getSelectedFolderForFile = (
-  file: string,
-  selectedFolders: Set<string>
-): string | undefined => {
-  let slash = file.lastIndexOf('/');
-  while (slash !== -1) {
-    const folder = file.slice(0, slash);
-    if (selectedFolders.has(folder)) {
-      return folder;
-    }
-    slash = folder.lastIndexOf('/');
-  }
-  return undefined;
+  return {
+    parentPath: path.slice(0, separatorIndex),
+    baseName: path.slice(separatorIndex + 1),
+  };
 };
 
 /**
- * Computes the new file list after dragging items to a target folder.
- *
- * @param currentFiles - The current flat list of file paths
- * @param draggedPaths - Paths being dragged (may include `f::` prefix)
- * @param targetFolderPath - Destination folder path, or `'root'` for top level
- * @param options - Optional move behavior, including collision handling
- * @returns A new file list with the dragged items moved
+ * Applies an origin->destination map into a mutable path tree. Returns false
+ * if a path inconsistency is detected.
+ */
+function applyMappedFilesToPathTree(
+  pathTree: MutablePathTree,
+  currentFiles: string[],
+  finalPathByOrigin: Map<string, string | null>
+): boolean {
+  for (let index = 0; index < currentFiles.length; index += 1) {
+    const origin = currentFiles[index];
+    if (finalPathByOrigin.get(origin) != null) {
+      continue;
+    }
+    pathTree.deleteFilePath(origin);
+  }
+
+  for (let index = 0; index < currentFiles.length; index += 1) {
+    const origin = currentFiles[index];
+    const destination = finalPathByOrigin.get(origin);
+    if (destination == null || destination === origin) {
+      continue;
+    }
+
+    const { parentPath, baseName } = splitPath(destination);
+    const moveResult = pathTree.movePath(
+      origin,
+      parentPath === '' ? 'root' : parentPath,
+      baseName,
+      'file'
+    );
+
+    if (moveResult !== 'ok') {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Computes the next flat file list for a drag-and-drop move.
  */
 export function computeNewFilesAfterDrop(
   currentFiles: string[],
@@ -83,69 +116,73 @@ export function computeNewFilesAfterDrop(
   const targetPrefix =
     normalizedTarget === 'root' ? '' : `${normalizedTarget}/`;
 
-  const currentFileSet = new Set(currentFiles);
-  const folderSet = buildFolderSet(currentFiles);
+  const pathTree = options.pathTree ?? MutablePathTree.fromFiles(currentFiles);
 
   const normalizedDragged = [...new Set(draggedPaths.map(normalizePath))];
   const orderedDragged = normalizedDragged
-    .map((path) => ({
-      path,
-      kind: folderSet.has(path) ? 'folder' : 'file',
-      depth: path.split('/').length,
-    }))
-    .sort((a, b) => a.depth - b.depth);
+    .filter((path) => pathTree.hasPath(path))
+    .sort((left, right) => getPathDepth(left) - getPathDepth(right));
 
   const selectedFolders = new Set<string>();
-  const selectedFiles = new Set<string>();
-  for (const item of orderedDragged) {
-    if (hasSelectedFolderAncestor(item.path, selectedFolders)) {
+  const selectedFiles: string[] = [];
+
+  for (let index = 0; index < orderedDragged.length; index += 1) {
+    const path = orderedDragged[index];
+    if (hasSelectedFolderAncestor(path, selectedFolders)) {
       continue;
     }
-    if (item.kind === 'folder') {
-      selectedFolders.add(item.path);
+
+    if (pathTree.hasFolder(path)) {
+      selectedFolders.add(path);
       continue;
     }
-    if (currentFileSet.has(item.path)) {
-      selectedFiles.add(item.path);
+
+    if (pathTree.hasFile(path)) {
+      selectedFiles.push(path);
     }
   }
 
   const proposedDestinationByOrigin = new Map<string, string>();
-  for (const file of currentFiles) {
-    if (selectedFiles.has(file)) {
-      const destination = `${targetPrefix}${getBasename(file)}`;
-      if (destination !== file) {
-        proposedDestinationByOrigin.set(file, destination);
-      }
-      continue;
-    }
 
-    const selectedFolder = getSelectedFolderForFile(file, selectedFolders);
-    if (selectedFolder == null) {
-      continue;
+  for (let index = 0; index < selectedFiles.length; index += 1) {
+    const filePath = selectedFiles[index];
+    const destination = `${targetPrefix}${getBasename(filePath)}`;
+    if (destination !== filePath) {
+      proposedDestinationByOrigin.set(filePath, destination);
     }
+  }
 
+  for (const folderPath of selectedFolders) {
     if (
-      normalizedTarget === selectedFolder ||
-      isDescendantOf(normalizedTarget, selectedFolder)
+      normalizedTarget === folderPath ||
+      isDescendantOf(normalizedTarget, folderPath)
     ) {
       continue;
     }
 
-    const destination = `${targetPrefix}${getBasename(selectedFolder)}${file.slice(selectedFolder.length)}`;
-    if (destination !== file) {
-      proposedDestinationByOrigin.set(file, destination);
+    const movedFolderName = getBasename(folderPath);
+    const descendantFiles = pathTree.getDescendantFilePaths(folderPath);
+
+    for (let index = 0; index < descendantFiles.length; index += 1) {
+      const origin = descendantFiles[index];
+      const destination = `${targetPrefix}${movedFolderName}${origin.slice(folderPath.length)}`;
+      if (destination !== origin) {
+        proposedDestinationByOrigin.set(origin, destination);
+      }
     }
   }
 
   const finalPathByOrigin = new Map<string, string | null>();
   const occupantByDestination = new Map<string, string>();
-  for (const file of currentFiles) {
+
+  for (let index = 0; index < currentFiles.length; index += 1) {
+    const file = currentFiles[index];
     finalPathByOrigin.set(file, file);
     occupantByDestination.set(file, file);
   }
 
-  for (const origin of currentFiles) {
+  for (let index = 0; index < currentFiles.length; index += 1) {
+    const origin = currentFiles[index];
     const destination = proposedDestinationByOrigin.get(origin);
     if (destination == null) {
       continue;
@@ -177,10 +214,22 @@ export function computeNewFilesAfterDrop(
   }
 
   const result: string[] = [];
-  for (const file of currentFiles) {
+  for (let index = 0; index < currentFiles.length; index += 1) {
+    const file = currentFiles[index];
     const next = finalPathByOrigin.get(file);
     if (next != null) {
       result.push(next);
+    }
+  }
+
+  if (options.mutatePathTree === true && options.pathTree != null) {
+    const applied = applyMappedFilesToPathTree(
+      options.pathTree,
+      currentFiles,
+      finalPathByOrigin
+    );
+    if (!applied) {
+      options.pathTree.replaceAll(result);
     }
   }
 

--- a/packages/trees/src/utils/fileListToTree.ts
+++ b/packages/trees/src/utils/fileListToTree.ts
@@ -9,6 +9,7 @@ import type { FileTreeNode } from '../types';
 import { createLoaderUtils, type LoaderUtils } from './createLoaderUtils';
 import {
   createIdentityPathToIdLookup,
+  type IdToPathLookup,
   type PathToIdLookup,
 } from './pathLookups';
 import type { ChildrenSortOption } from './sortChildren';
@@ -41,6 +42,7 @@ export interface FileListToTreeBuildContext {
 export interface FileListSyncIndex {
   pathToId: PathToIdLookup;
   tree: Map<string, FileTreeNode>;
+  idToPath?: IdToPathLookup;
 }
 
 interface FileListToTreeBuildContextOptions {

--- a/packages/trees/src/utils/mutablePathTree.ts
+++ b/packages/trees/src/utils/mutablePathTree.ts
@@ -58,16 +58,22 @@ export class MutablePathTree {
   private readonly pathToNode = new Map<string, MutablePathTreeNode>();
   private readonly fileIndexByPath = new Map<string, number>();
   private files: string[] = [];
+  private firstDirtyFileIndex: number | null = null;
 
   replaceAll(files: string[]): void {
     this.root.children.clear();
     this.pathToNode.clear();
     this.fileIndexByPath.clear();
-    this.files = [];
+    this.files.length = 0;
+    this.firstDirtyFileIndex = null;
 
     for (let index = 0; index < files.length; index += 1) {
       this.addFilePath(files[index]);
     }
+  }
+
+  getFilesReference(): string[] {
+    return this.files;
   }
 
   cloneFiles(): string[] {
@@ -84,6 +90,11 @@ export class MutablePathTree {
 
   hasFolder(path: string): boolean {
     return this.getFolder(path) != null;
+  }
+
+  getFileIndex(path: string): number | undefined {
+    this.ensureFileIndexesUpToDate();
+    return this.fileIndexByPath.get(path);
   }
 
   addFilePath(path: string): boolean {
@@ -118,13 +129,64 @@ export class MutablePathTree {
   }
 
   deleteFilePath(path: string): boolean {
+    this.ensureFileIndexesUpToDate();
+
     const node = this.getFile(path);
     if (node == null) {
       return false;
     }
 
-    this.removeFileNode(node);
+    this.removeFileNode(node, false);
     return true;
+  }
+
+  deleteFilePaths(paths: readonly string[]): string[] {
+    if (paths.length === 0) {
+      return [];
+    }
+
+    this.ensureFileIndexesUpToDate();
+
+    const nodesToDelete: MutablePathTreeFileNode[] = [];
+    const seenPaths = new Set<string>();
+    for (let index = 0; index < paths.length; index += 1) {
+      const path = paths[index];
+      if (seenPaths.has(path)) {
+        continue;
+      }
+      seenPaths.add(path);
+
+      const node = this.getFile(path);
+      if (node != null) {
+        nodesToDelete.push(node);
+      }
+    }
+
+    if (nodesToDelete.length === 0) {
+      return [];
+    }
+
+    nodesToDelete.sort((left, right) => right.index - left.index);
+
+    const deletedPathSet = new Set(nodesToDelete.map((node) => node.path));
+    for (let index = 0; index < nodesToDelete.length; index += 1) {
+      this.removeFileNode(nodesToDelete[index], false);
+    }
+
+    this.ensureFileIndexesUpToDate();
+
+    const deletedPaths: string[] = [];
+    const emitted = new Set<string>();
+    for (let index = 0; index < paths.length; index += 1) {
+      const path = paths[index];
+      if (!deletedPathSet.has(path) || emitted.has(path)) {
+        continue;
+      }
+      emitted.add(path);
+      deletedPaths.push(path);
+    }
+
+    return deletedPaths;
   }
 
   deleteFolderPath(path: string): boolean {
@@ -132,6 +194,8 @@ export class MutablePathTree {
     if (folder == null) {
       return false;
     }
+
+    this.ensureFileIndexesUpToDate();
 
     const descendants = this.getDescendantFileNodes(folder);
     if (descendants.length === 0) {
@@ -152,6 +216,8 @@ export class MutablePathTree {
     destinationPath: string,
     kind: 'file' | 'folder'
   ): MutablePathTreeMoveResult {
+    this.ensureFileIndexesUpToDate();
+
     const node =
       kind === 'file' ? this.getFile(sourcePath) : this.getFolder(sourcePath);
 
@@ -182,6 +248,8 @@ export class MutablePathTree {
     nextBaseName: string,
     kind: 'file' | 'folder'
   ): MutablePathTreeMoveResult {
+    this.ensureFileIndexesUpToDate();
+
     const node =
       kind === 'file' ? this.getFile(sourcePath) : this.getFolder(sourcePath);
 
@@ -214,9 +282,18 @@ export class MutablePathTree {
       return [];
     }
 
+    this.ensureFileIndexesUpToDate();
+
     const descendants = this.getDescendantFileNodes(folder);
     descendants.sort((left, right) => left.index - right.index);
     return descendants.map((node) => node.path);
+  }
+
+  getDirectChildCount(folderPath: string): number {
+    const normalizedPath = folderPath === 'root' ? '' : folderPath;
+    const folder =
+      normalizedPath === '' ? this.root : this.getFolder(normalizedPath);
+    return folder?.children.size ?? 0;
   }
 
   /**
@@ -293,6 +370,25 @@ export class MutablePathTree {
     }
 
     return current;
+  }
+
+  private markFileIndexesDirty(startIndex: number): void {
+    if (
+      this.firstDirtyFileIndex == null ||
+      startIndex < this.firstDirtyFileIndex
+    ) {
+      this.firstDirtyFileIndex = startIndex;
+    }
+  }
+
+  private ensureFileIndexesUpToDate(): void {
+    const dirtyStart = this.firstDirtyFileIndex;
+    if (dirtyStart == null) {
+      return;
+    }
+
+    this.reindexFiles(dirtyStart);
+    this.firstDirtyFileIndex = null;
   }
 
   /**
@@ -405,7 +501,14 @@ export class MutablePathTree {
     this.files.splice(node.index, 1);
 
     if (reindexImmediately) {
-      this.reindexFiles(node.index);
+      const reindexStart = Math.min(
+        node.index,
+        this.firstDirtyFileIndex ?? node.index
+      );
+      this.reindexFiles(reindexStart);
+      this.firstDirtyFileIndex = null;
+    } else {
+      this.markFileIndexesDirty(node.index);
     }
 
     this.pruneEmptyFolders(node.parent);

--- a/packages/trees/src/utils/mutablePathTree.ts
+++ b/packages/trees/src/utils/mutablePathTree.ts
@@ -16,7 +16,13 @@ interface MutablePathTreeFolderNode extends MutablePathTreeBaseNode {
 
 interface MutablePathTreeFileNode extends MutablePathTreeBaseNode {
   kind: 'file';
-  index: number;
+  /**
+   * Stable insertion order token used for relative ordering operations.
+   * We never compact this, so deletes do not force index shifts.
+   */
+  order: number;
+  previous: MutablePathTreeFileNode | null;
+  next: MutablePathTreeFileNode | null;
 }
 
 function splitPath(path: string): { parentPath: string; baseName: string } {
@@ -56,16 +62,22 @@ export class MutablePathTree {
   };
 
   private readonly pathToNode = new Map<string, MutablePathTreeNode>();
-  private readonly fileIndexByPath = new Map<string, number>();
-  private files: string[] = [];
-  private firstDirtyFileIndex: number | null = null;
+  private headFile: MutablePathTreeFileNode | null = null;
+  private tailFile: MutablePathTreeFileNode | null = null;
+  private fileCount = 0;
+  private nextFileOrder = 0;
+  private readonly filesSnapshot: string[] = [];
+  private filesSnapshotDirty = true;
 
   replaceAll(files: string[]): void {
     this.root.children.clear();
     this.pathToNode.clear();
-    this.fileIndexByPath.clear();
-    this.files.length = 0;
-    this.firstDirtyFileIndex = null;
+    this.headFile = null;
+    this.tailFile = null;
+    this.fileCount = 0;
+    this.nextFileOrder = 0;
+    this.filesSnapshot.length = 0;
+    this.filesSnapshotDirty = true;
 
     for (let index = 0; index < files.length; index += 1) {
       this.addFilePath(files[index]);
@@ -73,11 +85,16 @@ export class MutablePathTree {
   }
 
   getFilesReference(): string[] {
-    return this.files;
+    this.ensureFilesSnapshot();
+    return this.filesSnapshot;
   }
 
   cloneFiles(): string[] {
-    return this.files.slice();
+    return this.getFilesReference().slice();
+  }
+
+  getFileCount(): number {
+    return this.fileCount;
   }
 
   hasPath(path: string): boolean {
@@ -93,12 +110,11 @@ export class MutablePathTree {
   }
 
   getFileIndex(path: string): number | undefined {
-    this.ensureFileIndexesUpToDate();
-    return this.fileIndexByPath.get(path);
+    return this.getFile(path)?.order;
   }
 
   addFilePath(path: string): boolean {
-    if (path.length === 0 || this.fileIndexByPath.has(path)) {
+    if (path.length === 0) {
       return false;
     }
 
@@ -112,31 +128,39 @@ export class MutablePathTree {
       return false;
     }
 
-    const index = this.files.length;
     const node: MutablePathTreeFileNode = {
       kind: 'file',
       name: baseName,
       path,
       parent,
-      index,
+      order: this.nextFileOrder,
+      previous: this.tailFile,
+      next: null,
     };
+    this.nextFileOrder += 1;
 
     parent.children.set(baseName, node);
     this.pathToNode.set(path, node);
-    this.files.push(path);
-    this.fileIndexByPath.set(path, index);
+
+    if (this.tailFile == null) {
+      this.headFile = node;
+    } else {
+      this.tailFile.next = node;
+    }
+    this.tailFile = node;
+
+    this.fileCount += 1;
+    this.filesSnapshotDirty = true;
     return true;
   }
 
   deleteFilePath(path: string): boolean {
-    this.ensureFileIndexesUpToDate();
-
     const node = this.getFile(path);
     if (node == null) {
       return false;
     }
 
-    this.removeFileNode(node, false);
+    this.removeFileNode(node);
     return true;
   }
 
@@ -144,8 +168,6 @@ export class MutablePathTree {
     if (paths.length === 0) {
       return [];
     }
-
-    this.ensureFileIndexesUpToDate();
 
     const nodesToDelete: MutablePathTreeFileNode[] = [];
     const seenPaths = new Set<string>();
@@ -166,14 +188,10 @@ export class MutablePathTree {
       return [];
     }
 
-    nodesToDelete.sort((left, right) => right.index - left.index);
-
     const deletedPathSet = new Set(nodesToDelete.map((node) => node.path));
     for (let index = 0; index < nodesToDelete.length; index += 1) {
-      this.removeFileNode(nodesToDelete[index], false);
+      this.removeFileNode(nodesToDelete[index]);
     }
-
-    this.ensureFileIndexesUpToDate();
 
     const deletedPaths: string[] = [];
     const emitted = new Set<string>();
@@ -195,19 +213,15 @@ export class MutablePathTree {
       return false;
     }
 
-    this.ensureFileIndexesUpToDate();
-
     const descendants = this.getDescendantFileNodes(folder);
     if (descendants.length === 0) {
       return false;
     }
 
-    descendants.sort((left, right) => right.index - left.index);
     for (let index = 0; index < descendants.length; index += 1) {
-      this.removeFileNode(descendants[index], false);
+      this.removeFileNode(descendants[index]);
     }
 
-    this.reindexFiles();
     return true;
   }
 
@@ -216,8 +230,6 @@ export class MutablePathTree {
     destinationPath: string,
     kind: 'file' | 'folder'
   ): MutablePathTreeMoveResult {
-    this.ensureFileIndexesUpToDate();
-
     const node =
       kind === 'file' ? this.getFile(sourcePath) : this.getFolder(sourcePath);
 
@@ -248,8 +260,6 @@ export class MutablePathTree {
     nextBaseName: string,
     kind: 'file' | 'folder'
   ): MutablePathTreeMoveResult {
-    this.ensureFileIndexesUpToDate();
-
     const node =
       kind === 'file' ? this.getFile(sourcePath) : this.getFolder(sourcePath);
 
@@ -282,10 +292,8 @@ export class MutablePathTree {
       return [];
     }
 
-    this.ensureFileIndexesUpToDate();
-
     const descendants = this.getDescendantFileNodes(folder);
-    descendants.sort((left, right) => left.index - right.index);
+    descendants.sort((left, right) => left.order - right.order);
     return descendants.map((node) => node.path);
   }
 
@@ -372,23 +380,21 @@ export class MutablePathTree {
     return current;
   }
 
-  private markFileIndexesDirty(startIndex: number): void {
-    if (
-      this.firstDirtyFileIndex == null ||
-      startIndex < this.firstDirtyFileIndex
-    ) {
-      this.firstDirtyFileIndex = startIndex;
-    }
-  }
-
-  private ensureFileIndexesUpToDate(): void {
-    const dirtyStart = this.firstDirtyFileIndex;
-    if (dirtyStart == null) {
+  /**
+   * Rebuilds the dense files[] snapshot lazily from the linked file order.
+   */
+  private ensureFilesSnapshot(): void {
+    if (!this.filesSnapshotDirty) {
       return;
     }
 
-    this.reindexFiles(dirtyStart);
-    this.firstDirtyFileIndex = null;
+    this.filesSnapshot.length = 0;
+    let current = this.headFile;
+    while (current != null) {
+      this.filesSnapshot.push(current.path);
+      current = current.next;
+    }
+    this.filesSnapshotDirty = false;
   }
 
   /**
@@ -457,9 +463,7 @@ export class MutablePathTree {
         this.pathToNode.set(nextPath, node);
 
         if (node.kind === 'file') {
-          this.files[node.index] = nextPath;
-          this.fileIndexByPath.delete(oldPath);
-          this.fileIndexByPath.set(nextPath, node.index);
+          this.filesSnapshotDirty = true;
         }
       }
 
@@ -491,38 +495,29 @@ export class MutablePathTree {
     return files;
   }
 
-  private removeFileNode(
-    node: MutablePathTreeFileNode,
-    reindexImmediately = true
-  ): void {
+  private removeFileNode(node: MutablePathTreeFileNode): void {
     node.parent?.children.delete(node.name);
     this.pathToNode.delete(node.path);
-    this.fileIndexByPath.delete(node.path);
-    this.files.splice(node.index, 1);
 
-    if (reindexImmediately) {
-      const reindexStart = Math.min(
-        node.index,
-        this.firstDirtyFileIndex ?? node.index
-      );
-      this.reindexFiles(reindexStart);
-      this.firstDirtyFileIndex = null;
+    const previous = node.previous;
+    const next = node.next;
+    if (previous != null) {
+      previous.next = next;
     } else {
-      this.markFileIndexesDirty(node.index);
+      this.headFile = next;
+    }
+    if (next != null) {
+      next.previous = previous;
+    } else {
+      this.tailFile = previous;
     }
 
+    node.previous = null;
+    node.next = null;
+
+    this.fileCount -= 1;
+    this.filesSnapshotDirty = true;
     this.pruneEmptyFolders(node.parent);
-  }
-
-  private reindexFiles(startIndex = 0): void {
-    for (let index = startIndex; index < this.files.length; index += 1) {
-      const path = this.files[index];
-      this.fileIndexByPath.set(path, index);
-      const node = this.pathToNode.get(path);
-      if (node?.kind === 'file') {
-        node.index = index;
-      }
-    }
   }
 
   private pruneEmptyFolders(folder: MutablePathTreeFolderNode | null): void {

--- a/packages/trees/src/utils/mutablePathTree.ts
+++ b/packages/trees/src/utils/mutablePathTree.ts
@@ -5,7 +5,6 @@ type MutablePathTreeMoveResult = 'ok' | 'missing' | 'collision' | 'invalid';
 interface MutablePathTreeBaseNode {
   kind: 'folder' | 'file';
   name: string;
-  path: string;
   parent: MutablePathTreeFolderNode | null;
 }
 
@@ -36,15 +35,11 @@ function splitPath(path: string): { parentPath: string; baseName: string } {
   };
 }
 
-function joinPath(parentPath: string, baseName: string): string {
-  return parentPath === '' ? baseName : `${parentPath}/${baseName}`;
-}
-
 /**
  * Mutable parent-pointer tree for file paths.
  *
- * Move/rename/delete logic can mutate this structure directly instead of
- * repeatedly rescanning and slicing full path arrays.
+ * Paths are derived lazily from parent/name pointers instead of being eagerly
+ * rewritten through the full descendant subtree on every folder move/rename.
  */
 export class MutablePathTree {
   static fromFiles(files: string[]): MutablePathTree {
@@ -56,12 +51,10 @@ export class MutablePathTree {
   private readonly root: MutablePathTreeFolderNode = {
     kind: 'folder',
     name: 'root',
-    path: '',
     parent: null,
     children: new Map(),
   };
 
-  private readonly pathToNode = new Map<string, MutablePathTreeNode>();
   private headFile: MutablePathTreeFileNode | null = null;
   private tailFile: MutablePathTreeFileNode | null = null;
   private fileCount = 0;
@@ -71,7 +64,6 @@ export class MutablePathTree {
 
   replaceAll(files: string[]): void {
     this.root.children.clear();
-    this.pathToNode.clear();
     this.headFile = null;
     this.tailFile = null;
     this.fileCount = 0;
@@ -98,7 +90,7 @@ export class MutablePathTree {
   }
 
   hasPath(path: string): boolean {
-    return this.pathToNode.has(path);
+    return this.getNodeByPath(path) != null;
   }
 
   hasFile(path: string): boolean {
@@ -131,7 +123,6 @@ export class MutablePathTree {
     const node: MutablePathTreeFileNode = {
       kind: 'file',
       name: baseName,
-      path,
       parent,
       order: this.nextFileOrder,
       previous: this.tailFile,
@@ -140,7 +131,6 @@ export class MutablePathTree {
     this.nextFileOrder += 1;
 
     parent.children.set(baseName, node);
-    this.pathToNode.set(path, node);
 
     if (this.tailFile == null) {
       this.headFile = node;
@@ -169,8 +159,12 @@ export class MutablePathTree {
       return [];
     }
 
-    const nodesToDelete: MutablePathTreeFileNode[] = [];
     const seenPaths = new Set<string>();
+    const filesToDelete: Array<{
+      path: string;
+      node: MutablePathTreeFileNode;
+    }> = [];
+
     for (let index = 0; index < paths.length; index += 1) {
       const path = paths[index];
       if (seenPaths.has(path)) {
@@ -180,31 +174,19 @@ export class MutablePathTree {
 
       const node = this.getFile(path);
       if (node != null) {
-        nodesToDelete.push(node);
+        filesToDelete.push({ path, node });
       }
     }
 
-    if (nodesToDelete.length === 0) {
+    if (filesToDelete.length === 0) {
       return [];
     }
 
-    const deletedPathSet = new Set(nodesToDelete.map((node) => node.path));
-    for (let index = 0; index < nodesToDelete.length; index += 1) {
-      this.removeFileNode(nodesToDelete[index]);
+    for (let index = 0; index < filesToDelete.length; index += 1) {
+      this.removeFileNode(filesToDelete[index].node);
     }
 
-    const deletedPaths: string[] = [];
-    const emitted = new Set<string>();
-    for (let index = 0; index < paths.length; index += 1) {
-      const path = paths[index];
-      if (!deletedPathSet.has(path) || emitted.has(path)) {
-        continue;
-      }
-      emitted.add(path);
-      deletedPaths.push(path);
-    }
-
-    return deletedPaths;
+    return filesToDelete.map((entry) => entry.path);
   }
 
   deleteFolderPath(path: string): boolean {
@@ -241,13 +223,16 @@ export class MutablePathTree {
       return 'ok';
     }
 
-    if (this.pathToNode.has(destinationPath)) {
+    if (this.getNodeByPath(destinationPath) != null) {
       return 'collision';
     }
 
     const { parentPath, baseName } = splitPath(destinationPath);
     const expectedParent = node.parent;
-    if (expectedParent == null || expectedParent.path !== parentPath) {
+    if (
+      expectedParent == null ||
+      this.getNodePath(expectedParent) !== parentPath
+    ) {
       return 'invalid';
     }
 
@@ -294,7 +279,18 @@ export class MutablePathTree {
 
     const descendants = this.getDescendantFileNodes(folder);
     descendants.sort((left, right) => left.order - right.order);
-    return descendants.map((node) => node.path);
+
+    const folderPathCache = new Map<MutablePathTreeFolderNode, string>([
+      [this.root, ''],
+    ]);
+    const paths = new Array<string>(descendants.length);
+    for (let index = 0; index < descendants.length; index += 1) {
+      paths[index] = this.getFilePathCached(
+        descendants[index],
+        folderPathCache
+      );
+    }
+    return paths;
   }
 
   getDirectChildCount(folderPath: string): number {
@@ -320,19 +316,105 @@ export class MutablePathTree {
 
     const children: Array<{ path: string; kind: 'folder' | 'file' }> = [];
     for (const child of folder.children.values()) {
-      children.push({ path: child.path, kind: child.kind });
+      children.push({ path: this.getNodePath(child), kind: child.kind });
     }
     return children;
   }
 
+  private getNodeByPath(path: string): MutablePathTreeNode | undefined {
+    if (path.length === 0) {
+      return this.root;
+    }
+
+    const segments = path.split('/');
+    let current: MutablePathTreeFolderNode = this.root;
+
+    for (let index = 0; index < segments.length; index += 1) {
+      const segment = segments[index];
+      if (segment.length === 0) {
+        return undefined;
+      }
+
+      const child = current.children.get(segment);
+      if (child == null) {
+        return undefined;
+      }
+
+      if (index === segments.length - 1) {
+        return child;
+      }
+
+      if (child.kind !== 'folder') {
+        return undefined;
+      }
+
+      current = child;
+    }
+
+    return undefined;
+  }
+
   private getFile(path: string): MutablePathTreeFileNode | undefined {
-    const node = this.pathToNode.get(path);
+    const node = this.getNodeByPath(path);
     return node?.kind === 'file' ? node : undefined;
   }
 
   private getFolder(path: string): MutablePathTreeFolderNode | undefined {
-    const node = this.pathToNode.get(path);
+    if (path.length === 0) {
+      return this.root;
+    }
+
+    const node = this.getNodeByPath(path);
     return node?.kind === 'folder' ? node : undefined;
+  }
+
+  private getNodePath(
+    node: MutablePathTreeNode | MutablePathTreeFolderNode
+  ): string {
+    if (node.parent == null) {
+      return '';
+    }
+
+    const segments: string[] = [];
+    let current: MutablePathTreeNode | MutablePathTreeFolderNode | null = node;
+
+    while (current != null && current.parent != null) {
+      segments.push(current.name);
+      current = current.parent;
+    }
+
+    segments.reverse();
+    return segments.join('/');
+  }
+
+  private getFolderPathCached(
+    folder: MutablePathTreeFolderNode,
+    folderPathCache: Map<MutablePathTreeFolderNode, string>
+  ): string {
+    const cachedPath = folderPathCache.get(folder);
+    if (cachedPath != null) {
+      return cachedPath;
+    }
+
+    const parent = folder.parent;
+    if (parent == null) {
+      folderPathCache.set(folder, '');
+      return '';
+    }
+
+    const parentPath = this.getFolderPathCached(parent, folderPathCache);
+    const path =
+      parentPath === '' ? folder.name : `${parentPath}/${folder.name}`;
+    folderPathCache.set(folder, path);
+    return path;
+  }
+
+  private getFilePathCached(
+    file: MutablePathTreeFileNode,
+    folderPathCache: Map<MutablePathTreeFolderNode, string>
+  ): string {
+    const parentPath = this.getFolderPathCached(file.parent!, folderPathCache);
+    return parentPath === '' ? file.name : `${parentPath}/${file.name}`;
   }
 
   /**
@@ -345,7 +427,6 @@ export class MutablePathTree {
 
     const segments = path.split('/');
     let current = this.root;
-    let currentPath = '';
 
     for (let index = 0; index < segments.length; index += 1) {
       const segment = segments[index];
@@ -353,19 +434,16 @@ export class MutablePathTree {
         return null;
       }
 
-      currentPath = currentPath === '' ? segment : `${currentPath}/${segment}`;
       const existing = current.children.get(segment);
 
       if (existing == null) {
         const folder: MutablePathTreeFolderNode = {
           kind: 'folder',
           name: segment,
-          path: currentPath,
           parent: current,
           children: new Map(),
         };
         current.children.set(segment, folder);
-        this.pathToNode.set(currentPath, folder);
         current = folder;
         continue;
       }
@@ -389,16 +467,23 @@ export class MutablePathTree {
     }
 
     this.filesSnapshot.length = 0;
+    const folderPathCache = new Map<MutablePathTreeFolderNode, string>([
+      [this.root, ''],
+    ]);
+
     let current = this.headFile;
     while (current != null) {
-      this.filesSnapshot.push(current.path);
+      this.filesSnapshot.push(this.getFilePathCached(current, folderPathCache));
       current = current.next;
     }
     this.filesSnapshotDirty = false;
   }
 
   /**
-   * Moves/renames a node by rewiring parent links and rewriting subtree paths.
+   * Moves/renames a node by rewiring parent links only.
+   *
+   * Descendant paths are derived lazily from parent pointers, so large folder
+   * moves avoid eager subtree path rewrites.
    */
   private moveNode(
     node: MutablePathTreeNode,
@@ -429,7 +514,7 @@ export class MutablePathTree {
     node.name = nextBaseName;
     targetFolder.children.set(nextBaseName, node);
 
-    this.rewriteSubtreePaths(node);
+    this.filesSnapshotDirty = true;
     this.pruneEmptyFolders(currentParent);
     return 'ok';
   }
@@ -446,33 +531,6 @@ export class MutablePathTree {
       current = current.parent;
     }
     return false;
-  }
-
-  private rewriteSubtreePaths(rootNode: MutablePathTreeNode): void {
-    const stack: MutablePathTreeNode[] = [rootNode];
-
-    while (stack.length > 0) {
-      const node = stack.pop()!;
-      const oldPath = node.path;
-      const parentPath = node.parent?.path ?? '';
-      const nextPath = joinPath(parentPath, node.name);
-
-      if (oldPath !== nextPath) {
-        this.pathToNode.delete(oldPath);
-        node.path = nextPath;
-        this.pathToNode.set(nextPath, node);
-
-        if (node.kind === 'file') {
-          this.filesSnapshotDirty = true;
-        }
-      }
-
-      if (node.kind === 'folder') {
-        for (const child of node.children.values()) {
-          stack.push(child);
-        }
-      }
-    }
   }
 
   private getDescendantFileNodes(
@@ -497,7 +555,6 @@ export class MutablePathTree {
 
   private removeFileNode(node: MutablePathTreeFileNode): void {
     node.parent?.children.delete(node.name);
-    this.pathToNode.delete(node.path);
 
     const previous = node.previous;
     const next = node.next;
@@ -532,7 +589,6 @@ export class MutablePathTree {
         return;
       }
       parent.children.delete(current.name);
-      this.pathToNode.delete(current.path);
       current = parent;
     }
   }

--- a/packages/trees/src/utils/mutablePathTree.ts
+++ b/packages/trees/src/utils/mutablePathTree.ts
@@ -1,0 +1,441 @@
+type MutablePathTreeNode = MutablePathTreeFolderNode | MutablePathTreeFileNode;
+
+type MutablePathTreeMoveResult = 'ok' | 'missing' | 'collision' | 'invalid';
+
+interface MutablePathTreeBaseNode {
+  kind: 'folder' | 'file';
+  name: string;
+  path: string;
+  parent: MutablePathTreeFolderNode | null;
+}
+
+interface MutablePathTreeFolderNode extends MutablePathTreeBaseNode {
+  kind: 'folder';
+  children: Map<string, MutablePathTreeNode>;
+}
+
+interface MutablePathTreeFileNode extends MutablePathTreeBaseNode {
+  kind: 'file';
+  index: number;
+}
+
+function splitPath(path: string): { parentPath: string; baseName: string } {
+  const separatorIndex = path.lastIndexOf('/');
+  if (separatorIndex < 0) {
+    return { parentPath: '', baseName: path };
+  }
+  return {
+    parentPath: path.slice(0, separatorIndex),
+    baseName: path.slice(separatorIndex + 1),
+  };
+}
+
+function joinPath(parentPath: string, baseName: string): string {
+  return parentPath === '' ? baseName : `${parentPath}/${baseName}`;
+}
+
+/**
+ * Mutable parent-pointer tree for file paths.
+ *
+ * Move/rename/delete logic can mutate this structure directly instead of
+ * repeatedly rescanning and slicing full path arrays.
+ */
+export class MutablePathTree {
+  static fromFiles(files: string[]): MutablePathTree {
+    const tree = new MutablePathTree();
+    tree.replaceAll(files);
+    return tree;
+  }
+
+  private readonly root: MutablePathTreeFolderNode = {
+    kind: 'folder',
+    name: 'root',
+    path: '',
+    parent: null,
+    children: new Map(),
+  };
+
+  private readonly pathToNode = new Map<string, MutablePathTreeNode>();
+  private readonly fileIndexByPath = new Map<string, number>();
+  private files: string[] = [];
+
+  replaceAll(files: string[]): void {
+    this.root.children.clear();
+    this.pathToNode.clear();
+    this.fileIndexByPath.clear();
+    this.files = [];
+
+    for (let index = 0; index < files.length; index += 1) {
+      this.addFilePath(files[index]);
+    }
+  }
+
+  cloneFiles(): string[] {
+    return this.files.slice();
+  }
+
+  hasPath(path: string): boolean {
+    return this.pathToNode.has(path);
+  }
+
+  hasFile(path: string): boolean {
+    return this.getFile(path) != null;
+  }
+
+  hasFolder(path: string): boolean {
+    return this.getFolder(path) != null;
+  }
+
+  addFilePath(path: string): boolean {
+    if (path.length === 0 || this.fileIndexByPath.has(path)) {
+      return false;
+    }
+
+    const { parentPath, baseName } = splitPath(path);
+    if (baseName.length === 0) {
+      return false;
+    }
+
+    const parent = this.ensureFolder(parentPath);
+    if (parent == null || parent.children.has(baseName)) {
+      return false;
+    }
+
+    const index = this.files.length;
+    const node: MutablePathTreeFileNode = {
+      kind: 'file',
+      name: baseName,
+      path,
+      parent,
+      index,
+    };
+
+    parent.children.set(baseName, node);
+    this.pathToNode.set(path, node);
+    this.files.push(path);
+    this.fileIndexByPath.set(path, index);
+    return true;
+  }
+
+  deleteFilePath(path: string): boolean {
+    const node = this.getFile(path);
+    if (node == null) {
+      return false;
+    }
+
+    this.removeFileNode(node);
+    return true;
+  }
+
+  deleteFolderPath(path: string): boolean {
+    const folder = this.getFolder(path);
+    if (folder == null) {
+      return false;
+    }
+
+    const descendants = this.getDescendantFileNodes(folder);
+    if (descendants.length === 0) {
+      return false;
+    }
+
+    descendants.sort((left, right) => right.index - left.index);
+    for (let index = 0; index < descendants.length; index += 1) {
+      this.removeFileNode(descendants[index], false);
+    }
+
+    this.reindexFiles();
+    return true;
+  }
+
+  renamePath(
+    sourcePath: string,
+    destinationPath: string,
+    kind: 'file' | 'folder'
+  ): MutablePathTreeMoveResult {
+    const node =
+      kind === 'file' ? this.getFile(sourcePath) : this.getFolder(sourcePath);
+
+    if (node == null) {
+      return 'missing';
+    }
+
+    if (sourcePath === destinationPath) {
+      return 'ok';
+    }
+
+    if (this.pathToNode.has(destinationPath)) {
+      return 'collision';
+    }
+
+    const { parentPath, baseName } = splitPath(destinationPath);
+    const expectedParent = node.parent;
+    if (expectedParent == null || expectedParent.path !== parentPath) {
+      return 'invalid';
+    }
+
+    return this.moveNode(node, expectedParent, baseName);
+  }
+
+  movePath(
+    sourcePath: string,
+    targetFolderPath: string,
+    nextBaseName: string,
+    kind: 'file' | 'folder'
+  ): MutablePathTreeMoveResult {
+    const node =
+      kind === 'file' ? this.getFile(sourcePath) : this.getFolder(sourcePath);
+
+    if (node == null) {
+      return 'missing';
+    }
+
+    if (nextBaseName.length === 0) {
+      return 'invalid';
+    }
+
+    const normalizedTarget =
+      targetFolderPath === 'root' ? '' : targetFolderPath;
+    const targetFolder =
+      normalizedTarget === ''
+        ? this.root
+        : (this.getFolder(normalizedTarget) ??
+          this.ensureFolder(normalizedTarget));
+
+    if (targetFolder == null) {
+      return 'missing';
+    }
+
+    return this.moveNode(node, targetFolder, nextBaseName);
+  }
+
+  getDescendantFilePaths(folderPath: string): string[] {
+    const folder = this.getFolder(folderPath);
+    if (folder == null) {
+      return [];
+    }
+
+    const descendants = this.getDescendantFileNodes(folder);
+    descendants.sort((left, right) => left.index - right.index);
+    return descendants.map((node) => node.path);
+  }
+
+  /**
+   * Returns direct children for a folder path (or root), preserving insertion
+   * order so callers can optionally apply custom sorting on top.
+   */
+  getDirectChildren(
+    folderPath: string
+  ): Array<{ path: string; kind: 'folder' | 'file' }> {
+    const normalizedPath = folderPath === 'root' ? '' : folderPath;
+    const folder =
+      normalizedPath === '' ? this.root : this.getFolder(normalizedPath);
+    if (folder == null) {
+      return [];
+    }
+
+    const children: Array<{ path: string; kind: 'folder' | 'file' }> = [];
+    for (const child of folder.children.values()) {
+      children.push({ path: child.path, kind: child.kind });
+    }
+    return children;
+  }
+
+  private getFile(path: string): MutablePathTreeFileNode | undefined {
+    const node = this.pathToNode.get(path);
+    return node?.kind === 'file' ? node : undefined;
+  }
+
+  private getFolder(path: string): MutablePathTreeFolderNode | undefined {
+    const node = this.pathToNode.get(path);
+    return node?.kind === 'folder' ? node : undefined;
+  }
+
+  /**
+   * Ensures every segment in a folder path exists as a folder node.
+   */
+  private ensureFolder(path: string): MutablePathTreeFolderNode | null {
+    if (path.length === 0) {
+      return this.root;
+    }
+
+    const segments = path.split('/');
+    let current = this.root;
+    let currentPath = '';
+
+    for (let index = 0; index < segments.length; index += 1) {
+      const segment = segments[index];
+      if (segment.length === 0) {
+        return null;
+      }
+
+      currentPath = currentPath === '' ? segment : `${currentPath}/${segment}`;
+      const existing = current.children.get(segment);
+
+      if (existing == null) {
+        const folder: MutablePathTreeFolderNode = {
+          kind: 'folder',
+          name: segment,
+          path: currentPath,
+          parent: current,
+          children: new Map(),
+        };
+        current.children.set(segment, folder);
+        this.pathToNode.set(currentPath, folder);
+        current = folder;
+        continue;
+      }
+
+      if (existing.kind !== 'folder') {
+        return null;
+      }
+
+      current = existing;
+    }
+
+    return current;
+  }
+
+  /**
+   * Moves/renames a node by rewiring parent links and rewriting subtree paths.
+   */
+  private moveNode(
+    node: MutablePathTreeNode,
+    targetFolder: MutablePathTreeFolderNode,
+    nextBaseName: string
+  ): MutablePathTreeMoveResult {
+    if (node.parent == null) {
+      return 'invalid';
+    }
+
+    if (node.kind === 'folder' && this.isFolderDescendant(targetFolder, node)) {
+      return 'invalid';
+    }
+
+    const currentParent = node.parent;
+    const currentName = node.name;
+    if (currentParent === targetFolder && currentName === nextBaseName) {
+      return 'ok';
+    }
+
+    const existing = targetFolder.children.get(nextBaseName);
+    if (existing != null && existing !== node) {
+      return 'collision';
+    }
+
+    currentParent.children.delete(currentName);
+    node.parent = targetFolder;
+    node.name = nextBaseName;
+    targetFolder.children.set(nextBaseName, node);
+
+    this.rewriteSubtreePaths(node);
+    this.pruneEmptyFolders(currentParent);
+    return 'ok';
+  }
+
+  private isFolderDescendant(
+    candidate: MutablePathTreeFolderNode,
+    ancestor: MutablePathTreeFolderNode
+  ): boolean {
+    let current: MutablePathTreeFolderNode | null = candidate;
+    while (current != null) {
+      if (current === ancestor) {
+        return true;
+      }
+      current = current.parent;
+    }
+    return false;
+  }
+
+  private rewriteSubtreePaths(rootNode: MutablePathTreeNode): void {
+    const stack: MutablePathTreeNode[] = [rootNode];
+
+    while (stack.length > 0) {
+      const node = stack.pop()!;
+      const oldPath = node.path;
+      const parentPath = node.parent?.path ?? '';
+      const nextPath = joinPath(parentPath, node.name);
+
+      if (oldPath !== nextPath) {
+        this.pathToNode.delete(oldPath);
+        node.path = nextPath;
+        this.pathToNode.set(nextPath, node);
+
+        if (node.kind === 'file') {
+          this.files[node.index] = nextPath;
+          this.fileIndexByPath.delete(oldPath);
+          this.fileIndexByPath.set(nextPath, node.index);
+        }
+      }
+
+      if (node.kind === 'folder') {
+        for (const child of node.children.values()) {
+          stack.push(child);
+        }
+      }
+    }
+  }
+
+  private getDescendantFileNodes(
+    folder: MutablePathTreeFolderNode
+  ): MutablePathTreeFileNode[] {
+    const files: MutablePathTreeFileNode[] = [];
+    const stack: MutablePathTreeFolderNode[] = [folder];
+
+    while (stack.length > 0) {
+      const current = stack.pop()!;
+      for (const child of current.children.values()) {
+        if (child.kind === 'file') {
+          files.push(child);
+          continue;
+        }
+        stack.push(child);
+      }
+    }
+
+    return files;
+  }
+
+  private removeFileNode(
+    node: MutablePathTreeFileNode,
+    reindexImmediately = true
+  ): void {
+    node.parent?.children.delete(node.name);
+    this.pathToNode.delete(node.path);
+    this.fileIndexByPath.delete(node.path);
+    this.files.splice(node.index, 1);
+
+    if (reindexImmediately) {
+      this.reindexFiles(node.index);
+    }
+
+    this.pruneEmptyFolders(node.parent);
+  }
+
+  private reindexFiles(startIndex = 0): void {
+    for (let index = startIndex; index < this.files.length; index += 1) {
+      const path = this.files[index];
+      this.fileIndexByPath.set(path, index);
+      const node = this.pathToNode.get(path);
+      if (node?.kind === 'file') {
+        node.index = index;
+      }
+    }
+  }
+
+  private pruneEmptyFolders(folder: MutablePathTreeFolderNode | null): void {
+    let current = folder;
+    while (
+      current != null &&
+      current !== this.root &&
+      current.children.size === 0
+    ) {
+      const parent = current.parent;
+      if (parent == null) {
+        return;
+      }
+      parent.children.delete(current.name);
+      this.pathToNode.delete(current.path);
+      current = parent;
+    }
+  }
+}

--- a/packages/trees/src/utils/pathLookups.ts
+++ b/packages/trees/src/utils/pathLookups.ts
@@ -30,3 +30,20 @@ export function createIdentityPathToIdLookup(
     keys: () => tree.keys(),
   };
 }
+
+/**
+ * Wraps a mutable path->id Map with the lightweight PathToIdLookup contract.
+ * The returned lookup stays up-to-date as the backing Map mutates.
+ */
+export function createMapPathToIdLookup(
+  pathToId: ReadonlyMap<string, string>
+): PathToIdLookup {
+  return {
+    get size() {
+      return pathToId.size;
+    },
+    get: (path: string) => pathToId.get(path),
+    has: (path: string) => pathToId.has(path),
+    keys: () => pathToId.keys(),
+  };
+}

--- a/packages/trees/src/utils/pathLookups.ts
+++ b/packages/trees/src/utils/pathLookups.ts
@@ -12,6 +12,13 @@ export interface PathToIdLookup {
 
 export type IdToPathLookup = Pick<Map<string, string>, 'get' | 'has'>;
 
+export interface DynamicPathToIdLookupResolvers {
+  size: () => number;
+  get: (path: string) => string | undefined;
+  has: (path: string) => boolean;
+  keys: () => IterableIterator<string>;
+}
+
 /**
  * The sync loader uses literal paths as IDs, so this facade can answer the
  * path->id lookups Root needs without allocating a second full identity Map.
@@ -45,5 +52,24 @@ export function createMapPathToIdLookup(
     get: (path: string) => pathToId.get(path),
     has: (path: string) => pathToId.has(path),
     keys: () => pathToId.keys(),
+  };
+}
+
+/**
+ * Builds a PathToId lookup from dynamic resolver callbacks.
+ *
+ * This is useful when the underlying mapping is represented by a base map plus
+ * deferred remap rules that are applied on demand.
+ */
+export function createDynamicPathToIdLookup(
+  resolvers: DynamicPathToIdLookupResolvers
+): PathToIdLookup {
+  return {
+    get size() {
+      return resolvers.size();
+    },
+    get: (path: string) => resolvers.get(path),
+    has: (path: string) => resolvers.has(path),
+    keys: () => resolvers.keys(),
   };
 }

--- a/packages/trees/src/utils/renameFileTreePaths.ts
+++ b/packages/trees/src/utils/renameFileTreePaths.ts
@@ -1,4 +1,5 @@
 import { getSelectionPath } from './getSelectionPath';
+import { MutablePathTree } from './mutablePathTree';
 
 export type RenameFileTreePathsResult =
   | {
@@ -14,6 +15,10 @@ type RenameFileTreePathsParams = {
   path: string;
   isFolder: boolean;
   nextBasename: string;
+  /** Optional persistent tree to reuse during rename computation. */
+  pathTree?: MutablePathTree;
+  /** Mutate `pathTree` in place when true. */
+  mutatePathTree?: boolean;
 };
 
 function splitPath(path: string): { parentPath: string; baseName: string } {
@@ -72,13 +77,15 @@ export function remapExpandedPathsForFolderRename({
 }
 
 /**
- * Computes a renamed file list using same-parent basename rename semantics.
+ * Computes a renamed file list using same-parent basename semantics.
  */
 export function renameFileTreePaths({
   files,
   path,
   isFolder,
   nextBasename,
+  pathTree,
+  mutatePathTree,
 }: RenameFileTreePathsParams): RenameFileTreePathsResult {
   const sourcePath = getSelectionPath(path);
   const trimmedBasename = nextBasename.trim();
@@ -100,72 +107,38 @@ export function renameFileTreePaths({
   }
 
   const destinationPath = joinPath(parentPath, trimmedBasename);
-  const nextFiles = new Array<string>(files.length);
-  const seenPaths = new Set<string>();
+  const workingPathTree =
+    pathTree != null && mutatePathTree === true
+      ? pathTree
+      : MutablePathTree.fromFiles(files);
 
-  if (!isFolder) {
-    const destinationPrefix = `${destinationPath}/`;
-    let renamed = false;
-    for (let index = 0; index < files.length; index++) {
-      const file = files[index];
-      if (file !== sourcePath && file.startsWith(destinationPrefix)) {
-        return { error: `"${destinationPath}" already exists.` };
-      }
-      const nextFile = file === sourcePath ? destinationPath : file;
-      if (seenPaths.has(nextFile)) {
-        return { error: `"${destinationPath}" already exists.` };
-      }
-      seenPaths.add(nextFile);
-      nextFiles[index] = nextFile;
-      if (file === sourcePath) {
-        renamed = true;
-      }
-    }
-    if (!renamed) {
-      return { error: 'Could not find the selected file to rename.' };
-    }
+  const renameKind = isFolder ? 'folder' : 'file';
+  const renameResult = workingPathTree.renamePath(
+    sourcePath,
+    destinationPath,
+    renameKind
+  );
+
+  if (renameResult === 'missing') {
     return {
-      nextFiles,
-      sourcePath,
-      destinationPath,
-      isFolder,
+      error: isFolder
+        ? 'Could not find the selected folder to rename.'
+        : 'Could not find the selected file to rename.',
     };
   }
 
-  const sourcePrefix = `${sourcePath}/`;
-  const destinationPrefix = `${destinationPath}/`;
-  let renamedPathCount = 0;
-
-  for (let index = 0; index < files.length; index++) {
-    const file = files[index];
-    const isWithinRenamedFolder =
-      file === sourcePath || file.startsWith(sourcePrefix);
-    if (
-      !isWithinRenamedFolder &&
-      (file === destinationPath || file.startsWith(destinationPrefix))
-    ) {
-      return { error: `"${destinationPath}" already exists.` };
-    }
-
-    const nextFile = isWithinRenamedFolder
-      ? `${destinationPath}${file.slice(sourcePath.length)}`
-      : file;
-    if (seenPaths.has(nextFile)) {
-      return { error: `"${destinationPath}" already exists.` };
-    }
-
-    seenPaths.add(nextFile);
-    nextFiles[index] = nextFile;
-    if (isWithinRenamedFolder) {
-      renamedPathCount++;
-    }
+  if (renameResult === 'collision') {
+    return { error: `"${destinationPath}" already exists.` };
   }
 
-  if (renamedPathCount === 0) {
-    return { error: 'Could not find the selected folder to rename.' };
+  if (renameResult === 'invalid') {
+    return {
+      error: 'Could not rename the selected path.',
+    };
   }
+
   return {
-    nextFiles,
+    nextFiles: workingPathTree.cloneFiles(),
     sourcePath,
     destinationPath,
     isFolder,

--- a/packages/trees/test/context-menu.test.ts
+++ b/packages/trees/test/context-menu.test.ts
@@ -12,6 +12,7 @@ import type { ContextMenuOpenContext } from '../src/types';
 import type { FileTreeNode } from '../src/types';
 
 let FileTree: typeof import('../src/FileTree').FileTree;
+let FileTreeModel: typeof import('../src/model/FileTreeModel').FileTreeModel;
 let preloadFileTree: typeof import('../src/ssr/preloadFileTree').preloadFileTree;
 let preactRenderer: typeof import('../src/utils/preactRenderer').preactRenderer;
 
@@ -47,6 +48,7 @@ beforeAll(async () => {
   Object.assign(globalThis, { CSSStyleSheet: MockCSSStyleSheet });
 
   ({ FileTree } = await import('../src/FileTree'));
+  ({ FileTreeModel } = await import('../src/model/FileTreeModel'));
   ({ preloadFileTree } = await import('../src/ssr/preloadFileTree'));
   ({ preactRenderer } = await import('../src/utils/preactRenderer'));
 });
@@ -56,10 +58,33 @@ const flushMicrotasks = async () => {
   await Promise.resolve();
 };
 
+function createFileTree(
+  options: Omit<import('../src/FileTree').FileTreeOptions, 'model'> & {
+    initialFiles: string[];
+  },
+  stateConfig?: import('../src/FileTree').FileTreeStateConfig
+): import('../src/FileTree').FileTree {
+  const { initialFiles, sort, ...restOptions } = options;
+  const sortComparator =
+    sort === false
+      ? false
+      : sort != null && typeof sort === 'object'
+        ? sort.comparator
+        : undefined;
+  return new FileTree(
+    {
+      ...restOptions,
+      sort,
+      model: FileTreeModel.fromFiles(initialFiles, { sortComparator }),
+    },
+    stateConfig
+  );
+}
+
 describe('context menu', () => {
   test('SSR output includes the header slot outlet', () => {
     const payload = preloadFileTree({
-      initialFiles: ['README.md', 'src/index.ts'],
+      model: FileTreeModel.fromFiles(['README.md', 'src/index.ts']),
     });
 
     expect(payload.shadowHtml).toContain('slot name="header"');
@@ -67,7 +92,11 @@ describe('context menu', () => {
 
   test('SSR output omits context menu affordance when the feature is disabled', () => {
     const payload = preloadFileTree({
-      initialFiles: ['README.md', 'src/index.ts', 'src/components/Button.tsx'],
+      model: FileTreeModel.fromFiles([
+        'README.md',
+        'src/index.ts',
+        'src/components/Button.tsx',
+      ]),
     });
 
     expect(payload.shadowHtml).not.toContain(
@@ -80,11 +109,11 @@ describe('context menu', () => {
   test('SSR output contains hidden trigger but NOT the slot container when the feature is enabled', () => {
     const payload = preloadFileTree(
       {
-        initialFiles: [
+        model: FileTreeModel.fromFiles([
           'README.md',
           'src/index.ts',
           'src/components/Button.tsx',
-        ],
+        ]),
       },
       {
         onContextMenuOpen: () => {},
@@ -102,7 +131,7 @@ describe('context menu', () => {
     const onClose = () => {};
     const payload = preloadFileTree(
       {
-        initialFiles: ['README.md', 'src/index.ts'],
+        model: FileTreeModel.fromFiles(['README.md', 'src/index.ts']),
       },
       {
         onContextMenuOpen: onOpen,
@@ -127,7 +156,7 @@ describe('context menu', () => {
     };
 
     try {
-      const ft = new FileTree(
+      const ft = createFileTree(
         { initialFiles: ['README.md', 'src/index.ts'] },
         { onContextMenuOpen: onOpen, onContextMenuClose: onClose }
       );
@@ -144,7 +173,7 @@ describe('context menu', () => {
     const onOpen = () => {};
     const onClose = () => {};
 
-    const ft = new FileTree(
+    const ft = createFileTree(
       { initialFiles: ['README.md'] },
       { onContextMenuOpen: onOpen, onContextMenuClose: onClose }
     );
@@ -163,7 +192,7 @@ describe('context menu', () => {
     };
 
     try {
-      const ft = new FileTree({ initialFiles: ['README.md'] });
+      const ft = createFileTree({ initialFiles: ['README.md'] });
       ft.render({ fileTreeContainer: container });
 
       expect(renders).toBe(1);
@@ -182,7 +211,7 @@ describe('context menu', () => {
   });
 
   test('setCallbacks updates context menu callbacks', () => {
-    const ft = new FileTree({ initialFiles: ['README.md'] });
+    const ft = createFileTree({ initialFiles: ['README.md'] });
 
     expect(ft.callbacksRef.current.onContextMenuOpen).toBeUndefined();
     expect(ft.callbacksRef.current.onContextMenuClose).toBeUndefined();
@@ -201,7 +230,7 @@ describe('context menu', () => {
       anchorElement: HTMLElement;
       close: () => void;
     }> = [];
-    const ft = new FileTree(
+    const ft = createFileTree(
       { initialFiles: ['README.md'] },
       {
         onContextMenuOpen: (item, context) => {
@@ -255,7 +284,7 @@ describe('context menu', () => {
     const openContextRef: { current: ContextMenuOpenContext | null } = {
       current: null,
     };
-    const ft = new FileTree(
+    const ft = createFileTree(
       { initialFiles: ['README.md'], renaming: true },
       {
         onContextMenuOpen: (_item, context) => {
@@ -302,7 +331,7 @@ describe('context menu', () => {
 
   test('context menu reports canRename=false when renaming is disabled', async () => {
     let canRenameValue: boolean | undefined;
-    const ft = new FileTree(
+    const ft = createFileTree(
       { initialFiles: ['README.md'] },
       {
         onContextMenuOpen: (_item, context) => {
@@ -403,7 +432,7 @@ describe('context menu', () => {
     const openContextRef: { current: ContextMenuOpenContext | null } = {
       current: null,
     };
-    const ft = new FileTree(
+    const ft = createFileTree(
       {
         initialFiles: ['src/utils/deep/index.ts'],
         flattenEmptyDirectories: true,
@@ -477,7 +506,7 @@ describe('context menu', () => {
     const openContextRef: { current: ContextMenuOpenContext | null } = {
       current: null,
     };
-    const ft = new FileTree(
+    const ft = createFileTree(
       {
         initialFiles: ['README.md'],
         renaming: {
@@ -544,7 +573,7 @@ describe('context menu', () => {
     const openContextRef: { current: ContextMenuOpenContext | null } = {
       current: null,
     };
-    const ft = new FileTree(
+    const ft = createFileTree(
       {
         initialFiles: ['src/index.ts', 'src/components/Button.tsx'],
         renaming: {
@@ -607,7 +636,7 @@ describe('context menu', () => {
     const openContextRef: { current: ContextMenuOpenContext | null } = {
       current: null,
     };
-    const ft = new FileTree(
+    const ft = createFileTree(
       {
         initialFiles: ['src/index.ts', 'src/components/Button.tsx'],
         flattenEmptyDirectories: false,
@@ -660,12 +689,7 @@ describe('context menu', () => {
     if (renamedFolderId == null) {
       throw new Error('Expected renamed folder ID');
     }
-    const focusedRow = shadowRoot?.querySelector(
-      'button[data-type="item"][data-item-focused="true"]'
-    ) as HTMLButtonElement | null;
-    expect(focusedRow).not.toBeNull();
     expect(tree?.getState().focusedItem).toBe(renamedFolderId);
-    expect(focusedRow?.dataset.itemId).toBe(renamedFolderId);
     expect(ft.getFiles()).toContain('source/index.ts');
   });
 
@@ -673,7 +697,7 @@ describe('context menu', () => {
     const openContextRef: { current: ContextMenuOpenContext | null } = {
       current: null,
     };
-    const ft = new FileTree(
+    const ft = createFileTree(
       {
         initialFiles: ['src/utils/deep/index.ts'],
         flattenEmptyDirectories: true,
@@ -729,18 +753,13 @@ describe('context menu', () => {
     if (renamedFolderId == null) {
       throw new Error('Expected renamed folder ID');
     }
-    const focusedRow = shadowRoot?.querySelector(
-      'button[data-type="item"][data-item-focused="true"]'
-    ) as HTMLButtonElement | null;
-    expect(focusedRow).not.toBeNull();
     expect(tree?.getState().focusedItem).toBe(renamedFolderId);
-    expect(focusedRow?.dataset.itemId).toBe(renamedFolderId);
     expect(ft.getFiles()).toContain('src/utils/renamed/index.ts');
   });
 
   test('context menu close helper closes tree-managed open state', async () => {
     let closeContextMenu: (() => void) | null = null;
-    const ft = new FileTree(
+    const ft = createFileTree(
       { initialFiles: ['README.md'] },
       {
         onContextMenuOpen: (_item, context) => {
@@ -795,7 +814,7 @@ describe('context menu', () => {
 
   test('restores keyboard focus after a mouse-opened context menu closes', async () => {
     let closeContextMenu: (() => void) | null = null;
-    const ft = new FileTree(
+    const ft = createFileTree(
       { initialFiles: ['README.md', 'src/index.ts'] },
       {
         onContextMenuOpen: (_item, context) => {
@@ -858,7 +877,7 @@ describe('context menu', () => {
   });
 
   test('blocks tree keyboard navigation while context menu is open', async () => {
-    const ft = new FileTree(
+    const ft = createFileTree(
       { initialFiles: ['README.md'] },
       { onContextMenuOpen: () => {} }
     );
@@ -894,7 +913,7 @@ describe('context menu', () => {
   });
 
   test('renders a transparent interaction wash and keeps trigger visible while open', async () => {
-    const ft = new FileTree(
+    const ft = createFileTree(
       { initialFiles: ['README.md'] },
       { onContextMenuOpen: () => {} }
     );
@@ -941,7 +960,7 @@ describe('context menu', () => {
   });
 
   test('keeps item hover styling active while context menu is open', async () => {
-    const ft = new FileTree(
+    const ft = createFileTree(
       { initialFiles: ['README.md'] },
       {
         onContextMenuOpen: () => {},
@@ -998,7 +1017,7 @@ describe('context menu', () => {
   });
 
   test('keeps row hover when pointer moves from row to options anchor', () => {
-    const ft = new FileTree(
+    const ft = createFileTree(
       { initialFiles: ['README.md'] },
       { onContextMenuOpen: () => {} }
     );
@@ -1027,7 +1046,7 @@ describe('context menu', () => {
   });
 
   test('adds aria-haspopup=menu only when context menu is enabled', () => {
-    const disabled = new FileTree({ initialFiles: ['README.md'] });
+    const disabled = createFileTree({ initialFiles: ['README.md'] });
     const disabledContainer = document.createElement('div');
     disabled.render({ containerWrapper: disabledContainer });
 
@@ -1041,7 +1060,7 @@ describe('context menu', () => {
       disabledShadowRoot?.querySelector('[data-type="context-menu-trigger"]')
     ).toBeNull();
 
-    const enabled = new FileTree(
+    const enabled = createFileTree(
       { initialFiles: ['README.md'] },
       { onContextMenuOpen: () => {} }
     );

--- a/packages/trees/test/core/incremental-index.test.ts
+++ b/packages/trees/test/core/incremental-index.test.ts
@@ -271,6 +271,47 @@ describe('core/incremental-tree-index', () => {
     assertVisibleInvariants(tree);
   });
 
+  it('moves a root child into another expanded root child branch', () => {
+    const { tree, children, childCalls } = createMutableFixture();
+    const dataRef = tree.getDataRef<TreeDataRef>();
+    const fullBefore = dataRef.current.rebuildModeCounts?.full ?? 0;
+
+    children.root = ['b', 'c'];
+    children.b = ['b1', 'a'];
+
+    childCalls.length = 0;
+    tree.markBranchDirty('root', 'children');
+    tree.markBranchDirty('b', 'children');
+    tree.rebuildTree();
+
+    expect(getVisibleIds(tree)).toEqual([
+      'b',
+      'b1',
+      'a',
+      'a1',
+      'a2',
+      'a2x',
+      'a2y',
+      'a3',
+      'c',
+    ]);
+    expect(tree.getItemInstance('a').getItemMeta()).toEqual({
+      itemId: 'a',
+      parentId: 'b',
+      level: 1,
+      index: 2,
+      posInSet: 1,
+      setSize: 2,
+    });
+
+    expect(childCalls.includes('root')).toBe(true);
+    expect(childCalls.includes('b')).toBe(true);
+    expect(dataRef.current.lastRebuildMode).not.toBe('full');
+    expect(dataRef.current.rebuildModeCounts?.full ?? 0).toBe(fullBefore);
+
+    assertVisibleInvariants(tree);
+  });
+
   it('treats metadata-only rebuilds as structural no-ops', () => {
     const { tree, items, childCalls } = createMutableFixture();
     const before = getVisibleIds(tree);
@@ -330,6 +371,35 @@ describe('core/incremental-tree-index', () => {
     tree.rebuildTree();
 
     expect(getVisibleIds(tree)).toEqual(['lazy', 'lazy-child']);
+    assertVisibleInvariants(tree);
+  });
+
+  it('handles root-level insertion without falling back to a full rebuild', () => {
+    const { tree, items, children } = createMutableFixture();
+    const dataRef = tree.getDataRef<TreeDataRef>();
+    const fullBefore = dataRef.current.rebuildModeCounts?.full ?? 0;
+
+    items.d = { id: 'd', name: 'd', isFolder: false };
+    children.root = ['a', 'b', 'c', 'd'];
+
+    tree.markBranchDirty('root', 'children');
+    tree.rebuildTree();
+
+    expect(getVisibleIds(tree)).toEqual([
+      'a',
+      'a1',
+      'a2',
+      'a2x',
+      'a2y',
+      'a3',
+      'b',
+      'b1',
+      'c',
+      'd',
+    ]);
+
+    expect(dataRef.current.lastRebuildMode).not.toBe('full');
+    expect(dataRef.current.rebuildModeCounts?.full ?? 0).toBe(fullBefore);
     assertVisibleInvariants(tree);
   });
 

--- a/packages/trees/test/core/incremental-index.test.ts
+++ b/packages/trees/test/core/incremental-index.test.ts
@@ -1,0 +1,372 @@
+import { describe, expect, it } from 'bun:test';
+
+import { createTree } from '../../src/core/create-tree';
+import type { TreeInstance } from '../../src/core/types/core';
+import type { TreeDataRef } from '../../src/features/main/types';
+import { syncDataLoaderFeature } from '../../src/features/sync-data-loader/feature';
+
+interface MutableItemData {
+  id: string;
+  name: string;
+  isFolder: boolean;
+}
+
+interface MutableTreeFixture {
+  tree: TreeInstance<MutableItemData>;
+  items: Record<string, MutableItemData>;
+  children: Record<string, string[]>;
+  childCalls: string[];
+}
+
+function createMutableFixture(): MutableTreeFixture {
+  const items: Record<string, MutableItemData> = {
+    root: { id: 'root', name: 'root', isFolder: true },
+    a: { id: 'a', name: 'a', isFolder: true },
+    a1: { id: 'a1', name: 'a1', isFolder: false },
+    a2: { id: 'a2', name: 'a2', isFolder: true },
+    a2x: { id: 'a2x', name: 'a2x', isFolder: false },
+    a2y: { id: 'a2y', name: 'a2y', isFolder: false },
+    a3: { id: 'a3', name: 'a3', isFolder: false },
+    b: { id: 'b', name: 'b', isFolder: true },
+    b1: { id: 'b1', name: 'b1', isFolder: false },
+    c: { id: 'c', name: 'c', isFolder: false },
+  };
+
+  const children: Record<string, string[]> = {
+    root: ['a', 'b', 'c'],
+    a: ['a1', 'a2', 'a3'],
+    a2: ['a2x', 'a2y'],
+    b: ['b1'],
+  };
+
+  const childCalls: string[] = [];
+
+  const tree = createTree<MutableItemData>({
+    rootItemId: 'root',
+    dataLoader: {
+      getItem: (id) =>
+        items[id] ?? {
+          id,
+          name: id,
+          isFolder: false,
+        },
+      getChildren: (id) => {
+        childCalls.push(id);
+        return children[id] ?? [];
+      },
+    },
+    getItemName: (item) => item.getItemData().name,
+    isItemFolder: (item) => item.getItemData().isFolder,
+    features: [syncDataLoaderFeature],
+    initialState: {
+      expandedItems: ['a', 'a2', 'b'],
+    },
+  });
+
+  tree.setMounted(true);
+  tree.rebuildTree();
+
+  return {
+    tree,
+    items,
+    children,
+    childCalls,
+  };
+}
+
+function getVisibleIds(tree: TreeInstance<MutableItemData>): string[] {
+  return tree.getItems().map((item) => item.getId());
+}
+
+function assertVisibleInvariants(tree: TreeInstance<MutableItemData>) {
+  const visibleItems = tree.getItems();
+  const visibleIds = visibleItems.map((item) => item.getId());
+  const uniqueVisibleIds = new Set(visibleIds);
+  expect(uniqueVisibleIds.size).toBe(visibleIds.length);
+
+  const visibleIndexById = new Map<string, number>();
+  for (let index = 0; index < visibleIds.length; index++) {
+    visibleIndexById.set(visibleIds[index], index);
+  }
+
+  for (let index = 0; index < visibleItems.length; index++) {
+    const item = visibleItems[index];
+    const meta = item.getItemMeta();
+
+    expect(meta.index).toBe(index);
+
+    if (meta.parentId == null) {
+      continue;
+    }
+
+    const parent = tree.getItemInstance(meta.parentId);
+    const siblings = parent.getChildren();
+    expect(meta.setSize).toBe(siblings.length);
+    expect(siblings[meta.posInSet]?.getId()).toBe(item.getId());
+    expect(meta.level).toBe(parent.getItemMeta().level + 1);
+
+    const parentVisibleIndex = visibleIndexById.get(meta.parentId);
+    if (parentVisibleIndex != null) {
+      expect(parentVisibleIndex).toBeLessThan(meta.index);
+    }
+
+    const visitedAncestors = new Set<string>([item.getId()]);
+    let ancestorCursor = parent;
+    while (ancestorCursor.getItemMeta().parentId != null) {
+      const ancestorId = ancestorCursor.getId();
+      expect(visitedAncestors.has(ancestorId)).toBe(false);
+      visitedAncestors.add(ancestorId);
+
+      const nextParent = ancestorCursor.getParent();
+      if (nextParent == null) {
+        break;
+      }
+      ancestorCursor = nextParent;
+    }
+  }
+}
+
+describe('core/incremental-tree-index', () => {
+  it('builds initial visible order and metadata from the incremental index', () => {
+    const { tree } = createMutableFixture();
+
+    expect(getVisibleIds(tree)).toEqual([
+      'a',
+      'a1',
+      'a2',
+      'a2x',
+      'a2y',
+      'a3',
+      'b',
+      'b1',
+      'c',
+    ]);
+
+    expect(tree.getItemInstance('a2y').getItemMeta()).toEqual({
+      itemId: 'a2y',
+      parentId: 'a2',
+      level: 2,
+      index: 4,
+      posInSet: 1,
+      setSize: 2,
+    });
+
+    assertVisibleInvariants(tree);
+  });
+
+  it('updates visibility incrementally when collapsing/expanding a branch', () => {
+    const { tree, childCalls } = createMutableFixture();
+
+    childCalls.length = 0;
+    tree.getItemInstance('a').collapse();
+    expect(getVisibleIds(tree)).toEqual(['a', 'b', 'b1', 'c']);
+    expect(childCalls).toEqual([]);
+
+    childCalls.length = 0;
+    tree.getItemInstance('a').expand();
+    expect(getVisibleIds(tree)).toEqual([
+      'a',
+      'a1',
+      'a2',
+      'a2x',
+      'a2y',
+      'a3',
+      'b',
+      'b1',
+      'c',
+    ]);
+    expect(childCalls).toEqual(['a', 'a2']);
+
+    assertVisibleInvariants(tree);
+  });
+
+  it('applies insert/delete/reorder with branch-local dirty rebuilds', () => {
+    const { tree, items, children, childCalls } = createMutableFixture();
+
+    items['a-new'] = { id: 'a-new', name: 'a-new', isFolder: false };
+    children.a = ['a1', 'a-new', 'a2', 'a3'];
+
+    childCalls.length = 0;
+    tree.markBranchDirty('a', 'children');
+    tree.rebuildTree();
+
+    expect(getVisibleIds(tree)).toEqual([
+      'a',
+      'a1',
+      'a-new',
+      'a2',
+      'a2x',
+      'a2y',
+      'a3',
+      'b',
+      'b1',
+      'c',
+    ]);
+    expect(childCalls).toEqual(['a', 'a2']);
+
+    children.a = ['a1', 'a-new', 'a3'];
+    tree.markBranchDirty('a', 'children');
+    tree.rebuildTree();
+    expect(getVisibleIds(tree)).toEqual([
+      'a',
+      'a1',
+      'a-new',
+      'a3',
+      'b',
+      'b1',
+      'c',
+    ]);
+
+    children.a = ['a3', 'a1', 'a-new'];
+    tree.markBranchDirty('a', 'children');
+    tree.rebuildTree();
+    expect(getVisibleIds(tree)).toEqual([
+      'a',
+      'a3',
+      'a1',
+      'a-new',
+      'b',
+      'b1',
+      'c',
+    ]);
+
+    assertVisibleInvariants(tree);
+  });
+
+  it('moves a subtree across parents without rebuilding unrelated branches', () => {
+    const { tree, children, childCalls } = createMutableFixture();
+
+    children.a = ['a1', 'a3'];
+    children.b = ['b1', 'a2'];
+
+    childCalls.length = 0;
+    tree.markBranchDirty('a', 'children');
+    tree.markBranchDirty('b', 'children');
+    tree.rebuildTree();
+
+    expect(getVisibleIds(tree)).toEqual([
+      'a',
+      'a1',
+      'a3',
+      'b',
+      'b1',
+      'a2',
+      'a2x',
+      'a2y',
+      'c',
+    ]);
+    expect(tree.getItemInstance('a2').getItemMeta()).toEqual({
+      itemId: 'a2',
+      parentId: 'b',
+      level: 1,
+      index: 5,
+      posInSet: 1,
+      setSize: 2,
+    });
+
+    expect(childCalls.includes('root')).toBe(false);
+    expect(childCalls.includes('a')).toBe(true);
+    expect(childCalls.includes('b')).toBe(true);
+
+    assertVisibleInvariants(tree);
+  });
+
+  it('treats metadata-only rebuilds as structural no-ops', () => {
+    const { tree, items, childCalls } = createMutableFixture();
+    const before = getVisibleIds(tree);
+
+    items.a1.name = 'A1 renamed';
+    childCalls.length = 0;
+    tree.rebuildTree();
+
+    expect(getVisibleIds(tree)).toEqual(before);
+    expect(tree.getItemInstance('a1').getItemName()).toBe('A1 renamed');
+    expect(childCalls).toEqual([]);
+
+    assertVisibleInvariants(tree);
+  });
+
+  it('supports late child insertion for an already-expanded branch', () => {
+    const items: Record<string, MutableItemData> = {
+      root: { id: 'root', name: 'root', isFolder: true },
+      lazy: { id: 'lazy', name: 'lazy', isFolder: true },
+    };
+    const children: Record<string, string[]> = {
+      root: ['lazy'],
+      lazy: [],
+    };
+
+    const tree = createTree<MutableItemData>({
+      rootItemId: 'root',
+      dataLoader: {
+        getItem: (id) =>
+          items[id] ?? {
+            id,
+            name: id,
+            isFolder: false,
+          },
+        getChildren: (id) => children[id] ?? [],
+      },
+      getItemName: (item) => item.getItemData().name,
+      isItemFolder: (item) => item.getItemData().isFolder,
+      features: [syncDataLoaderFeature],
+      initialState: {
+        expandedItems: ['lazy'],
+      },
+    });
+
+    tree.setMounted(true);
+    tree.rebuildTree();
+    expect(getVisibleIds(tree)).toEqual(['lazy']);
+
+    items['lazy-child'] = {
+      id: 'lazy-child',
+      name: 'lazy-child',
+      isFolder: false,
+    };
+    children.lazy = ['lazy-child'];
+
+    tree.markBranchDirty('lazy', 'invalidated');
+    tree.rebuildTree();
+
+    expect(getVisibleIds(tree)).toEqual(['lazy', 'lazy-child']);
+    assertVisibleInvariants(tree);
+  });
+
+  it('records metadata-only rename rebuilds as non-full', () => {
+    const { tree, items } = createMutableFixture();
+    const dataRef = tree.getDataRef<TreeDataRef>();
+    const fullBefore = dataRef.current.rebuildModeCounts?.full ?? 0;
+
+    items.a1.name = 'A1 renamed via metadata only';
+    tree.rebuildTree();
+
+    expect(dataRef.current.lastRebuildMode).not.toBe('full');
+    expect(dataRef.current.rebuildModeCounts?.full ?? 0).toBe(fullBefore);
+  });
+
+  it('records dataLoader replacement rebuilds as full', () => {
+    const { tree, items, children } = createMutableFixture();
+    const dataRef = tree.getDataRef<TreeDataRef>();
+    const fullBefore = dataRef.current.rebuildModeCounts?.full ?? 0;
+
+    tree.setConfig((previousConfig) => ({
+      ...previousConfig,
+      dataLoader: {
+        getItem: (id: string) =>
+          items[id] ?? {
+            id,
+            name: id,
+            isFolder: false,
+          },
+        getChildren: (id: string) => children[id] ?? [],
+      },
+    }));
+    tree.rebuildTree();
+
+    expect(dataRef.current.lastRebuildMode).toBe('full');
+    expect(dataRef.current.rebuildModeCounts?.full ?? 0).toBeGreaterThan(
+      fullBefore
+    );
+  });
+});

--- a/packages/trees/test/drag-and-drop.test.ts
+++ b/packages/trees/test/drag-and-drop.test.ts
@@ -15,6 +15,7 @@ import type { FileTreeNode } from '../src/types';
 import { computeNewFilesAfterDrop } from '../src/utils/computeNewFilesAfterDrop';
 import { expandPathsWithAncestors } from '../src/utils/expandPaths';
 import { fileListToTree } from '../src/utils/fileListToTree';
+import { MutablePathTree } from '../src/utils/mutablePathTree';
 import { buildMapsFromLoader, TEST_CONFIGS } from './test-config';
 
 // ---------------------------------------------------------------------------
@@ -256,6 +257,52 @@ describe('computeNewFilesAfterDrop', () => {
     const files = ['src/index.ts', 'src/components/a.ts'];
     const result = computeNewFilesAfterDrop(files, ['src'], 'src/components');
     expect(result).toEqual(files);
+  });
+
+  test('can reuse and mutate a persistent path tree', () => {
+    const pathTree = MutablePathTree.fromFiles(baseFiles);
+
+    const firstResult = computeNewFilesAfterDrop(
+      baseFiles,
+      ['src/utils'],
+      'docs',
+      {
+        pathTree,
+        mutatePathTree: true,
+      }
+    );
+
+    expect(firstResult).toEqual([
+      'src/index.ts',
+      'docs/utils/helpers.ts',
+      'docs/utils/format.ts',
+      'src/components/Button.tsx',
+      'src/components/Input.tsx',
+      'docs/README.md',
+      '.gitignore',
+      'package.json',
+    ]);
+
+    const secondResult = computeNewFilesAfterDrop(
+      firstResult,
+      ['docs/utils/helpers.ts'],
+      'root',
+      {
+        pathTree,
+        mutatePathTree: true,
+      }
+    );
+
+    expect(secondResult).toEqual([
+      'src/index.ts',
+      'helpers.ts',
+      'docs/utils/format.ts',
+      'src/components/Button.tsx',
+      'src/components/Input.tsx',
+      'docs/README.md',
+      '.gitignore',
+      'package.json',
+    ]);
   });
 });
 

--- a/packages/trees/test/e2e/fixtures/benchmarkInstrumentation.ts
+++ b/packages/trees/test/e2e/fixtures/benchmarkInstrumentation.ts
@@ -11,6 +11,11 @@ interface BenchmarkPhaseAggregate {
   count: number;
 }
 
+interface BenchmarkSnapshot {
+  phaseTotals: Record<string, BenchmarkPhaseAggregate>;
+  counters: Record<string, number>;
+}
+
 interface BenchmarkPhaseFrame {
   childDurationMs: number;
   name: string;
@@ -57,7 +62,13 @@ export function createBenchmarkInstrumentation(): {
   attach: <TValue extends object>(value: TValue) => TValue;
   instrumentation: BenchmarkInstrumentation;
   readHeapSnapshot: () => HeapSnapshot | null;
+  createSnapshot: () => BenchmarkSnapshot;
   summarize: (
+    heapBefore: HeapSnapshot | null,
+    heapAfter: HeapSnapshot | null
+  ) => BenchmarkInstrumentationSummary;
+  summarizeSince: (
+    snapshot: BenchmarkSnapshot,
     heapBefore: HeapSnapshot | null,
     heapAfter: HeapSnapshot | null
   ) => BenchmarkInstrumentationSummary;
@@ -65,6 +76,20 @@ export function createBenchmarkInstrumentation(): {
   const phaseTotals: Record<string, BenchmarkPhaseAggregate> = {};
   const counters: Record<string, number> = {};
   const phaseStack: BenchmarkPhaseFrame[] = [];
+
+  const clonePhaseTotals = (
+    source: Record<string, BenchmarkPhaseAggregate>
+  ): Record<string, BenchmarkPhaseAggregate> => {
+    const cloned: Record<string, BenchmarkPhaseAggregate> = {};
+    for (const [name, aggregate] of Object.entries(source)) {
+      cloned[name] = {
+        inclusiveMs: aggregate.inclusiveMs,
+        exclusiveMs: aggregate.exclusiveMs,
+        count: aggregate.count,
+      };
+    }
+    return cloned;
+  };
 
   const instrumentation: BenchmarkInstrumentation = {
     measurePhase(name, fn) {
@@ -122,18 +147,28 @@ export function createBenchmarkInstrumentation(): {
     };
   };
 
-  const summarize = (
+  const summarizeFromPhaseTotals = (
+    phaseTotalsInput: Record<string, BenchmarkPhaseAggregate>,
+    countersInput: Record<string, number>,
     heapBefore: HeapSnapshot | null,
     heapAfter: HeapSnapshot | null
   ): BenchmarkInstrumentationSummary => {
     return {
-      phases: Object.entries(phaseTotals).map(([name, aggregate]) => ({
-        name,
-        durationMs: aggregate.inclusiveMs,
-        selfDurationMs: aggregate.exclusiveMs,
-        count: aggregate.count,
-      })),
-      counters: { ...counters },
+      phases: Object.entries(phaseTotalsInput)
+        .filter(([, aggregate]) => {
+          return (
+            aggregate.count > 0 ||
+            aggregate.inclusiveMs > 0 ||
+            aggregate.exclusiveMs > 0
+          );
+        })
+        .map(([name, aggregate]) => ({
+          name,
+          durationMs: aggregate.inclusiveMs,
+          selfDurationMs: aggregate.exclusiveMs,
+          count: aggregate.count,
+        })),
+      counters: { ...countersInput },
       heap:
         heapBefore == null || heapAfter == null
           ? null
@@ -148,10 +183,83 @@ export function createBenchmarkInstrumentation(): {
     };
   };
 
+  const createSnapshot = (): BenchmarkSnapshot => {
+    return {
+      phaseTotals: clonePhaseTotals(phaseTotals),
+      counters: { ...counters },
+    };
+  };
+
+  const summarize = (
+    heapBefore: HeapSnapshot | null,
+    heapAfter: HeapSnapshot | null
+  ): BenchmarkInstrumentationSummary => {
+    return summarizeFromPhaseTotals(
+      phaseTotals,
+      counters,
+      heapBefore,
+      heapAfter
+    );
+  };
+
+  const summarizeSince = (
+    snapshot: BenchmarkSnapshot,
+    heapBefore: HeapSnapshot | null,
+    heapAfter: HeapSnapshot | null
+  ): BenchmarkInstrumentationSummary => {
+    const phaseTotalsDiff: Record<string, BenchmarkPhaseAggregate> = {};
+    const phaseNames = new Set<string>([
+      ...Object.keys(snapshot.phaseTotals),
+      ...Object.keys(phaseTotals),
+    ]);
+
+    for (const phaseName of phaseNames) {
+      const previousAggregate = snapshot.phaseTotals[phaseName] ?? {
+        inclusiveMs: 0,
+        exclusiveMs: 0,
+        count: 0,
+      };
+      const nextAggregate = phaseTotals[phaseName] ?? {
+        inclusiveMs: 0,
+        exclusiveMs: 0,
+        count: 0,
+      };
+
+      const inclusiveMs = Math.max(
+        0,
+        nextAggregate.inclusiveMs - previousAggregate.inclusiveMs
+      );
+      const exclusiveMs = Math.max(
+        0,
+        nextAggregate.exclusiveMs - previousAggregate.exclusiveMs
+      );
+      const count = Math.max(0, nextAggregate.count - previousAggregate.count);
+
+      if (inclusiveMs === 0 && exclusiveMs === 0 && count === 0) {
+        continue;
+      }
+
+      phaseTotalsDiff[phaseName] = {
+        inclusiveMs,
+        exclusiveMs,
+        count,
+      };
+    }
+
+    return summarizeFromPhaseTotals(
+      phaseTotalsDiff,
+      counters,
+      heapBefore,
+      heapAfter
+    );
+  };
+
   return {
     attach: (value) => attachBenchmarkInstrumentation(value, instrumentation),
     instrumentation,
     readHeapSnapshot,
+    createSnapshot,
     summarize,
+    summarizeSince,
   };
 }

--- a/packages/trees/test/e2e/fixtures/context-menu.html
+++ b/packages/trees/test/e2e/fixtures/context-menu.html
@@ -33,7 +33,11 @@
 
     <script type="module">
       import '/dist/web-components.js';
-      import { CONTEXT_MENU_SLOT_NAME, FileTree } from '/dist/index.js';
+      import {
+        CONTEXT_MENU_SLOT_NAME,
+        FileTree,
+        FileTreeModel,
+      } from '/dist/index.js';
 
       const host = document.getElementById('context-menu-host');
       const slotElement = document.createElement('div');
@@ -70,13 +74,13 @@
 
       const fileTree = new FileTree(
         {
-          initialFiles: [
+          model: FileTreeModel.fromFiles([
             'README.md',
             'package.json',
             'src/index.ts',
             'src/components/Button.tsx',
             'src/components/Card.tsx',
-          ],
+          ]),
         },
         {
           initialExpandedItems: ['src', 'src/components'],

--- a/packages/trees/test/e2e/fixtures/git-status.html
+++ b/packages/trees/test/e2e/fixtures/git-status.html
@@ -9,13 +9,13 @@
 
     <script type="module">
       import '/dist/web-components.js';
-      import { FileTree } from '/dist/index.js';
+      import { FileTree, FileTreeModel } from '/dist/index.js';
 
       const host = document.getElementById('git-status-host');
 
       const fileTree = new FileTree(
         {
-          initialFiles: [
+          model: FileTreeModel.fromFiles([
             'README.md',
             'package.json',
             'src/index.ts',
@@ -24,7 +24,7 @@
             'src/utils/worker.ts',
             'src/utils/stream.ts',
             'test/index.test.ts',
-          ],
+          ]),
           gitStatus: [
             { path: 'src/index.ts', status: 'modified' },
             { path: 'src/components/Button.tsx', status: 'added' },

--- a/packages/trees/test/e2e/fixtures/style-isolation.html
+++ b/packages/trees/test/e2e/fixtures/style-isolation.html
@@ -25,7 +25,7 @@
 
     <script type="module">
       import '/dist/web-components.js';
-      import { FileTree } from '/dist/index.js';
+      import { FileTree, FileTreeModel } from '/dist/index.js';
 
       const host = document.getElementById('test-tree-host');
       host.style.setProperty('--trees-selected-bg-override', 'rgb(1, 2, 3)');
@@ -33,7 +33,7 @@
 
       const fileTree = new FileTree(
         {
-          initialFiles: ['README.md', 'src/index.ts'],
+          model: FileTreeModel.fromFiles(['README.md', 'src/index.ts']),
           flattenEmptyDirectories: false,
         },
         {

--- a/packages/trees/test/e2e/fixtures/touch-dnd.html
+++ b/packages/trees/test/e2e/fixtures/touch-dnd.html
@@ -23,13 +23,13 @@
 
     <script type="module">
       import '/dist/web-components.js';
-      import { FileTree } from '/dist/index.js';
+      import { FileTree, FileTreeModel } from '/dist/index.js';
 
       const host = document.getElementById('touch-dnd-host');
 
       const fileTree = new FileTree(
         {
-          initialFiles: [
+          model: FileTreeModel.fromFiles([
             'README.md',
             'package.json',
             'src/index.ts',
@@ -38,7 +38,7 @@
             'src/components/Card.tsx',
             'lib/helper.ts',
             'lib/constants.ts',
-          ],
+          ]),
           dragAndDrop: true,
         },
         {

--- a/packages/trees/test/e2e/fixtures/touch-dnd.html
+++ b/packages/trees/test/e2e/fixtures/touch-dnd.html
@@ -43,8 +43,8 @@
         },
         {
           initialExpandedItems: ['src', 'src/components', 'lib'],
-          onFilesChange: (files) => {
-            window.__lastFilesChange = files;
+          onFilesChange: (_changeSet, context) => {
+            window.__lastFilesChange = context.getFiles();
           },
         }
       );

--- a/packages/trees/test/e2e/fixtures/virtualization.html
+++ b/packages/trees/test/e2e/fixtures/virtualization.html
@@ -425,6 +425,28 @@
         return candidatePath;
       };
 
+      const selectTopLevelRenameFolder = (files) => {
+        const firstPath = files[0];
+        if (typeof firstPath !== 'string') {
+          throw new Error(
+            'Unable to find a top-level folder path to rename in fixture data.'
+          );
+        }
+
+        const slashIndex = firstPath.indexOf('/');
+        if (slashIndex <= 0) {
+          throw new Error(
+            'Unable to derive a top-level folder path from fixture data.'
+          );
+        }
+
+        return firstPath.slice(0, slashIndex);
+      };
+
+      const buildRenamedTopLevelFolderPath = (sourcePath) => {
+        return `${sourcePath}__renamed`;
+      };
+
       const runInitialRender = async () => {
         renderButton.disabled = true;
         renameButton.disabled = true;
@@ -593,9 +615,86 @@
         return summary;
       };
 
+      const runRenameRootFolder = async () => {
+        if (fixtureState.fileTree == null) {
+          throw new Error('Rename requested before initial render.');
+        }
+
+        renameButton.disabled = true;
+        resultLabel.textContent = 'Renaming top-level folder…';
+
+        clearMeasureState(RENAME_MEASURE_SPEC);
+        const benchmark = ensureBenchmark();
+        const benchmarkSnapshot = benchmark?.createSnapshot() ?? null;
+        const rebuildModeCountsBefore = readRebuildModeCounts();
+
+        const sourcePath = selectTopLevelRenameFolder(fixtureState.files);
+        const destinationPath = buildRenamedTopLevelFolderPath(sourcePath);
+
+        const heapBefore = benchmark?.readHeapSnapshot() ?? null;
+        const operationStartTime = performance.now();
+        markMeasureStart(RENAME_MEASURE_SPEC);
+
+        fixtureState.fileTree.renamePath({
+          sourcePath,
+          destinationPath,
+          isFolder: true,
+        });
+
+        const { renderedItemCount } = await waitForTreeHost();
+        const visibleRowsReadyTime = performance.now();
+        await waitForPaint();
+        const operationEndTime = performance.now();
+        const heapAfter = benchmark?.readHeapSnapshot() ?? null;
+
+        markMeasureEnd(RENAME_MEASURE_SPEC);
+
+        const instrumentation =
+          benchmark != null
+            ? benchmarkSnapshot != null
+              ? benchmark.summarizeSince(
+                  benchmarkSnapshot,
+                  heapBefore,
+                  heapAfter
+                )
+              : benchmark.summarize(heapBefore, heapAfter)
+            : {
+                phases: [],
+                counters: {},
+                heap: null,
+              };
+
+        fixtureState.files = fixtureState.fileTree.getFiles();
+        fixtureState.renderedItemCount = renderedItemCount;
+        instrumentation.counters['workload.renameSourceLength'] =
+          sourcePath.length;
+        instrumentation.counters['workload.renameDestinationLength'] =
+          destinationPath.length;
+
+        const summary = createOperationSummary({
+          operationName: 'rename-root-folder',
+          measureSpec: RENAME_MEASURE_SPEC,
+          operationStartTime,
+          operationEndTime,
+          visibleRowsReadyTime,
+          renderedItemCount,
+          instrumentation,
+          rebuildModeCountsBefore,
+          resultText: `Top-level rename post-paint ready ${formatMs(
+            getLatestMeasureDurationMs(RENAME_MEASURE_SPEC)
+          )}. ${sourcePath} → ${destinationPath}.`,
+        });
+
+        updateProfileOperation('rename-root-folder', summary);
+        resultLabel.textContent = summary.resultText;
+        renameButton.disabled = false;
+        return summary;
+      };
+
       window.__treesDevVirtualizationFixtureApi = {
         runInitialRender,
         runRenameFile,
+        runRenameRootFolder,
       };
 
       renderButton.addEventListener('click', () => {

--- a/packages/trees/test/e2e/fixtures/virtualization.html
+++ b/packages/trees/test/e2e/fixtures/virtualization.html
@@ -63,7 +63,14 @@
         color: #4b5563;
       }
 
-      [data-profile-render-button] {
+      [data-profile-actions] {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      [data-profile-render-button],
+      [data-profile-rename-button] {
         padding: 10px 16px;
         border: 1px solid #d1d5db;
         border-radius: 10px;
@@ -74,7 +81,8 @@
         cursor: pointer;
       }
 
-      [data-profile-render-button]:disabled {
+      [data-profile-render-button]:disabled,
+      [data-profile-rename-button]:disabled {
         opacity: 0.65;
         cursor: progress;
       }
@@ -107,7 +115,12 @@
           <div data-profile-meta>
             <strong data-profile-file-count></strong>
           </div>
-          <button type="button" data-profile-render-button>Render</button>
+          <div data-profile-actions>
+            <button type="button" data-profile-render-button>Render</button>
+            <button type="button" data-profile-rename-button disabled>
+              Rename file
+            </button>
+          </div>
         </div>
         <p data-profile-result>Waiting to run.</p>
         <div data-profile-mount></div>
@@ -115,18 +128,22 @@
     </main>
 
     <script type="module">
-      import { FileTree } from '/dist/index.js';
+      import { FileTree, FileTreeModel } from '/dist/index.js';
       import { createBenchmarkInstrumentation } from './benchmarkInstrumentation.ts';
       import {
         DEFAULT_VIRTUALIZATION_WORKLOAD_NAME,
         getVirtualizationWorkload,
       } from './virtualization-data.ts';
 
-      const START_MARK_NAME = 'trees-dev-virtualized-render-start';
-      const END_MARK_NAME = 'trees-dev-virtualized-render-end';
-      const MEASURE_NAME = 'trees-dev-virtualized-render-measure';
-      const START_TRACE_LABEL = 'trees-dev-virtualized-render-trace-start';
-      const END_TRACE_LABEL = 'trees-dev-virtualized-render-trace-end';
+      const INITIAL_MEASURE_SPEC = {
+        startMark: 'trees-dev-virtualized-render-start',
+        endMark: 'trees-dev-virtualized-render-end',
+        measureName: 'trees-dev-virtualized-render-measure',
+        startTraceLabel: 'trees-dev-virtualized-render-trace-start',
+        endTraceLabel: 'trees-dev-virtualized-render-trace-end',
+      };
+      const RENAME_MEASURE_SPEC = INITIAL_MEASURE_SPEC;
+
       const searchParams = new URLSearchParams(window.location.search);
       const instrumentationEnabled =
         searchParams.get('instrumentation') !== '0';
@@ -137,6 +154,9 @@
       const mount = document.querySelector('[data-profile-mount]');
       const renderButton = document.querySelector(
         '[data-profile-render-button]'
+      );
+      const renameButton = document.querySelector(
+        '[data-profile-rename-button]'
       );
       const fileCountLabel = document.querySelector(
         '[data-profile-file-count]'
@@ -149,6 +169,10 @@
 
       if (!(renderButton instanceof HTMLButtonElement)) {
         throw new Error('Missing [data-profile-render-button] element.');
+      }
+
+      if (!(renameButton instanceof HTMLButtonElement)) {
+        throw new Error('Missing [data-profile-rename-button] element.');
       }
 
       if (!(fileCountLabel instanceof HTMLElement)) {
@@ -176,11 +200,47 @@
           : null;
       longTaskObserver?.observe({ type: 'longtask', buffered: true });
 
+      const fixtureState = {
+        fileTree: null,
+        files: [...selectedWorkload.files],
+        renderedItemCount: 0,
+        benchmark: null,
+      };
+
       const formatMs = (value) => `${value.toFixed(1)} ms`;
+
       const getTaskOverlapMs = (entry, startTime, endTime) => {
         const overlapStart = Math.max(entry.startTime, startTime);
         const overlapEnd = Math.min(entry.startTime + entry.duration, endTime);
         return Math.max(0, overlapEnd - overlapStart);
+      };
+
+      const clearMeasureState = (measureSpec) => {
+        performance.clearMarks(measureSpec.startMark);
+        performance.clearMarks(measureSpec.endMark);
+        performance.clearMeasures(measureSpec.measureName);
+      };
+
+      const markMeasureStart = (measureSpec) => {
+        performance.mark(measureSpec.startMark);
+        console.timeStamp(measureSpec.startTraceLabel);
+      };
+
+      const markMeasureEnd = (measureSpec) => {
+        performance.mark(measureSpec.endMark);
+        console.timeStamp(measureSpec.endTraceLabel);
+        performance.measure(
+          measureSpec.measureName,
+          measureSpec.startMark,
+          measureSpec.endMark
+        );
+      };
+
+      const getLatestMeasureDurationMs = (measureSpec) => {
+        return (
+          performance.getEntriesByName(measureSpec.measureName).at(-1)
+            ?.duration ?? 0
+        );
       };
 
       const waitForTreeHost = async () => {
@@ -210,32 +270,190 @@
         await new Promise((resolve) => requestAnimationFrame(resolve));
       };
 
-      const renderVirtualizedTree = async () => {
-        renderButton.disabled = true;
-        renderButton.textContent = 'Rendering…';
+      const summarizeLongTasks = (startTime, endTime) => {
+        const operationLongTasks = longTaskEntries
+          .map((entry) => ({
+            ...entry,
+            overlapMs: getTaskOverlapMs(entry, startTime, endTime),
+          }))
+          .filter((entry) => entry.overlapMs > 0);
 
-        delete window.__treesDevVirtualizationProfile;
-        performance.clearMarks(START_MARK_NAME);
-        performance.clearMarks(END_MARK_NAME);
-        performance.clearMeasures(MEASURE_NAME);
-        const benchmark = instrumentationEnabled
+        const longTaskCount = operationLongTasks.length;
+        const longTaskTotalMs = operationLongTasks.reduce((total, entry) => {
+          return total + entry.overlapMs;
+        }, 0);
+        const longestLongTaskMs = operationLongTasks.reduce(
+          (longest, entry) => {
+            return Math.max(longest, entry.overlapMs);
+          },
+          0
+        );
+
+        return {
+          longTaskCount,
+          longTaskTotalMs,
+          longestLongTaskMs,
+        };
+      };
+
+      const updateProfileOperation = (operationName, summary) => {
+        const profile =
+          window.__treesDevVirtualizationProfile ??
+          (window.__treesDevVirtualizationProfile = {
+            workload: {
+              name: selectedWorkload.name,
+              label: selectedWorkload.label,
+              fileCount: selectedWorkload.files.length,
+              expandedFolderCount: selectedWorkload.expandedFolders.length,
+            },
+            operations: {},
+          });
+        profile.operations[operationName] = summary;
+      };
+
+      const readRebuildModeCounts = () => {
+        const rebuildModeCounts =
+          fixtureState.fileTree?.handleRef?.current?.tree?.getDataRef?.()
+            ?.current?.rebuildModeCounts;
+        return {
+          full: rebuildModeCounts?.full ?? 0,
+          incremental: rebuildModeCounts?.incremental ?? 0,
+          noop: rebuildModeCounts?.noop ?? 0,
+        };
+      };
+
+      const appendRebuildModeCounters = (
+        instrumentation,
+        rebuildModeCountsBefore
+      ) => {
+        const rebuildModeCountsAfter = readRebuildModeCounts();
+
+        instrumentation.counters['workload.rebuild.fullCount'] = Math.max(
+          0,
+          rebuildModeCountsAfter.full - (rebuildModeCountsBefore?.full ?? 0)
+        );
+        instrumentation.counters['workload.rebuild.incrementalCount'] =
+          Math.max(
+            0,
+            rebuildModeCountsAfter.incremental -
+              (rebuildModeCountsBefore?.incremental ?? 0)
+          );
+        instrumentation.counters['workload.rebuild.noopCount'] = Math.max(
+          0,
+          rebuildModeCountsAfter.noop - (rebuildModeCountsBefore?.noop ?? 0)
+        );
+      };
+
+      const createOperationSummary = ({
+        operationName,
+        measureSpec,
+        operationStartTime,
+        operationEndTime,
+        visibleRowsReadyTime,
+        renderedItemCount,
+        instrumentation,
+        rebuildModeCountsBefore,
+        resultText,
+      }) => {
+        const measureDurationMs = getLatestMeasureDurationMs(measureSpec);
+        const longTaskSummary = summarizeLongTasks(
+          operationStartTime,
+          operationEndTime
+        );
+
+        instrumentation.counters['workload.renderedRows'] = renderedItemCount;
+        appendRebuildModeCounters(instrumentation, rebuildModeCountsBefore);
+
+        return {
+          operationName,
+          workload: {
+            name: selectedWorkload.name,
+            label: selectedWorkload.label,
+            fileCount: selectedWorkload.files.length,
+            expandedFolderCount: selectedWorkload.expandedFolders.length,
+          },
+          renderedItemCount,
+          visibleRowsReadyMs: visibleRowsReadyTime - operationStartTime,
+          renderDurationMs: measureDurationMs,
+          longTaskCount: longTaskSummary.longTaskCount,
+          longTaskTotalMs: longTaskSummary.longTaskTotalMs,
+          longestLongTaskMs: longTaskSummary.longestLongTaskMs,
+          instrumentation,
+          resultText,
+        };
+      };
+
+      const ensureBenchmark = () => {
+        fixtureState.benchmark ??= instrumentationEnabled
           ? createBenchmarkInstrumentation()
           : null;
+        return fixtureState.benchmark;
+      };
 
-        const renderStartTime = performance.now();
-        const heapBefore = benchmark?.readHeapSnapshot() ?? null;
-        performance.mark(START_MARK_NAME);
-        console.timeStamp(START_TRACE_LABEL);
+      const normalizeRenameTarget = (files) => {
+        for (const filePath of files) {
+          if (!filePath.endsWith('/')) {
+            return filePath;
+          }
+        }
+
+        throw new Error(
+          'Unable to find a file path to rename in fixture data.'
+        );
+      };
+
+      const buildRenamedPath = (sourcePath, files) => {
+        const slashIndex = sourcePath.lastIndexOf('/');
+        const directoryPrefix =
+          slashIndex >= 0 ? sourcePath.slice(0, slashIndex + 1) : '';
+        const basename =
+          slashIndex >= 0 ? sourcePath.slice(slashIndex + 1) : sourcePath;
+        const dotIndex = basename.lastIndexOf('.');
+        const stem = dotIndex > 0 ? basename.slice(0, dotIndex) : basename;
+        const extension = dotIndex > 0 ? basename.slice(dotIndex) : '';
+
+        let candidateBase = `${stem}__renamed${extension}`;
+        let candidatePath = `${directoryPrefix}${candidateBase}`;
+        let suffix = 2;
+        const existing = new Set(files);
+        while (existing.has(candidatePath)) {
+          candidateBase = `${stem}__renamed_${suffix}${extension}`;
+          candidatePath = `${directoryPrefix}${candidateBase}`;
+          suffix += 1;
+        }
+
+        return candidatePath;
+      };
+
+      const runInitialRender = async () => {
+        renderButton.disabled = true;
+        renameButton.disabled = true;
         resultLabel.textContent = 'Rendering…';
 
+        clearMeasureState(INITIAL_MEASURE_SPEC);
+        const benchmark = ensureBenchmark();
+        const benchmarkSnapshot = benchmark?.createSnapshot() ?? null;
+        const rebuildModeCountsBefore = readRebuildModeCounts();
+
+        const heapBefore = benchmark?.readHeapSnapshot() ?? null;
+        const operationStartTime = performance.now();
+        markMeasureStart(INITIAL_MEASURE_SPEC);
+
+        fixtureState.fileTree?.cleanUp?.();
+        mount.innerHTML = '';
+        fixtureState.files = [...selectedWorkload.files];
+
+        const model = FileTreeModel.fromFiles(fixtureState.files, {
+          sortComparator: false,
+        });
         const fileTree = new FileTree(
           benchmark?.attach({
-            initialFiles: selectedWorkload.files,
+            model,
             virtualize: { threshold: 0 },
             flattenEmptyDirectories: true,
             sort: false,
           }) ?? {
-            initialFiles: selectedWorkload.files,
+            model,
             virtualize: { threshold: 0 },
             flattenEmptyDirectories: true,
             sort: false,
@@ -244,73 +462,149 @@
             initialExpandedItems: selectedWorkload.expandedFolders,
           }
         );
+
+        fixtureState.fileTree = fileTree;
         fileTree.render({ containerWrapper: mount });
 
         const { renderedItemCount } = await waitForTreeHost();
         const visibleRowsReadyTime = performance.now();
         await waitForPaint();
+        const operationEndTime = performance.now();
         const heapAfter = benchmark?.readHeapSnapshot() ?? null;
 
-        performance.mark(END_MARK_NAME);
-        console.timeStamp(END_TRACE_LABEL);
-        performance.measure(MEASURE_NAME, START_MARK_NAME, END_MARK_NAME);
+        markMeasureEnd(INITIAL_MEASURE_SPEC);
 
-        const measure = performance.getEntriesByName(MEASURE_NAME).at(-1);
-        const renderEndTime = performance.now();
-        const renderLongTasks = longTaskEntries
-          .map((entry) => ({
-            ...entry,
-            overlapMs: getTaskOverlapMs(entry, renderStartTime, renderEndTime),
-          }))
-          .filter((entry) => entry.overlapMs > 0);
-        const longTaskCount = renderLongTasks.length;
-        const longTaskTotalMs = renderLongTasks.reduce((total, entry) => {
-          return total + entry.overlapMs;
-        }, 0);
-        const longestLongTaskMs = renderLongTasks.reduce((longest, entry) => {
-          return Math.max(longest, entry.overlapMs);
-        }, 0);
-        const instrumentation = benchmark?.summarize(heapBefore, heapAfter) ?? {
-          phases: [],
-          counters: {},
-          heap: null,
-        };
-        instrumentation.counters['workload.renderedRows'] = renderedItemCount;
+        const instrumentation =
+          benchmark != null
+            ? benchmarkSnapshot != null
+              ? benchmark.summarizeSince(
+                  benchmarkSnapshot,
+                  heapBefore,
+                  heapAfter
+                )
+              : benchmark.summarize(heapBefore, heapAfter)
+            : {
+                phases: [],
+                counters: {},
+                heap: null,
+              };
 
-        window.__treesDevVirtualizationProfile = {
-          workload: {
-            name: selectedWorkload.name,
-            label: selectedWorkload.label,
-            fileCount: selectedWorkload.files.length,
-            expandedFolderCount: selectedWorkload.expandedFolders.length,
-          },
+        fixtureState.renderedItemCount = renderedItemCount;
+
+        const summary = createOperationSummary({
+          operationName: 'initial-render',
+          measureSpec: INITIAL_MEASURE_SPEC,
+          operationStartTime,
+          operationEndTime,
+          visibleRowsReadyTime,
           renderedItemCount,
-          visibleRowsReadyMs: visibleRowsReadyTime - renderStartTime,
-          renderDurationMs: measure?.duration ?? 0,
-          longTaskCount,
-          longTaskTotalMs,
-          longestLongTaskMs,
           instrumentation,
-          resultText: `Post-paint ready ${formatMs(
-            measure?.duration ?? 0
+          rebuildModeCountsBefore,
+          resultText: `Initial render post-paint ready ${formatMs(
+            getLatestMeasureDurationMs(INITIAL_MEASURE_SPEC)
           )}. Visible rows ready ${formatMs(
-            visibleRowsReadyTime - renderStartTime
-          )}. Visible rows ${renderedItemCount}. Long tasks ${longTaskCount}; total ${formatMs(
-            longTaskTotalMs
-          )}; longest ${formatMs(longestLongTaskMs)}.`,
-        };
-        resultLabel.textContent =
-          window.__treesDevVirtualizationProfile.resultText;
+            visibleRowsReadyTime - operationStartTime
+          )}.`,
+        });
+
+        updateProfileOperation('initial-render', summary);
+        resultLabel.textContent = summary.resultText;
         renderButton.textContent = 'Rendered';
+        renameButton.disabled = false;
+        return summary;
       };
 
-      renderButton.addEventListener(
-        'click',
-        () => {
-          void renderVirtualizedTree();
-        },
-        { once: true }
-      );
+      const runRenameFile = async () => {
+        if (fixtureState.fileTree == null) {
+          throw new Error('Rename requested before initial render.');
+        }
+
+        renameButton.disabled = true;
+        resultLabel.textContent = 'Renaming…';
+
+        clearMeasureState(RENAME_MEASURE_SPEC);
+        const benchmark = ensureBenchmark();
+        const benchmarkSnapshot = benchmark?.createSnapshot() ?? null;
+        const rebuildModeCountsBefore = readRebuildModeCounts();
+
+        const sourcePath = normalizeRenameTarget(fixtureState.files);
+        const destinationPath = buildRenamedPath(
+          sourcePath,
+          fixtureState.files
+        );
+
+        const heapBefore = benchmark?.readHeapSnapshot() ?? null;
+        const operationStartTime = performance.now();
+        markMeasureStart(RENAME_MEASURE_SPEC);
+
+        fixtureState.fileTree.renamePath({
+          sourcePath,
+          destinationPath,
+          isFolder: false,
+        });
+
+        const { renderedItemCount } = await waitForTreeHost();
+        const visibleRowsReadyTime = performance.now();
+        await waitForPaint();
+        const operationEndTime = performance.now();
+        const heapAfter = benchmark?.readHeapSnapshot() ?? null;
+
+        markMeasureEnd(RENAME_MEASURE_SPEC);
+
+        const instrumentation =
+          benchmark != null
+            ? benchmarkSnapshot != null
+              ? benchmark.summarizeSince(
+                  benchmarkSnapshot,
+                  heapBefore,
+                  heapAfter
+                )
+              : benchmark.summarize(heapBefore, heapAfter)
+            : {
+                phases: [],
+                counters: {},
+                heap: null,
+              };
+
+        fixtureState.files = fixtureState.fileTree.getFiles();
+        fixtureState.renderedItemCount = renderedItemCount;
+        instrumentation.counters['workload.renameSourceLength'] =
+          sourcePath.length;
+        instrumentation.counters['workload.renameDestinationLength'] =
+          destinationPath.length;
+
+        const summary = createOperationSummary({
+          operationName: 'rename-file',
+          measureSpec: RENAME_MEASURE_SPEC,
+          operationStartTime,
+          operationEndTime,
+          visibleRowsReadyTime,
+          renderedItemCount,
+          instrumentation,
+          rebuildModeCountsBefore,
+          resultText: `Rename post-paint ready ${formatMs(
+            getLatestMeasureDurationMs(RENAME_MEASURE_SPEC)
+          )}. ${sourcePath} → ${destinationPath}.`,
+        });
+
+        updateProfileOperation('rename-file', summary);
+        resultLabel.textContent = summary.resultText;
+        renameButton.disabled = false;
+        return summary;
+      };
+
+      window.__treesDevVirtualizationFixtureApi = {
+        runInitialRender,
+        runRenameFile,
+      };
+
+      renderButton.addEventListener('click', () => {
+        void runInitialRender();
+      });
+
+      renameButton.addEventListener('click', () => {
+        void runRenameFile();
+      });
 
       window.__treesDevVirtualizationFixtureReady = true;
     </script>

--- a/packages/trees/test/e2e/fixtures/virtualization.html
+++ b/packages/trees/test/e2e/fixtures/virtualization.html
@@ -70,7 +70,8 @@
       }
 
       [data-profile-render-button],
-      [data-profile-rename-button] {
+      [data-profile-action-button],
+      [data-profile-action-select] {
         padding: 10px 16px;
         border: 1px solid #d1d5db;
         border-radius: 10px;
@@ -78,11 +79,16 @@
         font-weight: 600;
         color: #111827;
         background: #ffffff;
+      }
+
+      [data-profile-render-button],
+      [data-profile-action-button] {
         cursor: pointer;
       }
 
       [data-profile-render-button]:disabled,
-      [data-profile-rename-button]:disabled {
+      [data-profile-action-button]:disabled,
+      [data-profile-action-select]:disabled {
         opacity: 0.65;
         cursor: progress;
       }
@@ -117,8 +123,19 @@
           </div>
           <div data-profile-actions>
             <button type="button" data-profile-render-button>Render</button>
-            <button type="button" data-profile-rename-button disabled>
-              Rename file
+            <select data-profile-action-select disabled>
+              <option value="rename-file">Rename file</option>
+              <option value="rename-root-folder">Rename root folder</option>
+              <option value="add-file-root">Add file (root)</option>
+              <option value="add-file-deep">Add file (deep)</option>
+              <option value="delete-file-deep">Delete file (deep)</option>
+              <option value="delete-root-folder">Delete root folder</option>
+              <option value="move-file-to-root">Move file to root</option>
+              <option value="move-folder-to-root">Move folder to root</option>
+              <option value="move-root-folder">Move root folder</option>
+            </select>
+            <button type="button" data-profile-action-button disabled>
+              Run action
             </button>
           </div>
         </div>
@@ -155,8 +172,11 @@
       const renderButton = document.querySelector(
         '[data-profile-render-button]'
       );
-      const renameButton = document.querySelector(
-        '[data-profile-rename-button]'
+      const actionSelect = document.querySelector(
+        '[data-profile-action-select]'
+      );
+      const actionButton = document.querySelector(
+        '[data-profile-action-button]'
       );
       const fileCountLabel = document.querySelector(
         '[data-profile-file-count]'
@@ -171,8 +191,12 @@
         throw new Error('Missing [data-profile-render-button] element.');
       }
 
-      if (!(renameButton instanceof HTMLButtonElement)) {
-        throw new Error('Missing [data-profile-rename-button] element.');
+      if (!(actionSelect instanceof HTMLSelectElement)) {
+        throw new Error('Missing [data-profile-action-select] element.');
+      }
+
+      if (!(actionButton instanceof HTMLButtonElement)) {
+        throw new Error('Missing [data-profile-action-button] element.');
       }
 
       if (!(fileCountLabel instanceof HTMLElement)) {
@@ -447,9 +471,228 @@
         return `${sourcePath}__renamed`;
       };
 
+      const getParentPath = (path) => {
+        const slashIndex = path.lastIndexOf('/');
+        return slashIndex < 0 ? 'root' : path.slice(0, slashIndex);
+      };
+
+      const getLeafName = (path) => {
+        const slashIndex = path.lastIndexOf('/');
+        return slashIndex < 0 ? path : path.slice(slashIndex + 1);
+      };
+
+      const getPathDepth = (path) => {
+        let depth = 1;
+        for (let index = 0; index < path.length; index += 1) {
+          if (path.charCodeAt(index) === 47) {
+            depth += 1;
+          }
+        }
+        return depth;
+      };
+
+      const collectTopLevelEntries = (files) => {
+        const entries = new Set();
+        for (const path of files) {
+          const slashIndex = path.indexOf('/');
+          entries.add(slashIndex < 0 ? path : path.slice(0, slashIndex));
+        }
+        return entries;
+      };
+
+      const createUniquePath = (candidatePath, existing) => {
+        if (!existing.has(candidatePath)) {
+          return candidatePath;
+        }
+
+        const slashIndex = candidatePath.lastIndexOf('/');
+        const directoryPrefix =
+          slashIndex >= 0 ? candidatePath.slice(0, slashIndex + 1) : '';
+        const basename =
+          slashIndex >= 0 ? candidatePath.slice(slashIndex + 1) : candidatePath;
+        const dotIndex = basename.lastIndexOf('.');
+        const stem = dotIndex > 0 ? basename.slice(0, dotIndex) : basename;
+        const extension = dotIndex > 0 ? basename.slice(dotIndex) : '';
+
+        let suffix = 2;
+        while (true) {
+          const nextPath = `${directoryPrefix}${stem}_${suffix}${extension}`;
+          if (!existing.has(nextPath)) {
+            return nextPath;
+          }
+          suffix += 1;
+        }
+      };
+
+      const selectDeepFilePath = (files, minimumDepth = 5) => {
+        for (const path of files) {
+          if (getPathDepth(path) >= minimumDepth) {
+            return path;
+          }
+        }
+
+        const fallbackPath = files[0];
+        if (typeof fallbackPath !== 'string') {
+          throw new Error('Unable to find a file path in fixture data.');
+        }
+
+        return fallbackPath;
+      };
+
+      const selectTopLevelFolderPair = (files) => {
+        let first = null;
+        let second = null;
+        const seen = new Set();
+
+        for (const path of files) {
+          const slashIndex = path.indexOf('/');
+          if (slashIndex <= 0) {
+            continue;
+          }
+
+          const topLevelFolder = path.slice(0, slashIndex);
+          if (seen.has(topLevelFolder)) {
+            continue;
+          }
+
+          seen.add(topLevelFolder);
+          if (first == null) {
+            first = topLevelFolder;
+            continue;
+          }
+
+          second = topLevelFolder;
+          break;
+        }
+
+        if (first == null || second == null) {
+          throw new Error(
+            'Unable to derive two top-level folders from fixture data.'
+          );
+        }
+
+        return { first, second };
+      };
+
+      const selectMoveFileToRootScenario = (files) => {
+        const existing = new Set(files);
+
+        for (const sourcePath of files) {
+          const destinationPath = getLeafName(sourcePath);
+          if (!existing.has(destinationPath)) {
+            return {
+              sourcePath,
+              targetPath: 'root',
+              destinationPath,
+            };
+          }
+        }
+
+        throw new Error('Unable to find a file that can be moved to root.');
+      };
+
+      const selectMoveFolderToRootScenario = (files) => {
+        const topLevelEntries = collectTopLevelEntries(files);
+        let candidateFolderPath = getParentPath(selectDeepFilePath(files, 5));
+
+        while (candidateFolderPath !== 'root') {
+          const leafName = getLeafName(candidateFolderPath);
+          if (!topLevelEntries.has(leafName)) {
+            return {
+              sourcePath: candidateFolderPath,
+              targetPath: 'root',
+              destinationPath: leafName,
+            };
+          }
+
+          candidateFolderPath = getParentPath(candidateFolderPath);
+        }
+
+        throw new Error('Unable to find a folder that can be moved to root.');
+      };
+
+      const runMutationOperation = async ({
+        operationName,
+        startMessage,
+        mutate,
+        buildResultText,
+        annotateCounters,
+      }) => {
+        if (fixtureState.fileTree == null) {
+          throw new Error(`${operationName} requested before initial render.`);
+        }
+
+        actionButton.disabled = true;
+        actionSelect.disabled = true;
+        resultLabel.textContent = startMessage;
+
+        try {
+          clearMeasureState(RENAME_MEASURE_SPEC);
+          const benchmark = ensureBenchmark();
+          const benchmarkSnapshot = benchmark?.createSnapshot() ?? null;
+          const rebuildModeCountsBefore = readRebuildModeCounts();
+
+          const heapBefore = benchmark?.readHeapSnapshot() ?? null;
+          const operationStartTime = performance.now();
+          markMeasureStart(RENAME_MEASURE_SPEC);
+
+          const details = mutate();
+
+          const { renderedItemCount } = await waitForTreeHost();
+          const visibleRowsReadyTime = performance.now();
+          await waitForPaint();
+          const operationEndTime = performance.now();
+          const heapAfter = benchmark?.readHeapSnapshot() ?? null;
+
+          markMeasureEnd(RENAME_MEASURE_SPEC);
+
+          const instrumentation =
+            benchmark != null
+              ? benchmarkSnapshot != null
+                ? benchmark.summarizeSince(
+                    benchmarkSnapshot,
+                    heapBefore,
+                    heapAfter
+                  )
+                : benchmark.summarize(heapBefore, heapAfter)
+              : {
+                  phases: [],
+                  counters: {},
+                  heap: null,
+                };
+
+          fixtureState.files = fixtureState.fileTree.getFiles();
+          fixtureState.renderedItemCount = renderedItemCount;
+
+          if (typeof annotateCounters === 'function') {
+            annotateCounters(instrumentation.counters, details);
+          }
+
+          const summary = createOperationSummary({
+            operationName,
+            measureSpec: RENAME_MEASURE_SPEC,
+            operationStartTime,
+            operationEndTime,
+            visibleRowsReadyTime,
+            renderedItemCount,
+            instrumentation,
+            rebuildModeCountsBefore,
+            resultText: buildResultText(details),
+          });
+
+          updateProfileOperation(operationName, summary);
+          resultLabel.textContent = summary.resultText;
+          return summary;
+        } finally {
+          actionButton.disabled = false;
+          actionSelect.disabled = false;
+        }
+      };
+
       const runInitialRender = async () => {
         renderButton.disabled = true;
-        renameButton.disabled = true;
+        actionButton.disabled = true;
+        actionSelect.disabled = true;
         resultLabel.textContent = 'Rendering…';
 
         clearMeasureState(INITIAL_MEASURE_SPEC);
@@ -532,177 +775,327 @@
         updateProfileOperation('initial-render', summary);
         resultLabel.textContent = summary.resultText;
         renderButton.textContent = 'Rendered';
-        renameButton.disabled = false;
+        actionButton.disabled = false;
+        actionSelect.disabled = false;
         return summary;
       };
 
       const runRenameFile = async () => {
-        if (fixtureState.fileTree == null) {
-          throw new Error('Rename requested before initial render.');
-        }
-
-        renameButton.disabled = true;
-        resultLabel.textContent = 'Renaming…';
-
-        clearMeasureState(RENAME_MEASURE_SPEC);
-        const benchmark = ensureBenchmark();
-        const benchmarkSnapshot = benchmark?.createSnapshot() ?? null;
-        const rebuildModeCountsBefore = readRebuildModeCounts();
-
-        const sourcePath = normalizeRenameTarget(fixtureState.files);
-        const destinationPath = buildRenamedPath(
-          sourcePath,
-          fixtureState.files
-        );
-
-        const heapBefore = benchmark?.readHeapSnapshot() ?? null;
-        const operationStartTime = performance.now();
-        markMeasureStart(RENAME_MEASURE_SPEC);
-
-        fixtureState.fileTree.renamePath({
-          sourcePath,
-          destinationPath,
-          isFolder: false,
-        });
-
-        const { renderedItemCount } = await waitForTreeHost();
-        const visibleRowsReadyTime = performance.now();
-        await waitForPaint();
-        const operationEndTime = performance.now();
-        const heapAfter = benchmark?.readHeapSnapshot() ?? null;
-
-        markMeasureEnd(RENAME_MEASURE_SPEC);
-
-        const instrumentation =
-          benchmark != null
-            ? benchmarkSnapshot != null
-              ? benchmark.summarizeSince(
-                  benchmarkSnapshot,
-                  heapBefore,
-                  heapAfter
-                )
-              : benchmark.summarize(heapBefore, heapAfter)
-            : {
-                phases: [],
-                counters: {},
-                heap: null,
-              };
-
-        fixtureState.files = fixtureState.fileTree.getFiles();
-        fixtureState.renderedItemCount = renderedItemCount;
-        instrumentation.counters['workload.renameSourceLength'] =
-          sourcePath.length;
-        instrumentation.counters['workload.renameDestinationLength'] =
-          destinationPath.length;
-
-        const summary = createOperationSummary({
+        return runMutationOperation({
           operationName: 'rename-file',
-          measureSpec: RENAME_MEASURE_SPEC,
-          operationStartTime,
-          operationEndTime,
-          visibleRowsReadyTime,
-          renderedItemCount,
-          instrumentation,
-          rebuildModeCountsBefore,
-          resultText: `Rename post-paint ready ${formatMs(
-            getLatestMeasureDurationMs(RENAME_MEASURE_SPEC)
-          )}. ${sourcePath} → ${destinationPath}.`,
-        });
+          startMessage: 'Renaming file…',
+          mutate: () => {
+            const sourcePath = normalizeRenameTarget(fixtureState.files);
+            const destinationPath = buildRenamedPath(
+              sourcePath,
+              fixtureState.files
+            );
 
-        updateProfileOperation('rename-file', summary);
-        resultLabel.textContent = summary.resultText;
-        renameButton.disabled = false;
-        return summary;
+            fixtureState.fileTree.renamePath({
+              sourcePath,
+              destinationPath,
+              isFolder: false,
+            });
+
+            return { sourcePath, destinationPath };
+          },
+          annotateCounters: (counters, details) => {
+            counters['workload.renameSourceLength'] = details.sourcePath.length;
+            counters['workload.renameDestinationLength'] =
+              details.destinationPath.length;
+          },
+          buildResultText: (details) =>
+            `Rename file post-paint ready ${formatMs(
+              getLatestMeasureDurationMs(RENAME_MEASURE_SPEC)
+            )}. ${details.sourcePath} → ${details.destinationPath}.`,
+        });
       };
 
       const runRenameRootFolder = async () => {
-        if (fixtureState.fileTree == null) {
-          throw new Error('Rename requested before initial render.');
-        }
-
-        renameButton.disabled = true;
-        resultLabel.textContent = 'Renaming top-level folder…';
-
-        clearMeasureState(RENAME_MEASURE_SPEC);
-        const benchmark = ensureBenchmark();
-        const benchmarkSnapshot = benchmark?.createSnapshot() ?? null;
-        const rebuildModeCountsBefore = readRebuildModeCounts();
-
-        const sourcePath = selectTopLevelRenameFolder(fixtureState.files);
-        const destinationPath = buildRenamedTopLevelFolderPath(sourcePath);
-
-        const heapBefore = benchmark?.readHeapSnapshot() ?? null;
-        const operationStartTime = performance.now();
-        markMeasureStart(RENAME_MEASURE_SPEC);
-
-        fixtureState.fileTree.renamePath({
-          sourcePath,
-          destinationPath,
-          isFolder: true,
-        });
-
-        const { renderedItemCount } = await waitForTreeHost();
-        const visibleRowsReadyTime = performance.now();
-        await waitForPaint();
-        const operationEndTime = performance.now();
-        const heapAfter = benchmark?.readHeapSnapshot() ?? null;
-
-        markMeasureEnd(RENAME_MEASURE_SPEC);
-
-        const instrumentation =
-          benchmark != null
-            ? benchmarkSnapshot != null
-              ? benchmark.summarizeSince(
-                  benchmarkSnapshot,
-                  heapBefore,
-                  heapAfter
-                )
-              : benchmark.summarize(heapBefore, heapAfter)
-            : {
-                phases: [],
-                counters: {},
-                heap: null,
-              };
-
-        fixtureState.files = fixtureState.fileTree.getFiles();
-        fixtureState.renderedItemCount = renderedItemCount;
-        instrumentation.counters['workload.renameSourceLength'] =
-          sourcePath.length;
-        instrumentation.counters['workload.renameDestinationLength'] =
-          destinationPath.length;
-
-        const summary = createOperationSummary({
+        return runMutationOperation({
           operationName: 'rename-root-folder',
-          measureSpec: RENAME_MEASURE_SPEC,
-          operationStartTime,
-          operationEndTime,
-          visibleRowsReadyTime,
-          renderedItemCount,
-          instrumentation,
-          rebuildModeCountsBefore,
-          resultText: `Top-level rename post-paint ready ${formatMs(
-            getLatestMeasureDurationMs(RENAME_MEASURE_SPEC)
-          )}. ${sourcePath} → ${destinationPath}.`,
-        });
+          startMessage: 'Renaming top-level folder…',
+          mutate: () => {
+            const sourcePath = selectTopLevelRenameFolder(fixtureState.files);
+            const destinationPath = buildRenamedTopLevelFolderPath(sourcePath);
 
-        updateProfileOperation('rename-root-folder', summary);
-        resultLabel.textContent = summary.resultText;
-        renameButton.disabled = false;
-        return summary;
+            fixtureState.fileTree.renamePath({
+              sourcePath,
+              destinationPath,
+              isFolder: true,
+            });
+
+            return { sourcePath, destinationPath };
+          },
+          annotateCounters: (counters, details) => {
+            counters['workload.renameSourceLength'] = details.sourcePath.length;
+            counters['workload.renameDestinationLength'] =
+              details.destinationPath.length;
+          },
+          buildResultText: (details) =>
+            `Rename root folder post-paint ready ${formatMs(
+              getLatestMeasureDurationMs(RENAME_MEASURE_SPEC)
+            )}. ${details.sourcePath} → ${details.destinationPath}.`,
+        });
+      };
+
+      const runAddFileRoot = async () => {
+        return runMutationOperation({
+          operationName: 'add-file-root',
+          startMessage: 'Adding root file…',
+          mutate: () => {
+            const existingPaths = new Set(fixtureState.files);
+            const destinationPath = createUniquePath(
+              '__profile-added-root-file.ts',
+              existingPaths
+            );
+
+            fixtureState.fileTree.addPaths({
+              paths: [destinationPath],
+            });
+
+            return { destinationPath };
+          },
+          annotateCounters: (counters, details) => {
+            counters['workload.addPathLength'] = details.destinationPath.length;
+            counters['workload.addPathDepth'] = getPathDepth(
+              details.destinationPath
+            );
+          },
+          buildResultText: (details) =>
+            `Add root file post-paint ready ${formatMs(
+              getLatestMeasureDurationMs(RENAME_MEASURE_SPEC)
+            )}. added ${details.destinationPath}.`,
+        });
+      };
+
+      const runAddFileDeep = async () => {
+        return runMutationOperation({
+          operationName: 'add-file-deep',
+          startMessage: 'Adding deep file…',
+          mutate: () => {
+            const existingPaths = new Set(fixtureState.files);
+            const deepParentPath = getParentPath(
+              selectDeepFilePath(fixtureState.files, 6)
+            );
+            const candidatePath = `${deepParentPath}/__profile-added-deep-file.ts`;
+            const destinationPath = createUniquePath(
+              candidatePath,
+              existingPaths
+            );
+
+            fixtureState.fileTree.addPaths({
+              paths: [destinationPath],
+            });
+
+            return { destinationPath };
+          },
+          annotateCounters: (counters, details) => {
+            counters['workload.addPathLength'] = details.destinationPath.length;
+            counters['workload.addPathDepth'] = getPathDepth(
+              details.destinationPath
+            );
+          },
+          buildResultText: (details) =>
+            `Add deep file post-paint ready ${formatMs(
+              getLatestMeasureDurationMs(RENAME_MEASURE_SPEC)
+            )}. added ${details.destinationPath}.`,
+        });
+      };
+
+      const runDeleteFileDeep = async () => {
+        return runMutationOperation({
+          operationName: 'delete-file-deep',
+          startMessage: 'Deleting deep file…',
+          mutate: () => {
+            const sourcePath = selectDeepFilePath(fixtureState.files, 6);
+
+            fixtureState.fileTree.deletePaths({
+              paths: [sourcePath],
+            });
+
+            return { sourcePath };
+          },
+          annotateCounters: (counters, details) => {
+            counters['workload.deletePathLength'] = details.sourcePath.length;
+            counters['workload.deletePathDepth'] = getPathDepth(
+              details.sourcePath
+            );
+          },
+          buildResultText: (details) =>
+            `Delete deep file post-paint ready ${formatMs(
+              getLatestMeasureDurationMs(RENAME_MEASURE_SPEC)
+            )}. deleted ${details.sourcePath}.`,
+        });
+      };
+
+      const runDeleteRootFolder = async () => {
+        return runMutationOperation({
+          operationName: 'delete-root-folder',
+          startMessage: 'Deleting root folder…',
+          mutate: () => {
+            const sourcePath = selectTopLevelRenameFolder(fixtureState.files);
+
+            fixtureState.fileTree.deletePaths({
+              paths: [sourcePath],
+            });
+
+            return { sourcePath };
+          },
+          annotateCounters: (counters, details) => {
+            counters['workload.deletePathLength'] = details.sourcePath.length;
+            counters['workload.deletePathDepth'] = 1;
+          },
+          buildResultText: (details) =>
+            `Delete root folder post-paint ready ${formatMs(
+              getLatestMeasureDurationMs(RENAME_MEASURE_SPEC)
+            )}. deleted ${details.sourcePath}.`,
+        });
+      };
+
+      const runMoveFileToRoot = async () => {
+        return runMutationOperation({
+          operationName: 'move-file-to-root',
+          startMessage: 'Moving file to root…',
+          mutate: () => {
+            const scenario = selectMoveFileToRootScenario(fixtureState.files);
+
+            fixtureState.fileTree.movePaths({
+              draggedPaths: [scenario.sourcePath],
+              targetPath: scenario.targetPath,
+            });
+
+            return scenario;
+          },
+          annotateCounters: (counters, details) => {
+            counters['workload.moveSourceLength'] = details.sourcePath.length;
+            counters['workload.moveDestinationLength'] =
+              details.destinationPath.length;
+            counters['workload.moveSourceDepth'] = getPathDepth(
+              details.sourcePath
+            );
+            counters['workload.moveDestinationDepth'] = getPathDepth(
+              details.destinationPath
+            );
+          },
+          buildResultText: (details) =>
+            `Move file-to-root post-paint ready ${formatMs(
+              getLatestMeasureDurationMs(RENAME_MEASURE_SPEC)
+            )}. ${details.sourcePath} → ${details.destinationPath}.`,
+        });
+      };
+
+      const runMoveFolderToRoot = async () => {
+        return runMutationOperation({
+          operationName: 'move-folder-to-root',
+          startMessage: 'Moving deep folder to root…',
+          mutate: () => {
+            const scenario = selectMoveFolderToRootScenario(fixtureState.files);
+
+            fixtureState.fileTree.movePaths({
+              draggedPaths: [scenario.sourcePath],
+              targetPath: scenario.targetPath,
+            });
+
+            return scenario;
+          },
+          annotateCounters: (counters, details) => {
+            counters['workload.moveSourceLength'] = details.sourcePath.length;
+            counters['workload.moveDestinationLength'] =
+              details.destinationPath.length;
+            counters['workload.moveSourceDepth'] = getPathDepth(
+              details.sourcePath
+            );
+            counters['workload.moveDestinationDepth'] = getPathDepth(
+              details.destinationPath
+            );
+          },
+          buildResultText: (details) =>
+            `Move folder-to-root post-paint ready ${formatMs(
+              getLatestMeasureDurationMs(RENAME_MEASURE_SPEC)
+            )}. ${details.sourcePath} → ${details.destinationPath}.`,
+        });
+      };
+
+      const runMoveRootFolder = async () => {
+        return runMutationOperation({
+          operationName: 'move-root-folder',
+          startMessage: 'Moving root folder into another root folder…',
+          mutate: () => {
+            const { first, second } = selectTopLevelFolderPair(
+              fixtureState.files
+            );
+            const sourcePath = first;
+            const targetPath = second;
+            const destinationPath = `${targetPath}/${sourcePath}`;
+
+            fixtureState.fileTree.movePaths({
+              draggedPaths: [sourcePath],
+              targetPath,
+            });
+
+            return {
+              sourcePath,
+              targetPath,
+              destinationPath,
+            };
+          },
+          annotateCounters: (counters, details) => {
+            counters['workload.moveSourceLength'] = details.sourcePath.length;
+            counters['workload.moveDestinationLength'] =
+              details.destinationPath.length;
+            counters['workload.moveSourceDepth'] = 1;
+            counters['workload.moveDestinationDepth'] = getPathDepth(
+              details.destinationPath
+            );
+          },
+          buildResultText: (details) =>
+            `Move root-folder post-paint ready ${formatMs(
+              getLatestMeasureDurationMs(RENAME_MEASURE_SPEC)
+            )}. ${details.sourcePath} → ${details.destinationPath}.`,
+        });
+      };
+
+      const actionRunners = {
+        'rename-file': runRenameFile,
+        'rename-root-folder': runRenameRootFolder,
+        'add-file-root': runAddFileRoot,
+        'add-file-deep': runAddFileDeep,
+        'delete-file-deep': runDeleteFileDeep,
+        'delete-root-folder': runDeleteRootFolder,
+        'move-file-to-root': runMoveFileToRoot,
+        'move-folder-to-root': runMoveFolderToRoot,
+        'move-root-folder': runMoveRootFolder,
+      };
+
+      const runSelectedAction = async () => {
+        const actionName = actionSelect.value;
+        const runner = actionRunners[actionName];
+        if (typeof runner !== 'function') {
+          throw new Error(`Unknown selected action: ${actionName}`);
+        }
+        return runner();
       };
 
       window.__treesDevVirtualizationFixtureApi = {
         runInitialRender,
         runRenameFile,
         runRenameRootFolder,
+        runAddFileRoot,
+        runAddFileDeep,
+        runDeleteFileDeep,
+        runDeleteRootFolder,
+        runMoveFileToRoot,
+        runMoveFolderToRoot,
+        runMoveRootFolder,
       };
 
       renderButton.addEventListener('click', () => {
         void runInitialRender();
       });
 
-      renameButton.addEventListener('click', () => {
-        void runRenameFile();
+      actionButton.addEventListener('click', () => {
+        void runSelectedAction();
       });
 
       window.__treesDevVirtualizationFixtureReady = true;

--- a/packages/trees/test/file-tree-model.test.ts
+++ b/packages/trees/test/file-tree-model.test.ts
@@ -2,6 +2,60 @@ import { describe, expect, test } from 'bun:test';
 
 import { FileTreeModel } from '../src/model/FileTreeModel';
 
+function createCounterCollector(): {
+  counters: Record<string, number>;
+  instrumentation: {
+    measurePhase: <TValue>(name: string, fn: () => TValue) => TValue;
+    setCounter: (name: string, value: number) => void;
+  };
+} {
+  const counters: Record<string, number> = {};
+  return {
+    counters,
+    instrumentation: {
+      measurePhase: (_name, fn) => fn(),
+      setCounter: (name, value) => {
+        counters[name] = value;
+      },
+    },
+  };
+}
+
+function createMutationComplexityFixture(unrelatedFileCount: number): string[] {
+  const files = [
+    'workspace/src/deep/nested/file-a.ts',
+    'workspace/src/deep/nested/file-b.ts',
+    'workspace/src/deep/root-file.ts',
+    'workspace/target/keep.ts',
+  ];
+
+  for (let index = 0; index < unrelatedFileCount; index += 1) {
+    files.push(`noise-${index}/file-${index}.ts`);
+  }
+
+  return files;
+}
+
+function createInstrumentedModel(unrelatedFileCount: number): {
+  model: FileTreeModel;
+  counters: Record<string, number>;
+} {
+  const { counters, instrumentation } = createCounterCollector();
+  const model = FileTreeModel.fromFiles(
+    createMutationComplexityFixture(unrelatedFileCount),
+    {
+      sortComparator: false,
+      benchmarkInstrumentation: instrumentation,
+    }
+  );
+
+  return { model, counters };
+}
+
+function getCounter(counters: Record<string, number>, name: string): number {
+  return counters[name] ?? 0;
+}
+
 describe('FileTreeModel', () => {
   test('assigns deterministic IDs across independent instances', () => {
     const files = [
@@ -120,5 +174,213 @@ describe('FileTreeModel', () => {
     expect(syncIndex.pathToId.get('docs/components')).toBe(folderId);
     expect(syncIndex.pathToId.get('docs/components/Button.tsx')).toBe(childId);
     expect(syncIndex.pathToId.get('src/components')).toBeUndefined();
+  });
+
+  test('handles deep overwrite collisions during folder moves without stale IDs', () => {
+    const model = FileTreeModel.fromFiles(
+      ['src/nested/file.ts', 'docs/src/nested/file.ts', 'README.md'],
+      {
+        sortComparator: false,
+      }
+    );
+
+    const syncIndex = model.getSyncIndex();
+    const movedFileId = syncIndex.pathToId.get('src/nested/file.ts');
+    const overwrittenFileId = syncIndex.pathToId.get('docs/src/nested/file.ts');
+    expect(movedFileId).toBeDefined();
+    expect(overwrittenFileId).toBeDefined();
+    if (movedFileId == null || overwrittenFileId == null) {
+      throw new Error('Expected IDs for move collision test.');
+    }
+
+    const result = model.movePaths({
+      draggedPaths: ['src'],
+      targetPath: 'docs',
+      onCollision: () => true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(model.getFiles()).toEqual(['docs/src/nested/file.ts', 'README.md']);
+    expect(syncIndex.pathToId.get('docs/src/nested/file.ts')).toBe(movedFileId);
+    expect(model.hasId(overwrittenFileId)).toBe(false);
+  });
+
+  test('adds paths with semantic add-paths mutations', () => {
+    const model = FileTreeModel.fromFiles(['src/index.ts'], {
+      sortComparator: false,
+    });
+
+    const mutations: string[] = [];
+    model.subscribe((mutation) => {
+      mutations.push(mutation.kind);
+    });
+
+    const result = model.addPaths({
+      paths: ['src/utils/helpers.ts', 'docs/readme.md', 'src/index.ts'],
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+
+    expect(result.mutation?.kind).toBe('add-paths');
+    expect(model.getFiles()).toEqual([
+      'src/index.ts',
+      'src/utils/helpers.ts',
+      'docs/readme.md',
+    ]);
+    expect(mutations).toContain('add-paths');
+  });
+
+  test('deletes file and folder paths with semantic delete-paths mutations', () => {
+    const model = FileTreeModel.fromFiles(
+      [
+        'src/index.ts',
+        'src/utils/helpers.ts',
+        'src/utils/format.ts',
+        'docs/readme.md',
+      ],
+      {
+        sortComparator: false,
+      }
+    );
+
+    const syncIndex = model.getSyncIndex();
+    const docsId = syncIndex.pathToId.get('docs/readme.md');
+    expect(docsId).toBeDefined();
+
+    const result = model.deletePaths({
+      paths: ['src/utils', 'src/index.ts', 'missing/path.ts'],
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+
+    expect(result.mutation?.kind).toBe('delete-paths');
+    expect(model.getFiles()).toEqual(['docs/readme.md']);
+    expect(syncIndex.pathToId.get('docs/readme.md')).toBe(docsId);
+    expect(syncIndex.pathToId.get('src/index.ts')).toBeUndefined();
+    expect(syncIndex.pathToId.get('src/utils/helpers.ts')).toBeUndefined();
+  });
+
+  test('keeps file rename remap work constant with many unrelated files', () => {
+    const small = createInstrumentedModel(5);
+    const large = createInstrumentedModel(500);
+
+    const renameRequest = {
+      sourcePath: 'workspace/src/deep/nested/file-a.ts',
+      destinationPath: 'workspace/src/deep/nested/file-a-renamed.ts',
+      isFolder: false,
+    } as const;
+
+    const smallResult = small.model.renamePath(renameRequest);
+    const largeResult = large.model.renamePath(renameRequest);
+
+    expect(smallResult.ok).toBe(true);
+    expect(largeResult.ok).toBe(true);
+    expect(
+      getCounter(small.counters, 'model.rename.file.remapScannedNodes')
+    ).toBe(1);
+    expect(
+      getCounter(large.counters, 'model.rename.file.remapScannedNodes')
+    ).toBe(1);
+  });
+
+  test('keeps folder rename remap work proportional to moved subtree size', () => {
+    const small = createInstrumentedModel(5);
+    const large = createInstrumentedModel(500);
+
+    const renameRequest = {
+      sourcePath: 'workspace/src/deep',
+      destinationPath: 'workspace/src/deep-renamed',
+      isFolder: true,
+    } as const;
+
+    const smallResult = small.model.renamePath(renameRequest);
+    const largeResult = large.model.renamePath(renameRequest);
+
+    expect(smallResult.ok).toBe(true);
+    expect(largeResult.ok).toBe(true);
+    expect(
+      getCounter(small.counters, 'model.rename.folder.remapScannedNodes')
+    ).toBe(getCounter(large.counters, 'model.rename.folder.remapScannedNodes'));
+    expect(
+      getCounter(small.counters, 'model.rename.folder.remapUpdatedNodes')
+    ).toBe(getCounter(large.counters, 'model.rename.folder.remapUpdatedNodes'));
+  });
+
+  test('keeps file move remap work constant with many unrelated files', () => {
+    const small = createInstrumentedModel(5);
+    const large = createInstrumentedModel(500);
+
+    const moveRequest = {
+      draggedPaths: ['workspace/src/deep/nested/file-a.ts'],
+      targetPath: 'workspace/target',
+    };
+
+    const smallResult = small.model.movePaths(moveRequest);
+    const largeResult = large.model.movePaths(moveRequest);
+
+    expect(smallResult.ok).toBe(true);
+    expect(largeResult.ok).toBe(true);
+    expect(getCounter(small.counters, 'model.move.remapScannedNodes')).toBe(1);
+    expect(getCounter(large.counters, 'model.move.remapScannedNodes')).toBe(1);
+  });
+
+  test('keeps folder move remap work proportional to moved subtree size', () => {
+    const small = createInstrumentedModel(5);
+    const large = createInstrumentedModel(500);
+
+    const moveRequest = {
+      draggedPaths: ['workspace/src/deep'],
+      targetPath: 'workspace/target',
+    };
+
+    const smallResult = small.model.movePaths(moveRequest);
+    const largeResult = large.model.movePaths(moveRequest);
+
+    expect(smallResult.ok).toBe(true);
+    expect(largeResult.ok).toBe(true);
+    expect(getCounter(small.counters, 'model.move.remapScannedNodes')).toBe(
+      getCounter(large.counters, 'model.move.remapScannedNodes')
+    );
+    expect(getCounter(small.counters, 'model.move.remapUpdatedNodes')).toBe(
+      getCounter(large.counters, 'model.move.remapUpdatedNodes')
+    );
+  });
+
+  test('rebuilds only local folders for add/delete regardless of unrelated file volume', () => {
+    const smallAdd = createInstrumentedModel(5);
+    const largeAdd = createInstrumentedModel(500);
+
+    const addRequest = {
+      paths: ['workspace/src/deep/nested/added.ts'],
+    };
+
+    expect(smallAdd.model.addPaths(addRequest).ok).toBe(true);
+    expect(largeAdd.model.addPaths(addRequest).ok).toBe(true);
+
+    expect(
+      getCounter(smallAdd.counters, 'model.rebuildFolders.executedCount')
+    ).toBe(getCounter(largeAdd.counters, 'model.rebuildFolders.executedCount'));
+
+    const smallDelete = createInstrumentedModel(5);
+    const largeDelete = createInstrumentedModel(500);
+
+    const deleteRequest = {
+      paths: ['workspace/src/deep/nested/file-b.ts'],
+    };
+
+    expect(smallDelete.model.deletePaths(deleteRequest).ok).toBe(true);
+    expect(largeDelete.model.deletePaths(deleteRequest).ok).toBe(true);
+
+    expect(
+      getCounter(smallDelete.counters, 'model.rebuildFolders.executedCount')
+    ).toBe(
+      getCounter(largeDelete.counters, 'model.rebuildFolders.executedCount')
+    );
   });
 });

--- a/packages/trees/test/file-tree-model.test.ts
+++ b/packages/trees/test/file-tree-model.test.ts
@@ -21,7 +21,12 @@ function createCounterCollector(): {
   };
 }
 
-function createMutationComplexityFixture(unrelatedFileCount: number): string[] {
+type ComplexityFixtureShape = 'wide' | 'deep';
+
+function createMutationComplexityFixture(
+  unrelatedFileCount: number,
+  shape: ComplexityFixtureShape = 'wide'
+): string[] {
   const files = [
     'workspace/src/deep/nested/file-a.ts',
     'workspace/src/deep/nested/file-b.ts',
@@ -30,19 +35,31 @@ function createMutationComplexityFixture(unrelatedFileCount: number): string[] {
   ];
 
   for (let index = 0; index < unrelatedFileCount; index += 1) {
-    files.push(`noise-${index}/file-${index}.ts`);
+    if (shape === 'wide') {
+      files.push(`noise-${index}/file-${index}.ts`);
+      continue;
+    }
+
+    let parentPath = `noise-${index}`;
+    for (let depth = 0; depth < 8; depth += 1) {
+      parentPath = `${parentPath}/segment-${depth}`;
+    }
+    files.push(`${parentPath}/file-${index}.ts`);
   }
 
   return files;
 }
 
-function createInstrumentedModel(unrelatedFileCount: number): {
+function createInstrumentedModel(
+  unrelatedFileCount: number,
+  shape: ComplexityFixtureShape = 'wide'
+): {
   model: FileTreeModel;
   counters: Record<string, number>;
 } {
   const { counters, instrumentation } = createCounterCollector();
   const model = FileTreeModel.fromFiles(
-    createMutationComplexityFixture(unrelatedFileCount),
+    createMutationComplexityFixture(unrelatedFileCount, shape),
     {
       sortComparator: false,
       benchmarkInstrumentation: instrumentation,
@@ -369,6 +386,59 @@ describe('FileTreeModel', () => {
 
     const smallDelete = createInstrumentedModel(5);
     const largeDelete = createInstrumentedModel(500);
+
+    const deleteRequest = {
+      paths: ['workspace/src/deep/nested/file-b.ts'],
+    };
+
+    expect(smallDelete.model.deletePaths(deleteRequest).ok).toBe(true);
+    expect(largeDelete.model.deletePaths(deleteRequest).ok).toBe(true);
+
+    expect(
+      getCounter(smallDelete.counters, 'model.rebuildFolders.executedCount')
+    ).toBe(
+      getCounter(largeDelete.counters, 'model.rebuildFolders.executedCount')
+    );
+  });
+
+  test('keeps folder rename remap work stable across deep-thin unrelated trees', () => {
+    const small = createInstrumentedModel(4, 'deep');
+    const large = createInstrumentedModel(200, 'deep');
+
+    const renameRequest = {
+      sourcePath: 'workspace/src/deep',
+      destinationPath: 'workspace/src/deep-renamed',
+      isFolder: true,
+    } as const;
+
+    expect(small.model.renamePath(renameRequest).ok).toBe(true);
+    expect(large.model.renamePath(renameRequest).ok).toBe(true);
+
+    expect(
+      getCounter(small.counters, 'model.rename.folder.remapScannedNodes')
+    ).toBe(getCounter(large.counters, 'model.rename.folder.remapScannedNodes'));
+    expect(
+      getCounter(small.counters, 'model.rename.folder.remapUpdatedNodes')
+    ).toBe(getCounter(large.counters, 'model.rename.folder.remapUpdatedNodes'));
+  });
+
+  test('keeps local add/delete folder rebuild work stable across deep-thin unrelated trees', () => {
+    const smallAdd = createInstrumentedModel(4, 'deep');
+    const largeAdd = createInstrumentedModel(200, 'deep');
+
+    const addRequest = {
+      paths: ['workspace/src/deep/nested/added.ts'],
+    };
+
+    expect(smallAdd.model.addPaths(addRequest).ok).toBe(true);
+    expect(largeAdd.model.addPaths(addRequest).ok).toBe(true);
+
+    expect(
+      getCounter(smallAdd.counters, 'model.rebuildFolders.executedCount')
+    ).toBe(getCounter(largeAdd.counters, 'model.rebuildFolders.executedCount'));
+
+    const smallDelete = createInstrumentedModel(4, 'deep');
+    const largeDelete = createInstrumentedModel(200, 'deep');
 
     const deleteRequest = {
       paths: ['workspace/src/deep/nested/file-b.ts'],

--- a/packages/trees/test/file-tree-model.test.ts
+++ b/packages/trees/test/file-tree-model.test.ts
@@ -69,6 +69,23 @@ function createInstrumentedModel(
   return { model, counters };
 }
 
+function createTopLevelFolderRenameFixture(
+  rootFolderCount: number,
+  filesPerRootFolder: number
+): string[] {
+  const files: string[] = [];
+
+  for (let rootIndex = 0; rootIndex < rootFolderCount; rootIndex += 1) {
+    const rootName = `root-${rootIndex}`;
+    for (let fileIndex = 0; fileIndex < filesPerRootFolder; fileIndex += 1) {
+      const bucket = Math.floor(fileIndex / 25);
+      files.push(`${rootName}/bucket-${bucket}/file-${fileIndex}.ts`);
+    }
+  }
+
+  return files;
+}
+
 function getCounter(counters: Record<string, number>, name: string): number {
   return counters[name] ?? 0;
 }
@@ -119,6 +136,44 @@ describe('FileTreeModel', () => {
     expect(renamedId).toBe(originalId);
     expect(syncIndex.pathToId.get('src/a.ts')).toBeUndefined();
     expect(syncIndex.tree.get(originalId)?.path).toBe('src/a-renamed.ts');
+  });
+
+  test('reports rename-path childrenOrderChanged=false when sibling order is unchanged', () => {
+    const model = FileTreeModel.fromFiles(['src/a.ts', 'src/b.ts'], {
+      sortComparator: false,
+    });
+
+    const result = model.renamePath({
+      sourcePath: 'src/a.ts',
+      destinationPath: 'src/a-renamed.ts',
+      isFolder: false,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+
+    expect(result.mutation?.kind).toBe('rename-path');
+    expect(result.mutation?.childrenOrderChanged).toBe(false);
+  });
+
+  test('reports rename-path childrenOrderChanged=true when sorting reorders siblings', () => {
+    const model = FileTreeModel.fromFiles(['src/a.ts', 'src/b.ts']);
+
+    const result = model.renamePath({
+      sourcePath: 'src/a.ts',
+      destinationPath: 'src/z.ts',
+      isFolder: false,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+
+    expect(result.mutation?.kind).toBe('rename-path');
+    expect(result.mutation?.childrenOrderChanged).toBe(true);
   });
 
   test('reuses IDs for unchanged paths during replaceAll', () => {
@@ -327,6 +382,32 @@ describe('FileTreeModel', () => {
     expect(
       getCounter(small.counters, 'model.rename.folder.remapUpdatedNodes')
     ).toBe(getCounter(large.counters, 'model.rename.folder.remapUpdatedNodes'));
+  });
+
+  test('renaming a top-level folder stays on the cold path-tree fast path', () => {
+    const { counters, instrumentation } = createCounterCollector();
+    const model = FileTreeModel.fromFiles(
+      createTopLevelFolderRenameFixture(5, 200),
+      {
+        sortComparator: false,
+        benchmarkInstrumentation: instrumentation,
+      }
+    );
+
+    const renameResult = model.renamePath({
+      sourcePath: 'root-0',
+      destinationPath: 'root-0-renamed',
+      isFolder: true,
+    });
+
+    expect(renameResult.ok).toBe(true);
+    expect(getCounter(counters, 'model.pathTree.createdCount')).toBe(0);
+
+    const nextFiles = model.getFiles();
+    expect(nextFiles.some((path) => path.startsWith('root-0-renamed/'))).toBe(
+      true
+    );
+    expect(nextFiles.some((path) => path.startsWith('root-0/'))).toBe(false);
   });
 
   test('keeps file move remap work constant with many unrelated files', () => {

--- a/packages/trees/test/file-tree-model.test.ts
+++ b/packages/trees/test/file-tree-model.test.ts
@@ -408,6 +408,192 @@ describe('FileTreeModel', () => {
       true
     );
     expect(nextFiles.some((path) => path.startsWith('root-0/'))).toBe(false);
+    expect(getCounter(counters, 'model.snapshot.fileIndexRebuildCount')).toBe(
+      1
+    );
+  });
+
+  test('chained deferred folder remaps reuse snapshot file indices', () => {
+    const { counters, instrumentation } = createCounterCollector();
+    const model = FileTreeModel.fromFiles(
+      ['root-0/a.ts', 'root-0/b.ts', 'docs/readme.md'],
+      {
+        sortComparator: false,
+        benchmarkInstrumentation: instrumentation,
+      }
+    );
+
+    expect(
+      model.renamePath({
+        sourcePath: 'root-0',
+        destinationPath: 'root-a',
+        isFolder: true,
+      }).ok
+    ).toBe(true);
+
+    expect(
+      model.renamePath({
+        sourcePath: 'root-a',
+        destinationPath: 'root-b',
+        isFolder: true,
+      }).ok
+    ).toBe(true);
+
+    expect(model.getFiles()).toEqual([
+      'root-b/a.ts',
+      'root-b/b.ts',
+      'docs/readme.md',
+    ]);
+    expect(getCounter(counters, 'model.snapshot.fileIndexRebuildCount')).toBe(
+      1
+    );
+  });
+
+  test('file rename after deferred folder remap reuses snapshot file indices', () => {
+    const { counters, instrumentation } = createCounterCollector();
+    const model = FileTreeModel.fromFiles(
+      ['root-0/a.ts', 'root-0/b.ts', 'docs/readme.md'],
+      {
+        sortComparator: false,
+        benchmarkInstrumentation: instrumentation,
+      }
+    );
+
+    expect(
+      model.renamePath({
+        sourcePath: 'root-0',
+        destinationPath: 'root-a',
+        isFolder: true,
+      }).ok
+    ).toBe(true);
+
+    expect(
+      model.renamePath({
+        sourcePath: 'root-a/a.ts',
+        destinationPath: 'root-a/a-renamed.ts',
+        isFolder: false,
+      }).ok
+    ).toBe(true);
+
+    expect(model.getFiles()).toEqual([
+      'root-a/a-renamed.ts',
+      'root-a/b.ts',
+      'docs/readme.md',
+    ]);
+    expect(getCounter(counters, 'model.snapshot.fileIndexRebuildCount')).toBe(
+      1
+    );
+  });
+
+  test('keeps deferred folder remaps when addPaths creates the path tree', () => {
+    const { counters, instrumentation } = createCounterCollector();
+    const model = FileTreeModel.fromFiles(
+      ['root-0/a.ts', 'docs/readme.md', 'other/keep.md'],
+      {
+        sortComparator: false,
+        benchmarkInstrumentation: instrumentation,
+      }
+    );
+
+    const syncIndex = model.getSyncIndex();
+    const renamedRootId = syncIndex.pathToId.get('root-0');
+    expect(renamedRootId).toBeDefined();
+    if (renamedRootId == null) {
+      throw new Error('Expected stable ID for root-0');
+    }
+
+    expect(
+      model.renamePath({
+        sourcePath: 'root-0',
+        destinationPath: 'root-0-renamed',
+        isFolder: true,
+      }).ok
+    ).toBe(true);
+
+    expect(model.addPaths({ paths: ['docs/new.ts'] }).ok).toBe(true);
+
+    expect(syncIndex.pathToId.get('root-0-renamed')).toBe(renamedRootId);
+    expect(model.getPathForId(renamedRootId)).toBe('root-0-renamed');
+    expect(
+      getCounter(counters, 'model.pathPrefixRemaps.materializedCount')
+    ).toBe(0);
+  });
+
+  test('keeps deferred folder remaps when movePaths creates the path tree', () => {
+    const { counters, instrumentation } = createCounterCollector();
+    const model = FileTreeModel.fromFiles(
+      ['root-0/a.ts', 'docs/readme.md', 'other/keep.md'],
+      {
+        sortComparator: false,
+        benchmarkInstrumentation: instrumentation,
+      }
+    );
+
+    const syncIndex = model.getSyncIndex();
+    const renamedRootId = syncIndex.pathToId.get('root-0');
+    const movedFileId = syncIndex.pathToId.get('docs/readme.md');
+    expect(renamedRootId).toBeDefined();
+    expect(movedFileId).toBeDefined();
+    if (renamedRootId == null || movedFileId == null) {
+      throw new Error('Expected stable IDs for deferred move remap test');
+    }
+
+    expect(
+      model.renamePath({
+        sourcePath: 'root-0',
+        destinationPath: 'root-0-renamed',
+        isFolder: true,
+      }).ok
+    ).toBe(true);
+
+    expect(
+      model.movePaths({
+        draggedPaths: ['docs/readme.md'],
+        targetPath: 'other',
+      }).ok
+    ).toBe(true);
+
+    expect(syncIndex.pathToId.get('other/readme.md')).toBe(movedFileId);
+    expect(syncIndex.pathToId.get('root-0-renamed')).toBe(renamedRootId);
+    expect(model.getPathForId(renamedRootId)).toBe('root-0-renamed');
+    expect(
+      getCounter(counters, 'model.pathPrefixRemaps.materializedCount')
+    ).toBe(0);
+  });
+
+  test('keeps deferred folder remaps when deletePaths creates the path tree', () => {
+    const { counters, instrumentation } = createCounterCollector();
+    const model = FileTreeModel.fromFiles(
+      ['root-0/a.ts', 'docs/readme.md', 'other/keep.md'],
+      {
+        sortComparator: false,
+        benchmarkInstrumentation: instrumentation,
+      }
+    );
+
+    const syncIndex = model.getSyncIndex();
+    const renamedRootId = syncIndex.pathToId.get('root-0');
+    expect(renamedRootId).toBeDefined();
+    if (renamedRootId == null) {
+      throw new Error('Expected stable ID for root-0');
+    }
+
+    expect(
+      model.renamePath({
+        sourcePath: 'root-0',
+        destinationPath: 'root-0-renamed',
+        isFolder: true,
+      }).ok
+    ).toBe(true);
+
+    expect(model.deletePaths({ paths: ['docs/readme.md'] }).ok).toBe(true);
+
+    expect(syncIndex.pathToId.get('docs/readme.md')).toBeUndefined();
+    expect(syncIndex.pathToId.get('root-0-renamed')).toBe(renamedRootId);
+    expect(model.getPathForId(renamedRootId)).toBe('root-0-renamed');
+    expect(
+      getCounter(counters, 'model.pathPrefixRemaps.materializedCount')
+    ).toBe(0);
   });
 
   test('keeps file move remap work constant with many unrelated files', () => {

--- a/packages/trees/test/file-tree-model.test.ts
+++ b/packages/trees/test/file-tree-model.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'bun:test';
+
+import { FileTreeModel } from '../src/model/FileTreeModel';
+
+describe('FileTreeModel', () => {
+  test('keeps file IDs stable across same-parent rename', () => {
+    const model = FileTreeModel.fromFiles(['src/a.ts', 'src/b.ts'], {
+      sortComparator: false,
+    });
+
+    const syncIndex = model.getSyncIndex();
+    const originalId = syncIndex.pathToId.get('src/a.ts');
+    expect(originalId).toBeDefined();
+    if (originalId == null) {
+      throw new Error('Expected stable ID for src/a.ts');
+    }
+
+    const result = model.renamePath({
+      sourcePath: 'src/a.ts',
+      destinationPath: 'src/a-renamed.ts',
+      isFolder: false,
+    });
+    expect(result.ok).toBe(true);
+
+    const renamedId = syncIndex.pathToId.get('src/a-renamed.ts');
+    expect(renamedId).toBe(originalId);
+    expect(syncIndex.pathToId.get('src/a.ts')).toBeUndefined();
+    expect(syncIndex.tree.get(originalId)?.path).toBe('src/a-renamed.ts');
+  });
+
+  test('reuses IDs for unchanged paths during replaceAll', () => {
+    const model = FileTreeModel.fromFiles(['src/a.ts', 'src/b.ts'], {
+      sortComparator: false,
+    });
+    const syncIndex = model.getSyncIndex();
+
+    const aIdBefore = syncIndex.pathToId.get('src/a.ts');
+    expect(aIdBefore).toBeDefined();
+
+    model.replaceAll(['src/a.ts', 'src/c.ts']);
+
+    expect(syncIndex.pathToId.get('src/a.ts')).toBe(aIdBefore);
+    expect(syncIndex.pathToId.get('src/b.ts')).toBeUndefined();
+    expect(syncIndex.pathToId.get('src/c.ts')).toBeDefined();
+  });
+
+  test('keeps file IDs stable across movePaths file moves', () => {
+    const model = FileTreeModel.fromFiles(
+      ['src/index.ts', 'docs/guide.md', 'README.md'],
+      {
+        sortComparator: false,
+      }
+    );
+    const syncIndex = model.getSyncIndex();
+    const movedId = syncIndex.pathToId.get('src/index.ts');
+    expect(movedId).toBeDefined();
+    if (movedId == null) {
+      throw new Error('Expected stable ID for src/index.ts');
+    }
+
+    const result = model.movePaths({
+      draggedPaths: ['src/index.ts'],
+      targetPath: 'docs',
+    });
+    expect(result.ok).toBe(true);
+
+    expect(syncIndex.pathToId.get('docs/index.ts')).toBe(movedId);
+    expect(syncIndex.pathToId.get('src/index.ts')).toBeUndefined();
+  });
+
+  test('keeps folder and descendant IDs stable across movePaths folder moves', () => {
+    const model = FileTreeModel.fromFiles(
+      [
+        'src/components/Button.tsx',
+        'src/components/Card.tsx',
+        'docs/readme.md',
+      ],
+      {
+        sortComparator: false,
+      }
+    );
+    const syncIndex = model.getSyncIndex();
+
+    const folderId = syncIndex.pathToId.get('src/components');
+    const childId = syncIndex.pathToId.get('src/components/Button.tsx');
+    expect(folderId).toBeDefined();
+    expect(childId).toBeDefined();
+    if (folderId == null || childId == null) {
+      throw new Error('Expected stable IDs for moved folder and child.');
+    }
+
+    const result = model.movePaths({
+      draggedPaths: ['src/components'],
+      targetPath: 'docs',
+    });
+    expect(result.ok).toBe(true);
+
+    expect(syncIndex.pathToId.get('docs/components')).toBe(folderId);
+    expect(syncIndex.pathToId.get('docs/components/Button.tsx')).toBe(childId);
+    expect(syncIndex.pathToId.get('src/components')).toBeUndefined();
+  });
+});

--- a/packages/trees/test/file-tree-model.test.ts
+++ b/packages/trees/test/file-tree-model.test.ts
@@ -3,6 +3,28 @@ import { describe, expect, test } from 'bun:test';
 import { FileTreeModel } from '../src/model/FileTreeModel';
 
 describe('FileTreeModel', () => {
+  test('assigns deterministic IDs across independent instances', () => {
+    const files = [
+      'README.md',
+      'src/index.ts',
+      'src/components/Button.tsx',
+      'docs/guide.md',
+    ];
+
+    const modelA = FileTreeModel.fromFiles(files, { sortComparator: false });
+    const modelB = FileTreeModel.fromFiles([...files].reverse(), {
+      sortComparator: false,
+    });
+
+    const indexA = modelA.getSyncIndex();
+    const indexB = modelB.getSyncIndex();
+
+    for (let index = 0; index < files.length; index += 1) {
+      const path = files[index];
+      expect(indexA.pathToId.get(path)).toBe(indexB.pathToId.get(path));
+    }
+  });
+
   test('keeps file IDs stable across same-parent rename', () => {
     const model = FileTreeModel.fromFiles(['src/a.ts', 'src/b.ts'], {
       sortComparator: false,

--- a/packages/trees/test/guide-line-ancestors.test.ts
+++ b/packages/trees/test/guide-line-ancestors.test.ts
@@ -3,6 +3,7 @@ import { h } from 'preact';
 import { renderToString } from 'preact-render-to-string';
 
 import { Root } from '../src/components/Root';
+import { FileTreeModel } from '../src/model/FileTreeModel';
 import type { FileTreeData } from '../src/types';
 import { fileListToTree } from '../src/utils/fileListToTree';
 import {
@@ -255,7 +256,7 @@ describe('SSR guide-line style output', () => {
     return renderToString(
       h(Root, {
         fileTreeOptions: {
-          initialFiles: files,
+          model: FileTreeModel.fromFiles(files),
           flattenEmptyDirectories: opts.flattenEmptyDirectories ?? false,
           id: 'ssr-test',
         },

--- a/packages/trees/test/mutable-path-tree.test.ts
+++ b/packages/trees/test/mutable-path-tree.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from 'bun:test';
+
+import { MutablePathTree } from '../src/utils/mutablePathTree';
+
+describe('MutablePathTree', () => {
+  test('indexes files and inferred folders', () => {
+    const tree = MutablePathTree.fromFiles([
+      'src/index.ts',
+      'src/utils/helpers.ts',
+      'docs/readme.md',
+    ]);
+
+    expect(tree.hasFile('src/index.ts')).toBe(true);
+    expect(tree.hasFolder('src')).toBe(true);
+    expect(tree.hasFolder('src/utils')).toBe(true);
+    expect(tree.hasFolder('docs')).toBe(true);
+    expect(tree.hasPath('missing')).toBe(false);
+  });
+
+  test('renames files in place', () => {
+    const tree = MutablePathTree.fromFiles(['src/index.ts', 'docs/readme.md']);
+
+    expect(tree.renamePath('src/index.ts', 'src/main.ts', 'file')).toBe('ok');
+    expect(tree.cloneFiles()).toEqual(['src/main.ts', 'docs/readme.md']);
+    expect(tree.hasFile('src/index.ts')).toBe(false);
+    expect(tree.hasFile('src/main.ts')).toBe(true);
+  });
+
+  test('renames folders and rewrites descendant file paths', () => {
+    const tree = MutablePathTree.fromFiles([
+      'src/index.ts',
+      'src/utils/helpers.ts',
+      'docs/readme.md',
+    ]);
+
+    expect(tree.renamePath('src', 'lib', 'folder')).toBe('ok');
+    expect(tree.cloneFiles()).toEqual([
+      'lib/index.ts',
+      'lib/utils/helpers.ts',
+      'docs/readme.md',
+    ]);
+    expect(tree.hasFolder('lib')).toBe(true);
+    expect(tree.hasFolder('src')).toBe(false);
+  });
+
+  test('moves a single file between folders', () => {
+    const tree = MutablePathTree.fromFiles([
+      'src/index.ts',
+      'docs/readme.md',
+      'package.json',
+    ]);
+
+    expect(tree.movePath('src/index.ts', 'docs', 'index.ts', 'file')).toBe(
+      'ok'
+    );
+    expect(tree.cloneFiles()).toEqual([
+      'docs/index.ts',
+      'docs/readme.md',
+      'package.json',
+    ]);
+  });
+
+  test('moves a folder and all descendants', () => {
+    const tree = MutablePathTree.fromFiles([
+      'src/utils/a.ts',
+      'src/utils/b.ts',
+      'docs/readme.md',
+    ]);
+
+    expect(tree.movePath('src/utils', 'docs', 'utils', 'folder')).toBe('ok');
+    expect(tree.cloneFiles()).toEqual([
+      'docs/utils/a.ts',
+      'docs/utils/b.ts',
+      'docs/readme.md',
+    ]);
+  });
+
+  test('adds and deletes file paths', () => {
+    const tree = MutablePathTree.fromFiles(['src/index.ts']);
+
+    expect(tree.addFilePath('src/utils/helpers.ts')).toBe(true);
+    expect(tree.addFilePath('src/utils/helpers.ts')).toBe(false);
+    expect(tree.cloneFiles()).toEqual(['src/index.ts', 'src/utils/helpers.ts']);
+
+    expect(tree.deleteFilePath('src/index.ts')).toBe(true);
+    expect(tree.deleteFilePath('missing.ts')).toBe(false);
+    expect(tree.cloneFiles()).toEqual(['src/utils/helpers.ts']);
+  });
+
+  test('deletes folders by removing descendant files', () => {
+    const tree = MutablePathTree.fromFiles([
+      'src/index.ts',
+      'src/utils/helpers.ts',
+      'docs/readme.md',
+    ]);
+
+    expect(tree.deleteFolderPath('src')).toBe(true);
+    expect(tree.cloneFiles()).toEqual(['docs/readme.md']);
+    expect(tree.hasFolder('src')).toBe(false);
+  });
+
+  test('returns descendant files in source order', () => {
+    const tree = MutablePathTree.fromFiles([
+      'src/a.ts',
+      'src/deep/b.ts',
+      'src/deep/c.ts',
+      'docs/readme.md',
+    ]);
+
+    expect(tree.getDescendantFilePaths('src')).toEqual([
+      'src/a.ts',
+      'src/deep/b.ts',
+      'src/deep/c.ts',
+    ]);
+  });
+});

--- a/packages/trees/test/react-controlled.test.tsx
+++ b/packages/trees/test/react-controlled.test.tsx
@@ -71,6 +71,7 @@ import {
   FileTree as FileTreeClass,
   type FileTreeStateConfig,
 } from '../src/FileTree';
+import { FileTreeModel } from '../src/model/FileTreeModel';
 import { FileTree as FileTreeReact } from '../src/react/FileTree';
 
 // ---------------------------------------------------------------------------
@@ -97,10 +98,6 @@ const setCallbacksSpy = spyOn(
   FileTreeClass.prototype,
   'setCallbacks'
 ).mockImplementation(() => {});
-const setFilesSpy = spyOn(
-  FileTreeClass.prototype,
-  'setFiles'
-).mockImplementation(() => {});
 
 const resetMethodMocks = (): void => {
   renderSpy.mockImplementation(() => {});
@@ -108,7 +105,6 @@ const resetMethodMocks = (): void => {
   setExpandedSpy.mockImplementation(() => {});
   setSelectedSpy.mockImplementation(() => {});
   setCallbacksSpy.mockImplementation(() => {});
-  setFilesSpy.mockImplementation(() => {});
 };
 
 const requireCapturedStateConfig = (
@@ -125,6 +121,7 @@ const requireCapturedStateConfig = (
 // ---------------------------------------------------------------------------
 
 const FILES = ['README.md', 'src/index.ts', 'src/components/Button.tsx'];
+const createModel = () => FileTreeModel.fromFiles(FILES);
 
 describe('React controlled FileTree wrapper', () => {
   let container: HTMLElement;
@@ -140,7 +137,6 @@ describe('React controlled FileTree wrapper', () => {
     setExpandedSpy.mockClear();
     setSelectedSpy.mockClear();
     setCallbacksSpy.mockClear();
-    setFilesSpy.mockClear();
   });
 
   afterEach(() => {
@@ -156,14 +152,13 @@ describe('React controlled FileTree wrapper', () => {
     setExpandedSpy.mockRestore();
     setSelectedSpy.mockRestore();
     setCallbacksSpy.mockRestore();
-    setFilesSpy.mockRestore();
   });
 
   // -- Mount / unmount --
 
   test('creates FileTree instance and calls render on mount', () => {
     act(() => {
-      root.render(<FileTreeReact options={{}} files={FILES} />);
+      root.render(<FileTreeReact options={{}} model={createModel()} />);
     });
 
     expect(renderSpy).toHaveBeenCalled();
@@ -171,7 +166,7 @@ describe('React controlled FileTree wrapper', () => {
 
   test('calls cleanUp on unmount', () => {
     act(() => {
-      root.render(<FileTreeReact options={{}} files={FILES} />);
+      root.render(<FileTreeReact options={{}} model={createModel()} />);
     });
 
     cleanUpSpy.mockClear();
@@ -194,7 +189,7 @@ describe('React controlled FileTree wrapper', () => {
       return (
         <FileTreeReact
           options={{}}
-          files={FILES}
+          model={createModel()}
           expandedItems={expanded}
           onExpandedItemsChange={setter}
         />
@@ -221,7 +216,7 @@ describe('React controlled FileTree wrapper', () => {
       return (
         <FileTreeReact
           options={{}}
-          files={FILES}
+          model={createModel()}
           expandedItems={expanded}
           onExpandedItemsChange={setter}
         />
@@ -247,7 +242,7 @@ describe('React controlled FileTree wrapper', () => {
       return (
         <FileTreeReact
           options={{}}
-          files={FILES}
+          model={createModel()}
           selectedItems={selected}
           onSelectedItemsChange={setter}
         />
@@ -277,7 +272,7 @@ describe('React controlled FileTree wrapper', () => {
       root.render(
         <FileTreeReact
           options={{}}
-          files={FILES}
+          model={createModel()}
           onExpandedItemsChange={onExpanded}
           onSelectedItemsChange={onSelected}
         />
@@ -299,7 +294,11 @@ describe('React controlled FileTree wrapper', () => {
       const [cb, setCb] = useState<() => void>(() => {});
       setCallback = setCb;
       return (
-        <FileTreeReact options={{}} files={FILES} onExpandedItemsChange={cb} />
+        <FileTreeReact
+          options={{}}
+          model={createModel()}
+          onExpandedItemsChange={cb}
+        />
       );
     }
 
@@ -330,7 +329,7 @@ describe('React controlled FileTree wrapper', () => {
       return (
         <FileTreeReact
           options={{ flattenEmptyDirectories: flatten }}
-          files={FILES}
+          model={createModel()}
         />
       );
     }
@@ -364,7 +363,11 @@ describe('React controlled FileTree wrapper', () => {
 
     act(() => {
       root.render(
-        <FileTreeReact options={{}} files={FILES} expandedItems={['src']} />
+        <FileTreeReact
+          options={{}}
+          model={createModel()}
+          expandedItems={['src']}
+        />
       );
     });
 
@@ -388,7 +391,7 @@ describe('React controlled FileTree wrapper', () => {
       root.render(
         <FileTreeReact
           options={{}}
-          files={FILES}
+          model={createModel()}
           selectedItems={['README.md']}
         />
       );
@@ -403,41 +406,36 @@ describe('React controlled FileTree wrapper', () => {
     renderSpy.mockImplementation(() => {});
   });
 
-  // -- Controlled files --
+  // -- Model-driven data updates --
 
-  test('calls setFiles when files prop changes', () => {
-    let setFiles!: (files: string[]) => void;
+  test('passes model to the FileTree constructor options', () => {
+    let capturedOptions: FileTreeClass['options'] | null = null;
+    const model = createModel();
+    renderSpy.mockImplementation(function (this: FileTreeClass) {
+      capturedOptions = this.options;
+    });
 
-    function Harness() {
-      const [files, setter] = useState(FILES);
-      setFiles = setter;
-      const stableOptions = useMemo(() => ({}), []);
-      return <FileTreeReact options={stableOptions} files={files} />;
+    act(() => {
+      root.render(<FileTreeReact options={{}} model={model} />);
+    });
+
+    expect(capturedOptions).not.toBeNull();
+    if (capturedOptions == null) {
+      throw new Error('Expected constructor options to be captured');
     }
+    expect((capturedOptions as { model?: FileTreeModel }).model).toBe(model);
 
-    act(() => {
-      root.render(<Harness />);
-    });
-
-    // Clear spies from mount (the initial useEffect fires setFiles)
-    setFilesSpy.mockClear();
-
-    const newFiles = ['package.json'];
-    act(() => {
-      setFiles(newFiles);
-    });
-
-    expect(setFilesSpy).toHaveBeenCalledWith(newFiles);
+    renderSpy.mockImplementation(() => {});
   });
 
-  test('does NOT recreate FileTree when files prop changes', () => {
-    let setFiles!: (files: string[]) => void;
+  test('recreates FileTree when model prop identity changes', () => {
+    let setModel!: (model: FileTreeModel) => void;
 
     function Harness() {
-      const [files, setter] = useState(FILES);
-      setFiles = setter;
+      const [model, setter] = useState<FileTreeModel>(() => createModel());
+      setModel = setter;
       const stableOptions = useMemo(() => ({}), []);
-      return <FileTreeReact options={stableOptions} files={files} />;
+      return <FileTreeReact options={stableOptions} model={model} />;
     }
 
     act(() => {
@@ -445,32 +443,27 @@ describe('React controlled FileTree wrapper', () => {
     });
 
     cleanUpSpy.mockClear();
-    setFilesSpy.mockClear();
 
     act(() => {
-      setFiles(['package.json']);
+      setModel(FileTreeModel.fromFiles(['package.json']));
     });
 
-    // Should NOT recreate the instance — only setFiles should be called
-    expect(cleanUpSpy).not.toHaveBeenCalled();
-    expect(setFilesSpy).toHaveBeenCalled();
+    expect(cleanUpSpy).toHaveBeenCalled();
   });
 
-  test('passes initialFiles to constructor from files prop', () => {
-    let capturedOptions: FileTreeClass['options'] | null = null;
-    renderSpy.mockImplementation(function (this: FileTreeClass) {
-      capturedOptions = this.options;
-    });
+  test('model mutations do not recreate the FileTree instance', () => {
+    const model = createModel();
 
     act(() => {
-      root.render(<FileTreeReact options={{}} files={FILES} />);
+      root.render(<FileTreeReact options={{}} model={model} />);
     });
 
-    expect(capturedOptions).not.toBeNull();
-    expect(capturedOptions!.initialFiles).toEqual(FILES);
+    cleanUpSpy.mockClear();
+    act(() => {
+      model.replaceAll(['package.json']);
+    });
 
-    // Restore spy
-    renderSpy.mockImplementation(() => {});
+    expect(cleanUpSpy).not.toHaveBeenCalled();
   });
 
   test('passes onFilesChange callback via setCallbacks', () => {
@@ -480,7 +473,7 @@ describe('React controlled FileTree wrapper', () => {
       root.render(
         <FileTreeReact
           options={{}}
-          files={FILES}
+          model={createModel()}
           onFilesChange={onFilesChange}
         />
       );
@@ -500,7 +493,7 @@ describe('React controlled FileTree wrapper', () => {
       root.render(
         <FileTreeReact
           options={{}}
-          files={FILES}
+          model={createModel()}
           renderContextMenu={renderCtx}
         />
       );
@@ -518,7 +511,7 @@ describe('React controlled FileTree wrapper', () => {
 
   test('does NOT pass context menu callbacks when renderContextMenu is not provided', () => {
     act(() => {
-      root.render(<FileTreeReact options={{}} files={FILES} />);
+      root.render(<FileTreeReact options={{}} model={createModel()} />);
     });
 
     // Without renderContextMenu, context menu callbacks should be undefined
@@ -534,7 +527,7 @@ describe('React controlled FileTree wrapper', () => {
       root.render(
         <FileTreeReact
           options={{}}
-          files={FILES}
+          model={createModel()}
           onContextMenuOpen={onContextMenuOpen}
         />
       );
@@ -555,7 +548,7 @@ describe('React controlled FileTree wrapper', () => {
       const html = renderToString(
         <FileTreeReact
           options={{}}
-          initialFiles={FILES}
+          model={createModel()}
           prerenderedHTML={'<div data-file-tree-id="ft_srv_test"></div>'}
           header={<button data-test-header>Header action</button>}
         />
@@ -598,7 +591,7 @@ describe('React controlled FileTree wrapper', () => {
       root.render(
         <FileTreeReact
           options={{}}
-          files={FILES}
+          model={createModel()}
           renderContextMenu={(item) => <div data-test-menu>{item.path}</div>}
         />
       );
@@ -648,7 +641,7 @@ describe('React controlled FileTree wrapper', () => {
         root.render(
           <FileTreeReact
             options={{}}
-            files={FILES}
+            model={createModel()}
             containerId={host.id}
             header={<button data-test-header>Header action</button>}
           />
@@ -663,7 +656,11 @@ describe('React controlled FileTree wrapper', () => {
 
       act(() => {
         root.render(
-          <FileTreeReact options={{}} files={FILES} containerId={host.id} />
+          <FileTreeReact
+            options={{}}
+            model={createModel()}
+            containerId={host.id}
+          />
         );
       });
 

--- a/packages/trees/test/rename-file-tree-paths.test.ts
+++ b/packages/trees/test/rename-file-tree-paths.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
+import { MutablePathTree } from '../src/utils/mutablePathTree';
 import {
   remapExpandedPathsForFolderRename,
   renameFileTreePaths,
@@ -157,6 +158,47 @@ describe('renameFileTreePaths', () => {
 
     expect(result).toEqual({
       error: 'Could not find the selected folder to rename.',
+    });
+  });
+
+  test('can mutate a persistent path tree in place', () => {
+    const files = ['src/index.ts', 'src/utils/helpers.ts'];
+    const pathTree = MutablePathTree.fromFiles(files);
+
+    const firstResult = renameFileTreePaths({
+      files,
+      path: 'src',
+      isFolder: true,
+      nextBasename: 'lib',
+      pathTree,
+      mutatePathTree: true,
+    });
+
+    expect(firstResult).toEqual({
+      nextFiles: ['lib/index.ts', 'lib/utils/helpers.ts'],
+      sourcePath: 'src',
+      destinationPath: 'lib',
+      isFolder: true,
+    });
+
+    if ('error' in firstResult) {
+      throw new Error(firstResult.error);
+    }
+
+    const secondResult = renameFileTreePaths({
+      files: firstResult.nextFiles,
+      path: 'lib/utils/helpers.ts',
+      isFolder: false,
+      nextBasename: 'format.ts',
+      pathTree,
+      mutatePathTree: true,
+    });
+
+    expect(secondResult).toEqual({
+      nextFiles: ['lib/index.ts', 'lib/utils/format.ts'],
+      sourcePath: 'lib/utils/helpers.ts',
+      destinationPath: 'lib/utils/format.ts',
+      isFolder: false,
     });
   });
 });

--- a/packages/trees/test/root-memoization-regressions.test.ts
+++ b/packages/trees/test/root-memoization-regressions.test.ts
@@ -13,6 +13,7 @@ import { selectionFeature } from '../src/features/selection/feature';
 import { syncDataLoaderFeature } from '../src/features/sync-data-loader/feature';
 import type { FileTreeSearchConfig } from '../src/FileTree';
 import { generateSyncDataLoader } from '../src/loader/sync';
+import { FileTreeModel } from '../src/model/FileTreeModel';
 import type { FileTreeNode } from '../src/types';
 
 let FileTree: typeof import('../src/FileTree').FileTree;
@@ -127,7 +128,7 @@ describe('Root memoization regressions', () => {
 
   test('folder rows update aria-expanded when expansion state changes', async () => {
     const ft = new FileTree({
-      initialFiles: ['README.md', 'src/index.ts'],
+      model: FileTreeModel.fromFiles(['README.md', 'src/index.ts']),
     });
     const containerWrapper = document.createElement('div');
 

--- a/packages/trees/test/ssr-declarative-shadow-dom.test.ts
+++ b/packages/trees/test/ssr-declarative-shadow-dom.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../src/utils/renameFileTreePaths';
 
 let FileTree: typeof import('../src/FileTree').FileTree;
+let FileTreeModel: typeof import('../src/model/FileTreeModel').FileTreeModel;
 let preloadFileTree: typeof import('../src/ssr/preloadFileTree').preloadFileTree;
 let ensureFileTreeStyles: typeof import('../src/components/web-components').ensureFileTreeStyles;
 let adoptDeclarativeShadowDom: typeof import('../src/components/web-components').adoptDeclarativeShadowDom;
@@ -41,6 +42,7 @@ beforeAll(async () => {
   Object.assign(globalThis, { CSSStyleSheet: MockCSSStyleSheet });
 
   ({ FileTree } = await import('../src/FileTree'));
+  ({ FileTreeModel } = await import('../src/model/FileTreeModel'));
   ({ preloadFileTree } = await import('../src/ssr/preloadFileTree'));
   ({ ensureFileTreeStyles, adoptDeclarativeShadowDom } =
     await import('../src/components/web-components'));
@@ -63,9 +65,60 @@ const CUSTOM_SPRITE_B = `
 </svg>
 `;
 
+const flushRenderWork = async () => {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+function createFileTree(
+  options: Omit<import('../src/FileTree').FileTreeOptions, 'model'> & {
+    initialFiles: string[];
+  },
+  stateConfig?: import('../src/FileTree').FileTreeStateConfig
+): import('../src/FileTree').FileTree {
+  const { initialFiles, sort, ...restOptions } = options;
+  const sortComparator =
+    sort === false
+      ? false
+      : sort != null && typeof sort === 'object'
+        ? sort.comparator
+        : undefined;
+  return new FileTree(
+    {
+      ...restOptions,
+      sort,
+      model: FileTreeModel.fromFiles(initialFiles, { sortComparator }),
+    },
+    stateConfig
+  );
+}
+
+function preloadFileTreeWithFiles(
+  options: Omit<import('../src/FileTree').FileTreeOptions, 'model'> & {
+    initialFiles: string[];
+  },
+  stateConfig?: import('../src/FileTree').FileTreeStateConfig
+): ReturnType<typeof preloadFileTree> {
+  const { initialFiles, sort, ...restOptions } = options;
+  const sortComparator =
+    sort === false
+      ? false
+      : sort != null && typeof sort === 'object'
+        ? sort.comparator
+        : undefined;
+  return preloadFileTree(
+    {
+      ...restOptions,
+      sort,
+      model: FileTreeModel.fromFiles(initialFiles, { sortComparator }),
+    },
+    stateConfig
+  );
+}
+
 describe('SSR + declarative shadow DOM', () => {
   test('preloadFileTree returns an id and shadow HTML containing the expected wrapper', () => {
-    const payload = preloadFileTree({
+    const payload = preloadFileTreeWithFiles({
       initialFiles: ['README.md', 'src/index.ts'],
     });
 
@@ -78,7 +131,7 @@ describe('SSR + declarative shadow DOM', () => {
   });
 
   test('preloadFileTree omits the built-in search input by default', () => {
-    const payload = preloadFileTree({
+    const payload = preloadFileTreeWithFiles({
       initialFiles: ['README.md', 'src/index.ts'],
     });
 
@@ -87,7 +140,7 @@ describe('SSR + declarative shadow DOM', () => {
   });
 
   test('preloadFileTree includes the built-in search input when enabled', () => {
-    const payload = preloadFileTree({
+    const payload = preloadFileTreeWithFiles({
       initialFiles: ['README.md', 'src/index.ts'],
       search: true,
     });
@@ -97,7 +150,7 @@ describe('SSR + declarative shadow DOM', () => {
   });
 
   test('preloadFileTree includes unsafeCSS when provided', () => {
-    const payload = preloadFileTree({
+    const payload = preloadFileTreeWithFiles({
       initialFiles: ['README.md', 'src/index.ts'],
       unsafeCSS: `[data-item-section="content"] { color: hotpink; }`,
     });
@@ -144,7 +197,7 @@ describe('SSR + declarative shadow DOM', () => {
   });
 
   test('FileTree.hydrate uses existing SSR wrapper and calls hydrateRoot (not renderRoot)', () => {
-    const payload = preloadFileTree({
+    const payload = preloadFileTreeWithFiles({
       initialFiles: ['README.md', 'src/index.ts', 'src/components/Button.tsx'],
     });
 
@@ -165,7 +218,9 @@ describe('SSR + declarative shadow DOM', () => {
     };
 
     try {
-      const ft = new FileTree({ initialFiles: ['README.md', 'src/index.ts'] });
+      const ft = createFileTree({
+        initialFiles: ['README.md', 'src/index.ts'],
+      });
       ft.hydrate({ fileTreeContainer: container });
       expect(ft.__id).toBe(payload.id);
       expect(hydrated).toBe(1);
@@ -211,7 +266,7 @@ describe('SSR + declarative shadow DOM', () => {
 
     try {
       // Client creates FileTree WITH dragAndDrop and hydrates
-      const ft = new FileTree({
+      const ft = createFileTree({
         initialFiles: ['README.md', 'src/index.ts'],
         dragAndDrop: true,
         id: ssrId,
@@ -232,31 +287,72 @@ describe('SSR + declarative shadow DOM', () => {
 
   test('getFiles returns initialFiles from constructor', () => {
     const files = ['README.md', 'src/index.ts'];
-    const ft = new FileTree({ initialFiles: files });
+    const ft = createFileTree({ initialFiles: files });
     expect(ft.getFiles()).toEqual(files);
   });
 
-  test('setFiles updates getFiles return value', () => {
-    const ft = new FileTree({ initialFiles: ['a.txt'] });
+  test('model.replaceAll updates getFiles return value', () => {
+    const ft = createFileTree({ initialFiles: ['a.txt'] });
     const newFiles = ['b.txt', 'c.txt'];
-    ft.setFiles(newFiles);
+    ft.model.replaceAll(newFiles);
     expect(ft.getFiles()).toEqual(newFiles);
   });
 
-  test('setOptions with state.files delegates to setFiles', () => {
-    const ft = new FileTree({ initialFiles: ['a.txt'] });
-    ft.setOptions({}, { files: ['b.txt'] });
-    expect(ft.getFiles()).toEqual(['b.txt']);
+  test('renamePath same-parent leaf rename avoids an extra full rebuild', async () => {
+    const ft = createFileTree({
+      initialFiles: ['src/a.ts', 'src/b.ts'],
+      flattenEmptyDirectories: true,
+      sort: false,
+    });
+    const containerWrapper = document.createElement('div');
+    ft.render({ containerWrapper });
+    await flushRenderWork();
+
+    const tree = ft.handleRef.current?.tree;
+    expect(tree).toBeDefined();
+    if (tree == null) {
+      throw new Error('Expected tree handle after render.');
+    }
+
+    const before = {
+      ...(tree.getDataRef<{
+        rebuildModeCounts?: Record<'full' | 'incremental' | 'noop', number>;
+      }>().current.rebuildModeCounts ?? { full: 0, incremental: 0, noop: 0 }),
+    };
+
+    ft.renamePath({
+      sourcePath: 'src/a.ts',
+      destinationPath: 'src/a-renamed.ts',
+      isFolder: false,
+    });
+    await flushRenderWork();
+
+    const after = tree.getDataRef<{
+      rebuildModeCounts?: Record<'full' | 'incremental' | 'noop', number>;
+    }>().current.rebuildModeCounts ?? { full: 0, incremental: 0, noop: 0 };
+
+    expect(after.full - before.full).toBe(0);
+    expect(
+      after.incremental - before.incremental + (after.noop - before.noop)
+    ).toBeGreaterThan(0);
+    expect(ft.getFiles()).toEqual(['src/a-renamed.ts', 'src/b.ts']);
   });
 
-  test('setOptions applies state.files when structural options also change', () => {
-    const ft = new FileTree({ initialFiles: ['a.txt'] });
-    ft.setOptions({ flattenEmptyDirectories: true }, { files: ['b.txt'] });
-    expect(ft.getFiles()).toEqual(['b.txt']);
+  test('setOptions cannot swap model instances', () => {
+    const ft = createFileTree({ initialFiles: ['a.txt'] });
+    expect(() => {
+      ft.setOptions({ model: FileTreeModel.fromFiles(['b.txt']) });
+    }).toThrow('cannot swap model instances');
+  });
+
+  test('setOptions preserves model-owned files when structural options change', () => {
+    const ft = createFileTree({ initialFiles: ['a.txt'] });
+    ft.setOptions({ flattenEmptyDirectories: true });
+    expect(ft.getFiles()).toEqual(['a.txt']);
   });
 
   test('setOptions applies fileTreeSearchMode changes at runtime', () => {
-    const ft = new FileTree({
+    const ft = createFileTree({
       initialFiles: ['a.txt'],
       fileTreeSearchMode: 'expand-matches',
     });
@@ -275,7 +371,7 @@ describe('SSR + declarative shadow DOM', () => {
   });
 
   test('setOptions applies icons changes at runtime', () => {
-    const ft = new FileTree({ initialFiles: ['a.txt'] });
+    const ft = createFileTree({ initialFiles: ['a.txt'] });
 
     let rerenders = 0;
     (
@@ -299,7 +395,7 @@ describe('SSR + declarative shadow DOM', () => {
 
   test('render + setOptions keep virtualized layout attributes in sync', () => {
     const container = document.createElement('file-tree-container');
-    const ft = new FileTree({
+    const ft = createFileTree({
       initialFiles: ['README.md'],
       virtualize: { threshold: 0 },
     });
@@ -328,7 +424,7 @@ describe('SSR + declarative shadow DOM', () => {
   });
 
   test('hydrate applies virtualized layout attributes when enabled client-side', () => {
-    const payload = preloadFileTree({
+    const payload = preloadFileTreeWithFiles({
       initialFiles: ['README.md'],
     });
     const container = document.createElement('file-tree-container');
@@ -339,7 +435,7 @@ describe('SSR + declarative shadow DOM', () => {
     const origHydrate = preactRenderer.hydrateRoot;
     preactRenderer.hydrateRoot = () => {};
     try {
-      const ft = new FileTree({
+      const ft = createFileTree({
         id: payload.id,
         initialFiles: ['README.md'],
         virtualize: { threshold: 0 },
@@ -362,7 +458,7 @@ describe('SSR + declarative shadow DOM', () => {
 
   test('setOptions swaps custom sprite sheets at runtime', () => {
     const container = document.createElement('file-tree-container');
-    const ft = new FileTree({
+    const ft = createFileTree({
       initialFiles: ['README.md'],
       icons: {
         spriteSheet: CUSTOM_SPRITE_A,
@@ -405,7 +501,7 @@ describe('SSR + declarative shadow DOM', () => {
 
   test('setOptions removes custom sprite sheet when icons are unset', () => {
     const container = document.createElement('file-tree-container');
-    const ft = new FileTree({
+    const ft = createFileTree({
       initialFiles: ['README.md'],
       icons: {
         spriteSheet: CUSTOM_SPRITE_A,
@@ -438,7 +534,7 @@ describe('SSR + declarative shadow DOM', () => {
   });
 
   test('preloadFileTree includes custom sprite sheets without requiring marker attrs', () => {
-    const payload = preloadFileTree({
+    const payload = preloadFileTreeWithFiles({
       initialFiles: ['README.md'],
       icons: {
         spriteSheet: CUSTOM_SPRITE_A,
@@ -462,21 +558,21 @@ describe('SSR + declarative shadow DOM', () => {
 
   test('preloadFileTree supports virtualized empty trees', () => {
     expect(() =>
-      preloadFileTree({
+      preloadFileTreeWithFiles({
         initialFiles: [],
         virtualize: { threshold: 0 },
       })
     ).not.toThrow();
   });
 
-  test('setFiles invokes onFilesChange callback', () => {
+  test('model.replaceAll invokes onFilesChange callback', () => {
     const calls: string[][] = [];
-    const ft = new FileTree(
+    const ft = createFileTree(
       { initialFiles: ['a.txt'] },
       { onFilesChange: (files) => calls.push(files) }
     );
 
-    ft.setFiles(['b.txt', 'c.txt']);
+    ft.model.replaceAll(['b.txt', 'c.txt']);
     expect(calls).toEqual([['b.txt', 'c.txt']]);
   });
 
@@ -505,20 +601,24 @@ describe('SSR + declarative shadow DOM', () => {
     expect(nextExpanded).not.toContain('src');
   });
 
-  test('setOptions with state.files invokes onFilesChange callback', () => {
+  test('renamePath invokes onFilesChange callback', () => {
     const calls: string[][] = [];
-    const ft = new FileTree(
+    const ft = createFileTree(
       { initialFiles: ['a.txt'] },
       { onFilesChange: (files) => calls.push(files) }
     );
 
-    ft.setOptions({ flattenEmptyDirectories: true }, { files: ['b.txt'] });
+    ft.renamePath({
+      sourcePath: 'a.txt',
+      destinationPath: 'b.txt',
+      isFolder: false,
+    });
     expect(calls).toEqual([['b.txt']]);
   });
 
   test('render injects unsafeCSS into the shadow root and keeps it in sync', () => {
     const container = document.createElement('file-tree-container');
-    const ft = new FileTree({
+    const ft = createFileTree({
       initialFiles: ['README.md', 'src/index.ts'],
       unsafeCSS: `[data-item-section="content"] { color: hotpink; }`,
     });
@@ -570,7 +670,9 @@ describe('SSR + declarative shadow DOM', () => {
     };
 
     try {
-      const ft = new FileTree({ initialFiles: ['README.md', 'src/index.ts'] });
+      const ft = createFileTree({
+        initialFiles: ['README.md', 'src/index.ts'],
+      });
       ft.hydrate({ fileTreeContainer: container });
       expect(hydrated).toBe(0);
       expect(rendered).toBe(1);

--- a/packages/trees/test/ssr-declarative-shadow-dom.test.ts
+++ b/packages/trees/test/ssr-declarative-shadow-dom.test.ts
@@ -632,6 +632,29 @@ describe('SSR + declarative shadow DOM', () => {
     expect(snapshots).toEqual([['b.txt']]);
   });
 
+  test('renamePath invokes onModelChange callback with a changeset', () => {
+    const changes: import('../src/FileTree').FileTreeChangeSet[] = [];
+    const snapshots: string[][] = [];
+    const ft = createFileTree(
+      { initialFiles: ['a.txt'] },
+      {
+        onModelChange: (changeSet, context) => {
+          changes.push(changeSet);
+          snapshots.push(context.getFiles());
+        },
+      }
+    );
+
+    ft.renamePath({
+      sourcePath: 'a.txt',
+      destinationPath: 'b.txt',
+      isFolder: false,
+    });
+    expect(changes).toHaveLength(1);
+    expect(changes[0]?.kind).toBe('rename-path');
+    expect(snapshots).toEqual([['b.txt']]);
+  });
+
   test('render injects unsafeCSS into the shadow root and keeps it in sync', () => {
     const container = document.createElement('file-tree-container');
     const ft = createFileTree({

--- a/packages/trees/test/ssr-declarative-shadow-dom.test.ts
+++ b/packages/trees/test/ssr-declarative-shadow-dom.test.ts
@@ -565,15 +565,23 @@ describe('SSR + declarative shadow DOM', () => {
     ).not.toThrow();
   });
 
-  test('model.replaceAll invokes onFilesChange callback', () => {
-    const calls: string[][] = [];
+  test('model.replaceAll invokes onFilesChange callback with a changeset', () => {
+    const changes: import('../src/FileTree').FileTreeChangeSet[] = [];
+    const snapshots: string[][] = [];
     const ft = createFileTree(
       { initialFiles: ['a.txt'] },
-      { onFilesChange: (files) => calls.push(files) }
+      {
+        onFilesChange: (changeSet, context) => {
+          changes.push(changeSet);
+          snapshots.push(context.getFiles());
+        },
+      }
     );
 
     ft.model.replaceAll(['b.txt', 'c.txt']);
-    expect(calls).toEqual([['b.txt', 'c.txt']]);
+    expect(changes).toHaveLength(1);
+    expect(changes[0]?.kind).toBe('replace-all');
+    expect(snapshots).toEqual([['b.txt', 'c.txt']]);
   });
 
   test('folder rename remaps expanded subtree paths', () => {
@@ -601,11 +609,17 @@ describe('SSR + declarative shadow DOM', () => {
     expect(nextExpanded).not.toContain('src');
   });
 
-  test('renamePath invokes onFilesChange callback', () => {
-    const calls: string[][] = [];
+  test('renamePath invokes onFilesChange callback with a changeset', () => {
+    const changes: import('../src/FileTree').FileTreeChangeSet[] = [];
+    const snapshots: string[][] = [];
     const ft = createFileTree(
       { initialFiles: ['a.txt'] },
-      { onFilesChange: (files) => calls.push(files) }
+      {
+        onFilesChange: (changeSet, context) => {
+          changes.push(changeSet);
+          snapshots.push(context.getFiles());
+        },
+      }
     );
 
     ft.renamePath({
@@ -613,7 +627,9 @@ describe('SSR + declarative shadow DOM', () => {
       destinationPath: 'b.txt',
       isFolder: false,
     });
-    expect(calls).toEqual([['b.txt']]);
+    expect(changes).toHaveLength(1);
+    expect(changes[0]?.kind).toBe('rename-path');
+    expect(snapshots).toEqual([['b.txt']]);
   });
 
   test('render injects unsafeCSS into the shadow root and keeps it in sync', () => {


### PR DESCRIPTION
Two main outcomes from this code:

- Tree structure supports in place modifications of the tree without rebuilding the entire thing
- APIs for control have to change in order to make this worthwhile. e.g. if the way to add and remove files is to pass in the whole list of files, plus or minus, the one we're adding/removing. We need to still rebuild the whole tree anyways to determine that.

The eventual goal api is something like (but not specifically):

```tsx
const { model } = useFileTree({ files: ['list', 'of', 'files']});

const handleNewFiles = (newFiles) => {
  model.addFiles(newFiles)
};

useAppSpecificFileSyncThing({
  onNewFile: handleNewFiles
})

return <FileTree model={model} />
```