### PR TITLE
Add options for modifying tree density easily

### DIFF
--- a/apps/docs/app/trees/TreesHomePage.tsx
+++ b/apps/docs/app/trees/TreesHomePage.tsx
@@ -6,6 +6,7 @@ import type { ProductId } from '../product-config';
 import {
   A11ySection,
   CustomIconsSection,
+  DensitySection,
   DragDropSection,
   FlatteningSection,
   GitStatusSection,
@@ -43,6 +44,7 @@ export default function TreesHomePage() {
         <CustomIconsSection />
         <ThemingSection />
         <StylingSection />
+        <DensitySection />
       </section>
 
       <PierreCompanySection />

--- a/apps/docs/app/trees/tree-examples/DensitySection.tsx
+++ b/apps/docs/app/trees/tree-examples/DensitySection.tsx
@@ -1,0 +1,94 @@
+import { FileTree } from '@pierre/trees/react';
+import { preloadFileTree } from '@pierre/trees/ssr';
+import Link from 'next/link';
+import type { CSSProperties } from 'react';
+
+import { TreeExampleHeading } from '../../components/TreeExampleHeading';
+import { FeatureHeader } from '../../diff-examples/FeatureHeader';
+import {
+  baseTreeOptions,
+  DEFAULT_FILE_TREE_PANEL_CLASS,
+  DEFAULT_FILE_TREE_PANEL_STYLE,
+} from './demo-data';
+import { TreeExampleSection } from './TreeExampleSection';
+
+const PRESELECTED_FILE = 'src/components/Button.tsx';
+
+function densityStyle(density: number): CSSProperties {
+  return {
+    ...DEFAULT_FILE_TREE_PANEL_STYLE,
+    ['--trees-density-override' as string]: density,
+  };
+}
+
+function createPrerenderedHTML(id: string): string {
+  return preloadFileTree(
+    { ...baseTreeOptions, id },
+    { initialSelectedItems: [PRESELECTED_FILE] }
+  ).shadowHtml;
+}
+
+const tightHTML = createPrerenderedHTML('density-demo-tight');
+const defaultHTML = createPrerenderedHTML('density-demo-default');
+const relaxedHTML = createPrerenderedHTML('density-demo-relaxed');
+
+export function DensitySection() {
+  return (
+    <TreeExampleSection>
+      <FeatureHeader
+        id="density"
+        title="Adjustable density"
+        description={
+          <>
+            Control the visual density of the entire tree with a single CSS
+            variable. Set <code>--trees-density-override</code> to a unitless
+            scale factor and row height, padding, gaps, and indentation all
+            adjust together. See the{' '}
+            <Link href="/preview/trees/docs#styling" className="inline-link">
+              Styling docs
+            </Link>{' '}
+            for more info.
+          </>
+        }
+      />
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <div>
+          <TreeExampleHeading description="--trees-density-override: 0.8">
+            Tight
+          </TreeExampleHeading>
+          <FileTree
+            className={DEFAULT_FILE_TREE_PANEL_CLASS}
+            prerenderedHTML={tightHTML}
+            options={{ ...baseTreeOptions, id: 'density-demo-tight' }}
+            initialSelectedItems={[PRESELECTED_FILE]}
+            style={densityStyle(0.8)}
+          />
+        </div>
+        <div>
+          <TreeExampleHeading description="--trees-density-override: 1 (default)">
+            Default
+          </TreeExampleHeading>
+          <FileTree
+            className={DEFAULT_FILE_TREE_PANEL_CLASS}
+            prerenderedHTML={defaultHTML}
+            options={{ ...baseTreeOptions, id: 'density-demo-default' }}
+            initialSelectedItems={[PRESELECTED_FILE]}
+            style={densityStyle(1)}
+          />
+        </div>
+        <div>
+          <TreeExampleHeading description="--trees-density-override: 1.25">
+            Relaxed
+          </TreeExampleHeading>
+          <FileTree
+            className={DEFAULT_FILE_TREE_PANEL_CLASS}
+            prerenderedHTML={relaxedHTML}
+            options={{ ...baseTreeOptions, id: 'density-demo-relaxed' }}
+            initialSelectedItems={[PRESELECTED_FILE]}
+            style={densityStyle(1.25)}
+          />
+        </div>
+      </div>
+    </TreeExampleSection>
+  );
+}

--- a/apps/docs/app/trees/tree-examples/index.ts
+++ b/apps/docs/app/trees/tree-examples/index.ts
@@ -1,5 +1,6 @@
 export { A11ySection } from './A11ySection';
 export { CustomIconsSection } from './CustomIconsSection';
+export { DensitySection } from './DensitySection';
 export { DragDropSection } from './DragDropSection';
 export { FlatteningSection } from './FlatteningSection';
 export { GitStatusSection } from './GitStatusSection';

--- a/packages/trees/src/style.css
+++ b/packages/trees/src/style.css
@@ -94,6 +94,17 @@
       --trees-file-icon-color-zig
       --trees-file-icon-color-zip
 
+      // Density
+      //
+      // A unitless scale factor that drives row height, padding, gaps,
+      // and indentation. Individual layout overrides still take precedence.
+      //
+      //   Tight:   0.8  (row height ~24px)
+      //   Default: 1    (row height  30px)
+      //   Relaxed: 1.25 (row height ~38px)
+      //
+      --trees-density-override
+
       // Available CSS Layout Overrides
       --trees-gap-override
       --trees-border-radius-override
@@ -151,7 +162,10 @@
         light-dark(oklch(0% 0 0 / 0.2), oklch(100% 0 0 / 0.2))
       )
     );
-    --trees-border-radius: var(--trees-border-radius-override, 6px);
+    --trees-border-radius: var(
+      --trees-border-radius-override,
+      calc(6px * var(--trees-density))
+    );
 
     --trees-font-family: var(--trees-font-family-override, system-ui);
     --trees-font-size: var(--trees-font-size-override, 13px);
@@ -447,15 +461,37 @@
       var(--trees-icon-orange)
     );
 
-    --trees-level-gap: var(--trees-level-gap-override, 8px);
-    --trees-item-padding-x: var(--trees-item-padding-x-override, 8px);
-    --trees-item-margin-x: var(--trees-item-margin-x-override, 2px);
-    --trees-item-row-gap: var(--trees-item-row-gap-override, 6px);
+    --trees-density: var(--trees-density-override, 1);
+
+    --trees-level-gap: var(
+      --trees-level-gap-override,
+      calc(8px * var(--trees-density))
+    );
+    --trees-item-padding-x: var(
+      --trees-item-padding-x-override,
+      calc(8px * var(--trees-density))
+    );
+    --trees-item-margin-x: var(
+      --trees-item-margin-x-override,
+      calc(2px * var(--trees-density))
+    );
+    --trees-item-row-gap: var(
+      --trees-item-row-gap-override,
+      calc(6px * var(--trees-density))
+    );
     --trees-icon-width: var(--trees-icon-width-override, 16px);
-    --trees-icon-nudge: var(--trees-icon-nudge-override, 1px);
-    --trees-row-height: var(--trees-row-height-override, 30px);
+    --trees-icon-nudge: var(
+      --trees-icon-nudge-override,
+      calc(1px * var(--trees-density))
+    );
+    --trees-row-height: var(
+      --trees-row-height-override,
+      calc(30px * var(--trees-density))
+    );
+    --ft-internal-row-height: var(--trees-row-height);
 
     color-scheme: light dark;
+    container-type: inline-size;
     display: flex;
     flex-direction: column;
     font-size: var(--trees-font-size);
@@ -639,7 +675,7 @@
   [data-item-flattened-subitems] {
     display: inline-flex;
     align-items: center;
-    gap: 2px;
+    gap: calc(2px * var(--trees-density, 1));
   }
   [data-item-flattened-subitem]:hover,
   [data-item-flattened-subitem-drag-target='true'] {
@@ -837,14 +873,14 @@
     min-width: 0;
     font-family: inherit;
     font-size: inherit;
-    line-height: calc(var(--trees-row-height) - 8px);
-    height: calc(var(--trees-row-height) - 8px);
+    line-height: calc(var(--trees-row-height) - 8px * var(--trees-density, 1));
+    height: calc(var(--trees-row-height) - 8px * var(--trees-density, 1));
     color: inherit;
     background-color: var(--trees-search-bg);
     border: 1px solid var(--trees-border-color);
     /* border-radius: calc(var(--trees-border-radius) - 1px);border-radius */
-    padding-inline: 6px;
-    margin-right: 40px;
+    padding-inline: calc(6px * var(--trees-density, 1));
+    margin-right: calc(var(--trees-row-height) + 10px);
     outline: none;
   }
 
@@ -856,7 +892,7 @@
 
   [data-item-section='status'] {
     flex: 0 0 auto;
-    width: 12px;
+    width: calc(12px * var(--trees-density, 1));
     text-align: center;
     align-items: center;
   }
@@ -909,6 +945,17 @@
     & + & {
       margin-left: calc(
         var(--trees-item-row-gap) + calc(var(--trees-icon-width) / 2) - 0.5px
+      );
+    }
+  }
+
+  @container (max-width: 300px) {
+    [data-item-section='spacing-item'] {
+      margin-right: calc(var(--trees-level-gap) / 2 - 1px);
+    }
+    [data-item-section='spacing-item'] + [data-item-section='spacing-item'] {
+      margin-left: calc(
+        (var(--trees-item-row-gap) + var(--trees-icon-width) / 2 - 0.5px) / 2
       );
     }
   }


### PR DESCRIPTION
Add a `--trees-density-override` CSS variable that scales row height, padding, gaps, indentation, and border radius from a single unitless value (`0.8` tight, `1` default, `1.25` relaxed). Existing `*-override` variables still win when set.

Promote several hard-coded px values (status width, flattened gap, rename input) to density-aware calc expressions. Wire `--ft-internal-row-height` to `--trees-row-height` so the virtualizer picks up density changes automatically.

Add a `@container (max-width: 300px)` query that halves `--trees-level-gap` in narrow containers, keeping guide lines aligned with parent chevrons.

New 3-column density demo on the Trees homepage.