### PR TITLE
Hunk Separators: add hidden expand all button

### DIFF
--- a/packages/diffs/src/managers/InteractionManager.ts
+++ b/packages/diffs/src/managers/InteractionManager.ts
@@ -26,6 +26,7 @@ interface TokenCache {
 interface ExpandCache {
   hunkIndex: number | undefined;
   direction: ExpansionDirections;
+  all: boolean;
 }
 
 export type LogTypes = 'click' | 'move' | 'both' | 'none';
@@ -77,6 +78,7 @@ interface ExpandoEventProps {
   type: 'line-info';
   hunkIndex: number;
   direction: ExpansionDirections;
+  all: boolean;
 }
 
 export type GetHoveredLineResult<TMode extends InteractionManagerMode> =
@@ -517,8 +519,8 @@ export class InteractionManager<TMode extends InteractionManagerMode> {
         if (isExpandoPointerTarget(target) && onHunkExpand != null) {
           onHunkExpand(
             target.hunkIndex,
-            event.shiftKey ? 'both' : target.direction,
-            event.shiftKey ? Number.POSITIVE_INFINITY : undefined
+            target.all || event.shiftKey ? 'both' : target.direction,
+            target.all || event.shiftKey ? Number.POSITIVE_INFINITY : undefined
           );
           break;
         }
@@ -1458,7 +1460,11 @@ export class InteractionManager<TMode extends InteractionManagerMode> {
         continue;
       }
 
-      if (expandInfo == null && element.hasAttribute('data-expand-button')) {
+      if (
+        expandInfo == null &&
+        (element.hasAttribute('data-expand-button') ||
+          element.hasAttribute('data-unmodified-lines'))
+      ) {
         expandInfo = {
           hunkIndex: undefined,
           direction: (() => {
@@ -1470,6 +1476,7 @@ export class InteractionManager<TMode extends InteractionManagerMode> {
             }
             return 'both';
           })(),
+          all: element.hasAttribute('data-expand-all-button'),
         };
         continue;
       }
@@ -1501,6 +1508,7 @@ export class InteractionManager<TMode extends InteractionManagerMode> {
         type: 'line-info',
         hunkIndex: expandInfo.hunkIndex,
         direction: expandInfo.direction,
+        all: expandInfo.all,
       } as ResolvedPointerTarget<TMode>;
     }
 

--- a/packages/diffs/src/style.css
+++ b/packages/diffs/src/style.css
@@ -753,6 +753,11 @@
     background-color: var(--diffs-bg-separator);
   }
 
+  [data-expand-index] [data-separator-content]:hover {
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
   [data-expand-button] {
     justify-content: center;
     flex-shrink: 0;

--- a/packages/diffs/src/style.css
+++ b/packages/diffs/src/style.css
@@ -765,6 +765,10 @@
     &:hover {
       color: var(--diffs-fg);
     }
+
+    &[data-expand-all-button] {
+      display: none;
+    }
   }
 
   [data-expand-down] [data-icon] {

--- a/packages/diffs/src/utils/createSeparator.ts
+++ b/packages/diffs/src/utils/createSeparator.ts
@@ -44,6 +44,7 @@ export function createSeparator({
   isFirstHunk,
   isLastHunk,
 }: CreateSeparatorProps): HASTElement {
+  let buttonCount = 0;
   const children = [];
   if (type === 'metadata' && content != null) {
     children.push(
@@ -63,12 +64,15 @@ export function createSeparator({
             !isFirstHunk && !isLastHunk ? 'both' : isFirstHunk ? 'down' : 'up'
           )
         );
+        buttonCount++;
       } else {
         if (!isFirstHunk) {
           contentChildren.push(createExpandButton('up'));
+          buttonCount++;
         }
         if (!isLastHunk) {
           contentChildren.push(createExpandButton('down'));
+          buttonCount++;
         }
       }
     }
@@ -85,14 +89,25 @@ export function createSeparator({
         properties: { 'data-separator-content': '' },
       })
     );
+    if (chunked && expandIndex != null) {
+      contentChildren.push(
+        createHastElement({
+          tagName: 'span',
+          children: [createTextNodeElement('Expand All')],
+          properties: {
+            'data-expand-button': '',
+            'data-expand-all-button': '',
+          },
+        })
+      );
+    }
     children.push(
       createHastElement({
         tagName: 'div',
         children: contentChildren,
         properties: {
           'data-separator-wrapper': '',
-          'data-separator-multi-button':
-            contentChildren.length > 2 ? '' : undefined,
+          'data-separator-multi-button': buttonCount > 1 ? '' : undefined,
         },
       })
     );

--- a/packages/diffs/test/__snapshots__/DiffHunksRendererVirtualization.test.ts.snap
+++ b/packages/diffs/test/__snapshots__/DiffHunksRendererVirtualization.test.ts.snap
@@ -1834,6 +1834,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.2: Part
               "tagName": "div",
               "type": "element",
             },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
+              "type": "element",
+            },
           ],
           "properties": {
             "data-separator-multi-button": "",
@@ -4061,6 +4075,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.2: Part
                 "data-separator-content": "",
               },
               "tagName": "div",
+              "type": "element",
+            },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
               "type": "element",
             },
           ],
@@ -13621,6 +13649,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.2: Part
               "tagName": "div",
               "type": "element",
             },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
+              "type": "element",
+            },
           ],
           "properties": {
             "data-separator-multi-button": "",
@@ -14348,6 +14390,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.2: Part
                 "data-separator-content": "",
               },
               "tagName": "div",
+              "type": "element",
+            },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
               "type": "element",
             },
           ],
@@ -15252,6 +15308,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.2: Part
                 "data-separator-content": "",
               },
               "tagName": "div",
+              "type": "element",
+            },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
               "type": "element",
             },
           ],
@@ -16886,6 +16956,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.2: Part
                 "data-separator-content": "",
               },
               "tagName": "div",
+              "type": "element",
+            },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
               "type": "element",
             },
           ],
@@ -19038,6 +19122,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.2: Part
                 "data-separator-content": "",
               },
               "tagName": "div",
+              "type": "element",
+            },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
               "type": "element",
             },
           ],
@@ -27488,6 +27586,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.2: Part
               "tagName": "div",
               "type": "element",
             },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
+              "type": "element",
+            },
           ],
           "properties": {
             "data-separator-multi-button": "",
@@ -28242,6 +28354,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.2: Part
                 "data-separator-content": "",
               },
               "tagName": "div",
+              "type": "element",
+            },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
               "type": "element",
             },
           ],
@@ -29182,6 +29308,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.2: Part
                 "data-separator-content": "",
               },
               "tagName": "div",
+              "type": "element",
+            },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
               "type": "element",
             },
           ],
@@ -30578,6 +30718,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.3: Part
                 "data-separator-content": "",
               },
               "tagName": "div",
+              "type": "element",
+            },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
               "type": "element",
             },
           ],
@@ -33154,6 +33308,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.3: Part
               "tagName": "div",
               "type": "element",
             },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
+              "type": "element",
+            },
           ],
           "properties": {
             "data-separator-multi-button": "",
@@ -42712,6 +42880,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.3: Part
               "tagName": "div",
               "type": "element",
             },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
+              "type": "element",
+            },
           ],
           "properties": {
             "data-separator-multi-button": "",
@@ -43439,6 +43621,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.3: Part
                 "data-separator-content": "",
               },
               "tagName": "div",
+              "type": "element",
+            },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
               "type": "element",
             },
           ],
@@ -44343,6 +44539,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.3: Part
                 "data-separator-content": "",
               },
               "tagName": "div",
+              "type": "element",
+            },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
               "type": "element",
             },
           ],
@@ -45497,6 +45707,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.3: Part
                 "data-separator-content": "",
               },
               "tagName": "div",
+              "type": "element",
+            },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
               "type": "element",
             },
           ],
@@ -48011,6 +48235,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.3: Part
               "tagName": "div",
               "type": "element",
             },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
+              "type": "element",
+            },
           ],
           "properties": {
             "data-separator-multi-button": "",
@@ -56459,6 +56697,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.3: Part
               "tagName": "div",
               "type": "element",
             },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
+              "type": "element",
+            },
           ],
           "properties": {
             "data-separator-multi-button": "",
@@ -57213,6 +57465,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.3: Part
                 "data-separator-content": "",
               },
               "tagName": "div",
+              "type": "element",
+            },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
               "type": "element",
             },
           ],
@@ -58153,6 +58419,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.3: Part
                 "data-separator-content": "",
               },
               "tagName": "div",
+              "type": "element",
+            },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
               "type": "element",
             },
           ],
@@ -59245,6 +59525,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.4: Part
               "tagName": "div",
               "type": "element",
             },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
+              "type": "element",
+            },
           ],
           "properties": {
             "data-separator-multi-button": "",
@@ -59811,6 +60105,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.4: Part
                 "data-separator-content": "",
               },
               "tagName": "div",
+              "type": "element",
+            },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
               "type": "element",
             },
           ],
@@ -61322,6 +61630,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.4: Part
               "tagName": "div",
               "type": "element",
             },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
+              "type": "element",
+            },
           ],
           "properties": {
             "data-separator-multi-button": "",
@@ -62302,6 +62624,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.4: Part
                 "data-separator-content": "",
               },
               "tagName": "div",
+              "type": "element",
+            },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
               "type": "element",
             },
           ],
@@ -71862,6 +72198,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.4: Part
               "tagName": "div",
               "type": "element",
             },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
+              "type": "element",
+            },
           ],
           "properties": {
             "data-separator-multi-button": "",
@@ -72589,6 +72939,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.4: Part
                 "data-separator-content": "",
               },
               "tagName": "div",
+              "type": "element",
+            },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
               "type": "element",
             },
           ],
@@ -73495,6 +73859,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.4: Part
               "tagName": "div",
               "type": "element",
             },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
+              "type": "element",
+            },
           ],
           "properties": {
             "data-separator-multi-button": undefined,
@@ -74333,6 +74711,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.4: Part
               "tagName": "div",
               "type": "element",
             },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
+              "type": "element",
+            },
           ],
           "properties": {
             "data-separator-multi-button": "",
@@ -74919,6 +75311,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.4: Part
                 "data-separator-content": "",
               },
               "tagName": "div",
+              "type": "element",
+            },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
               "type": "element",
             },
           ],
@@ -76325,6 +76731,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.4: Part
               "tagName": "div",
               "type": "element",
             },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
+              "type": "element",
+            },
           ],
           "properties": {
             "data-separator-multi-button": "",
@@ -77343,6 +77763,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.4: Part
                 "data-separator-content": "",
               },
               "tagName": "div",
+              "type": "element",
+            },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
               "type": "element",
             },
           ],
@@ -85793,6 +86227,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.4: Part
               "tagName": "div",
               "type": "element",
             },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
+              "type": "element",
+            },
           ],
           "properties": {
             "data-separator-multi-button": "",
@@ -86547,6 +86995,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.4: Part
                 "data-separator-content": "",
               },
               "tagName": "div",
+              "type": "element",
+            },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
               "type": "element",
             },
           ],
@@ -87489,6 +87951,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.4: Part
               "tagName": "div",
               "type": "element",
             },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
+              "type": "element",
+            },
           ],
           "properties": {
             "data-separator-multi-button": undefined,
@@ -88304,6 +88780,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.5: Wind
                 "data-separator-content": "",
               },
               "tagName": "div",
+              "type": "element",
+            },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
               "type": "element",
             },
           ],
@@ -89662,6 +90152,20 @@ exports[`DiffHunksRenderer - Virtualization expanded collapsed regions 3.5: Wind
                 "data-separator-content": "",
               },
               "tagName": "div",
+              "type": "element",
+            },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Expand All",
+                },
+              ],
+              "properties": {
+                "data-expand-all-button": "",
+                "data-expand-button": "",
+              },
+              "tagName": "span",
               "type": "element",
             },
           ],


### PR DESCRIPTION
A quick pass at adding a hidden Expand All button to hunk separators for more flexibility when using custom css.

Also made the `unmodified lines` clickable as well to expand in both directions.

- [x] Need to add an underline css style to unmodified lines to help explain clickability