### PR TITLE
Launch fixes

### DIFF
--- a/apps/docs/app/trees/DemoA11yClient.tsx
+++ b/apps/docs/app/trees/DemoA11yClient.tsx
@@ -19,13 +19,20 @@ const a11yStyle: CSSProperties = {
 };
 const PRESELECTED_PATH = 'package.json';
 
-const KEYBOARD_SHORTCUTS: readonly { description: string; key: string }[] = [
-  { key: '↑ ↓', description: 'Move focus between items' },
+type KeyboardShortcut = {
+  description: string;
+} & ({ key: string; keys?: never } | { key?: never; keys: readonly string[] });
+
+const KEYBOARD_SHORTCUTS: readonly KeyboardShortcut[] = [
+  { keys: ['↑', '↓'], description: 'Move focus between items' },
   { key: '→', description: 'Expand folder or move to first child' },
   { key: '←', description: 'Collapse folder or move to parent' },
-  { key: 'Enter / Space', description: 'Select focused item; toggle folder' },
   {
-    key: '⌘/Ctrl + Space',
+    keys: ['Enter', 'Space'],
+    description: 'Select focused item; toggle folder',
+  },
+  {
+    keys: ['⌘/Ctrl', 'Space'],
     description: 'Add or remove focused item from selection',
   },
   { key: 'a–z', description: 'Type-ahead to jump by name' },
@@ -70,21 +77,31 @@ export function DemoA11yClient({ preloadedData }: DemoA11yClientProps) {
               </tr>
             </thead>
             <tbody>
-              {KEYBOARD_SHORTCUTS.map(({ key, description }) => (
-                <tr
-                  key={key}
-                  className="border-b border-[var(--color-border)] last:border-b-0"
-                >
-                  <td className="px-4 py-2">
-                    <kbd className="bg-muted rounded-sm border border-[var(--color-border)] px-1.5 py-0.5 font-mono text-xs">
-                      {key}
-                    </kbd>
-                  </td>
-                  <td className="text-muted-foreground px-4 py-2">
-                    {description}
-                  </td>
-                </tr>
-              ))}
+              {KEYBOARD_SHORTCUTS.map(({ key, keys, description }) => {
+                const shortcutKeys = keys ?? [key];
+                return (
+                  <tr
+                    key={shortcutKeys.join('+')}
+                    className="border-b border-[var(--color-border)] last:border-b-0"
+                  >
+                    <td className="px-4 py-2">
+                      <span className="inline-flex flex-wrap gap-1">
+                        {shortcutKeys.map((k) => (
+                          <kbd
+                            key={k}
+                            className="bg-muted rounded-sm border border-[var(--color-border)] px-1.5 py-0.5 font-mono text-xs"
+                          >
+                            {k}
+                          </kbd>
+                        ))}
+                      </span>
+                    </td>
+                    <td className="text-muted-foreground px-4 py-2">
+                      {description}
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/apps/docs/app/trees/DemoA11yClient.tsx
+++ b/apps/docs/app/trees/DemoA11yClient.tsx
@@ -10,7 +10,7 @@ import type { CSSProperties } from 'react';
 import { FeatureHeader } from '../diff-examples/FeatureHeader';
 import { sampleFileList } from './demo-data';
 import { TREE_NEW_VIEWPORT_HEIGHTS } from './dimensions';
-import { DEFAULT_FILE_TREE_PANEL_CLASS } from './tree-examples/demo-data';
+import { getDefaultFileTreePanelClass } from './tree-examples/demo-data';
 import { TreeExampleSection } from './tree-examples/TreeExampleSection';
 
 const a11yStyle: CSSProperties = {
@@ -63,7 +63,7 @@ export function DemoA11yClient({ preloadedData }: DemoA11yClientProps) {
       />
       <div className="grid grid-cols-1 items-start gap-6 md:grid-cols-2">
         <FileTree
-          className={DEFAULT_FILE_TREE_PANEL_CLASS}
+          className={getDefaultFileTreePanelClass()}
           model={model}
           preloadedData={preloadedData}
           style={a11yStyle}

--- a/apps/docs/app/trees/DemoCustomIconsClient.tsx
+++ b/apps/docs/app/trees/DemoCustomIconsClient.tsx
@@ -15,8 +15,8 @@ import { FeatureHeader } from '../diff-examples/FeatureHeader';
 import { sampleFileList } from './demo-data';
 import { TREE_NEW_VIEWPORT_HEIGHTS } from './dimensions';
 import {
-  DEFAULT_FILE_TREE_PANEL_CLASS,
   DEFAULT_FILE_TREE_PANEL_STYLE,
+  getDefaultFileTreePanelClass,
 } from './tree-examples/demo-data';
 import { TreeExampleSection } from './tree-examples/TreeExampleSection';
 import { PRODUCTS } from '@/app/product-config';
@@ -85,7 +85,7 @@ function IconDemoTree({
         {config.title}
       </TreeExampleHeading>
       <FileTree
-        className={DEFAULT_FILE_TREE_PANEL_CLASS}
+        className={getDefaultFileTreePanelClass()}
         model={model}
         preloadedData={preloadedData}
         style={panelStyle}

--- a/apps/docs/app/trees/DemoDensityClient.tsx
+++ b/apps/docs/app/trees/DemoDensityClient.tsx
@@ -13,7 +13,7 @@ import { TreeExampleHeading } from '../components/TreeExampleHeading';
 import { FeatureHeader } from '../diff-examples/FeatureHeader';
 import { sampleFileList } from './demo-data';
 import { TREE_NEW_VIEWPORT_HEIGHTS } from './dimensions';
-import { DEFAULT_FILE_TREE_PANEL_CLASS } from './tree-examples/demo-data';
+import { getDefaultFileTreePanelClass } from './tree-examples/demo-data';
 import { TreeExampleSection } from './tree-examples/TreeExampleSection';
 import { PRODUCTS } from '@/app/product-config';
 
@@ -90,7 +90,7 @@ function DensityTree({
 
   return (
     <FileTree
-      className={DEFAULT_FILE_TREE_PANEL_CLASS}
+      className={getDefaultFileTreePanelClass()}
       model={model}
       preloadedData={preloadedData}
       style={densityStyle(density, itemHeight, viewportHeight)}

--- a/apps/docs/app/trees/DemoDragDropClient.tsx
+++ b/apps/docs/app/trees/DemoDragDropClient.tsx
@@ -13,7 +13,7 @@ import { useEffect, useState } from 'react';
 import { FeatureHeader } from '../diff-examples/FeatureHeader';
 import { sampleFileList } from './demo-data';
 import { TREE_NEW_VIEWPORT_HEIGHTS } from './dimensions';
-import { DEFAULT_FILE_TREE_PANEL_CLASS } from './tree-examples/demo-data';
+import { getDefaultFileTreePanelClass } from './tree-examples/demo-data';
 import { TreeExampleSection } from './tree-examples/TreeExampleSection';
 import { PRODUCTS } from '@/app/product-config';
 import { Button } from '@/components/ui/button';
@@ -136,7 +136,7 @@ export function DemoDragDropClient({ preloadedData }: DemoDragDropClientProps) {
         </div>
 
         <FileTree
-          className={DEFAULT_FILE_TREE_PANEL_CLASS}
+          className={getDefaultFileTreePanelClass()}
           model={activeModel}
           preloadedData={activePreloadedData}
           style={{

--- a/apps/docs/app/trees/DemoFlatten.tsx
+++ b/apps/docs/app/trees/DemoFlatten.tsx
@@ -13,7 +13,7 @@ import { TreeExampleHeading } from '../components/TreeExampleHeading';
 import { FeatureHeader } from '../diff-examples/FeatureHeader';
 import { sampleFileList } from './demo-data';
 import { TREE_NEW_VIEWPORT_HEIGHTS } from './dimensions';
-import { DEFAULT_FILE_TREE_PANEL_CLASS } from './tree-examples/demo-data';
+import { getDefaultFileTreePanelClass } from './tree-examples/demo-data';
 import { TreeExampleSection } from './tree-examples/TreeExampleSection';
 import { PRODUCTS } from '@/app/product-config';
 import type { FileTreePathOptions } from '@/lib/fileTreePathOptions';
@@ -62,7 +62,7 @@ function FlattenDemoTree({
 
   return (
     <FileTree
-      className={DEFAULT_FILE_TREE_PANEL_CLASS}
+      className={getDefaultFileTreePanelClass()}
       model={model}
       preloadedData={preloadedData}
       style={{

--- a/apps/docs/app/trees/DemoGitStatus.tsx
+++ b/apps/docs/app/trees/DemoGitStatus.tsx
@@ -17,7 +17,7 @@ import {
   TREE_NEW_GIT_STATUS_EXPANDED_PATHS,
   TREE_NEW_GIT_STATUSES,
 } from './gitStatusDemoData';
-import { DEFAULT_FILE_TREE_PANEL_CLASS } from './tree-examples/demo-data';
+import { getDefaultFileTreePanelClass } from './tree-examples/demo-data';
 import { TreeExampleSection } from './tree-examples/TreeExampleSection';
 import { PRODUCTS } from '@/app/product-config';
 import { Button } from '@/components/ui/button';
@@ -184,7 +184,7 @@ export function DemoGitStatus({ preloadedData }: DemoGitStatusProps) {
         </div>
 
         <FileTree
-          className={DEFAULT_FILE_TREE_PANEL_CLASS}
+          className={getDefaultFileTreePanelClass(colorMode)}
           model={model}
           preloadedData={activePreloadedData}
           style={{

--- a/apps/docs/app/trees/DemoSearchClient.tsx
+++ b/apps/docs/app/trees/DemoSearchClient.tsx
@@ -14,7 +14,7 @@ import { TreeExampleHeading } from '../components/TreeExampleHeading';
 import { FeatureHeader } from '../diff-examples/FeatureHeader';
 import { sampleFileList } from './demo-data';
 import { TREE_NEW_VIEWPORT_HEIGHTS } from './dimensions';
-import { DEFAULT_FILE_TREE_PANEL_CLASS } from './tree-examples/demo-data';
+import { getDefaultFileTreePanelClass } from './tree-examples/demo-data';
 import { TreeExampleSection } from './tree-examples/TreeExampleSection';
 import { PRODUCTS } from '@/app/product-config';
 
@@ -92,7 +92,7 @@ function SearchModeTree({
         <code>{modeDemo.title}</code>
       </TreeExampleHeading>
       <FileTree
-        className={DEFAULT_FILE_TREE_PANEL_CLASS}
+        className={getDefaultFileTreePanelClass()}
         model={model}
         preloadedData={preloadedData}
         style={{

--- a/apps/docs/app/trees/DemoStylingClient.tsx
+++ b/apps/docs/app/trees/DemoStylingClient.tsx
@@ -161,7 +161,7 @@ export function DemoStylingClient({
         <div>
           <TreeExampleHeading>Light mode</TreeExampleHeading>
           <StyledTree
-            className="min-h-[320px] rounded-lg border border-neutral-200 bg-neutral-50 p-2"
+            className="min-h-[320px] rounded-lg border border-neutral-200 bg-neutral-50 py-2"
             id="trees-styling-demo-light"
             preloadedData={preloadedData.light}
             selectedPath={selectedPaths.light}
@@ -175,7 +175,7 @@ export function DemoStylingClient({
         <div>
           <TreeExampleHeading>Dark mode</TreeExampleHeading>
           <StyledTree
-            className="min-h-[320px] rounded-lg border border-neutral-700 bg-neutral-900 p-2"
+            className="min-h-[320px] rounded-lg border border-neutral-700 bg-neutral-900 py-2"
             id="trees-styling-demo-dark"
             preloadedData={preloadedData.dark}
             selectedPath={selectedPaths.dark}
@@ -189,7 +189,7 @@ export function DemoStylingClient({
         <div>
           <TreeExampleHeading>Synthwave &apos;84</TreeExampleHeading>
           <StyledTree
-            className="min-h-[320px] rounded-lg border border-[#f92aad]/40 bg-[#1e1b2b] p-2 shadow-[inset_0_0_60px_rgba(249,42,173,0.08)]"
+            className="min-h-[320px] rounded-lg border border-[#f92aad]/40 bg-[#1e1b2b] py-2 shadow-[inset_0_0_60px_rgba(249,42,173,0.08)]"
             id="trees-styling-demo-synthwave"
             preloadedData={preloadedData.synthwave}
             selectedPath={selectedPaths.synthwave}

--- a/apps/docs/app/trees/DemoThemingClient.tsx
+++ b/apps/docs/app/trees/DemoThemingClient.tsx
@@ -22,7 +22,7 @@ import { FeatureHeader } from '../diff-examples/FeatureHeader';
 import { sampleFileList } from './demo-data';
 import { TREE_NEW_VIEWPORT_HEIGHTS } from './dimensions';
 import {
-  DEFAULT_FILE_TREE_PANEL_CLASS,
+  getDefaultFileTreePanelClass,
   GIT_STATUSES_A,
 } from './tree-examples/demo-data';
 import { TreeExampleSection } from './tree-examples/TreeExampleSection';
@@ -319,7 +319,7 @@ export function DemoThemingClient({
         ) : null}
         {themeStyles != null ? (
           <FileTree
-            className={`${DEFAULT_FILE_TREE_PANEL_CLASS} min-h-[320px]`}
+            className={`${getDefaultFileTreePanelClass()} min-h-[320px]`}
             model={model}
             preloadedData={preloadedData}
             style={{

--- a/apps/docs/app/trees/DemoVirtualizationClient.tsx
+++ b/apps/docs/app/trees/DemoVirtualizationClient.tsx
@@ -9,7 +9,7 @@ import type { CSSProperties } from 'react';
 
 import { FeatureHeader } from '../diff-examples/FeatureHeader';
 import { TREE_NEW_VIEWPORT_HEIGHTS } from './dimensions';
-import { DEFAULT_FILE_TREE_PANEL_CLASS } from './tree-examples/demo-data';
+import { getDefaultFileTreePanelClass } from './tree-examples/demo-data';
 import { TreeExampleSection } from './tree-examples/TreeExampleSection';
 
 const FILE_COUNT_FORMATTER = new Intl.NumberFormat('en-US');
@@ -54,7 +54,7 @@ export function DemoVirtualizationClient({
       />
 
       <FileTree
-        className={DEFAULT_FILE_TREE_PANEL_CLASS}
+        className={getDefaultFileTreePanelClass()}
         model={model}
         preloadedData={preloadedData}
         style={panelStyle}

--- a/apps/docs/app/trees/tree-examples/demo-data.ts
+++ b/apps/docs/app/trees/tree-examples/demo-data.ts
@@ -3,8 +3,13 @@ import type { CSSProperties } from 'react';
 import type { GitStatusEntry } from '@/lib/treesCompat';
 
 /** Default panel look for FileTree in docs examples. Apply via className + style on FileTree. */
-export const DEFAULT_FILE_TREE_PANEL_CLASS =
-  'dark min-h-0 flex-1 overflow-auto rounded-lg py-3 border border-neutral-200 dark:border-neutral-800';
+export function getDefaultFileTreePanelClass(
+  colorMode: 'light' | 'dark' = 'dark'
+): string {
+  const base =
+    'min-h-0 flex-1 overflow-auto rounded-lg py-3 border border-neutral-200 dark:border-neutral-800';
+  return colorMode === 'dark' ? `dark ${base}` : base;
+}
 
 export const DEFAULT_FILE_TREE_PANEL_STYLE: CSSProperties = {
   colorScheme: 'dark',

--- a/apps/docs/components/TreeApp.tsx
+++ b/apps/docs/components/TreeApp.tsx
@@ -1109,7 +1109,7 @@ export function TreeApp<LAnnotation = unknown>({
           {showTabs && openPaths.length > 0 ? (
             <div
               className="group/tabbar flex h-10 items-center gap-1 overflow-x-auto px-2"
-              style={{ backgroundColor: 'light-dark(#fff, #070707)' }}
+              style={{ backgroundColor: '#070707' }}
             >
               {openPaths.map((path) => {
                 const tabContext: TreeAppTabRenderContext = {

--- a/apps/docs/components/TreeApp.tsx
+++ b/apps/docs/components/TreeApp.tsx
@@ -921,15 +921,16 @@ export function TreeApp<LAnnotation = unknown>({
     ) as CSSProperties;
   }, [treeStyleRecord]);
 
-  const containerStyle = useMemo<CSSProperties>(
-    () => ({
+  const containerStyle = useMemo<CSSProperties>(() => {
+    const normalizedHeight =
+      typeof height === 'number' ? `${String(height)}px` : height;
+    return {
       ...treeCssVariables,
       '--tree-app-tree-surface': treeSurfaceColor,
-      height,
+      '--tree-app-height': normalizedHeight,
       ...style,
-    }),
-    [height, style, treeCssVariables, treeSurfaceColor]
-  );
+    } as CSSProperties;
+  }, [height, style, treeCssVariables, treeSurfaceColor]);
 
   const sidebarStyle = useMemo<CSSProperties>(
     () =>
@@ -944,7 +945,8 @@ export function TreeApp<LAnnotation = unknown>({
       ...treeStyle,
       width: '100%',
       height: '100%',
-      borderRadius: '8px',
+      paddingBottom: 10,
+      borderRadius: 8,
       border: '1px solid rgb(255 255 255 / 0.05)',
     }),
     [treeStyle]
@@ -1055,7 +1057,7 @@ export function TreeApp<LAnnotation = unknown>({
         file={file}
         options={fileOptions}
         prerenderedHTML={prerenderedHTML}
-        className="h-full min-h-0 overflow-auto"
+        className="min-h-0 flex-1 overflow-auto"
       />
     );
   }, [
@@ -1070,7 +1072,7 @@ export function TreeApp<LAnnotation = unknown>({
   return (
     <div
       className={[
-        'flex flex-col overflow-hidden rounded-xl border bg-[#070707] text-zinc-200 shadow-lg p-1.5',
+        'flex flex-col overflow-hidden rounded-xl border bg-[#070707] text-zinc-200 shadow-lg p-1.5 h-[calc(var(--tree-app-height)+170px)] md:h-[var(--tree-app-height)]',
         className,
       ]
         .filter(Boolean)
@@ -1112,7 +1114,7 @@ export function TreeApp<LAnnotation = unknown>({
         <section className="flex min-w-0 flex-1 flex-col">
           {showTabs && openPaths.length > 0 ? (
             <div
-              className="group/tabbar flex h-10 items-center gap-1 overflow-x-auto px-2"
+              className="group/tabbar flex h-10 items-center gap-1 overflow-x-auto px-2 pt-2 md:pt-0"
               style={{ backgroundColor: '#070707' }}
             >
               {openPaths.map((path) => {
@@ -1147,7 +1149,7 @@ export function TreeApp<LAnnotation = unknown>({
             </div>
           ) : null}
           <div
-            className="flex min-h-0 flex-1 flex-col"
+            className="flex min-h-0 flex-1"
             style={{ backgroundColor: '#070707' }}
           >
             {editor}

--- a/apps/docs/components/TreeApp.tsx
+++ b/apps/docs/components/TreeApp.tsx
@@ -932,13 +932,17 @@ export function TreeApp<LAnnotation = unknown>({
   );
 
   const sidebarStyle = useMemo<CSSProperties>(
-    () => ({ width: `${String(explorer.width)}px` }),
+    () =>
+      ({
+        '--tree-app-explorer-width': `${String(explorer.width)}px`,
+      }) as CSSProperties,
     [explorer.width]
   );
 
   const treeHostStyle = useMemo<CSSProperties>(
     () => ({
       ...treeStyle,
+      width: '100%',
       height: '100%',
       borderRadius: '8px',
       border: '1px solid rgb(255 255 255 / 0.05)',
@@ -1081,9 +1085,9 @@ export function TreeApp<LAnnotation = unknown>({
       {windowChromeNode != null ? (
         <div className="shrink-0">{windowChromeNode}</div>
       ) : null}
-      <div className="flex min-h-0 flex-1">
+      <div className="flex min-h-0 flex-1 flex-col md:flex-row">
         <aside
-          className="group/tree-app-explorer flex min-h-0 shrink-0 flex-col"
+          className="group/tree-app-explorer flex min-h-[260px] w-full shrink-0 flex-col md:min-h-0 md:w-[var(--tree-app-explorer-width)]"
           style={sidebarStyle}
         >
           <FileTree
@@ -1103,7 +1107,7 @@ export function TreeApp<LAnnotation = unknown>({
           onPointerMove={explorer.onPointerMove}
           onPointerUp={explorer.onPointerUp}
           onPointerCancel={explorer.onPointerUp}
-          className="relative w-px shrink-0 cursor-col-resize bg-white/0 after:absolute after:inset-y-0 after:-left-1 after:w-2 after:content-['']"
+          className="relative hidden w-px shrink-0 cursor-col-resize bg-white/0 after:absolute after:inset-y-0 after:-left-1 after:w-2 after:content-[''] md:block"
         />
         <section className="flex min-w-0 flex-1 flex-col">
           {showTabs && openPaths.length > 0 ? (

--- a/apps/docs/components/TreeApp.tsx
+++ b/apps/docs/components/TreeApp.tsx
@@ -808,7 +808,7 @@ function DefaultTab({
       className={[
         'group relative isolate flex h-7 max-w-[200px] items-center overflow-hidden rounded-sm text-xs font-medium transition-colors',
         isActive
-          ? 'bg-transparent text-zinc-100 group-hover/tabbar:bg-neutral-900'
+          ? 'bg-neutral-900 text-zinc-100'
           : 'bg-transparent text-zinc-400 group-hover/tabbar:bg-neutral-900/30 group-hover/tabbar:hover:bg-neutral-800/60 group-hover/tabbar:hover:text-zinc-200',
       ].join(' ')}
     >

--- a/packages/trees/src/style.css
+++ b/packages/trees/src/style.css
@@ -743,7 +743,6 @@
   }
 
   [data-file-tree-search-input] {
-    --trees-focus-ring-width: 2px;
     font-family: var(--trees-font-family);
     font-size: var(--trees-font-size);
     flex: 1;


### PR DESCRIPTION
- No more clipping for search on focus, reduced outline to 1px
- Responsive TreeApp demo component
- Fix random light-dark() function causing a white toolbar in TreeApp
- Fix some heights and overflow from adding new tree items to our demo data
- Fixes border color in light mode by conditionally toggling `.dark` at demo call
- Makes active tab clearer in TreeApp