### PR TITLE
Context menu section first pass

### DIFF
--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -2,7 +2,7 @@
 @import 'tw-animate-css';
 
 @custom-variant light (&:is(.light *));
-@custom-variant dark (&:is(.dark *));
+@custom-variant dark (&:is(.dark *, .dark));
 
 @theme {
   --font-geist: var(--font-geist-sans);

--- a/apps/docs/app/trees/TreesHomePage.tsx
+++ b/apps/docs/app/trees/TreesHomePage.tsx
@@ -5,6 +5,7 @@ import { Hero } from '../Hero';
 import type { ProductId } from '../product-config';
 import {
   A11ySection,
+  ContextMenuSection,
   CustomIconsSection,
   DragDropSection,
   FlatteningSection,
@@ -37,6 +38,7 @@ export default function TreesHomePage() {
         <FlatteningSection />
         <GitStatusSection />
         <DragDropSection />
+        <ContextMenuSection />
         <SearchSection />
         <VirtualizationSection />
         <A11ySection />

--- a/apps/docs/app/trees/tree-examples/ContextMenuSection.tsx
+++ b/apps/docs/app/trees/tree-examples/ContextMenuSection.tsx
@@ -1,0 +1,20 @@
+import { preloadFileTree } from '@pierre/trees/ssr';
+
+import { ContextMenuSectionClient } from './ContextMenuSectionClient';
+import { baseTreeOptions } from './demo-data';
+
+const DEMO_ID = 'context-menu-demo';
+
+const prerenderedHTML = preloadFileTree(
+  {
+    ...baseTreeOptions,
+    id: DEMO_ID,
+  },
+  {
+    initialExpandedItems: ['src', 'src/components'],
+  }
+).shadowHtml;
+
+export function ContextMenuSection() {
+  return <ContextMenuSectionClient prerenderedHTML={prerenderedHTML} />;
+}

--- a/apps/docs/app/trees/tree-examples/ContextMenuSectionClient.tsx
+++ b/apps/docs/app/trees/tree-examples/ContextMenuSectionClient.tsx
@@ -1,0 +1,289 @@
+'use client';
+
+import { IconRefresh } from '@pierre/icons';
+import type {
+  ContextMenuItem,
+  ContextMenuOpenContext,
+  GitStatusEntry,
+} from '@pierre/trees';
+import { FileTree } from '@pierre/trees/react';
+import Link from 'next/link';
+import type { CSSProperties } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+
+import { FeatureHeader } from '../../diff-examples/FeatureHeader';
+import { baseTreeOptions, DEFAULT_FILE_TREE_PANEL_CLASS } from './demo-data';
+import { TreeExampleSection } from './TreeExampleSection';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+} from '@/components/ui/dropdown-menu';
+
+const DEMO_ID = 'context-menu-demo';
+
+const panelStyle = {
+  colorScheme: 'dark',
+  '--trees-search-bg-override': 'light-dark(#fff, oklch(14.5% 0 0))',
+} as CSSProperties;
+
+const initialFiles = baseTreeOptions.initialFiles;
+const initialFilesSet = new Set(initialFiles);
+
+const options = {
+  ...baseTreeOptions,
+  id: DEMO_ID,
+  renaming: true,
+};
+
+interface ContextMenuActions {
+  onAddFile: (parentPath: string) => void;
+  onAddFolder: (parentPath: string) => void;
+  onCopyPath: (path: string) => void;
+  onDelete: (path: string, isFolder: boolean) => void;
+}
+
+export function ContextMenuSectionClient({
+  prerenderedHTML,
+}: {
+  prerenderedHTML: string;
+}) {
+  const [files, setFiles] = useState(initialFiles);
+  const [lastAction, setLastAction] = useState<string | null>(null);
+  const [hasChanges, setHasChanges] = useState(false);
+  const [resetKey, setResetKey] = useState(0);
+
+  /** Mark any file not in the original set as "added" (directories aren't tracked by git). */
+  const gitStatus = useMemo<GitStatusEntry[]>(() => {
+    const entries: GitStatusEntry[] = [];
+    for (const path of files) {
+      if (!initialFilesSet.has(path) && !path.endsWith('/')) {
+        entries.push({ path, status: 'added' });
+      }
+    }
+    return entries;
+  }, [files]);
+
+  const handleFilesChange = useCallback((nextFiles: string[]) => {
+    setFiles(nextFiles);
+    setHasChanges(true);
+  }, []);
+
+  const handleReset = useCallback(() => {
+    setFiles(initialFiles);
+    setLastAction(null);
+    setHasChanges(false);
+    setResetKey((k) => k + 1);
+  }, []);
+
+  const actions = useMemo<ContextMenuActions>(
+    () => ({
+      onAddFile: (parentPath: string) => {
+        const name = window.prompt('File name:');
+        if (name == null || name.trim() === '') return;
+        const newPath = `${parentPath}/${name.trim()}`;
+        setFiles((prev) =>
+          prev.includes(newPath) ? prev : [...prev, newPath]
+        );
+        setHasChanges(true);
+        setLastAction(`New file → ${newPath}`);
+      },
+      onAddFolder: (parentPath: string) => {
+        const name = window.prompt('Folder name:');
+        if (name == null || name.trim() === '') return;
+        const newPath = `${parentPath}/${name.trim()}/`;
+        setFiles((prev) =>
+          prev.includes(newPath) ? prev : [...prev, newPath]
+        );
+        setHasChanges(true);
+        setLastAction(`New folder → ${newPath}`);
+      },
+      onCopyPath: (path: string) => {
+        navigator.clipboard.writeText(path).then(
+          () => setLastAction(`Copied → ${path}`),
+          () => setLastAction(`Copy failed → ${path}`)
+        );
+      },
+      onDelete: (path: string, isFolder: boolean) => {
+        setFiles((prev) => {
+          if (isFolder) {
+            const prefix = path.endsWith('/') ? path : `${path}/`;
+            return prev.filter((f) => f !== path && !f.startsWith(prefix));
+          }
+          return prev.filter((f) => f !== path);
+        });
+        setHasChanges(true);
+        setLastAction(`Deleted → ${path}`);
+      },
+    }),
+    []
+  );
+
+  const renderContextMenu = useCallback(
+    (item: ContextMenuItem, context: ContextMenuOpenContext) => {
+      return (
+        <TreeContextMenu
+          item={item}
+          context={context}
+          actions={actions}
+          onAction={setLastAction}
+        />
+      );
+    },
+    [actions]
+  );
+
+  return (
+    <TreeExampleSection>
+      <FeatureHeader
+        id="context-menu"
+        title="Context menu"
+        description={
+          <>
+            Add a custom context menu via the <code>renderContextMenu</code>{' '}
+            callback. The tree provides the anchor position, file path, and type
+            so you can render any menu component — Radix, headless UI, or plain
+            HTML. Click the ellipsis button or press <kbd>Shift+F10</kbd> on a
+            focused row.{' '}
+            <Link
+              href="/preview/trees/docs#core-types-filetreeprops"
+              className="inline-link"
+            >
+              See FileTreeProps…
+            </Link>
+          </>
+        }
+      />
+      <div className="space-y-4">
+        <div className="flex flex-wrap items-center gap-4">
+          <Button
+            variant="outline"
+            disabled={!hasChanges}
+            onClick={handleReset}
+          >
+            <IconRefresh />
+            Reset
+          </Button>
+        </div>
+
+        <FileTree
+          key={resetKey}
+          className={DEFAULT_FILE_TREE_PANEL_CLASS}
+          prerenderedHTML={prerenderedHTML}
+          options={options}
+          files={files}
+          onFilesChange={handleFilesChange}
+          gitStatus={gitStatus}
+          initialExpandedItems={['src', 'src/components']}
+          style={panelStyle}
+          renderContextMenu={renderContextMenu}
+        />
+        {lastAction != null ? (
+          <p className="text-muted-foreground text-sm">
+            Last action: <code>{lastAction}</code>
+          </p>
+        ) : null}
+      </div>
+    </TreeExampleSection>
+  );
+}
+
+function TreeContextMenu({
+  item,
+  context,
+  actions,
+  onAction,
+}: {
+  item: ContextMenuItem;
+  context: ContextMenuOpenContext;
+  actions: ContextMenuActions;
+  onAction: (action: string) => void;
+}) {
+  const fileName = useMemo(() => {
+    const segments = item.path.replace(/\/$/, '').split('/');
+    return segments[segments.length - 1];
+  }, [item.path]);
+
+  const folderPath = useMemo(() => item.path.replace(/\/$/, ''), [item.path]);
+
+  return (
+    <DropdownMenu
+      open
+      onOpenChange={(open) => {
+        if (!open) context.close();
+      }}
+    >
+      <DropdownMenuContent
+        side="bottom"
+        align="end"
+        sideOffset={0}
+        className="dark w-52"
+        onCloseAutoFocus={(e) => e.preventDefault()}
+        style={
+          {
+            position: 'fixed',
+            top: context.anchorRect.bottom + 4,
+            left: context.anchorRect.right - 208,
+          } as CSSProperties
+        }
+      >
+        {item.isFolder ? (
+          <>
+            <DropdownMenuItem
+              onClick={() => {
+                context.close();
+                actions.onAddFile(folderPath);
+              }}
+            >
+              New file…
+              <DropdownMenuShortcut>⌘N</DropdownMenuShortcut>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() => {
+                context.close();
+                actions.onAddFolder(folderPath);
+              }}
+            >
+              New folder…
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
+        ) : null}
+        <DropdownMenuItem
+          onClick={() => {
+            actions.onCopyPath(item.path);
+            context.close();
+          }}
+        >
+          Copy path
+          <DropdownMenuShortcut>⌘⇧C</DropdownMenuShortcut>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        {context.canRename === true ? (
+          <DropdownMenuItem
+            onClick={() => {
+              onAction(`Rename → ${item.path}`);
+              context.startRenaming?.();
+            }}
+          >
+            Rename
+            <DropdownMenuShortcut>F2</DropdownMenuShortcut>
+          </DropdownMenuItem>
+        ) : null}
+        <DropdownMenuItem
+          variant="danger"
+          onClick={() => {
+            actions.onDelete(item.path, item.isFolder);
+            context.close();
+          }}
+        >
+          Delete {fileName}
+          <DropdownMenuShortcut>⌘⌫</DropdownMenuShortcut>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/docs/app/trees/tree-examples/index.ts
+++ b/apps/docs/app/trees/tree-examples/index.ts
@@ -1,4 +1,5 @@
 export { A11ySection } from './A11ySection';
+export { ContextMenuSection } from './ContextMenuSection';
 export { CustomIconsSection } from './CustomIconsSection';
 export { DragDropSection } from './DragDropSection';
 export { FlatteningSection } from './FlatteningSection';

--- a/apps/docs/components/ui/dropdown-menu.tsx
+++ b/apps/docs/components/ui/dropdown-menu.tsx
@@ -47,7 +47,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border border-[rgb(0_0_0_/_0.15)] bg-clip-padding p-1 shadow-lg dark:border-[rgb(255_255_255_/_0.15)] dark:shadow-black/25',
+      'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border border-[rgb(0_0_0_/_0.15)] bg-clip-padding p-1 shadow-lg dark:border-border dark:shadow-black/25',
       className
     )}
     {...props}
@@ -107,7 +107,7 @@ const DropdownMenuContent = React.forwardRef<
           ref={setRefs}
           sideOffset={sideOffset}
           className={cn(
-            'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] space-y-[1px] overflow-hidden rounded-lg border border-[rgb(0_0_0_/_0.15)] bg-clip-padding p-1 shadow-md dark:border-[rgb(255_255_255_/_0.15)] dark:shadow-black/25',
+            'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] space-y-[1px] overflow-hidden rounded-md border border-[rgb(0_0_0_/_0.15)] bg-clip-padding p-1 shadow-md dark:border-border dark:shadow-black/25',
             className
           )}
           {...props}
@@ -139,7 +139,7 @@ const DropdownMenuItem = React.forwardRef<
     <DropdownMenuPrimitive.Item
       ref={ref}
       className={cn(
-        'focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center rounded-md px-3 py-1.5 text-sm outline-none select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        'focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center rounded-sm px-3 py-1.5 text-sm outline-none select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
         selected && 'bg-accent text-accent-foreground',
         variant === 'danger' &&
           'text-destructive focus:bg-destructive/15 focus:text-destructive dark:text-destructive dark:focus:bg-destructive/15 dark:focus:text-destructive',

--- a/packages/trees/src/style.css
+++ b/packages/trees/src/style.css
@@ -1003,6 +1003,11 @@
     flex: 0 0 auto;
   }
 
+  /* Hide git status badge when the context menu trigger is overlaying the row */
+  [data-item-context-hover='true'] > [data-item-section='status'] {
+    visibility: hidden;
+  }
+
   [data-type='context-menu-wash'] {
     position: absolute;
     inset: 0;


### PR DESCRIPTION
Adds new context menu example to Trees homepage. Includes some dropdown changes again—was hoping to get this working with dark mode inside the dark theme of the parent, but goodness I can't for the life of me. So punting on that for now and we'll have a dropdown menu that responds to the page color mode and not the theme color mode to start perhaps.