### PR TITLE
Add footnote link to VS Code icon theme

### DIFF
--- a/apps/docs/app/components/PierreIconsFootnote.tsx
+++ b/apps/docs/app/components/PierreIconsFootnote.tsx
@@ -1,0 +1,20 @@
+import { IconArrowDownRight } from '@pierre/icons';
+
+import { IconFootnote } from './IconFootnote';
+
+export function PierreIconsFootnote() {
+  return (
+    <IconFootnote icon={<IconArrowDownRight />}>
+      Want matching file icons in your editor?{' '}
+      <a
+        href="https://marketplace.visualstudio.com/items?itemName=pierrecomputer.pierre-vscode-icons"
+        className="inline-link"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Install Pierre Icons for VS Code
+      </a>{' '}
+      to bring the same icon set into your sidebar.
+    </IconFootnote>
+  );
+}

--- a/apps/docs/app/trees/tree-examples/CustomIconsSection.tsx
+++ b/apps/docs/app/trees/tree-examples/CustomIconsSection.tsx
@@ -3,6 +3,7 @@ import { FileTree } from '@pierre/trees/react';
 import { preloadFileTree } from '@pierre/trees/ssr';
 import type { CSSProperties } from 'react';
 
+import { PierreIconsFootnote } from '../../components/PierreIconsFootnote';
 import { TreeExampleHeading } from '../../components/TreeExampleHeading';
 import { FeatureHeader } from '../../diff-examples/FeatureHeader';
 import {
@@ -137,6 +138,7 @@ export function CustomIconsSection() {
           />
         </div>
       </div>
+      <PierreIconsFootnote />
     </TreeExampleSection>
   );
 }


### PR DESCRIPTION
Lil footy for the cross linking of our icons in VS Code editors.