### PR TITLE
More launch prep

### DIFF
--- a/apps/docs/app/trees/DemoA11yClient.tsx
+++ b/apps/docs/app/trees/DemoA11yClient.tsx
@@ -89,7 +89,7 @@ export function DemoA11yClient({ preloadedData }: DemoA11yClientProps) {
                         {shortcutKeys.map((k) => (
                           <kbd
                             key={k}
-                            className="bg-muted rounded-sm border border-[var(--color-border)] px-1.5 py-0.5 font-mono text-xs"
+                            className="bg-muted rounded-sm border border-[var(--color-border)] px-1.5 py-0.5 font-mono text-xs shadow-[0_1px_0_var(--color-border)]"
                           >
                             {k}
                           </kbd>

--- a/apps/docs/app/trees/DemoCustomIconsClient.tsx
+++ b/apps/docs/app/trees/DemoCustomIconsClient.tsx
@@ -123,7 +123,7 @@ export function DemoCustomIconsClient({
           </>
         }
       />
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
         {ICON_DEMO_CONFIGS.map((config) => (
           <IconDemoTree
             key={config.id}

--- a/apps/docs/app/trees/DemoSearchClient.tsx
+++ b/apps/docs/app/trees/DemoSearchClient.tsx
@@ -130,7 +130,7 @@ export function DemoSearchClient({ preloadedDataById }: DemoSearchClientProps) {
         }
       />
       <div className="space-y-4">
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {SEARCH_MODE_DEMOS.map((modeDemo) => (
             <SearchModeTree
               key={modeDemo.id}

--- a/apps/docs/app/trees/DemoStylingClient.tsx
+++ b/apps/docs/app/trees/DemoStylingClient.tsx
@@ -22,6 +22,7 @@ import { PRODUCTS } from '@/app/product-config';
 function lightTheme(): CSSProperties {
   return {
     colorScheme: 'light',
+    ['--trees-bg-override' as string]: 'oklch(98.5% 0 0)',
     ['--trees-fg-override' as string]: 'oklch(14.5% 0 0)',
     ['--trees-fg-muted-override' as string]: 'oklch(45% 0 0)',
     ['--trees-bg-muted-override' as string]: 'oklch(96% 0 0)',

--- a/apps/docs/app/trees/DemoStylingClient.tsx
+++ b/apps/docs/app/trees/DemoStylingClient.tsx
@@ -158,7 +158,7 @@ export function DemoStylingClient({
           </>
         }
       />
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
         <div>
           <TreeExampleHeading>Light mode</TreeExampleHeading>
           <StyledTree

--- a/apps/docs/app/trees/DemoThemingClient.tsx
+++ b/apps/docs/app/trees/DemoThemingClient.tsx
@@ -22,9 +22,10 @@ import { FeatureHeader } from '../diff-examples/FeatureHeader';
 import { sampleFileList } from './demo-data';
 import { TREE_NEW_VIEWPORT_HEIGHTS } from './dimensions';
 import {
-  getDefaultFileTreePanelClass,
-  GIT_STATUSES_A,
-} from './tree-examples/demo-data';
+  TREE_NEW_GIT_STATUS_EXPANDED_PATHS,
+  TREE_NEW_GIT_STATUSES,
+} from './gitStatusDemoData';
+import { getDefaultFileTreePanelClass } from './tree-examples/demo-data';
 import { TreeExampleSection } from './tree-examples/TreeExampleSection';
 import { PRODUCTS } from '@/app/product-config';
 import { Button } from '@/components/ui/button';
@@ -118,9 +119,9 @@ export function DemoThemingClient({
 }: DemoThemingClientProps) {
   const { model } = useFileTree({
     flattenEmptyDirectories: true,
-    gitStatus: GIT_STATUSES_A,
+    gitStatus: TREE_NEW_GIT_STATUSES,
     id: 'trees-shiki-themes-tree',
-    initialExpandedPaths: ['src', 'src/components'],
+    initialExpandedPaths: TREE_NEW_GIT_STATUS_EXPANDED_PATHS,
     initialSelectedPaths: ['package.json'],
     paths: sampleFileList,
     initialVisibleRowCount: TREE_NEW_VIEWPORT_HEIGHTS.theming / 30,

--- a/apps/docs/app/trees/DemoThemingClient.tsx
+++ b/apps/docs/app/trees/DemoThemingClient.tsx
@@ -36,11 +36,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 
-const DEFAULT_LIGHT = 'default-light' as const;
-const DEFAULT_DARK = 'default-dark' as const;
-
 const LIGHT_THEMES = [
-  DEFAULT_LIGHT,
   'pierre-light',
   'catppuccin-latte',
   'everforest-light',
@@ -63,7 +59,6 @@ const LIGHT_THEMES = [
 ] as const;
 
 const DARK_THEMES = [
-  DEFAULT_DARK,
   'pierre-dark',
   'andromeeda',
   'aurora-x',
@@ -111,16 +106,6 @@ const DARK_THEMES = [
 
 type LightTheme = (typeof LIGHT_THEMES)[number];
 type DarkTheme = (typeof DARK_THEMES)[number];
-
-function themeDisplayName(theme: string): string {
-  if (theme === DEFAULT_LIGHT) return 'Default Light';
-  if (theme === DEFAULT_DARK) return 'Default Dark';
-  return theme;
-}
-
-function isDefaultTheme(theme: string): boolean {
-  return theme === DEFAULT_LIGHT || theme === DEFAULT_DARK;
-}
 
 interface DemoThemingClientProps {
   initialThemeStyles: TreeThemeStyles;
@@ -173,14 +158,6 @@ export function DemoThemingClient({
 
   const loadTheme = useCallback(async (themeName: string) => {
     setError(null);
-    if (isDefaultTheme(themeName)) {
-      setThemeStyles({
-        colorScheme: themeName === DEFAULT_LIGHT ? 'light' : 'dark',
-      } as TreeThemeStyles);
-      setLoading(false);
-      return;
-    }
-
     setLoading(true);
     try {
       const theme = await resolveTheme(
@@ -213,8 +190,7 @@ export function DemoThemingClient({
             </Link>{' '}
             can style the <code>FileTree</code>. Sidebar and Git decoration
             colors come from your choice of themes. Pick a theme and switch
-            light/dark to see the tree update live. Compare against our default
-            themes in light and dark mode, too. See the{' '}
+            light/dark to see the tree update live. See the{' '}
             <Link
               href={`${PRODUCTS.trees.docsPath}#styling-and-theming`}
               className="inline-link"
@@ -231,7 +207,7 @@ export function DemoThemingClient({
             <DropdownMenuTrigger asChild>
               <Button variant="outline" className="flex-1 justify-start">
                 <IconColorLight />
-                {themeDisplayName(selectedLightTheme)}
+                {selectedLightTheme}
                 <IconChevronSm className="text-muted-foreground ml-auto" />
               </Button>
             </DropdownMenuTrigger>
@@ -245,7 +221,7 @@ export function DemoThemingClient({
                   }}
                   selected={selectedLightTheme === theme}
                 >
-                  {themeDisplayName(theme)}
+                  {theme}
                   {selectedLightTheme === theme ? (
                     <IconCheck className="ml-auto" />
                   ) : null}
@@ -258,7 +234,7 @@ export function DemoThemingClient({
             <DropdownMenuTrigger asChild>
               <Button variant="outline" className="flex-1 justify-start">
                 <IconColorDark />
-                {themeDisplayName(selectedDarkTheme)}
+                {selectedDarkTheme}
                 <IconChevronSm className="text-muted-foreground ml-auto" />
               </Button>
             </DropdownMenuTrigger>
@@ -276,7 +252,7 @@ export function DemoThemingClient({
                   }}
                   selected={selectedDarkTheme === theme}
                 >
-                  {themeDisplayName(theme)}
+                  {theme}
                   {selectedDarkTheme === theme ? (
                     <IconCheck className="ml-auto" />
                   ) : (

--- a/apps/docs/components/Header.tsx
+++ b/apps/docs/components/Header.tsx
@@ -111,19 +111,25 @@ export function Header({ onMobileMenuToggle, className }: HeaderProps) {
         className
       )}
     >
-      <Link
-        href={homeHref}
-        className="text-foreground hover:text-foreground/80 flex items-center gap-2 transition-colors"
-      >
-        <div className="flex items-baseline gap-1.5">
-          <span className="text-lg leading-[20px] font-semibold">
-            {product.name}
-          </span>
-          <small className="text-muted-foreground hidden text-sm leading-[20px] md:inline">
-            by The Pierre Computer Co.
-          </small>
-        </div>
-      </Link>
+      <div className="flex items-baseline gap-1.5">
+        <Link
+          href={homeHref}
+          className="text-foreground hover:text-foreground/80 text-lg leading-[20px] font-semibold transition-colors"
+        >
+          {product.name}
+        </Link>
+        <span className="text-muted-foreground hidden text-sm leading-[20px] md:inline">
+          by{' '}
+          <Link
+            href="https://pierre.computer"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-muted-foreground hover:text-foreground/80 hidden text-sm leading-[20px] transition-colors md:inline"
+          >
+            The Pierre Computer Co.
+          </Link>
+        </span>
+      </div>
 
       {showMobileMenu && (
         <div className="mr-auto flex items-center gap-1 md:hidden">

--- a/packages/trees/src/style.css
+++ b/packages/trees/src/style.css
@@ -743,6 +743,7 @@
   }
 
   [data-file-tree-search-input] {
+    --trees-focus-ring-width: 2px;
     font-family: var(--trees-font-family);
     font-size: var(--trees-font-size);
     flex: 1;


### PR DESCRIPTION
- Restore 2px focus on search
- Split links in header to **ProjectName** goes to top/root, and `The Pierre Computer Co` goes to `pierre.computer`
- Slight kbd style tweak
- Remove Default Light and Default Dark theme options from theming section
- Match gaps