### PR TITLE
[trees] Docs: use Trees title and description instead of Diffs

### DIFF
--- a/apps/docs/app/trees/docs/page.tsx
+++ b/apps/docs/app/trees/docs/page.tsx
@@ -6,6 +6,7 @@ import { Fragment } from 'react';
 import { DocsLayout } from '../../docs/DocsLayout';
 import { HeadingAnchors } from '../../docs/HeadingAnchors';
 import { ProseWrapper } from '../../docs/ProseWrapper';
+import { TREES_DOCS_DESCRIPTION, TREES_TITLE } from '../metadata';
 import * as chooseYourIntegrationConstants from './Guides/ChooseYourIntegration/constants';
 import * as customizeIconsConstants from './Guides/CustomizeIcons/constants';
 import * as getStartedWithReactConstants from './Guides/GetStartedWithReact/constants';
@@ -100,9 +101,16 @@ const REFERENCE_SECTIONS: readonly DocsSection[] = [
 ];
 
 export const metadata: Metadata = {
-  title: 'Trees, from Pierre',
-  description:
-    'Guide-first documentation for @pierre/trees, covering React, vanilla, prepared input, styling, icons, Git status, large trees, and SSR hydration.',
+  title: TREES_TITLE,
+  description: TREES_DOCS_DESCRIPTION,
+  openGraph: {
+    title: TREES_TITLE,
+    description: TREES_DOCS_DESCRIPTION,
+  },
+  twitter: {
+    title: TREES_TITLE,
+    description: TREES_DOCS_DESCRIPTION,
+  },
 };
 
 export default function TreesDocsPage() {

--- a/apps/docs/app/trees/layout.tsx
+++ b/apps/docs/app/trees/layout.tsx
@@ -1,12 +1,22 @@
 import type { Metadata } from 'next';
 
-// Clear the root layout's `metadata.icons` so Next.js falls back to the
-// file-based conventions colocated with this segment (`icon.ico` and
-// `apple-icon.png` in `app/trees/`). Without this override, the explicit
-// `icons` object in the root layout takes precedence and the trees-specific
-// icons are dropped from the head.
+import { TREES_PRODUCT_DESCRIPTION, TREES_TITLE } from './metadata';
+
 export const metadata: Metadata = {
+  // Clear the root layout's `metadata.icons` so Next.js falls back to the
+  // file-based conventions colocated with this segment (`icon.ico` and
+  // `apple-icon.png` in `app/trees/`). Without this override, the explicit
+  // `icons` object in the root layout takes precedence and the trees-specific
+  // icons are dropped from the head.
   icons: null,
+  openGraph: {
+    title: TREES_TITLE,
+    description: TREES_PRODUCT_DESCRIPTION,
+  },
+  twitter: {
+    title: TREES_TITLE,
+    description: TREES_PRODUCT_DESCRIPTION,
+  },
 };
 
 export default function TreesLayout({

--- a/apps/docs/app/trees/metadata.ts
+++ b/apps/docs/app/trees/metadata.ts
@@ -1,0 +1,7 @@
+export const TREES_TITLE = 'Trees, from Pierre';
+
+export const TREES_PRODUCT_DESCRIPTION =
+  "@pierre/trees is an open source file tree rendering library. It's built for performance and flexibility, is super customizable, and comes packed with features.";
+
+export const TREES_DOCS_DESCRIPTION =
+  'Guide-first documentation for @pierre/trees, covering React, vanilla, prepared input, styling, icons, Git status, large trees, and SSR hydration.';

--- a/apps/docs/app/trees/page.tsx
+++ b/apps/docs/app/trees/page.tsx
@@ -22,6 +22,7 @@ import {
   TREE_NEW_GIT_STATUS_EXPANDED_PATHS,
   TREE_NEW_GIT_STATUSES,
 } from './gitStatusDemoData';
+import { TREES_PRODUCT_DESCRIPTION, TREES_TITLE } from './metadata';
 import Footer from '@/components/Footer';
 import { Header } from '@/components/Header';
 import { PierreCompanySection } from '@/components/PierreCompanySection';
@@ -29,9 +30,8 @@ import { PierreCompanySection } from '@/components/PierreCompanySection';
 const PRODUCT_ID: ProductId = 'trees';
 
 export const metadata: Metadata = {
-  title: 'Trees, from Pierre',
-  description:
-    "@pierre/trees is an open source file tree rendering library. It's built for performance and flexibility, is super customizable, and comes packed with features.",
+  title: TREES_TITLE,
+  description: TREES_PRODUCT_DESCRIPTION,
 };
 
 export default function TreesPage() {


### PR DESCRIPTION
### Description

This PR changes the Open Graph metadata for the "Trees, Pierre" website that is using the "Diffs, Pierre".

I absolutely don't know the codebase, so feel free to modify directly the PR/branch, or close the PR to redo something elsewhere, no problem at all :)

Based on the following URLs I've spotted, we'd need to modify the metadata for `og` (Open Graph) and `twitter`:
- https://trees.software/
- https://trees.software/docs

In order to avoid duplicate the strings, I've added a new file to store these strings, but maybe it's not how you deal with this in the reste of the codebase.

### Motivation & Context

@mdo shared with me https://trees.software/ in Discord:

<img width="449" height="367" alt="Screenshot 2026-04-21 at 21 45 11" src="https://github.com/user-attachments/assets/7e181b90-2479-42e6-a109-3edca380a4aa" />

As you can see the Open Graph title and description corresponds to "Diffs, Pierre" instead of "Trees, Pierre".

In https://trees.software/:
<img width="896" height="343" alt="Screenshot 2026-04-21 at 21 49 29" src="https://github.com/user-attachments/assets/c77ab793-b291-49cd-bfda-3b195f8a3ce0" />

In https://trees.software/docs:
<img width="892" height="347" alt="Screenshot 2026-04-21 at 21 49 40" src="https://github.com/user-attachments/assets/8c2950dd-16ac-4ba2-9fd6-c00f1262e43f" />


### Type of changes

- [x] Documentation update

### Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/pierrecomputer/pierre/blob/main/.github/CONTRIBUTING.md)
- ~My code follows the code style of the project (`bun run lint`)~
  - ⚠️ `bun run lint` was failing in the `main` branch already
- [x] My code is formatted properly (`bun run format`)
- [x] I have updated the documentation accordingly (if applicable)
- (N/A) I have added tests to cover my changes (if applicable)
- [x] All new and existing tests pass (`bun run diffs:test`)

### How was AI used in generating this PR

AI auto-completion was used in VS Code with GPT-5.3-Codex.