### PR TITLE
[wt] fix env for everything

### DIFF
--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -58,9 +58,11 @@ export const viewport: Viewport = {
   initialScale: 1,
 };
 
-// When running in a worktree (NEXT_PUBLIC_WORKTREE_SLUG set by wt), prefix the
-// title with a stable emoji + slug so browser tabs for different worktrees are
-// distinguishable at a glance. No-op in the main clone.
+// When running in a worktree, prefix the title with a stable emoji + slug so
+// browser tabs for different worktrees are distinguishable at a glance. The
+// slug reaches this file via `next.config.mjs`, which loads `.env.worktree`
+// and bridges `PIERRE_WORKTREE_SLUG` into `NEXT_PUBLIC_WORKTREE_SLUG`. No-op
+// in the main clone.
 const WORKTREE_EMOJI_PALETTE = [
   '🟢',
   '🔵',

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -1,3 +1,23 @@
+import { loadWorktreeEnv } from '../../scripts/load-worktree-env.mjs';
+
+// `next dev` runs under Node, which (like Bun) only auto-loads the standard
+// `.env*` names. Our worktree helper writes `PIERRE_WORKTREE_SLUG` /
+// `PIERRE_PORT_OFFSET` into `.env.worktree` at the worktree root, so pull those
+// in manually before Next inspects `process.env`. When `ws.ts` is in the call
+// chain it has already injected the same keys; the loader preserves those.
+loadWorktreeEnv();
+
+// The browser title prefix (see `app/layout.tsx`) reads
+// `NEXT_PUBLIC_WORKTREE_SLUG` so the value survives into the client bundle.
+// Bridge it from the non-prefixed worktree slug so `.env.worktree` stays the
+// single source of truth.
+if (
+  process.env.PIERRE_WORKTREE_SLUG &&
+  !process.env.NEXT_PUBLIC_WORKTREE_SLUG
+) {
+  process.env.NEXT_PUBLIC_WORKTREE_SLUG = process.env.PIERRE_WORKTREE_SLUG;
+}
+
 const site = process.env.NEXT_PUBLIC_SITE ?? 'diffs';
 const isTrees = site === 'trees';
 

--- a/apps/docs/test/e2e/playwright.config.ts
+++ b/apps/docs/test/e2e/playwright.config.ts
@@ -1,5 +1,11 @@
 import { defineConfig, devices } from '@playwright/test';
 
+import { loadWorktreeEnv } from '../../../../scripts/load-worktree-env.mjs';
+
+// Pull `PIERRE_PORT_OFFSET` from `.env.worktree` when Playwright is launched
+// outside a `bun ws` call (e.g. `bunx playwright test` from the package root).
+loadWorktreeEnv();
+
 const portOffset = Number(process.env.PIERRE_PORT_OFFSET ?? 0);
 const e2ePort = 4174 + portOffset;
 const e2eBaseUrl = `http://127.0.0.1:${e2ePort}`;

--- a/packages/path-store/test/e2e/playwright.config.js
+++ b/packages/path-store/test/e2e/playwright.config.js
@@ -1,5 +1,11 @@
 import { defineConfig, devices } from '@playwright/test';
 
+import { loadWorktreeEnv } from '../../../../scripts/load-worktree-env.mjs';
+
+// Pull `PIERRE_PORT_OFFSET` from `.env.worktree` when Playwright is launched
+// outside a `bun ws` call (e.g. `bunx playwright test` from the package root).
+loadWorktreeEnv();
+
 const portOffset = Number(process.env.PIERRE_PORT_OFFSET ?? 0);
 const e2ePort = 4176 + portOffset;
 const e2eBaseUrl = `http://127.0.0.1:${e2ePort}`;

--- a/packages/trees/test/e2e/playwright.config.ts
+++ b/packages/trees/test/e2e/playwright.config.ts
@@ -1,5 +1,11 @@
 import { defineConfig, devices } from '@playwright/test';
 
+import { loadWorktreeEnv } from '../../../../scripts/load-worktree-env.mjs';
+
+// Pull `PIERRE_PORT_OFFSET` from `.env.worktree` when Playwright is launched
+// outside a `bun ws` call (e.g. `bunx playwright test` from the package root).
+loadWorktreeEnv();
+
 const portOffset = Number(process.env.PIERRE_PORT_OFFSET ?? 0);
 const e2ePort = 4173 + portOffset;
 const e2eBaseUrl = `http://127.0.0.1:${e2ePort}`;

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -115,8 +115,12 @@ By default:
 - A port offset is picked (see "Ports" below), deterministic from the slug but
   bumped if it collides with an existing worktree.
 - `.env.worktree` is written at the worktree root with the offset and slug.
-- `apps/docs/.env.local` gets `NEXT_PUBLIC_WORKTREE_SLUG=<slug>` so the browser
-  tab title prefixes with an emoji + slug.
+  Configs that need those keys outside of a `bun ws` chain (Next's
+  `next.config.mjs`, each Playwright config, `chrome-remote-debug.sh`) load the
+  file themselves via `scripts/load-worktree-env.mjs` / the inlined bash
+  walk-up. The browser tab title prefix reads `NEXT_PUBLIC_WORKTREE_SLUG`, which
+  `next.config.mjs` bridges from `PIERRE_WORKTREE_SLUG` so `.env.worktree` stays
+  the single source of truth.
 - `bun install` runs automatically so husky hooks regenerate and the worktree's
   `node_modules` is ready.
 - A summary of the worktree's URLs and the `cd` command is printed.
@@ -345,11 +349,13 @@ bun install
   stray copy there would shift your main-clone ports.
 - **Direct invocations bypass `ws`.** If you `cd apps/docs && bun run trees:dev`
   (without going through `bun ws`), `ws` is not in the call chain and won't
-  inject `PIERRE_PORT_OFFSET`. The belt-and-suspenders `apps/docs/.env.local`
-  that `wt new` writes covers `NEXT_PUBLIC_*` vars that Next loads
-  automatically, but `PORT` resolution still needs the offset to be in the env —
-  so always prefer `bun ws …` from the worktree root (this is already the
-  convention in `AGENTS.md`).
+  inject `PIERRE_PORT_OFFSET` into the shell that computes `PORT`. The
+  package.json script still resolves `${PIERRE_PORT_OFFSET:-0}` to `0` and the
+  dev server binds the main clone's port. Configs that run _after_ the shell
+  (Next's `next.config.mjs`, Playwright configs) will still pick up
+  `.env.worktree` on their own — but `PORT` arithmetic in a package.json script
+  is resolved by the shell, so always prefer `bun ws …` from the worktree root
+  (this is already the convention in `AGENTS.md`).
 - **Port offsets can't be manually re-used between worktrees.** If you want two
   worktrees on deterministic sibling ports, just let `wt new` pick — the hash is
   stable per slug.

--- a/scripts/chrome-remote-debug.sh
+++ b/scripts/chrome-remote-debug.sh
@@ -18,6 +18,52 @@
 
 set -euo pipefail
 
+# Neither bash nor `bun run` auto-load `.env.worktree`, so when this script is
+# launched outside of a `bun ws` chain (e.g. `bun run chrome` from the worktree
+# root) the `PIERRE_*` vars would otherwise be missing and chrome would open on
+# the main clone's debug port. Walk up from $PWD until we find `.env.worktree`
+# or hit a `.git` entry (worktree root marker) and source the file so its keys
+# are exported for the remainder of this script. Pre-existing env vars win.
+load_worktree_env() {
+  local dir="$PWD"
+  local env_file=""
+  while [[ "$dir" != "/" ]]; do
+    if [[ -f "$dir/.env.worktree" ]]; then
+      env_file="$dir/.env.worktree"
+      break
+    fi
+    if [[ -e "$dir/.git" ]]; then
+      return
+    fi
+    dir="$(dirname "$dir")"
+  done
+  [[ -z "$env_file" ]] && return
+
+  local line key value
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    # Trim leading/trailing whitespace and skip blanks / comments.
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [[ -z "$line" || "${line:0:1}" == "#" ]] && continue
+    [[ "$line" != *"="* ]] && continue
+    key="${line%%=*}"
+    value="${line#*=}"
+    # Strip matching surrounding single or double quotes if present.
+    if [[ ${#value} -ge 2 ]]; then
+      local first="${value:0:1}"
+      local last="${value: -1}"
+      if { [[ "$first" == '"' && "$last" == '"' ]] || [[ "$first" == "'" && "$last" == "'" ]]; }; then
+        value="${value:1:-1}"
+      fi
+    fi
+    # Preserve anything already set by the caller / ws.
+    if [[ -z "${!key+x}" ]]; then
+      export "$key=$value"
+    fi
+  done < "$env_file"
+}
+load_worktree_env
+
 OFFSET="${PIERRE_PORT_OFFSET:-0}"
 SLUG="${PIERRE_WORKTREE_SLUG:-codex}"
 PORT=$((9222 + OFFSET))

--- a/scripts/load-worktree-env.d.mts
+++ b/scripts/load-worktree-env.d.mts
@@ -1,0 +1,2 @@
+export function findWorktreeEnv(startDir?: string): Record<string, string>;
+export function loadWorktreeEnv(startDir?: string): Record<string, string>;

--- a/scripts/load-worktree-env.mjs
+++ b/scripts/load-worktree-env.mjs
@@ -1,0 +1,82 @@
+// Shared `.env.worktree` loader for JS/TS runtimes (Next's config, Playwright
+// configs, anything else that runs in Node or Bun outside the `bun ws` call
+// chain).
+//
+// Why this file exists: `scripts/wt.ts` writes `.env.worktree` at the worktree
+// root with `PIERRE_WORKTREE_SLUG` / `PIERRE_PORT_OFFSET`. Neither Bun nor Next
+// nor Playwright auto-load a file with that non-standard name — only the
+// conventional `.env*` variants. `scripts/ws.ts` injects those vars when it is
+// in the call chain, but direct invocations (e.g. `bun run trees:dev` inside
+// `apps/docs`, or `bunx playwright test` inside a package) skip `ws` entirely.
+// This helper closes that gap by letting configs pull the file in themselves.
+//
+// The walk starts at `startDir` (defaults to `process.cwd()`) and stops at
+// either the first `.env.worktree` it finds or the nearest `.git` entry (the
+// worktree root), whichever comes first. Values already present in
+// `process.env` are *not* clobbered, so `ws`-injected vars still win.
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+// Parse an env file into a plain record. Supports `KEY=value`, `# comments`,
+// and optional surrounding single/double quotes on the value.
+/** @param {string} path */
+function parseEnvFile(path) {
+  /** @type {Record<string, string>} */
+  const out = {};
+  const text = readFileSync(path, 'utf8');
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if (
+      value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'")))
+    ) {
+      value = value.slice(1, -1);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+// Walk up from `startDir` looking for `.env.worktree`. Returns the parsed
+// contents, or an empty object if no file is found before hitting `.git` or
+// the filesystem root.
+/**
+ * @param {string} [startDir]
+ * @returns {Record<string, string>}
+ */
+export function findWorktreeEnv(startDir = process.cwd()) {
+  let dir = resolve(startDir);
+  while (true) {
+    const candidate = resolve(dir, '.env.worktree');
+    if (existsSync(candidate)) {
+      return parseEnvFile(candidate);
+    }
+    if (existsSync(resolve(dir, '.git'))) return {};
+    const parent = dirname(dir);
+    if (parent === dir) return {};
+    dir = parent;
+  }
+}
+
+// Load `.env.worktree` values into `process.env`. Existing keys win so that
+// anything `ws.ts` (or a caller) has already injected stays authoritative.
+/**
+ * @param {string} [startDir]
+ * @returns {Record<string, string>}
+ */
+export function loadWorktreeEnv(startDir = process.cwd()) {
+  const values = findWorktreeEnv(startDir);
+  for (const [key, value] of Object.entries(values)) {
+    if (process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+  return values;
+}

--- a/scripts/wt.ts
+++ b/scripts/wt.ts
@@ -25,7 +25,7 @@
 import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir, userInfo } from 'node:os';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 
 const WORKTREES_HOME = join(homedir(), 'pierre', 'pierre-worktrees');
 
@@ -164,18 +164,6 @@ async function cmdNew(rest: string[]): Promise<number> {
     `PIERRE_WORKTREE_SLUG=${slug}\nPIERRE_PORT_OFFSET=${offset}\n`,
     'utf8'
   );
-
-  // Belt-and-suspenders for direct `cd apps/docs && bun run trees:dev` runs:
-  // Next auto-loads .env.local so the title tag still picks up the slug even
-  // when ws.ts isn't in the call chain.
-  const appsDocsEnvLocal = join(worktreePath, 'apps', 'docs', '.env.local');
-  if (existsSync(dirname(appsDocsEnvLocal))) {
-    writeFileSync(
-      appsDocsEnvLocal,
-      `NEXT_PUBLIC_WORKTREE_SLUG=${slug}\n`,
-      'utf8'
-    );
-  }
 
   console.log(`\nInstalling dependencies in ${worktreePath}...`);
   const bunInstall = spawnSync('bun', ['install'], {


### PR DESCRIPTION
a little sad, but: 

  1. Only Next auto-loads .env.local from its own dir. Bun auto-loads from cwd, not a walked-up ancestor. Playwright doesn't
  auto-load env at all. Bash never does. So you still need the same walk-up loader for Playwright and chrome-remote-debug.sh —
   the complexity doesn't go away, it just shifts to a differently-named file.
  2. .env.local would multiply files. To reach every consumer you'd need apps/docs/.env.local,
  packages/trees/test/e2e/.env.local (doesn't actually help — Playwright ignores it), packages/path-store/..., plus something
  for the bash script. One .env.worktree at the worktree root is a single source of truth.
  3. Name collision with developer intent. .env.local is the conventional spot for personal API keys / secrets / overrides.
  The previous wt new implementation was overwriting apps/docs/.env.local wholesale every time — genuinely destructive if
  someone put a real secret there. .env.worktree is unambiguously worktree infrastructure.
  4. The bridge to NEXT_PUBLIC_* still needs code. Even if Next auto-loaded the file, you'd still want to expose the
  non-prefixed PIERRE_WORKTREE_SLUG to the client without duplicating it in the file — which means a next.config.mjs tweak
  anyway. Once you have that file loading .env.worktree, it's cheaper to do the whole load there.

  The one scenario where .env.local would be cleaner is if only Next needed the vars. We have at least three consumers, so the
   dedicated file + shared loader wins.