### PR TITLE
Fix scroll appearing on split view with annotations

### DIFF
--- a/packages/diffs/src/managers/ResizeManager.ts
+++ b/packages/diffs/src/managers/ResizeManager.ts
@@ -175,7 +175,7 @@ export class ResizeManager {
 
   private handleResizeObserver = (entries: ResizeObserverEntry[]) => {
     for (const entry of entries) {
-      const { target, borderBoxSize } = entry;
+      const { target, borderBoxSize, contentBoxSize } = entry;
       if (!(target instanceof HTMLElement)) {
         console.error(
           'FileDiff.handleResizeObserver: Invalid element for ResizeObserver',
@@ -191,7 +191,6 @@ export class ResizeManager {
         );
         continue;
       }
-      const specs = borderBoxSize[0];
       if (item.type === 'annotations') {
         const column = (() => {
           if (target === item.column1.child) {
@@ -211,14 +210,14 @@ export class ResizeManager {
           continue;
         }
 
-        column.childHeight = specs.blockSize;
+        column.childHeight = borderBoxSize[0].blockSize;
         const newHeight = Math.max(
           item.column1.childHeight,
           item.column2.childHeight
         );
         this.applyNewHeight(item, newHeight);
       } else if (item.type === 'code') {
-        const update: CodeColumnUpdate = [target, specs.inlineSize];
+        const update: CodeColumnUpdate = [target, contentBoxSize[0].inlineSize];
         const updates = this.queuedUpdates.get(item) ?? [];
         updates.push(update);
         this.queuedUpdates.set(item, updates);


### PR DESCRIPTION
When using split-view and annotations, the annotation content width is overestimated by 1px leading to unnecessary scroll.

#### Before

(Note the horizontal scroll at the bottom)

<img width="1265" height="771" alt="image" src="https://github.com/user-attachments/assets/db646bd5-8e4e-4abe-afa5-a9fc28b49d69" />

#### After

<img width="1261" height="769" alt="image" src="https://github.com/user-attachments/assets/12f88ba3-97b6-48c3-8f9d-82ba9bcf3a5f" />