### PR TITLE
Trees Custom Scrollbars

### DIFF
--- a/apps/docs/app/trees/tree-examples/demo-data.ts
+++ b/apps/docs/app/trees/tree-examples/demo-data.ts
@@ -4,7 +4,7 @@ import type { GitStatusEntry } from '@/lib/treesCompat';
 
 /** Default panel look for FileTree in docs examples. Apply via className + style on FileTree. */
 export const DEFAULT_FILE_TREE_PANEL_CLASS =
-  'dark min-h-0 flex-1 overflow-auto rounded-lg p-3 border border-neutral-200 dark:border-neutral-800';
+  'dark min-h-0 flex-1 overflow-auto rounded-lg py-3 border border-neutral-200 dark:border-neutral-800';
 
 export const DEFAULT_FILE_TREE_PANEL_STYLE: CSSProperties = {
   colorScheme: 'dark',

--- a/packages/trees/src/components/web-components.ts
+++ b/packages/trees/src/components/web-components.ts
@@ -1,6 +1,8 @@
 import { FILE_TREE_STYLE_ATTRIBUTE, FILE_TREE_TAG_NAME } from '../constants';
 import rawStyles from '../style.css';
 import { wrapCoreCSS } from '../utils/cssWrappers';
+import { ensureMeasuredScrollbarGutter } from '../utils/scrollbarGutter';
+
 let sheet: CSSStyleSheet | undefined;
 
 export function ensureFileTreeStyles(shadowRoot: ShadowRoot): void {
@@ -43,6 +45,17 @@ export function ensureFileTreeStyles(shadowRoot: ShadowRoot): void {
   }
 }
 
+// Keeps every tree host on the same setup path so runtime mounting, hydration,
+// and autonomous custom-element upgrades share one shadow-root preparation step.
+export function prepareFileTreeShadowRoot(
+  host: HTMLElement,
+  shadowRoot: ShadowRoot
+): void {
+  adoptDeclarativeShadowDom(host, shadowRoot);
+  ensureFileTreeStyles(shadowRoot);
+  ensureMeasuredScrollbarGutter(host, shadowRoot);
+}
+
 export function adoptDeclarativeShadowDom(
   host: HTMLElement,
   shadowRoot: ShadowRoot
@@ -80,8 +93,7 @@ if (
 
     connectedCallback() {
       const shadowRoot = this.shadowRoot ?? this.attachShadow({ mode: 'open' });
-      adoptDeclarativeShadowDom(this, shadowRoot);
-      ensureFileTreeStyles(shadowRoot);
+      prepareFileTreeShadowRoot(this, shadowRoot);
     }
   }
 
@@ -98,8 +110,7 @@ if (
     )) {
       if (!(el instanceof HTMLElement)) continue;
       const shadowRoot = el.shadowRoot ?? el.attachShadow({ mode: 'open' });
-      adoptDeclarativeShadowDom(el, shadowRoot);
-      ensureFileTreeStyles(shadowRoot);
+      prepareFileTreeShadowRoot(el, shadowRoot);
     }
   }
 }

--- a/packages/trees/src/constants.ts
+++ b/packages/trees/src/constants.ts
@@ -2,6 +2,11 @@ export const FILE_TREE_TAG_NAME = 'file-tree-container' as const;
 export const FILE_TREE_STYLE_ATTRIBUTE = 'data-file-tree-style' as const;
 export const FILE_TREE_UNSAFE_CSS_ATTRIBUTE =
   'data-file-tree-unsafe-css' as const;
+export const FILE_TREE_SCROLLBAR_MEASURE_ATTRIBUTE =
+  'data-file-tree-scrollbar-measure' as const;
+
+export const FILE_TREE_SCROLLBAR_GUTTER_MEASURED_PROPERTY =
+  '--trees-scrollbar-gutter-measured';
 
 /**
  * Prefix used for flattened node IDs.

--- a/packages/trees/src/render/FileTree.ts
+++ b/packages/trees/src/render/FileTree.ts
@@ -11,9 +11,8 @@ import {
   isColoredBuiltInIconSet,
 } from '../builtInIcons';
 import {
-  adoptDeclarativeShadowDom,
-  ensureFileTreeStyles,
   FileTreeContainerLoaded,
+  prepareFileTreeShadowRoot,
 } from '../components/web-components';
 import {
   FILE_TREE_STYLE_ATTRIBUTE,
@@ -675,8 +674,7 @@ export class FileTree
     }
 
     const shadowRoot = host.shadowRoot ?? host.attachShadow({ mode: 'open' });
-    adoptDeclarativeShadowDom(host, shadowRoot);
-    ensureFileTreeStyles(shadowRoot);
+    prepareFileTreeShadowRoot(host, shadowRoot);
     this.#syncUnsafeCSS(shadowRoot);
     host.dataset.fileTreeVirtualized = 'true';
     host.style.display = 'flex';

--- a/packages/trees/src/style.css
+++ b/packages/trees/src/style.css
@@ -601,7 +601,7 @@
 
   [data-file-tree-virtualized-scroll='true'] {
     position: relative;
-    overscroll-behavior: none;
+    overflow-y: auto;
     flex: 1 1 0;
     min-height: 0;
     padding-inline: max(

--- a/packages/trees/src/style.css
+++ b/packages/trees/src/style.css
@@ -114,6 +114,8 @@
       --trees-item-row-gap-override
       --trees-icon-width-override
       --trees-icon-nudge-override
+      --trees-scrollbar-gutter-override
+      --trees-padding-inline-override
     */
 
     --trees-fg: var(
@@ -512,6 +514,9 @@
         var(--trees-focus-ring-width)
     );
 
+    --trees-scrollbar-gutter: var(--trees-scrollbar-gutter-override, 6px);
+    --trees-padding-inline: var(--trees-padding-inline-override, 16px);
+
     color-scheme: light dark;
     display: flex;
     flex-direction: column;
@@ -542,11 +547,104 @@
     overflow: hidden;
   }
 
+  [data-file-tree-virtualized-scroll='true'],
+  [data-file-tree-scrollbar-measure='true'] {
+    overflow-y: auto;
+    scrollbar-gutter: stable;
+
+    &::-webkit-scrollbar {
+      width: var(--trees-scrollbar-gutter);
+      height: var(--trees-scrollbar-gutter);
+    }
+
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background-color: transparent;
+      border: 1px solid transparent;
+      background-clip: content-box;
+      border-radius: calc(var(--trees-scrollbar-gutter) / 2);
+    }
+
+    &::-webkit-scrollbar-corner {
+      background-color: transparent;
+    }
+
+    &:hover::-webkit-scrollbar-thumb {
+      background-color: var(--trees-bg-muted);
+    }
+  }
+
+  /* These are styles for a temporarily generated element to measure the size
+   * of the scrollbar.  It's intended to be somewhat similar in scrollbar style
+   * scope to the scrollable tree so `--trees-scrollbar-gutter-measured` is an
+   * accurate reflection of the size the scrollbar gutter takes up. */
+  [data-file-tree-scrollbar-measure='true'] {
+    position: absolute;
+    top: 0;
+    left: 0;
+    visibility: hidden;
+    pointer-events: none;
+    width: 100px;
+    height: 100px;
+  }
+
+  @supports (-moz-appearance: none) {
+    [data-file-tree-virtualized-scroll='true'],
+    [data-file-tree-scrollbar-measure='true'] {
+      scrollbar-width: thin;
+      scrollbar-color: var(--trees-bg-muted) transparent;
+    }
+  }
+
   [data-file-tree-virtualized-scroll='true'] {
     position: relative;
-    overflow-y: auto;
+    overscroll-behavior: none;
     flex: 1 1 0;
     min-height: 0;
+    padding-inline: max(
+        calc(var(--trees-padding-inline) - var(--trees-item-margin-x)),
+        0px
+      )
+      /* NOTE(amadeus): We can assume that all Webkit based browser gutters
+       * will align to the value of '--trees-scrollbar-gutter', however if not, then
+       * `--trees-scrollbar-gutter-measured` should correct it. Mostly we are
+       * hoping to avoid SSR alignment jumps if possible. In non-SSR'd environments
+       * `--trees-scrollbar-gutter-measured` should always be immediately available.
+       */
+      max(
+        calc(
+          var(--trees-padding-inline) - var(--trees-item-margin-x) -
+            var(
+              --trees-scrollbar-gutter-measured,
+              var(--trees-scrollbar-gutter)
+            )
+        ),
+        0px
+      );
+  }
+
+  @supports (-moz-appearance: none) {
+    [data-file-tree-virtualized-scroll='true'] {
+      padding-inline: max(
+          calc(var(--trees-padding-inline) - var(--trees-item-margin-x)),
+          0px
+        )
+        /* NOTE(amadeus): However on Firefox it can vary a little bit, but most
+         * likely the majority of cases will default to a 0px width scrollbar lets
+         * inherit that first to avoid SSR jumps. In non-SSR'd environments
+         * `--trees-scrollbar-gutter-measured` should always be immediately available.
+         */
+        max(
+          calc(
+            var(--trees-padding-inline) - var(--trees-item-margin-x) -
+              var(--trees-scrollbar-gutter-measured, 0px)
+          ),
+          0px
+        );
+    }
   }
 
   [data-file-tree-virtualized-list='true'] {
@@ -575,7 +673,8 @@
   [data-file-tree-search-container] {
     display: flex;
     padding: 0;
-    margin: 0 var(--trees-item-margin-x) var(--trees-item-row-gap);
+    padding-inline: var(--trees-padding-inline);
+    margin-bottom: var(--trees-item-row-gap);
   }
 
   [data-file-tree-search-input] {

--- a/packages/trees/src/utils/scrollbarGutter.ts
+++ b/packages/trees/src/utils/scrollbarGutter.ts
@@ -1,0 +1,48 @@
+import {
+  FILE_TREE_SCROLLBAR_GUTTER_MEASURED_PROPERTY,
+  FILE_TREE_SCROLLBAR_MEASURE_ATTRIBUTE,
+} from '../constants';
+
+const measuredGutterCache = new WeakMap<ShadowRoot, number>();
+
+// Measures the scrollbar inside a real tree shadow root. The probe opts into
+// the same shared scrollbar selector as the real scroll surface, but carries a
+// dedicated attribute so the live DOM stays unchanged.
+function measureScrollbarGutter(shadowRoot: ShadowRoot): number | undefined {
+  const cachedScrollbarGutter = measuredGutterCache.get(shadowRoot);
+  if (cachedScrollbarGutter != null) {
+    return cachedScrollbarGutter;
+  }
+
+  const wrapper = document.createElement('div');
+  wrapper.setAttribute(FILE_TREE_SCROLLBAR_MEASURE_ATTRIBUTE, 'true');
+  const child = document.createElement('div');
+  child.style.position = 'relative';
+  child.style.height = '200%';
+  wrapper.appendChild(child);
+  shadowRoot.appendChild(wrapper);
+
+  const measuredGutter = Math.max(wrapper.offsetWidth - wrapper.clientWidth, 0);
+  wrapper.remove();
+  measuredGutterCache.set(shadowRoot, measuredGutter);
+  return measuredGutter;
+}
+
+export function ensureMeasuredScrollbarGutter(
+  host: HTMLElement,
+  shadowRoot: ShadowRoot
+): void {
+  if (!host.isConnected) {
+    return;
+  }
+
+  const measuredScrollbarGutter = measureScrollbarGutter(shadowRoot);
+  if (measuredScrollbarGutter == null) {
+    return;
+  }
+
+  host.style.setProperty(
+    FILE_TREE_SCROLLBAR_GUTTER_MEASURED_PROPERTY,
+    `${measuredScrollbarGutter}px`
+  );
+}


### PR DESCRIPTION
This is a quick initial pass at adding a custom scrollbar implementation similar to diffs, although making it a bit more configurable with a css override. Additionally there was a quick pass at inline padding for the scroll view that also helps apply to the search input.

<img width="846" height="768" alt="CleanShot 2026-04-19 at 15 38 04" src="https://github.com/user-attachments/assets/910fae57-14ec-4229-b252-59b43c488184" />

Standard css scrollbar properties must be only selectively enabled, or else they opt the browser into a specific render path that forces default scrollbars and ignores custom styles. In practice this is basically just Mozilla specific gating, as the non-standard APIs will _just work_ in even ancient versions of Chrome and Safari.

This PR also includes the ability to `measure` the actual gutter size to ensure inline padding accomodates this.