### PR TITLE
[trees] vibe-coded scroll perf fixes

### DIFF
--- a/packages/trees/src/path-store/view.tsx
+++ b/packages/trees/src/path-store/view.tsx
@@ -959,7 +959,6 @@ export function PathStoreTreesView({
   const contextMenuAnchorRef = useRef<HTMLDivElement>(null);
   const contextMenuTriggerRef = useRef<HTMLButtonElement>(null);
   const isScrollingRef = useRef(false);
-  const listRef = useRef<HTMLDivElement>(null);
   const renameInputRef = useRef<HTMLInputElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -1007,20 +1006,20 @@ export function PathStoreTreesView({
   } | null>(null);
   const contextMenuStateRef = useRef(contextMenuState);
   contextMenuStateRef.current = contextMenuState;
-  const [itemCount, setItemCount] = useState(() =>
-    controller.getVisibleCount()
-  );
+  const initialItemCount = controller.getVisibleCount();
+  const initialRange = computeWindowRange({
+    itemCount: initialItemCount,
+    itemHeight,
+    overscan,
+    scrollTop: 0,
+    viewportHeight,
+  });
+  const [itemCount, setItemCount] = useState(() => initialItemCount);
   const [resolvedViewportHeight, setResolvedViewportHeight] =
     useState<number>(viewportHeight);
-  const [range, setRange] = useState(() =>
-    computeWindowRange({
-      itemCount: controller.getVisibleCount(),
-      itemHeight,
-      overscan,
-      scrollTop: 0,
-      viewportHeight,
-    })
-  );
+  const [range, setRange] = useState(() => initialRange);
+  const rangeRef = useRef(range);
+  rangeRef.current = range;
   const contextMenuEnabled =
     composition?.contextMenu?.enabled === true ||
     composition?.contextMenu?.render != null ||
@@ -1809,7 +1808,6 @@ export function PathStoreTreesView({
   useLayoutEffect(() => {
     let scrollTimer: ReturnType<typeof setTimeout> | null = null;
     const scrollElement = scrollRef.current;
-    const listElement = listRef.current;
     if (scrollElement == null) {
       return;
     }
@@ -1838,21 +1836,20 @@ export function PathStoreTreesView({
           ? previousHeight
           : nextViewportHeight
       );
-      setRange((previousRange) => {
-        const nextRange = computeWindowRange(
-          {
-            itemCount: nextItemCount,
-            itemHeight,
-            overscan,
-            scrollTop,
-            viewportHeight: nextViewportHeight,
-          },
-          previousRange
-        );
-        return rangesEqual(previousRange, nextRange)
-          ? previousRange
-          : nextRange;
-      });
+      const nextRange = computeWindowRange(
+        {
+          itemCount: nextItemCount,
+          itemHeight,
+          overscan,
+          scrollTop,
+          viewportHeight: nextViewportHeight,
+        },
+        rangeRef.current
+      );
+      if (!rangesEqual(rangeRef.current, nextRange)) {
+        rangeRef.current = nextRange;
+        setRange(nextRange);
+      }
     };
 
     updateViewportRef.current = update;
@@ -1869,20 +1866,10 @@ export function PathStoreTreesView({
       setContextHoverPath((previousPath) =>
         previousPath == null ? previousPath : null
       );
-
-      // Mark the list as scrolling to suppress hover styles on items.
-      // Applied to the list (inside the scroll container) so the container
-      // itself still receives scroll events.
-      if (listElement != null) {
-        listElement.dataset.isScrolling ??= '';
-      }
       if (scrollTimer != null) {
         clearTimeout(scrollTimer);
       }
       scrollTimer = setTimeout(() => {
-        if (listElement != null) {
-          delete listElement.dataset.isScrolling;
-        }
         isScrollingRef.current = false;
         scrollTimer = null;
       }, 50);
@@ -1904,9 +1891,6 @@ export function PathStoreTreesView({
       scrollElement.removeEventListener('scroll', onScroll);
       if (scrollTimer != null) {
         clearTimeout(scrollTimer);
-      }
-      if (listElement != null) {
-        delete listElement.dataset.isScrolling;
       }
       isScrollingRef.current = false;
       resizeObserver?.disconnect();
@@ -2423,7 +2407,6 @@ export function PathStoreTreesView({
       ) : null}
       <div ref={scrollRef} data-file-tree-virtualized-scroll="true">
         <div
-          ref={listRef}
           data-file-tree-virtualized-list="true"
           style={{ height: `${stickyLayout.totalHeight}px` }}
         >

--- a/packages/trees/src/path-store/view.tsx
+++ b/packages/trees/src/path-store/view.tsx
@@ -163,6 +163,7 @@ function getPathStoreTreesRowAriaLabel(row: PathStoreTreesVisibleRow): string {
   return flattenedSegments.map((segment) => segment.name).join(' / ');
 }
 
+const SCROLL_HOVER_SUPPRESSION_DELAY = 100;
 const TOUCH_LONG_PRESS_DELAY = 400;
 const TOUCH_LONG_PRESS_MOVE_THRESHOLD = 10;
 const DRAG_EDGE_SCROLL_THRESHOLD = 40;
@@ -959,6 +960,7 @@ export function PathStoreTreesView({
   const contextMenuAnchorRef = useRef<HTMLDivElement>(null);
   const contextMenuTriggerRef = useRef<HTMLButtonElement>(null);
   const isScrollingRef = useRef(false);
+  const listRef = useRef<HTMLDivElement>(null);
   const renameInputRef = useRef<HTMLInputElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -1851,14 +1853,48 @@ export function PathStoreTreesView({
         setRange(nextRange);
       }
     };
+    let scheduledUpdateHandle: number | null = null;
+
+    // Coalesce scroll-driven range updates to one paint so wheel bursts do not
+    // queue repeated rerenders before the browser can present the next frame.
+    const scheduleUpdate = (): void => {
+      if (scheduledUpdateHandle != null) {
+        return;
+      }
+
+      const flushUpdate = (): void => {
+        scheduledUpdateHandle = null;
+        update();
+      };
+
+      scheduledUpdateHandle =
+        typeof window.requestAnimationFrame === 'function'
+          ? window.requestAnimationFrame(() => {
+              flushUpdate();
+            })
+          : window.setTimeout(flushUpdate, 0);
+    };
+
+    const cancelScheduledUpdate = (): void => {
+      if (scheduledUpdateHandle == null) {
+        return;
+      }
+
+      if (typeof window.cancelAnimationFrame === 'function') {
+        window.cancelAnimationFrame(scheduledUpdateHandle);
+      } else {
+        window.clearTimeout(scheduledUpdateHandle);
+      }
+      scheduledUpdateHandle = null;
+    };
 
     updateViewportRef.current = update;
     const unsubscribe = controller.subscribe(() => {
       setControllerRevision((revision) => revision + 1);
       update();
     });
-    const onScroll = (): void => {
-      update();
+    const listElement = listRef.current;
+    const beginScrollSuppression = (): void => {
       if (contextMenuStateRef.current != null) {
         closeContextMenuRef.current();
       }
@@ -1866,20 +1902,37 @@ export function PathStoreTreesView({
       setContextHoverPath((previousPath) =>
         previousPath == null ? previousPath : null
       );
+
+      if (listElement != null) {
+        listElement.dataset.isScrolling ??= '';
+      }
       if (scrollTimer != null) {
         clearTimeout(scrollTimer);
       }
+      // Keep suppression active across short wheel gaps so hover styles do not
+      // flicker back on between consecutive input bursts.
       scrollTimer = setTimeout(() => {
+        if (listElement != null) {
+          delete listElement.dataset.isScrolling;
+        }
         isScrollingRef.current = false;
         scrollTimer = null;
-      }, 50);
+      }, SCROLL_HOVER_SUPPRESSION_DELAY);
+    };
+    const onWheel = (): void => {
+      beginScrollSuppression();
+    };
+    const onScroll = (): void => {
+      scheduleUpdate();
+      beginScrollSuppression();
     };
 
+    scrollElement.addEventListener('wheel', onWheel, { passive: true });
     scrollElement.addEventListener('scroll', onScroll, { passive: true });
     const resizeObserver =
       typeof ResizeObserver !== 'undefined'
         ? new ResizeObserver(() => {
-            update();
+            scheduleUpdate();
           })
         : null;
     resizeObserver?.observe(scrollElement);
@@ -1888,9 +1941,14 @@ export function PathStoreTreesView({
     return () => {
       updateViewportRef.current = () => {};
       unsubscribe();
+      scrollElement.removeEventListener('wheel', onWheel);
       scrollElement.removeEventListener('scroll', onScroll);
+      cancelScheduledUpdate();
       if (scrollTimer != null) {
         clearTimeout(scrollTimer);
+      }
+      if (listElement != null) {
+        delete listElement.dataset.isScrolling;
       }
       isScrollingRef.current = false;
       resizeObserver?.disconnect();
@@ -2407,6 +2465,7 @@ export function PathStoreTreesView({
       ) : null}
       <div ref={scrollRef} data-file-tree-virtualized-scroll="true">
         <div
+          ref={listRef}
           data-file-tree-virtualized-list="true"
           style={{ height: `${stickyLayout.totalHeight}px` }}
         >

--- a/packages/trees/src/path-store/virtualization.ts
+++ b/packages/trees/src/path-store/virtualization.ts
@@ -114,6 +114,10 @@ export function computeStickyWindowLayout({
 
   const offsetHeight = range.start * itemHeight;
   const windowHeight = (range.end - range.start + 1) * itemHeight;
+  // NOTE: Using a random value that's in the range of 0 to  itemHeight, we can
+  // make fast scrolls don't feel like the elements are stuck on a grid (feels
+  // artificial)
+  const randomStickyOffset = (Math.random() * itemHeight) >> 0;
 
   return {
     totalHeight,
@@ -121,6 +125,9 @@ export function computeStickyWindowLayout({
     windowHeight,
     // The sticky window is usually taller than the viewport once overscan is
     // included, so a negative inset keeps the full overscanned slice pinned.
-    stickyInset: Math.min(0, viewportHeight - windowHeight),
+    stickyInset: Math.min(
+      0,
+      viewportHeight - windowHeight + randomStickyOffset
+    ),
   };
 }

--- a/packages/trees/src/style.css
+++ b/packages/trees/src/style.css
@@ -578,12 +578,6 @@
     gap: var(--trees-item-row-gap);
     border-radius: var(--trees-border-radius);
 
-    &:hover,
-    &[data-item-context-hover='true'] {
-      background-color: var(--trees-bg-muted);
-      --truncate-marker-background-color: var(--trees-bg-muted);
-    }
-
     &[data-item-focused='true'],
     &:focus-visible {
       z-index: 2;
@@ -621,6 +615,14 @@
     }
   }
 
+  [data-file-tree-virtualized-list='true']:not([data-is-scrolling])
+    [data-type='item']:hover,
+  [data-file-tree-virtualized-list='true']:not([data-is-scrolling])
+    [data-type='item'][data-item-context-hover='true'] {
+    background-color: var(--trees-bg-muted);
+    --truncate-marker-background-color: var(--trees-bg-muted);
+  }
+
   [data-item-selected='true']:has(+ [data-item-selected='true']) {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -630,16 +632,23 @@
     border-top-left-radius: 0;
     border-top-right-radius: 0;
   }
-
   /* Flattened Directory Parts */
   [data-item-flattened-subitems] {
     display: inline-flex;
     align-items: center;
     gap: 2px;
   }
-  [data-item-flattened-subitem]:hover,
+  [data-file-tree-virtualized-list='true']:not([data-is-scrolling])
+    [data-item-flattened-subitem]:hover,
   [data-item-flattened-subitem-drag-target='true'] {
     text-decoration: underline;
+  }
+
+  [data-file-tree-virtualized-list='true'][data-is-scrolling]
+    [data-type='item'],
+  [data-file-tree-virtualized-list='true'][data-is-scrolling]
+    [data-item-flattened-subitem] {
+    pointer-events: none;
   }
 
   /* Icon for each item */
@@ -900,7 +909,6 @@
     height: 100%;
     margin-right: calc(var(--trees-level-gap) - 1px);
     opacity: 0;
-    transition: opacity 150ms ease;
 
     & + & {
       margin-left: calc(
@@ -909,10 +917,16 @@
     }
   }
 
-  :host(:hover) [data-item-section='spacing-item'] {
+  :host(:hover)
+    [data-file-tree-virtualized-list='true']:not([data-is-scrolling])
+    [data-item-section='spacing-item'] {
     opacity: 0.75;
   }
 
+  [data-file-tree-virtualized-list='true'][data-is-scrolling]
+    [data-item-section='spacing-item'] {
+    opacity: 0;
+  }
   /* Git status indicator */
 
   /* This is a folder that contains a git change */
@@ -1044,7 +1058,6 @@
     margin: var(--trees-focus-ring-width);
     height: calc(var(--trees-row-height) - var(--trees-focus-ring-width) * 2);
     border-width: 0;
-    transition: color 120ms ease;
 
     display: flex;
   }
@@ -1249,6 +1262,13 @@
         (var(--truncate-internal-fade-marker-width) * 2)
     );
     margin: var(--truncate-internal-fade-marker-width) 0;
+  }
+
+  [data-file-tree-virtualized-list='true'][data-is-scrolling]
+    [data-truncate-marker],
+  [data-file-tree-virtualized-list='true'][data-is-scrolling]
+    [data-truncate-fade] {
+    display: none;
   }
 
   [data-truncate-group-container='middle'] {

--- a/packages/trees/src/style.css
+++ b/packages/trees/src/style.css
@@ -497,10 +497,6 @@
     min-height: 100%;
     width: 100%;
     overflow-anchor: none;
-
-    &[data-is-scrolling] {
-      pointer-events: none;
-    }
   }
 
   [data-file-tree-virtualized-sticky-offset='true'] {

--- a/packages/trees/src/style.css
+++ b/packages/trees/src/style.css
@@ -490,6 +490,13 @@
     overflow-y: auto;
     flex: 1 1 0;
     min-height: 0;
+    /* NOTE(amadeus): There's a chance in many cases a user could use strict
+     * here, however not trying to assume, therefore `content` felt like the safest
+     * bet */
+    contain: content;
+    /* NOTE(amadeus): will-change _may_ help with heavy scroll state, but may
+     * also not be worth it. */
+    will-change: scroll-position;
   }
 
   [data-file-tree-virtualized-list='true'] {
@@ -500,7 +507,7 @@
   }
 
   [data-file-tree-virtualized-sticky-offset='true'] {
-    contain: layout size;
+    contain: strict;
   }
 
   [data-file-tree-virtualized-sticky='true'] {
@@ -509,6 +516,13 @@
     display: flex;
     flex-direction: column;
     isolation: isolate;
+    /* NOTE(amadeus): Strict _may_ help hear with the heavey dom thrash this
+     * component will have */
+    contain: strict;
+    /* NOTE(amadeus): will-change _may_ help with the noisy virtualized state */
+    will-change: contents;
+    /* NOTE(amadeus): background color here _may_ help with compositing */
+    background-color: var(--trees-bg);
   }
 
   [data-file-tree-search-container] {

--- a/packages/trees/test/path-store-render-scroll.test.ts
+++ b/packages/trees/test/path-store-render-scroll.test.ts
@@ -1084,7 +1084,7 @@ describe('path-store render + scroll', () => {
     }
   });
 
-  test('marks the virtualized list as scrolling to suppress hover styles', async () => {
+  test('scroll keeps sticky window geometry and hover suppression out of DOM attributes', async () => {
     const { cleanup, dom } = installDom();
     try {
       const { PathStoreFileTree } = await import('../src/path-store');
@@ -1109,6 +1109,9 @@ describe('path-store render + scroll', () => {
       const listElement = shadowRoot?.querySelector(
         '[data-file-tree-virtualized-list="true"]'
       );
+      const stickyContentElement = shadowRoot?.querySelector(
+        '[data-file-tree-virtualized-sticky-content="true"]'
+      );
 
       if (!(scrollElement instanceof dom.window.HTMLElement)) {
         throw new Error('missing scroll element');
@@ -1119,16 +1122,18 @@ describe('path-store render + scroll', () => {
 
       const viewport = scrollElement as HTMLElement;
       const list = listElement as HTMLDivElement;
-
+      expect(stickyContentElement).toBeNull();
       expect(list.dataset.isScrolling).toBeUndefined();
 
       viewport.scrollTop = 1500;
       viewport.dispatchEvent(new dom.window.Event('scroll'));
       await flushDom();
 
-      expect(list.dataset.isScrolling).toBe('');
-
-      await new Promise((resolve) => setTimeout(resolve, 60));
+      expect(
+        shadowRoot?.querySelector(
+          '[data-file-tree-virtualized-sticky-content="true"]'
+        )
+      ).toBeNull();
       expect(list.dataset.isScrolling).toBeUndefined();
 
       fileTree.cleanUp();

--- a/packages/trees/test/path-store-render-scroll.test.ts
+++ b/packages/trees/test/path-store-render-scroll.test.ts
@@ -1084,7 +1084,7 @@ describe('path-store render + scroll', () => {
     }
   });
 
-  test('scroll keeps sticky window geometry and hover suppression out of DOM attributes', async () => {
+  test('wheel input marks the virtualized list as scrolling before scroll updates and still avoids a sticky content wrapper', async () => {
     const { cleanup, dom } = installDom();
     try {
       const { PathStoreFileTree } = await import('../src/path-store');
@@ -1125,6 +1125,11 @@ describe('path-store render + scroll', () => {
       expect(stickyContentElement).toBeNull();
       expect(list.dataset.isScrolling).toBeUndefined();
 
+      viewport.dispatchEvent(
+        new dom.window.WheelEvent('wheel', { bubbles: true, deltaY: 80 })
+      );
+      expect(list.dataset.isScrolling).toBe('');
+
       viewport.scrollTop = 1500;
       viewport.dispatchEvent(new dom.window.Event('scroll'));
       await flushDom();
@@ -1134,6 +1139,9 @@ describe('path-store render + scroll', () => {
           '[data-file-tree-virtualized-sticky-content="true"]'
         )
       ).toBeNull();
+      expect(list.dataset.isScrolling).toBe('');
+
+      await new Promise((resolve) => setTimeout(resolve, 120));
       expect(list.dataset.isScrolling).toBeUndefined();
 
       fileTree.cleanUp();


### PR DESCRIPTION
# Trees path-store scroll performance handoff

## Current code state

Use the current branch as the handoff base.

Key files touched during this work:
- `packages/trees/src/path-store/view.tsx`
- `packages/trees/src/path-store/virtualization.ts`
- `packages/trees/src/path-store/types.ts`
- `packages/trees/src/path-store/index.ts`
- `packages/trees/src/style.css`
- `packages/trees/test/path-store-render-scroll.test.ts`

Current design decisions that should be preserved unless there is strong trace evidence otherwise:
- Reverse-sticky window virtualization is restored and kept.
- The translated sticky-buffer experiment was abandoned.
- Scroll suppression is armed on `wheel` and refreshed on `scroll`.
- Scroll-driven range updates are coalesced to one scheduled update per frame.
- During active scroll, row-level hover interaction is suppressed.
- Truncate marker / fade decoration is hidden during active scroll.
- Scroll suppression uses a 100ms trailing delay to bridge short wheel gaps.

## Verification state

Current code passes:
- `AGENT=1 bun test test/path-store-render-scroll.test.ts`
- `AGENT=1 bun test test/path-store-composition-surfaces.test.ts`
- `AGENT=1 bun run tsc`
- `AGENT=1 bun run format`

## Trace files used during this work

- Baseline: `Trace-20260416T205528.json`
- Hover regression after removing scroll-state suppression: `Trace-20260417T105930.json`
- Old list-scoped suppression restored: `Trace-20260417T115158.json`
- Style-only hover suppression + rAF batching: `Trace-20260417T120934.json`
- Wheel-armed suppression: `Trace-20260417T121957.json`
- Full hover cleanup: `Trace-20260417T123111.json`
- Truncate marker / fade hidden during scroll: `Trace-20260417T123942.json`

## What we tried and what we learned

### 1. Stable sticky buffer + translated content reduced measured layout in synthetic profiling, but broke the non-blanking technique

What changed:
- introduced `computeStickyBufferLayout` / `computeStickyBufferRange`
- translated mounted content inside a larger sticky shell
- removed `data-is-scrolling`

What happened:
- automated profiling initially looked promising
- fast scrolling and large jumps showed more blanking in real use
- comparison to `packages/diffs` and to the original reverse-sticky design clarified the issue

Why it failed:
- the original technique works because the mounted content itself is what the browser scrolls
- the translated-shell version reintroduced JS-positioned content inside blank regions
- that weakened the anti-blanking property the current sticky design was chosen for

Action taken:
- fully reverted the sticky-buffer translation geometry
- restored `computeStickyWindowLayout`
- restored the original sticky DOM structure

Conclusion:
- do not return to the translated sticky-shell approach unless the design goal changes and blanking is acceptable

### 2. Removing `data-is-scrolling` caused real hover/style churn

Trace:
- `Trace-20260417T105930.json`

Compared to the baseline `Trace-20260416T205528.json`:
- style recalculation/sec: `13.7 -> 44.9`
- pointerover+mouseover/sec: `1.1 -> 27.0`
- layout ms/sec: `165.6 -> 196.5`
- paint ms/sec: `127.7 -> 143.4`

Observed in the trace window:
- `pointerover`: `193`
- `mouseover`: `193`
- `data-is-scrolling`: absent

Conclusion:
- losing the list scroll-state attribute was a real regression
- CSS hover churn during mouse-wheel scrolling is material

### 3. Restoring old list-scoped `data-is-scrolling` helped hover churn, but did not solve the whole problem

Trace:
- `Trace-20260417T115158.json`

Improvement vs the hover-regressed trace:
- pointerover+mouseover/sec: `27.0 -> 9.0`
- style recalculation/sec: `44.9 -> 30.5`

But overall scroll numbers in that run were still poor:
- dropped/sec: `87.4`
- layout ms/sec: `252.8`
- updateLayoutTree ms/sec: `62.6`

Conclusion:
- hover suppression was necessary, but not sufficient

### 4. Style-only hover gating was a bad idea

What changed:
- kept `data-is-scrolling`
- removed pointer suppression
- gated hover visuals only via CSS selectors

Trace:
- `Trace-20260417T120934.json`

Result:
- hover/pointer churn stayed high or got worse
- pointerover+mouseover/sec: `30.6`
- style recalculation/sec: `50.1`

Why:
- style gating stops the visual effect
- it does not stop hover hit-testing, event dispatch, or hover invalidation

Conclusion:
- style-only suppression is not enough

### 5. Coalescing scroll-driven updates to one frame was a real improvement

What changed:
- scroll and resize now schedule viewport recomputation at most once per frame
- imperative callers using `updateViewportRef.current()` still update immediately for focus/drag codepaths

Why it was tried:
- `packages/diffs` batches render work through a frame queue
- trees path-store previously recomputed directly on every scroll event

Conclusion:
- batching viewport recomputation like diffs’ render queue is a good pattern
- keep it

### 6. Arming suppression on `wheel` before `scroll` helped materially

What changed:
- begin scroll suppression from `wheel`
- still refresh it on `scroll`

Trace:
- `Trace-20260417T121957.json`

Compared to `Trace-20260417T120934.json`:
- dropped/sec: `77.7 -> 58.1`
- layout ms/sec: `221.4 -> 183.5`
- updateLayoutTree ms/sec: `46.8 -> 37.5`
- paint ms/sec: `171.1 -> 131.6`

Conclusion:
- the “hover before scroll handler fires” gap was real
- wheel-arming should stay

### 7. Full hover cleanup worked for hover/transition churn, but did not fix layout

What changed:
- 100ms suppression window
- descendant-level pointer suppression during scroll
- spacing guide hover hidden during scroll
- removed spacing opacity transition
- removed context trigger color transition

Trace:
- `Trace-20260417T123111.json`

Improvements vs `Trace-20260417T121957.json`:
- pointerover+mouseover/sec: `26.2 -> 8.4`
- pointermove+mousemove/sec: `38.6 -> 16.9`
- transition/sec: `143.8 -> 0`
- style recalculation/sec: `43.4 -> 22.1`

But overall:
- dropped/sec: `58.1 -> 67.2`
- layout ms/sec: `183.5 -> 194.6`

Conclusion:
- hover/transition cleanup was real and worthwhile
- the remaining bottleneck after this point was more clearly layout/main-thread scroll work, not hover noise

### 8. Truncate marker paint was a real hotspot, despite only a few visibly truncated rows

This was the most surprising result.

Trace before truncate suppression:
- `Trace-20260417T123111.json`

Evidence:
- `PaintImage` count: `18150`
- `PaintImage/sec`: `1825.4`
- sampled `PaintImage` events were CSS pseudo-elements:
  - `nodeName: "::before"` / `"::after"`
  - `isCSS: true`
  - tiny `srcWidth: 4`
- this maps closely to truncate marker / fade pseudo-elements in `style.css`

What changed:
- hide `[data-truncate-marker]` and `[data-truncate-fade]` while `data-is-scrolling` is active

Trace after truncate suppression:
- `Trace-20260417T123942.json`

Result vs `Trace-20260417T123111.json`:
- `PaintImage` count: `18150 -> 338`
- `PaintImage/sec`: `1825.4 -> 33.2`
- paint ms/sec: `149.1 -> 126.0`
- style recalculation/sec: `22.1 -> 18.1`
- pointerover+mouseover/sec: `8.4 -> 0.6`
- pointermove+mousemove/sec: `16.9 -> 0`

Conclusion:
- truncate marker/fade decoration was definitely a real paint hotspot
- hiding it during scroll should stay

## Current best read from the trace series

### Baseline
`Trace-20260416T205528.json`

Normalized during scroll:
- dropped/sec: `60.1`
- layout ms/sec: `165.6`
- updateLayoutTree ms/sec: `30.2`
- paint ms/sec: `127.7`
- paintImage/sec: `1451.0`
- styleRecalc/sec: `13.7`
- pointerover+mouseover/sec: `1.1`

### Latest cleaned-up trace
`Trace-20260417T123942.json`

Normalized during scroll:
- dropped/sec: `74.7`
- layout ms/sec: `225.3`
- updateLayoutTree ms/sec: `38.8`
- paint ms/sec: `126.0`
- paintImage/sec: `33.2`
- styleRecalc/sec: `18.1`
- pointerover+mouseover/sec: `0.6`

Interpretation:
- hover / pointer / transition / truncate paint noise is now largely under control
- overall paint is roughly back to baseline or slightly better
- the remaining major regression is layout / main-thread scroll work

## Important caveat on the manual traces

The manual scroll runs were not identical in intensity:
- later runs often had different counts of `wheel`, `scroll`, and `SCROLL_MAIN_THREAD`
- use normalized per-second metrics, but do not over-interpret any single run as perfectly apples-to-apples
- still, the directional conclusions above were strong enough to guide the changes confidently

## What is likely still hot now

The latest trace points away from hover/truncate paint and toward layout.

Most likely remaining hotspots:
- main-thread layout / update work during scroll
- scroll-driven rerender churn in `PathStoreTreesView`
- geometry reads / state updates around floating context trigger positioning

## Highest-confidence next wins

### 1. Investigate scroll-driven React/render churn inside `PathStoreTreesView`

We already coalesce viewport updates to one frame.
The next question is: what still rerenders on every range change?

Best next step:
- instrument render counts during scroll
- measure how many rows rerender per frame when the range changes
- identify whether range rebases are causing more row work than expected

Likely win if confirmed:
- reduce state churn during scroll
- move some purely scroll-adjacent visuals out of React/state if possible

### 2. Freeze or defer floating context-trigger positioning during active scroll

Observed indicators across the process:
- `updateTriggerPosition` showed up repeatedly in trace-string searches
- `getBoundingClientRect` appeared repeatedly as well
- trigger positioning uses layout reads and a `useLayoutEffect`

This is not yet proven as the top remaining cost, but it is a credible next candidate.

Best next experiment:
- temporarily freeze or defer context trigger anchor positioning while `data-is-scrolling` is active
- re-run trace and compare layout / updateLayoutTree

If it wins:
- only reposition the trigger after scrolling settles

### 3. Verify whether layout is still escaping the tree subtree

The original baseline showed document-level layout:
- all observed `Layout` events during the scroll window were `partialLayout: false`
- layout root was `#document`

If the latest traces still show that, the real remaining problem is likely not paint micro-optimizations but a remaining invalidation source that escapes the tree subtree.

Best next step:
- inspect latest trace `Layout` event args for `partialLayout` and layout root again
- if still document-level, search for the remaining invalidation source instead of continuing CSS pruning

### 4. Do not revisit the translated sticky-shell approach

This is worth repeating:
- the sticky-buffer translateY approach improved some synthetic layout numbers
- but it broke the anti-blanking behavior the current sticky technique exists to preserve

Treat that idea as closed unless the design goal changes.

## What not to change casually

Keep these unless new trace evidence proves they are harmful:
- reverse-sticky window geometry
- wheel-armed suppression
- frame-coalesced scroll updates
- descendant-level pointer suppression during scroll
- 100ms trailing suppression delay
- hidden truncate markers/fades during scroll

## Useful reference

`packages/diffs` was helpful as a reference for batching/scheduling patterns, especially frame-coalesced updates.

It was **not** a drop-in geometry model for trees.
Treat diffs as inspiration for render scheduling, not for replacing the reverse-sticky non-blanking technique.

## Most likely next best move

If there is time for only one more optimization pass:
- investigate and reduce layout work caused by scroll-driven React state and context-trigger positioning

If there is time for two:
1. freeze/defer floating context trigger anchor updates during active scroll and trace it
2. instrument row rerender / commit counts inside the `PathStoreTreesView.update()` path and cut unnecessary scroll-time rerenders
