### PR TITLE
Worktree helper for monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ tsconfig.tsbuildinfo
 .claude/*
 .codemogger/*
 .omx/
+.env.worktree
 
 #tmp
 packages/trees/PLAN.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,38 @@ export AGENT=1
   the root scripts should not do something different than the package-level
   script, it's simply a shortcut to calling it from the root.
 
+## Worktrees
+
+We use `git worktree` to parallelize work. Each worktree lives at
+`~/pierre/pierre-worktrees/<slug>/` and owns a **port offset** so dev servers,
+E2E fixtures, and the Chrome remote-debug instance don't collide across
+worktrees. The main clone keeps the historical default ports; only worktrees
+shift.
+
+The `bun run wt` command suite (defined in `scripts/wt.ts`) manages worktrees:
+
+```bash
+bun run wt new <slug>    # create a worktree, allocate offset, bun install
+bun run wt rm <slug>     # kill its processes, remove the worktree
+bun run wt clean         # kill zombie servers on all worktrees' ports
+bun run wt ps            # show per-worktree port status (LISTEN / —)
+bun run wt list          # summary of all worktrees (managed + external)
+```
+
+Dev scripts inside a worktree automatically pick up the offset through
+`scripts/ws.ts`, which reads `<worktree>/.env.worktree` when invoked. Before
+starting, they run `scripts/run-dev.sh` to kill any stale process bound to the
+target port (zombies survive uncleanly-closed terminals, which is common under
+AI agents).
+
+**Cleanup contract for agents.** If you spin up dev servers, Playwright
+fixtures, or Chrome debug instances inside a worktree, **you must run
+`bun run wt clean` (or `bun run wt rm <slug>` if the worktree itself is being
+torn down) before completing your turn.** This releases ports and kills spawned
+processes so they don't accumulate across runs. Running `wt clean` with no
+arguments cleans every managed worktree; prefer the targeted `wt clean <slug>`
+when you know which worktree you were working in.
+
 ## Linting
 
 We use `oxlint` at the root of the monorepo rather than per-package lint setups.

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -58,8 +58,37 @@ export const viewport: Viewport = {
   initialScale: 1,
 };
 
+// When running in a worktree (NEXT_PUBLIC_WORKTREE_SLUG set by wt), prefix the
+// title with a stable emoji + slug so browser tabs for different worktrees are
+// distinguishable at a glance. No-op in the main clone.
+const WORKTREE_EMOJI_PALETTE = [
+  '🟢',
+  '🔵',
+  '🟡',
+  '🟠',
+  '🟣',
+  '🔴',
+  '🟤',
+  '⚪',
+] as const;
+
+function worktreeTitlePrefix(): string {
+  const slug = process.env.NEXT_PUBLIC_WORKTREE_SLUG;
+  if (!slug) return '';
+  let hash = 0;
+  for (let i = 0; i < slug.length; i++) {
+    hash = (hash * 31 + slug.charCodeAt(i)) >>> 0;
+  }
+  const emoji = WORKTREE_EMOJI_PALETTE[hash % WORKTREE_EMOJI_PALETTE.length];
+  return `${emoji} [${slug}] `;
+}
+
+const WORKTREE_PREFIX = worktreeTitlePrefix();
+const baseTitle = 'Diffs, from Pierre';
+const taggedTitle = `${WORKTREE_PREFIX}${baseTitle}`;
+
 export const metadata: Metadata = {
-  title: 'Diffs, from Pierre',
+  title: taggedTitle,
   description:
     'An open source diff and file rendering library by The Pierre Computer Company.',
   icons: {
@@ -71,13 +100,13 @@ export const metadata: Metadata = {
     shortcut: '/favicon.ico',
   },
   openGraph: {
-    title: 'Diffs, from Pierre',
+    title: taggedTitle,
     description:
       'An open source diff and file rendering library by The Pierre Computer Company.',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Diffs, from Pierre',
+    title: taggedTitle,
     description:
       'An open source diff and file rendering library by The Pierre Computer Company.',
   },

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -9,8 +9,8 @@
     "build:deps:diffs": "output=$(cd ../../packages/diffs && bun run build 2>&1) && echo '[diffs] Successfully cleaned and built.' || (echo \"$output\" >&2 && exit 1)",
     "build:deps:tree": "output=$(cd ../../packages/trees && bun run build 2>&1) && echo '[trees] Successfully cleaned and built.' || (echo \"$output\" >&2 && exit 1)",
     "build:deps:truncate": "output=$(cd ../../packages/truncate && bun run build 2>&1) && echo '[truncate] Successfully cleaned and built.' || (echo \"$output\" >&2 && exit 1)",
-    "diffs:dev": "export NEXT_PUBLIC_SITE=diffs PORT=3690 && bun run _dev",
-    "trees:dev": "export NEXT_PUBLIC_SITE=trees PORT=3691 && bun run _dev",
+    "diffs:dev": "export NEXT_PUBLIC_SITE=diffs PORT=$((${PIERRE_PORT_OFFSET:-0} + 3690)) && bash ../../scripts/run-dev.sh \"$PORT\" -- bun run _dev",
+    "trees:dev": "export NEXT_PUBLIC_SITE=trees PORT=$((${PIERRE_PORT_OFFSET:-0} + 3691)) && bash ../../scripts/run-dev.sh \"$PORT\" -- bun run _dev",
     "_dev": "bun run build:deps && bun concurrently \"bun run dev:deps:diffs\" \"bun run dev:deps:tree\" \"bun run dev:deps:truncate\" \"bun run dev:next\" --names \"diffs,trees,truncate,docs\" --prefix-colors \"blue,green,yellow,purple\"",
     "dev:next": "next dev",
     "dev:deps:diffs": "(cd ../../packages/diffs && bun run dev)",
@@ -21,7 +21,7 @@
     "generate-llms-txt": "bun scripts/generate-llms-txt.ts",
     "test:e2e": "bun run build:deps && bun run build:next && (bun ./test/e2e/check-playwright-binary.ts || bun run test:e2e:installbinary) && bunx playwright test -c test/e2e/playwright.config.ts",
     "test:e2e:installbinary": "bunx playwright@1.51.1 install chromium",
-    "test:e2e:server": "PORT=4174 bun run start",
+    "test:e2e:server": "PORT=$((${PIERRE_PORT_OFFSET:-0} + 4174)) bash ../../scripts/run-dev.sh \"$PORT\" -- bun run start",
     "tsc": "bun run build:deps && tsgo --noEmit --pretty"
   },
   "dependencies": {

--- a/apps/docs/test/e2e/playwright.config.ts
+++ b/apps/docs/test/e2e/playwright.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig, devices } from '@playwright/test';
 
-const e2ePort = 4174;
+const portOffset = Number(process.env.PIERRE_PORT_OFFSET ?? 0);
+const e2ePort = 4174 + portOffset;
 const e2eBaseUrl = `http://127.0.0.1:${e2ePort}`;
-const e2eOutputDir = '/tmp/pierre-docs-playwright-results';
+const e2eOutputDir = `/tmp/pierre-docs-playwright-results${portOffset > 0 ? `-${portOffset}` : ''}`;
 
 export default defineConfig({
   testDir: '.',

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
   "type": "module",
   "scripts": {
     "ws": "bun --silent scripts/ws.ts",
+    "wt": "bun --silent scripts/wt.ts",
     "tsc": "bun run ws \"*\" tsc",
     "clean": "bunx del-cli 'apps/*/.{next,source}' 'packages/*/dist' 'apps/*/tsconfig.tsbuildinfo' 'packages/*/tsconfig.tsbuildinfo'",
     "clean:all": "bun run clean && bunx del-cli '**/node_modules'",

--- a/packages/path-store/test/e2e/playwright.config.js
+++ b/packages/path-store/test/e2e/playwright.config.js
@@ -1,8 +1,9 @@
 import { defineConfig, devices } from '@playwright/test';
 
-const e2ePort = 4176;
+const portOffset = Number(process.env.PIERRE_PORT_OFFSET ?? 0);
+const e2ePort = 4176 + portOffset;
 const e2eBaseUrl = `http://127.0.0.1:${e2ePort}`;
-const e2eOutputDir = '/tmp/pierre-path-store-playwright-results';
+const e2eOutputDir = `/tmp/pierre-path-store-playwright-results${portOffset > 0 ? `-${portOffset}` : ''}`;
 
 export default defineConfig({
   testDir: '.',

--- a/packages/trees/test/e2e/playwright.config.ts
+++ b/packages/trees/test/e2e/playwright.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig, devices } from '@playwright/test';
 
-const e2ePort = 4173;
+const portOffset = Number(process.env.PIERRE_PORT_OFFSET ?? 0);
+const e2ePort = 4173 + portOffset;
 const e2eBaseUrl = `http://127.0.0.1:${e2ePort}`;
-const e2eOutputDir = '/tmp/pierre-trees-playwright-results';
+const e2eOutputDir = `/tmp/pierre-trees-playwright-results${portOffset > 0 ? `-${portOffset}` : ''}`;
 
 export default defineConfig({
   testDir: '.',

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,387 @@
+# scripts/
+
+This folder contains the small set of scripts that drive day-to-day development
+in the monorepo. Most of the time you'll interact with them through root
+`package.json` entries:
+
+- `bun ws …` — run an npm script in a specific workspace package.
+- `bun run wt …` — manage `git worktree`s and their port isolation.
+
+The other two scripts are helpers the above invoke internally:
+
+- `run-dev.sh` — kill-before-start preamble for dev servers.
+- `chrome-remote-debug.sh` — launches Chrome Dev with the DevTools protocol
+  enabled, worktree-aware.
+- `build-sprite.js`, `precommit-tsc.ts` — build/CI helpers, unrelated to the
+  worktree workflow below.
+
+The rest of this document explains `ws` and `wt` in detail and walks through the
+most common workflows.
+
+---
+
+## `bun ws` — the workspace script runner
+
+`bun ws <package> <script> [args…]` runs an npm script inside a specific
+workspace. It exists for three reasons:
+
+1. You can run it from anywhere in the monorepo — you don't have to `cd` into
+   the package first.
+2. It accepts a short package name (`diffs` resolves to `@pierre/diffs` in
+   `packages/diffs`) or a path (`packages/diffs`) or a glob (`packages/*`).
+3. It loads a worktree's `.env.worktree` so per-worktree port offsets propagate
+   into the script automatically (see "Worktrees" below).
+
+### Syntax
+
+```bash
+bun ws <package> <script> [args...]
+bun ws <package> <script> --verbose        # don't elide lines in output
+bun ws 'packages/*' <script>                # fan out across a glob
+bun ws '*' <script>                         # every workspace (apps + packages)
+```
+
+`ws` forwards every argument after the script name to the underlying `bun run`
+invocation. You do **not** need `--` to separate them unless a downstream tool
+requires it. The only flag `ws` itself eats is `-v` / `--verbose`.
+
+### Package name resolution
+
+In priority order:
+
+1. **Exact path** (`packages/diffs`, `apps/docs`) — filesystem directory, used
+   verbatim.
+2. **Short name** (`diffs`) — tried as `packages/diffs`, then `apps/diffs`.
+3. **Glob** (`packages/*`, `*`) — delegated to `bun run -F <filter>`.
+
+### Examples
+
+```bash
+bun ws diffs build           # build packages/diffs
+bun ws docs trees:dev        # run the docs trees dev server
+bun ws trees test            # bun test in packages/trees
+bun ws 'packages/*' build    # build every package
+bun ws '*' tsc               # typecheck everything
+```
+
+### How `ws` interacts with worktrees
+
+When invoked, `ws` walks up from your current directory looking for a
+`.env.worktree` file. If it finds one (which happens only inside a worktree
+created by `wt new`), it merges those keys into the spawned child's env. In
+practice this means `PIERRE_PORT_OFFSET` reaches your dev scripts without you
+having to think about it.
+
+In the main clone, there is no `.env.worktree`, nothing is merged, and every
+script sees its historical default ports.
+
+---
+
+## `bun run wt` — the worktree command suite
+
+`wt` manages sibling worktrees of the main clone so you can work on multiple
+branches in parallel without port collisions, zombie dev servers piling up, or
+browser tabs you can't tell apart.
+
+Every worktree managed by `wt` lives at:
+
+```
+~/pierre/pierre-worktrees/<dir>/
+```
+
+where `<dir>` is the slug with any `/` characters replaced by `-`. Worktrees the
+tool didn't create (e.g. agent-spawned ones under `.omx/worktrees/` or
+`/private/tmp/`) are left alone.
+
+### Subcommands at a glance
+
+```bash
+bun run wt new <slug> [--branch <name>] [--base <ref>]
+bun run wt rm  <slug> [--keep-branch] [--force]
+bun run wt clean [<slug>|--all]
+bun run wt ps
+bun run wt list
+```
+
+### `wt new <slug>` — create a worktree
+
+Creates a new worktree rooted at `~/pierre/pierre-worktrees/<slug>/`, on a fresh
+branch, with ports that won't collide with any other worktree's.
+
+By default:
+
+- Branch name is `$USER/<slug>` (e.g. `alex/fix-drag-drop`).
+- Base ref is `main`.
+- A port offset is picked (see "Ports" below), deterministic from the slug but
+  bumped if it collides with an existing worktree.
+- `.env.worktree` is written at the worktree root with the offset and slug.
+- `apps/docs/.env.local` gets `NEXT_PUBLIC_WORKTREE_SLUG=<slug>` so the browser
+  tab title prefixes with an emoji + slug.
+- `bun install` runs automatically so husky hooks regenerate and the worktree's
+  `node_modules` is ready.
+- A summary of the worktree's URLs and the `cd` command is printed.
+
+Flags:
+
+- `--branch <name>` — attach an **existing** branch to the new worktree, rather
+  than creating a new one named `$USER/<slug>`.
+- `--base <ref>` — when creating a fresh branch, root it at `<ref>` instead of
+  `main`.
+
+Examples:
+
+```bash
+bun run wt new drag-drop-fix
+# → creates branch alex/drag-drop-fix from main
+#   in ~/pierre/pierre-worktrees/drag-drop-fix/
+
+bun run wt new trees/perf --base alex/trees/main-current-work
+# → creates branch alex/trees/perf from alex/trees/main-current-work
+#   in ~/pierre/pierre-worktrees/trees-perf/   (slash → dash in dir name)
+
+bun run wt new resume --branch mdo/wip-feature
+# → attaches existing branch mdo/wip-feature to a new worktree at
+#   ~/pierre/pierre-worktrees/resume/
+```
+
+**Why `wt new` cannot `cd` for you.** A child process cannot change its parent
+shell's working directory. The script prints the `cd` command at the end;
+copy-paste it. If you want true auto-cd, wrap `wt new` in a shell function of
+your own (out of scope for this repo, deliberately — we don't force anyone to
+install anything).
+
+### `wt rm <slug>` — tear down a worktree
+
+Runs `wt clean <slug>` first (kills any processes bound to the worktree's
+ports), then `git worktree remove`, then tries to delete the branch with
+`git branch -d` (which refuses to delete unmerged branches — safe by default).
+
+Flags:
+
+- `--force` — passes `--force` through to `git worktree remove` (needed when the
+  worktree has uncommitted changes).
+- `--keep-branch` — skip the branch deletion step.
+
+### `wt clean` — nuke zombies
+
+Dev servers sometimes outlive the terminal that started them (an uncleanly
+closed shell, an agent crash, `concurrently` children getting reparented to
+launchd, etc.). When that happens, subsequent starts either collide or silently
+launch a duplicate. `wt clean` fixes this on demand.
+
+- `bun run wt clean` — scans every managed worktree's expected ports and kills
+  any process listening on them. (Agent-spawned worktrees without a
+  `.env.worktree` are skipped — `wt` doesn't know their ports.)
+- `bun run wt clean <slug>` — same, but only for that worktree.
+
+Agents in particular should run `bun run wt clean` before ending their turn
+(this is documented in `AGENTS.md`).
+
+### `wt ps` — see what's listening
+
+Prints a table with one row per worktree and one column per service (diffs/trees
+dev, docs/trees/path-store E2E, chrome debug). Each cell is either the port
+number + PID if something is listening, or just the port number if it's free.
+Great for answering "wait, which worktree is on 3711 again?"
+
+### `wt list` — summary
+
+One line per worktree showing slug, offset, branch, and path. Includes the main
+clone (shown as `(main)`, offset `—`) and unmanaged/agent worktrees (shown as
+`(unmanaged)`).
+
+---
+
+## Ports: how the offset system works
+
+Each of our dev/test services has a **base port**:
+
+| Service                   | Base port |
+| ------------------------- | --------- |
+| `apps/docs` diffs dev     | 3690      |
+| `apps/docs` trees dev     | 3691      |
+| `apps/docs` E2E           | 4174      |
+| `packages/trees` E2E      | 4173      |
+| `packages/path-store` E2E | 4176      |
+| Chrome remote debug       | 9222      |
+
+Every worktree owns a **port offset** (0, 10, 20, 30, …). Its actual ports are
+`base + offset`. Main clone is always offset 0 — its ports are unchanged.
+
+### How the offset is chosen
+
+`wt new` picks an offset deterministically from the slug's hash (so recreating a
+worktree with the same slug tends to give you the same ports and preserve your
+browser bookmarks). If that candidate collides with another live worktree's
+offset, it bumps by 10 until it finds a free slot. Discovery of live offsets is
+stateless — `git worktree list` + each worktree's `.env.worktree` is the source
+of truth. There is no central registry file.
+
+### How the offset reaches your dev scripts
+
+1. `wt new` writes `.env.worktree` at the worktree root:
+   ```
+   PIERRE_WORKTREE_SLUG=drag-drop-fix
+   PIERRE_PORT_OFFSET=30
+   ```
+2. When you run `bun ws docs trees:dev`, `ws` walks up from your cwd, finds
+   `.env.worktree`, and injects its keys into the child env.
+3. The package.json script itself uses shell arithmetic to derive the final
+   port:
+   ```json
+   "trees:dev": "export NEXT_PUBLIC_SITE=trees PORT=$((${PIERRE_PORT_OFFSET:-0} + 3691)) && …"
+   ```
+   In the main clone `PIERRE_PORT_OFFSET` is unset, so PORT is 3691. In a
+   worktree with offset 30, PORT is 3721.
+
+If you're adding a new dev script that binds a port, follow the same pattern:
+`PORT=$((${PIERRE_PORT_OFFSET:-0} + <your_base>))`.
+
+---
+
+## `run-dev.sh` — kill-before-start
+
+`scripts/run-dev.sh <PORT> -- <command> [args…]` is a tiny preamble that every
+dev script in the repo uses. It:
+
+1. Runs `lsof -ti :$PORT -sTCP:LISTEN` to find any process currently bound to
+   the port.
+2. Sends SIGTERM, waits 300ms, sends SIGKILL to anything still bound.
+3. Execs the downstream command.
+
+This means **running a dev script always replaces the prior run on that port**.
+You never hit "port already in use" errors. Zombies from uncleanly closed
+terminals or crashed agents are automatically cleaned up on the next start.
+
+Because the port offset guarantees no two live worktrees share a port,
+`run-dev.sh` can never accidentally kill another worktree's server.
+
+---
+
+## `chrome-remote-debug.sh`
+
+`bun run chrome` launches Chrome Dev with the DevTools remote-debugging protocol
+on port 9222 (main clone) or `9222 + offset` (worktree). Each worktree gets its
+own `--user-data-dir` (e.g. `/tmp/chrome-devtools-<slug>`) so Chromes launched
+from different worktrees don't fight over a shared profile.
+
+After launching, the script waits until the debug port actually accepts
+connections before returning. This prevents a race where an agent runs the
+script, sees it exit, immediately tries to attach, and fails because the macOS
+permissions dialog hadn't finished resolving yet.
+
+---
+
+## Common workflows
+
+### Start a new parallel feature
+
+```bash
+bun run wt new drag-drop-fix
+cd ~/pierre/pierre-worktrees/drag-drop-fix
+bun ws docs trees:dev
+# → serves on http://localhost:<3691 + offset>, tab title prefixed with
+#   an emoji + "[drag-drop-fix]"
+```
+
+### Work on two features at once
+
+```bash
+bun run wt new feature-a
+bun run wt new feature-b
+# Each has its own port set. Open their dev servers in separate terminals.
+bun run wt ps    # see what's bound where
+```
+
+### I don't know which worktree is running on which port
+
+```bash
+bun run wt ps
+```
+
+### Agent left zombies behind / `port already in use`
+
+```bash
+bun run wt clean           # nuke every managed worktree's stale servers
+bun run wt clean <slug>    # only a specific worktree
+```
+
+You should never actually need the `clean` command mid-flow — every dev script
+already kills its predecessor on start. Use it when zombies are eating RAM
+between runs, or when an agent that doesn't know about `run-dev.sh` spawned a
+server directly.
+
+### Finished with a feature, PR merged
+
+```bash
+bun run wt rm drag-drop-fix
+# kills the servers, removes the worktree, deletes the (merged) branch.
+```
+
+If you have uncommitted work you're ready to throw away:
+
+```bash
+bun run wt rm drag-drop-fix --force
+```
+
+### Need to attach to an existing branch someone else pushed
+
+```bash
+git fetch
+bun run wt new review-mdos-pr --branch mdo/new-feature
+cd ~/pierre/pierre-worktrees/review-mdos-pr
+bun install
+```
+
+---
+
+## Constraints and gotchas
+
+- **`wt new` cannot auto-`cd`.** Copy the `cd` line it prints, or wrap it in
+  your own shell function.
+- **The main clone is always offset 0.** Nothing reserves this — there's just no
+  `.env.worktree` for `ws` to find, so `${PIERRE_PORT_OFFSET:-0}` resolves to 0.
+  Don't drop a `.env.worktree` in the main clone; it's in `.gitignore` but a
+  stray copy there would shift your main-clone ports.
+- **Direct invocations bypass `ws`.** If you `cd apps/docs && bun run trees:dev`
+  (without going through `bun ws`), `ws` is not in the call chain and won't
+  inject `PIERRE_PORT_OFFSET`. The belt-and-suspenders `apps/docs/.env.local`
+  that `wt new` writes covers `NEXT_PUBLIC_*` vars that Next loads
+  automatically, but `PORT` resolution still needs the offset to be in the env —
+  so always prefer `bun ws …` from the worktree root (this is already the
+  convention in `AGENTS.md`).
+- **Port offsets can't be manually re-used between worktrees.** If you want two
+  worktrees on deterministic sibling ports, just let `wt new` pick — the hash is
+  stable per slug.
+- **Unmanaged worktrees are visible but ignored for offset accounting.** Agent
+  worktrees under `.omx/worktrees/` or `/private/tmp/pierre-*` show up in
+  `wt list` and `wt ps`, but they don't claim offsets and `wt clean --all`
+  doesn't try to guess their ports.
+- **Hooks / generated files.** Fresh worktrees don't have `.husky/_/` (it's
+  regenerated by husky's `prepare` script on install). `wt new` runs
+  `bun install` automatically so this is usually invisible.
+
+---
+
+## Adding a new port-bound service
+
+If you add a dev or E2E server with a fixed port, do three things:
+
+1. In the package.json script, write the port as
+   `PORT=$((${PIERRE_PORT_OFFSET:-0} + <your_base>))` and wrap the command in
+   `scripts/run-dev.sh`:
+
+   ```json
+   "myservice:dev": "PORT=$((${PIERRE_PORT_OFFSET:-0} + 4321)) bash ../../scripts/run-dev.sh \"$PORT\" -- bun run _myservice"
+   ```
+
+2. If a config file reads the port (e.g. playwright configs), read from
+   `process.env.PIERRE_PORT_OFFSET` and add it to your base:
+
+   ```ts
+   const portOffset = Number(process.env.PIERRE_PORT_OFFSET ?? 0);
+   const e2ePort = 4321 + portOffset;
+   ```
+
+3. Add the new service to `PORT_BASES` in `scripts/wt.ts` so `wt ps` and
+   `wt clean` know about it.

--- a/scripts/chrome-remote-debug.sh
+++ b/scripts/chrome-remote-debug.sh
@@ -1,5 +1,40 @@
 #!/bin/bash
+#
+# Launches Google Chrome Dev with the DevTools remote-debugging protocol
+# enabled so agents / scripts can attach.
+#
+# Per-worktree isolation (opt-in via env):
+#   - PIERRE_PORT_OFFSET shifts the debug port by that many units (default 0).
+#   - PIERRE_WORKTREE_SLUG names the user-data-dir so each worktree has its own
+#     isolated Chrome profile and the worktrees don't fight over a shared dir.
+#
+# Main clone (neither var set) keeps the historical port 9222 and the
+# "/tmp/chrome-devtools-codex" user-data-dir so nothing changes for users not
+# running out of a worktree.
+#
+# After launching, this script waits for the debug port to accept connections
+# before returning, so callers can attach immediately without racing the
+# first-launch macOS permissions dialog.
+
+set -euo pipefail
+
+OFFSET="${PIERRE_PORT_OFFSET:-0}"
+SLUG="${PIERRE_WORKTREE_SLUG:-codex}"
+PORT=$((9222 + OFFSET))
+USER_DATA_DIR="/tmp/chrome-devtools-${SLUG}"
 
 open -g -n -a "Google Chrome Dev" --args \
-  --remote-debugging-port=9222 \
-  --user-data-dir=/tmp/chrome-devtools-codex
+  --remote-debugging-port="${PORT}" \
+  --user-data-dir="${USER_DATA_DIR}"
+
+# Wait up to ~6s for the debug port to start accepting connections.
+for _ in $(seq 1 30); do
+  if nc -z 127.0.0.1 "${PORT}" 2>/dev/null; then
+    echo "chrome debug port listening on ${PORT} (user-data-dir ${USER_DATA_DIR})"
+    exit 0
+  fi
+  sleep 0.2
+done
+
+echo "chrome debug port ${PORT} never opened (user-data-dir ${USER_DATA_DIR})" >&2
+exit 1

--- a/scripts/run-dev.sh
+++ b/scripts/run-dev.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Kill-before-start preamble for dev servers that bind a fixed port.
+#
+# Usage: scripts/run-dev.sh <PORT> -- <command> [args...]
+#
+# Finds any process currently listening on <PORT>, SIGTERMs it, waits briefly,
+# then SIGKILLs survivors. Then execs the provided command, which should start
+# a new server on the same port.
+#
+# This exists because terminals close uncleanly (especially under AI agents),
+# which can leave `concurrently` / `next dev` children reparented to launchd
+# and still bound to the port. Rather than require manual cleanup, every dev
+# script nukes whatever stale process owns its port before starting fresh.
+#
+# Worktree port offsets (see scripts/wt.ts) guarantee that no two live
+# worktrees share a port, so this never clobbers another worktree's work.
+
+set -euo pipefail
+
+if [ $# -lt 3 ] || [ "$2" != "--" ]; then
+  echo "usage: run-dev.sh <PORT> -- <command> [args...]" >&2
+  exit 2
+fi
+
+PORT="$1"
+shift 2
+
+# lsof -ti exits non-zero if nothing is listening; that's fine.
+PIDS=$(lsof -ti ":${PORT}" -sTCP:LISTEN 2>/dev/null || true)
+if [ -n "${PIDS}" ]; then
+  echo "[run-dev] killing stale process on port ${PORT}: ${PIDS}" >&2
+  # shellcheck disable=SC2086
+  kill -TERM ${PIDS} 2>/dev/null || true
+  sleep 0.3
+  SURVIVORS=$(lsof -ti ":${PORT}" -sTCP:LISTEN 2>/dev/null || true)
+  if [ -n "${SURVIVORS}" ]; then
+    # shellcheck disable=SC2086
+    kill -KILL ${SURVIVORS} 2>/dev/null || true
+    sleep 0.1
+  fi
+fi
+
+exec "$@"

--- a/scripts/ws.ts
+++ b/scripts/ws.ts
@@ -1,11 +1,62 @@
 #!/usr/bin/env bun
 
 import { spawn, type ChildProcess, spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import { delimiter, resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { delimiter, dirname, resolve } from 'node:path';
 
 const args = process.argv.slice(2);
 const cwd = process.cwd();
+
+// Walk up from `startDir` looking for a `.env.worktree` file. Worktrees created
+// by `scripts/wt.ts` write one at their root with `PIERRE_PORT_OFFSET` etc.
+// The main clone has no such file, so this returns {} there and nothing changes.
+//
+// We stop at the git worktree root (the first ancestor containing a `.git`
+// entry — dir in the main clone, file in a linked worktree). That cap prevents
+// a stray `.env.worktree` in an ancestor directory (e.g. `$HOME`) from being
+// silently picked up by anyone invoking `bun ws`.
+function loadWorktreeEnv(startDir: string): Record<string, string> {
+  let dir = resolve(startDir);
+  while (true) {
+    const candidate = resolve(dir, '.env.worktree');
+    if (existsSync(candidate)) {
+      return parseEnvFile(candidate);
+    }
+    if (existsSync(resolve(dir, '.git'))) {
+      return {};
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      return {};
+    }
+    dir = parent;
+  }
+}
+
+function parseEnvFile(path: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  const text = readFileSync(path, 'utf8');
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    // Strip matching surrounding quotes if present.
+    if (
+      value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'")))
+    ) {
+      value = value.slice(1, -1);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+const worktreeEnv = loadWorktreeEnv(cwd);
 
 const SIGNAL_EXIT_CODES: Partial<Record<NodeJS.Signals, number>> = {
   SIGHUP: 129,
@@ -93,6 +144,7 @@ function createScriptEnv(pkgDir: string) {
   ];
   return {
     ...process.env,
+    ...worktreeEnv,
     FORCE_COLOR: '1',
     PATH: pathParts.join(delimiter),
   };

--- a/scripts/wt.ts
+++ b/scripts/wt.ts
@@ -1,0 +1,544 @@
+#!/usr/bin/env bun
+//
+// Worktree command suite for this monorepo.
+//
+//   bun run wt new <slug> [--branch <name>] [--base <ref>]
+//   bun run wt rm <slug> [--keep-branch] [--force]
+//   bun run wt clean [<slug>|--all]
+//   bun run wt ps
+//   bun run wt list
+//
+// Design notes (see AGENTS.md "Worktrees" section for the user-facing summary):
+//
+// - Worktrees live at ~/pierre/pierre-worktrees/<dir>/ where <dir> is the slug
+//   with '/' replaced by '-'. Each worktree owns a port offset stored in
+//   <worktree>/.env.worktree. Dev scripts resolve ports as
+//   `${PIERRE_PORT_OFFSET:-0} + <default>` so the main clone (no env file) keeps
+//   its historical ports unchanged.
+// - Discovery is stateless: `git worktree list --porcelain` is the source of
+//   truth. Each worktree's own `.env.worktree` is the source of truth for its
+//   offset. There is no central registry.
+// - Agent-created worktrees (e.g. under .omx/worktrees/, /private/tmp/pierre-*)
+//   have no `.env.worktree`; they are visible to `wt list`/`wt ps` but they
+//   don't claim offsets and are skipped by `wt clean --all`.
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir, userInfo } from 'node:os';
+import { dirname, join } from 'node:path';
+
+const WORKTREES_HOME = join(homedir(), 'pierre', 'pierre-worktrees');
+
+// Port bases. The offset is added to these to get a worktree's actual ports.
+const PORT_BASES = {
+  docsDiffs: 3690,
+  docsTrees: 3691,
+  docsE2E: 4174,
+  treesE2E: 4173,
+  pathStoreE2E: 4176,
+  chrome: 9222,
+} as const;
+
+type PortMap = Record<keyof typeof PORT_BASES, number>;
+
+interface Worktree {
+  path: string;
+  branch: string | null;
+  head: string | null;
+  /** Null for worktrees that don't participate in our offset system (main clone, agent worktrees). */
+  offset: number | null;
+  /** Null when no `.env.worktree` / no claimed slug. */
+  slug: string | null;
+  /** True if this is the primary (non-linked) worktree — i.e. the main clone. */
+  isMain: boolean;
+}
+
+// -----------------------------------------------------------------------------
+// Entry point
+// -----------------------------------------------------------------------------
+
+const args = process.argv.slice(2);
+const sub = args[0];
+
+const commands: Record<string, (rest: string[]) => Promise<number> | number> = {
+  new: cmdNew,
+  rm: cmdRm,
+  clean: cmdClean,
+  ps: cmdPs,
+  list: cmdList,
+  help: cmdHelp,
+  '--help': cmdHelp,
+  '-h': cmdHelp,
+};
+
+if (!sub || !(sub in commands)) {
+  cmdHelp();
+  process.exit(sub ? 1 : 0);
+}
+
+Promise.resolve(commands[sub](args.slice(1))).then(
+  (code) => process.exit(code ?? 0),
+  (err) => {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+);
+
+function cmdHelp(): number {
+  console.log(`Usage: bun run wt <subcommand> [args]
+
+Subcommands:
+  new <slug> [--branch <name>] [--base <ref>]
+      Create a new worktree at ~/pierre/pierre-worktrees/<slug>.
+      Branch defaults to "$USER/<slug>". --branch attaches an existing branch.
+      --base selects the starting ref (default: main).
+
+  rm <slug> [--keep-branch] [--force]
+      Kill any processes bound to the worktree's ports, then remove it.
+      --force passes --force through to git worktree remove.
+
+  clean [<slug>|--all]
+      Kill processes bound to a worktree's expected ports. Without arguments
+      or with --all, does this for every managed worktree.
+
+  ps  List every worktree with per-service port status (LISTEN / —).
+  list  One-line-per-worktree summary.
+`);
+  return 0;
+}
+
+// -----------------------------------------------------------------------------
+// wt new
+// -----------------------------------------------------------------------------
+
+async function cmdNew(rest: string[]): Promise<number> {
+  const { slug, branch: branchOverride, base } = parseNewArgs(rest);
+  if (!slug) {
+    console.error('wt new: missing <slug>');
+    return 1;
+  }
+
+  const user = userInfo().username;
+  const branch = branchOverride ?? `${user}/${slug}`;
+  const dirName = slugify(slug);
+  const worktreePath = join(WORKTREES_HOME, dirName);
+
+  if (existsSync(worktreePath)) {
+    console.error(`wt new: ${worktreePath} already exists`);
+    return 1;
+  }
+
+  const worktrees = enumerateWorktrees();
+  for (const wt of worktrees) {
+    if (wt.branch === `refs/heads/${branch}` || wt.branch === branch) {
+      console.error(
+        `wt new: branch ${branch} is already checked out at ${wt.path}`
+      );
+      return 1;
+    }
+  }
+
+  mkdirSync(WORKTREES_HOME, { recursive: true });
+
+  const offset = allocateOffset(
+    slug,
+    worktrees.map((w) => w.offset).filter((o): o is number => o !== null)
+  );
+
+  // Decide how to invoke `git worktree add`:
+  //   - If --branch was passed, the branch may already exist locally: use
+  //     `git worktree add <path> <branch>` (no -b).
+  //   - Otherwise create a new branch rooted at <base> (default: main):
+  //     `git worktree add -b <branch> <path> <base>`.
+  const gitArgs = branchOverride
+    ? ['worktree', 'add', worktreePath, branch]
+    : ['worktree', 'add', '-b', branch, worktreePath, base ?? 'main'];
+
+  const gitResult = spawnSync('git', gitArgs, { stdio: 'inherit' });
+  if (gitResult.status !== 0) {
+    return gitResult.status ?? 1;
+  }
+
+  writeFileSync(
+    join(worktreePath, '.env.worktree'),
+    `PIERRE_WORKTREE_SLUG=${slug}\nPIERRE_PORT_OFFSET=${offset}\n`,
+    'utf8'
+  );
+
+  // Belt-and-suspenders for direct `cd apps/docs && bun run trees:dev` runs:
+  // Next auto-loads .env.local so the title tag still picks up the slug even
+  // when ws.ts isn't in the call chain.
+  const appsDocsEnvLocal = join(worktreePath, 'apps', 'docs', '.env.local');
+  if (existsSync(dirname(appsDocsEnvLocal))) {
+    writeFileSync(
+      appsDocsEnvLocal,
+      `NEXT_PUBLIC_WORKTREE_SLUG=${slug}\n`,
+      'utf8'
+    );
+  }
+
+  console.log(`\nInstalling dependencies in ${worktreePath}...`);
+  const bunInstall = spawnSync('bun', ['install'], {
+    cwd: worktreePath,
+    stdio: 'inherit',
+  });
+  if (bunInstall.status !== 0) {
+    console.error(
+      'wt new: bun install failed; the worktree was created but may be incomplete'
+    );
+    return bunInstall.status ?? 1;
+  }
+
+  printPortMap(slug, offset, worktreePath);
+  return 0;
+}
+
+function parseNewArgs(rest: string[]): {
+  slug?: string;
+  branch?: string;
+  base?: string;
+} {
+  let slug: string | undefined;
+  let branch: string | undefined;
+  let base: string | undefined;
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i];
+    if (a === '--branch') {
+      branch = rest[++i];
+    } else if (a === '--base') {
+      base = rest[++i];
+    } else if (!slug && !a.startsWith('--')) {
+      slug = a;
+    }
+  }
+  return { slug, branch, base };
+}
+
+// -----------------------------------------------------------------------------
+// wt rm
+// -----------------------------------------------------------------------------
+
+function cmdRm(rest: string[]): number {
+  const keepBranch = rest.includes('--keep-branch');
+  const force = rest.includes('--force');
+  const slug = rest.find((a) => !a.startsWith('--'));
+  if (!slug) {
+    console.error('wt rm: missing <slug>');
+    return 1;
+  }
+
+  const wt = findWorktreeBySlug(slug);
+  if (!wt) {
+    console.error(`wt rm: no managed worktree with slug "${slug}"`);
+    return 1;
+  }
+
+  killWorktreePorts(wt);
+
+  const removeArgs = ['worktree', 'remove'];
+  if (force) removeArgs.push('--force');
+  removeArgs.push(wt.path);
+  const removeResult = spawnSync('git', removeArgs, { stdio: 'inherit' });
+  if (removeResult.status !== 0) {
+    return removeResult.status ?? 1;
+  }
+
+  if (!keepBranch && wt.branch) {
+    const branchName = wt.branch.replace(/^refs\/heads\//, '');
+    // `git branch -d` is safe: it refuses to delete unmerged branches.
+    const del = spawnSync('git', ['branch', '-d', branchName], {
+      stdio: 'pipe',
+      encoding: 'utf8',
+    });
+    if (del.status === 0) {
+      console.log(`Deleted branch ${branchName} (was merged).`);
+    } else {
+      console.log(
+        `Left branch ${branchName} in place (${del.stderr.trim() || 'unmerged'}).`
+      );
+    }
+  }
+
+  return 0;
+}
+
+// -----------------------------------------------------------------------------
+// wt clean
+// -----------------------------------------------------------------------------
+
+function cmdClean(rest: string[]): number {
+  const all = rest.length === 0 || rest.includes('--all');
+  const targets: Worktree[] = [];
+  if (all) {
+    for (const wt of enumerateWorktrees()) {
+      if (wt.offset !== null || wt.isMain) targets.push(wt);
+    }
+  } else {
+    const slug = rest.find((a) => !a.startsWith('--'));
+    if (!slug) {
+      console.error('wt clean: missing <slug> (or pass --all)');
+      return 1;
+    }
+    const wt = findWorktreeBySlug(slug);
+    if (!wt) {
+      console.error(`wt clean: no managed worktree with slug "${slug}"`);
+      return 1;
+    }
+    targets.push(wt);
+  }
+
+  for (const wt of targets) {
+    killWorktreePorts(wt);
+  }
+  return 0;
+}
+
+// -----------------------------------------------------------------------------
+// wt ps
+// -----------------------------------------------------------------------------
+
+function cmdPs(): number {
+  const worktrees = enumerateWorktrees();
+  const services: Array<[keyof typeof PORT_BASES, string]> = [
+    ['docsDiffs', 'diffs'],
+    ['docsTrees', 'trees'],
+    ['docsE2E', 'docsE2E'],
+    ['treesE2E', 'treesE2E'],
+    ['pathStoreE2E', 'psE2E'],
+    ['chrome', 'chrome'],
+  ];
+
+  const header = [
+    padRight('worktree', 28),
+    padRight('offset', 8),
+    ...services.map(([, label]) => padRight(label, 14)),
+  ].join(' ');
+  console.log(header);
+  console.log('-'.repeat(header.length));
+
+  for (const wt of worktrees) {
+    const label =
+      wt.slug ?? (wt.isMain ? '(main)' : `(unmanaged:${basename(wt.path)})`);
+    const offsetCell = wt.offset === null ? '—' : String(wt.offset);
+    const portMap = wt.offset === null ? null : resolvePortMap(wt.offset);
+    const cells = services.map(([key]) => {
+      if (!portMap) return padRight('—', 14);
+      const port = portMap[key];
+      const pid = pidOnPort(port);
+      return padRight(pid ? `${port}:${pid}` : `${port}`, 14);
+    });
+    console.log(
+      [padRight(label, 28), padRight(offsetCell, 8), ...cells].join(' ')
+    );
+  }
+  return 0;
+}
+
+// -----------------------------------------------------------------------------
+// wt list
+// -----------------------------------------------------------------------------
+
+function cmdList(): number {
+  for (const wt of enumerateWorktrees()) {
+    const offset = wt.offset === null ? '—' : String(wt.offset);
+    const slug = wt.slug ?? (wt.isMain ? '(main)' : '(unmanaged)');
+    const branch = wt.branch
+      ? wt.branch.replace(/^refs\/heads\//, '')
+      : '(detached)';
+    console.log(
+      `${padRight(slug, 28)} offset=${padRight(offset, 4)} ${padRight(branch, 40)} ${wt.path}`
+    );
+  }
+  return 0;
+}
+
+// -----------------------------------------------------------------------------
+// Shared helpers
+// -----------------------------------------------------------------------------
+
+// Parse `git worktree list --porcelain`. Each record is terminated by a blank
+// line. Fields we care about: `worktree <path>`, `HEAD <sha>`, `branch
+// refs/heads/<name>` (or `detached`).
+function enumerateWorktrees(): Worktree[] {
+  const result = spawnSync('git', ['worktree', 'list', '--porcelain'], {
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    throw new Error(`git worktree list failed:\n${result.stderr}`);
+  }
+
+  const records: Worktree[] = [];
+  let current: Partial<Worktree> & { path?: string } = {};
+  let primarySeen = false;
+  const flush = () => {
+    if (!current.path) return;
+    const path = current.path;
+    const isMain = !primarySeen;
+    primarySeen = true;
+    const envPath = join(path, '.env.worktree');
+    let offset: number | null = null;
+    let slug: string | null = null;
+    if (existsSync(envPath)) {
+      try {
+        const parsed = parseEnvFile(envPath);
+        if (parsed.PIERRE_PORT_OFFSET !== undefined) {
+          const n = Number(parsed.PIERRE_PORT_OFFSET);
+          if (Number.isFinite(n)) offset = n;
+        }
+        if (parsed.PIERRE_WORKTREE_SLUG !== undefined) {
+          slug = parsed.PIERRE_WORKTREE_SLUG;
+        }
+      } catch {
+        // Malformed env file; treat as unmanaged.
+      }
+    }
+    records.push({
+      path,
+      branch: current.branch ?? null,
+      head: current.head ?? null,
+      offset,
+      slug,
+      isMain,
+    });
+    current = {};
+  };
+
+  for (const rawLine of result.stdout.split('\n')) {
+    const line = rawLine.trim();
+    if (line === '') {
+      flush();
+      continue;
+    }
+    if (line.startsWith('worktree ')) {
+      current.path = line.slice('worktree '.length);
+    } else if (line.startsWith('HEAD ')) {
+      current.head = line.slice('HEAD '.length);
+    } else if (line.startsWith('branch ')) {
+      current.branch = line.slice('branch '.length);
+    }
+  }
+  flush();
+  return records;
+}
+
+function findWorktreeBySlug(slug: string): Worktree | undefined {
+  return enumerateWorktrees().find((w) => w.slug === slug);
+}
+
+// Stable, deterministic offset candidate from slug. Steps by 10 so ports in
+// adjacent slots (e.g. docsDiffs=3690 and docsTrees=3691) never overlap across
+// worktrees. Main clone is offset 0 — reserved, never allocated to a worktree.
+function allocateOffset(slug: string, inUse: number[]): number {
+  const taken = new Set<number>(inUse);
+  taken.add(0);
+  let hash = 0;
+  for (let i = 0; i < slug.length; i++) {
+    hash = (hash * 31 + slug.charCodeAt(i)) >>> 0;
+  }
+  let offset = ((hash % 10) + 1) * 10; // starts at 10, wraps through 100
+  for (let i = 0; i < 100; i++) {
+    if (!taken.has(offset)) return offset;
+    offset += 10;
+  }
+  throw new Error('wt new: could not allocate a free port offset');
+}
+
+function resolvePortMap(offset: number): PortMap {
+  const out: Partial<PortMap> = {};
+  for (const key of Object.keys(PORT_BASES) as (keyof typeof PORT_BASES)[]) {
+    out[key] = PORT_BASES[key] + offset;
+  }
+  return out as PortMap;
+}
+
+// Find listener PIDs for `port`, SIGTERM them, wait, then SIGKILL survivors.
+function killPorts(ports: number[]): void {
+  for (const port of ports) {
+    const pids = pidsOnPort(port);
+    if (pids.length === 0) continue;
+    console.log(`[wt clean] port ${port}: killing ${pids.join(', ')}`);
+    spawnSync('kill', ['-TERM', ...pids.map(String)], { stdio: 'ignore' });
+  }
+  // Single shared pause, then kill survivors.
+  if (ports.some((p) => pidsOnPort(p).length > 0)) {
+    spawnSync('sleep', ['0.3']);
+  }
+  for (const port of ports) {
+    const survivors = pidsOnPort(port);
+    if (survivors.length === 0) continue;
+    console.log(`[wt clean] port ${port}: SIGKILL ${survivors.join(', ')}`);
+    spawnSync('kill', ['-KILL', ...survivors.map(String)], { stdio: 'ignore' });
+  }
+}
+
+function killWorktreePorts(wt: Worktree): void {
+  if (wt.offset === null) return;
+  killPorts(Object.values(resolvePortMap(wt.offset)));
+}
+
+function pidsOnPort(port: number): number[] {
+  const r = spawnSync('lsof', ['-ti', `:${port}`, '-sTCP:LISTEN'], {
+    encoding: 'utf8',
+  });
+  if (r.status !== 0) return [];
+  return r.stdout
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .map((s) => Number(s))
+    .filter((n) => Number.isFinite(n));
+}
+
+function pidOnPort(port: number): number | null {
+  const pids = pidsOnPort(port);
+  return pids[0] ?? null;
+}
+
+function parseEnvFile(path: string): Record<string, string> {
+  const text = readFileSync(path, 'utf8');
+  const out: Record<string, string> = {};
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if (
+      value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'")))
+    ) {
+      value = value.slice(1, -1);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+function slugify(input: string): string {
+  return input.replace(/[/\\]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+function padRight(s: string, n: number): string {
+  return s.length >= n ? s : s + ' '.repeat(n - s.length);
+}
+
+function basename(p: string): string {
+  return p.split('/').filter(Boolean).pop() ?? p;
+}
+
+function printPortMap(slug: string, offset: number, path: string): void {
+  const ports = resolvePortMap(offset);
+  console.log(`
+Worktree: ${slug} (offset ${offset})
+  diffs dev:    http://localhost:${ports.docsDiffs}
+  trees dev:    http://localhost:${ports.docsTrees}
+  docs E2E:     http://localhost:${ports.docsE2E}
+  trees E2E:    http://localhost:${ports.treesE2E}
+  path-store:   http://localhost:${ports.pathStoreE2E}
+  chrome debug: localhost:${ports.chrome} (user-data-dir /tmp/chrome-devtools-${slug})
+
+cd ${path}
+`);
+}

--- a/scripts/wt.ts
+++ b/scripts/wt.ts
@@ -471,9 +471,13 @@ function killPorts(ports: number[]): void {
   }
 }
 
+// The main clone has no `.env.worktree` and therefore no offset, but it still
+// owns the default ports (offset 0). Treat it as offset 0 so `wt clean` on the
+// main clone terminates stale servers on 3690/3691/4173/4174/4176/9222.
 function killWorktreePorts(wt: Worktree): void {
-  if (wt.offset === null) return;
-  killPorts(Object.values(resolvePortMap(wt.offset)));
+  const offset = wt.offset ?? (wt.isMain ? 0 : null);
+  if (offset === null) return;
+  killPorts(Object.values(resolvePortMap(offset)));
 }
 
 function pidsOnPort(port: number): number[] {


### PR DESCRIPTION
# scripts/

This folder contains the small set of scripts that drive day-to-day development
in the monorepo. Most of the time you'll interact with them through root
`package.json` entries:

- `bun ws …` — run an npm script in a specific workspace package.
- `bun run wt …` — manage `git worktree`s and their port isolation.

The other two scripts are helpers the above invoke internally:

- `run-dev.sh` — kill-before-start preamble for dev servers.
- `chrome-remote-debug.sh` — launches Chrome Dev with the DevTools protocol
  enabled, worktree-aware.
- `build-sprite.js`, `precommit-tsc.ts` — build/CI helpers, unrelated to the
  worktree workflow below.

The rest of this document explains `ws` and `wt` in detail and walks through the
most common workflows.

---

## `bun ws` — the workspace script runner

`bun ws <package> <script> [args…]` runs an npm script inside a specific
workspace. It exists for three reasons:

1. You can run it from anywhere in the monorepo — you don't have to `cd` into
   the package first.
2. It accepts a short package name (`diffs` resolves to `@pierre/diffs` in
   `packages/diffs`) or a path (`packages/diffs`) or a glob (`packages/*`).
3. It loads a worktree's `.env.worktree` so per-worktree port offsets propagate
   into the script automatically (see "Worktrees" below).

### Syntax

```bash
bun ws <package> <script> [args...]
bun ws <package> <script> --verbose        # don't elide lines in output
bun ws 'packages/*' <script>                # fan out across a glob
bun ws '*' <script>                         # every workspace (apps + packages)
```

`ws` forwards every argument after the script name to the underlying `bun run`
invocation. You do **not** need `--` to separate them unless a downstream tool
requires it. The only flag `ws` itself eats is `-v` / `--verbose`.

### Package name resolution

In priority order:

1. **Exact path** (`packages/diffs`, `apps/docs`) — filesystem directory, used
   verbatim.
2. **Short name** (`diffs`) — tried as `packages/diffs`, then `apps/diffs`.
3. **Glob** (`packages/*`, `*`) — delegated to `bun run -F <filter>`.

### Examples

```bash
bun ws diffs build           # build packages/diffs
bun ws docs trees:dev        # run the docs trees dev server
bun ws trees test            # bun test in packages/trees
bun ws 'packages/*' build    # build every package
bun ws '*' tsc               # typecheck everything
```

### How `ws` interacts with worktrees

When invoked, `ws` walks up from your current directory looking for a
`.env.worktree` file. If it finds one (which happens only inside a worktree
created by `wt new`), it merges those keys into the spawned child's env. In
practice this means `PIERRE_PORT_OFFSET` reaches your dev scripts without you
having to think about it.

In the main clone, there is no `.env.worktree`, nothing is merged, and every
script sees its historical default ports.

---

## `bun run wt` — the worktree command suite

`wt` manages sibling worktrees of the main clone so you can work on multiple
branches in parallel without port collisions, zombie dev servers piling up, or
browser tabs you can't tell apart.

Every worktree managed by `wt` lives at:

```
~/pierre/pierre-worktrees/<dir>/
```

where `<dir>` is the slug with any `/` characters replaced by `-`. Worktrees the
tool didn't create (e.g. agent-spawned ones under `.omx/worktrees/` or
`/private/tmp/`) are left alone.

### Subcommands at a glance

```bash
bun run wt new <slug> [--branch <name>] [--base <ref>]
bun run wt rm  <slug> [--keep-branch] [--force]
bun run wt clean [<slug>|--all]
bun run wt ps
bun run wt list
```

### `wt new <slug>` — create a worktree

Creates a new worktree rooted at `~/pierre/pierre-worktrees/<slug>/`, on a fresh
branch, with ports that won't collide with any other worktree's.

By default:

- Branch name is `$USER/<slug>` (e.g. `alex/fix-drag-drop`).
- Base ref is `main`.
- A port offset is picked (see "Ports" below), deterministic from the slug but
  bumped if it collides with an existing worktree.
- `.env.worktree` is written at the worktree root with the offset and slug.
- `apps/docs/.env.local` gets `NEXT_PUBLIC_WORKTREE_SLUG=<slug>` so the browser
  tab title prefixes with an emoji + slug.
- `bun install` runs automatically so husky hooks regenerate and the worktree's
  `node_modules` is ready.
- A summary of the worktree's URLs and the `cd` command is printed.

Flags:

- `--branch <name>` — attach an **existing** branch to the new worktree, rather
  than creating a new one named `$USER/<slug>`.
- `--base <ref>` — when creating a fresh branch, root it at `<ref>` instead of
  `main`.

Examples:

```bash
bun run wt new drag-drop-fix
# → creates branch alex/drag-drop-fix from main
#   in ~/pierre/pierre-worktrees/drag-drop-fix/

bun run wt new trees/perf --base alex/trees/main-current-work
# → creates branch alex/trees/perf from alex/trees/main-current-work
#   in ~/pierre/pierre-worktrees/trees-perf/   (slash → dash in dir name)

bun run wt new resume --branch mdo/wip-feature
# → attaches existing branch mdo/wip-feature to a new worktree at
#   ~/pierre/pierre-worktrees/resume/
```

**Why `wt new` cannot `cd` for you.** A child process cannot change its parent
shell's working directory. The script prints the `cd` command at the end;
copy-paste it. If you want true auto-cd, wrap `wt new` in a shell function of
your own (out of scope for this repo, deliberately — we don't force anyone to
install anything).

### `wt rm <slug>` — tear down a worktree

Runs `wt clean <slug>` first (kills any processes bound to the worktree's
ports), then `git worktree remove`, then tries to delete the branch with
`git branch -d` (which refuses to delete unmerged branches — safe by default).

Flags:

- `--force` — passes `--force` through to `git worktree remove` (needed when the
  worktree has uncommitted changes).
- `--keep-branch` — skip the branch deletion step.

### `wt clean` — nuke zombies

Dev servers sometimes outlive the terminal that started them (an uncleanly
closed shell, an agent crash, `concurrently` children getting reparented to
launchd, etc.). When that happens, subsequent starts either collide or silently
launch a duplicate. `wt clean` fixes this on demand.

- `bun run wt clean` — scans every managed worktree's expected ports and kills
  any process listening on them. (Agent-spawned worktrees without a
  `.env.worktree` are skipped — `wt` doesn't know their ports.)
- `bun run wt clean <slug>` — same, but only for that worktree.

Agents in particular should run `bun run wt clean` before ending their turn
(this is documented in `AGENTS.md`).

### `wt ps` — see what's listening

Prints a table with one row per worktree and one column per service (diffs/trees
dev, docs/trees/path-store E2E, chrome debug). Each cell is either the port
number + PID if something is listening, or just the port number if it's free.
Great for answering "wait, which worktree is on 3711 again?"

### `wt list` — summary

One line per worktree showing slug, offset, branch, and path. Includes the main
clone (shown as `(main)`, offset `—`) and unmanaged/agent worktrees (shown as
`(unmanaged)`).

---

## Ports: how the offset system works

Each of our dev/test services has a **base port**:

| Service                   | Base port |
| ------------------------- | --------- |
| `apps/docs` diffs dev     | 3690      |
| `apps/docs` trees dev     | 3691      |
| `apps/docs` E2E           | 4174      |
| `packages/trees` E2E      | 4173      |
| `packages/path-store` E2E | 4176      |
| Chrome remote debug       | 9222      |

Every worktree owns a **port offset** (0, 10, 20, 30, …). Its actual ports are
`base + offset`. Main clone is always offset 0 — its ports are unchanged.

### How the offset is chosen

`wt new` picks an offset deterministically from the slug's hash (so recreating a
worktree with the same slug tends to give you the same ports and preserve your
browser bookmarks). If that candidate collides with another live worktree's
offset, it bumps by 10 until it finds a free slot. Discovery of live offsets is
stateless — `git worktree list` + each worktree's `.env.worktree` is the source
of truth. There is no central registry file.

### How the offset reaches your dev scripts

1. `wt new` writes `.env.worktree` at the worktree root:
   ```
   PIERRE_WORKTREE_SLUG=drag-drop-fix
   PIERRE_PORT_OFFSET=30
   ```
2. When you run `bun ws docs trees:dev`, `ws` walks up from your cwd, finds
   `.env.worktree`, and injects its keys into the child env.
3. The package.json script itself uses shell arithmetic to derive the final
   port:
   ```json
   "trees:dev": "export NEXT_PUBLIC_SITE=trees PORT=$((${PIERRE_PORT_OFFSET:-0} + 3691)) && …"
   ```
   In the main clone `PIERRE_PORT_OFFSET` is unset, so PORT is 3691. In a
   worktree with offset 30, PORT is 3721.

If you're adding a new dev script that binds a port, follow the same pattern:
`PORT=$((${PIERRE_PORT_OFFSET:-0} + <your_base>))`.

---

## `run-dev.sh` — kill-before-start

`scripts/run-dev.sh <PORT> -- <command> [args…]` is a tiny preamble that every
dev script in the repo uses. It:

1. Runs `lsof -ti :$PORT -sTCP:LISTEN` to find any process currently bound to
   the port.
2. Sends SIGTERM, waits 300ms, sends SIGKILL to anything still bound.
3. Execs the downstream command.

This means **running a dev script always replaces the prior run on that port**.
You never hit "port already in use" errors. Zombies from uncleanly closed
terminals or crashed agents are automatically cleaned up on the next start.

Because the port offset guarantees no two live worktrees share a port,
`run-dev.sh` can never accidentally kill another worktree's server.

---

## `chrome-remote-debug.sh`

`bun run chrome` launches Chrome Dev with the DevTools remote-debugging protocol
on port 9222 (main clone) or `9222 + offset` (worktree). Each worktree gets its
own `--user-data-dir` (e.g. `/tmp/chrome-devtools-<slug>`) so Chromes launched
from different worktrees don't fight over a shared profile.

After launching, the script waits until the debug port actually accepts
connections before returning. This prevents a race where an agent runs the
script, sees it exit, immediately tries to attach, and fails because the macOS
permissions dialog hadn't finished resolving yet.

---

## Common workflows

### Start a new parallel feature

```bash
bun run wt new drag-drop-fix
cd ~/pierre/pierre-worktrees/drag-drop-fix
bun ws docs trees:dev
# → serves on http://localhost:<3691 + offset>, tab title prefixed with
#   an emoji + "[drag-drop-fix]"
```

### Work on two features at once

```bash
bun run wt new feature-a
bun run wt new feature-b
# Each has its own port set. Open their dev servers in separate terminals.
bun run wt ps    # see what's bound where
```

### I don't know which worktree is running on which port

```bash
bun run wt ps
```

### Agent left zombies behind / `port already in use`

```bash
bun run wt clean           # nuke every managed worktree's stale servers
bun run wt clean <slug>    # only a specific worktree
```

You should never actually need the `clean` command mid-flow — every dev script
already kills its predecessor on start. Use it when zombies are eating RAM
between runs, or when an agent that doesn't know about `run-dev.sh` spawned a
server directly.

### Finished with a feature, PR merged

```bash
bun run wt rm drag-drop-fix
# kills the servers, removes the worktree, deletes the (merged) branch.
```

If you have uncommitted work you're ready to throw away:

```bash
bun run wt rm drag-drop-fix --force
```

### Need to attach to an existing branch someone else pushed

```bash
git fetch
bun run wt new review-mdos-pr --branch mdo/new-feature
cd ~/pierre/pierre-worktrees/review-mdos-pr
bun install
```

---

## Constraints and gotchas

- **`wt new` cannot auto-`cd`.** Copy the `cd` line it prints, or wrap it in
  your own shell function.
- **The main clone is always offset 0.** Nothing reserves this — there's just no
  `.env.worktree` for `ws` to find, so `${PIERRE_PORT_OFFSET:-0}` resolves to 0.
  Don't drop a `.env.worktree` in the main clone; it's in `.gitignore` but a
  stray copy there would shift your main-clone ports.
- **Direct invocations bypass `ws`.** If you `cd apps/docs && bun run trees:dev`
  (without going through `bun ws`), `ws` is not in the call chain and won't
  inject `PIERRE_PORT_OFFSET`. The belt-and-suspenders `apps/docs/.env.local`
  that `wt new` writes covers `NEXT_PUBLIC_*` vars that Next loads
  automatically, but `PORT` resolution still needs the offset to be in the env —
  so always prefer `bun ws …` from the worktree root (this is already the
  convention in `AGENTS.md`).
- **Port offsets can't be manually re-used between worktrees.** If you want two
  worktrees on deterministic sibling ports, just let `wt new` pick — the hash is
  stable per slug.
- **Unmanaged worktrees are visible but ignored for offset accounting.** Agent
  worktrees under `.omx/worktrees/` or `/private/tmp/pierre-*` show up in
  `wt list` and `wt ps`, but they don't claim offsets and `wt clean --all`
  doesn't try to guess their ports.
- **Hooks / generated files.** Fresh worktrees don't have `.husky/_/` (it's
  regenerated by husky's `prepare` script on install). `wt new` runs
  `bun install` automatically so this is usually invisible.

---

## Adding a new port-bound service

If you add a dev or E2E server with a fixed port, do three things:

1. In the package.json script, write the port as
   `PORT=$((${PIERRE_PORT_OFFSET:-0} + <your_base>))` and wrap the command in
   `scripts/run-dev.sh`:

   ```json
   "myservice:dev": "PORT=$((${PIERRE_PORT_OFFSET:-0} + 4321)) bash ../../scripts/run-dev.sh \"$PORT\" -- bun run _myservice"
   ```

2. If a config file reads the port (e.g. playwright configs), read from
   `process.env.PIERRE_PORT_OFFSET` and add it to your base:

   ```ts
   const portOffset = Number(process.env.PIERRE_PORT_OFFSET ?? 0);
   const e2ePort = 4321 + portOffset;
   ```

3. Add the new service to `PORT_BASES` in `scripts/wt.ts` so `wt ps` and
   `wt clean` know about it.
