### PR TITLE
Fix infinite loop on plain-text diffs

### DIFF
--- a/packages/diffs/src/highlighter/languages/areLanguagesAttached.ts
+++ b/packages/diffs/src/highlighter/languages/areLanguagesAttached.ts
@@ -5,6 +5,9 @@ export function areLanguagesAttached(
   languages: SupportedLanguages | SupportedLanguages[]
 ): boolean {
   for (const language of Array.isArray(languages) ? languages : [languages]) {
+    if (language === 'text' || language === 'ansi') {
+      continue;
+    }
     if (!AttachedLanguages.has(language)) {
       return false;
     }

--- a/packages/diffs/test/areLanguagesAttached.test.ts
+++ b/packages/diffs/test/areLanguagesAttached.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+
+import { areLanguagesAttached } from '../src/highlighter/languages/areLanguagesAttached';
+import { AttachedLanguages } from '../src/highlighter/languages/constants';
+
+describe('areLanguagesAttached', () => {
+  test('treats builtin text-like languages as already attached', () => {
+    AttachedLanguages.clear();
+
+    expect(areLanguagesAttached('text')).toBe(true);
+    expect(areLanguagesAttached('ansi')).toBe(true);
+  });
+
+  test('still requires explicit attachment for non-builtin languages', () => {
+    AttachedLanguages.clear();
+
+    expect(areLanguagesAttached('typescript')).toBe(false);
+
+    AttachedLanguages.add('typescript');
+    expect(areLanguagesAttached('typescript')).toBe(true);
+  });
+});


### PR DESCRIPTION
### Description

Rendering a diff with language "text" or "ansi" would cause an infinite loop, because those languages are skipped in `getSharedHighlighter` and so never become attached.

This change updates `areLanguagesAttached` to always return true for those languages, to match the corresponding special treatment of those languages in other places.

### Motivation & Context

Infinite loop when rendering "text" diffs. I specifically saw this on a `.gitignore` diff in my project using the Vanilla JS API. This diff had no attached language but the autodetection chose "text" as the language.

Excerpt of the stack trace:

```
  rerender (FileDiff.js:287)
  (anonymous) (FileDiff.js:76)
  onHighlightSuccess (DiffHunksRenderer.js:275)
  (anonymous) (DiffHunksRenderer.js:224)
  Promise.then
  renderDiff (DiffHunksRenderer.js:222)
  render (FileDiff.js:353)
  rerender (FileDiff.js:287)
  (anonymous) (FileDiff.js:76)
  onHighlightSuccess (DiffHunksRenderer.js:275)
  (anonymous) (DiffHunksRenderer.js:224)
  Promise.then
  renderDiff (DiffHunksRenderer.js:222)
  render (FileDiff.js:353)
  rerender (FileDiff.js:287)
```

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality). You must have
      first discussed with the dev team and they should be aware that this PR is
      being opened
- [ ] Breaking change (fix or feature that would change existing functionality).
      You must have first discussed with the dev team and they should be aware
      that this PR is being opened
- [ ] Documentation update

### Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/pierrecomputer/pierre/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project (`bun run lint`)
- [x] My code is formatted properly (`bun run format`)
- [N/A] I have updated the documentation accordingly (if applicable)
- [x] I have added tests to cover my changes (if applicable)
- [x] All new and existing tests pass (`bun run diffs:test`)  -- Used `cd packages/diffs && bun run test` since diffs:test command doesn't seem to exist.

### How was AI used in generating this PR

Fed the above stack trace into Codex, which diagnosed the error and generated the fix and tests.

I manually reviewed all changes and verified that it fixes the problem in my application.

### Related issues

<!-- Please link any related issues here. -->
