### PR TITLE
Redo density as a singular config option

### DIFF
--- a/apps/docs/app/trees/DemoDensity.tsx
+++ b/apps/docs/app/trees/DemoDensity.tsx
@@ -1,3 +1,4 @@
+import { FILE_TREE_DENSITY_PRESETS } from '@pierre/trees';
 import { preloadFileTree } from '@pierre/trees/ssr';
 
 import { sampleFileList } from './demo-data';
@@ -7,25 +8,31 @@ import { TREE_NEW_VIEWPORT_HEIGHTS } from './dimensions';
 const compactPreloadedData = preloadFileTree({
   flattenEmptyDirectories: true,
   id: 'trees-density-demo-compact',
-  itemHeight: 24,
+  density: 'compact',
   paths: sampleFileList,
-  initialVisibleRowCount: TREE_NEW_VIEWPORT_HEIGHTS.densityCompact / 24,
+  initialVisibleRowCount:
+    TREE_NEW_VIEWPORT_HEIGHTS.densityCompact /
+    FILE_TREE_DENSITY_PRESETS.compact.itemHeight,
 });
 
 const defaultPreloadedData = preloadFileTree({
   flattenEmptyDirectories: true,
   id: 'trees-density-demo-default',
-  itemHeight: 30,
+  density: 'default',
   paths: sampleFileList,
-  initialVisibleRowCount: TREE_NEW_VIEWPORT_HEIGHTS.densityDefault / 30,
+  initialVisibleRowCount:
+    TREE_NEW_VIEWPORT_HEIGHTS.densityDefault /
+    FILE_TREE_DENSITY_PRESETS.default.itemHeight,
 });
 
 const relaxedPreloadedData = preloadFileTree({
   flattenEmptyDirectories: true,
   id: 'trees-density-demo-relaxed',
-  itemHeight: 36,
+  density: 'relaxed',
   paths: sampleFileList,
-  initialVisibleRowCount: TREE_NEW_VIEWPORT_HEIGHTS.densityRelaxed / 36,
+  initialVisibleRowCount:
+    TREE_NEW_VIEWPORT_HEIGHTS.densityRelaxed /
+    FILE_TREE_DENSITY_PRESETS.relaxed.itemHeight,
 });
 
 export function DemoDensity() {

--- a/apps/docs/app/trees/DemoDensityClient.tsx
+++ b/apps/docs/app/trees/DemoDensityClient.tsx
@@ -1,12 +1,15 @@
 'use client';
 
 import {
+  FILE_TREE_DENSITY_PRESETS,
+  type FileTreeDensityKeyword,
+} from '@pierre/trees';
+import {
   FileTree,
   type FileTreePreloadedData,
   useFileTree,
 } from '@pierre/trees/react';
 import Link from 'next/link';
-import type { CSSProperties } from 'react';
 import { useEffect, useState } from 'react';
 
 import { TreeExampleHeading } from '../components/TreeExampleHeading';
@@ -22,56 +25,35 @@ const PRESELECTED_FILE = 'src/components/Button.tsx';
 
 const DENSITY_PRESETS = [
   {
-    density: 0.8,
-    description: '24px rows, density 0.8',
-    height: 24,
+    density: 'compact',
+    description: '24px rows, 0.8 spacing',
     id: 'trees-density-demo-compact',
-    key: 'compact',
     label: 'Compact',
     viewportHeight: TREE_NEW_VIEWPORT_HEIGHTS.densityCompact,
   },
   {
-    density: 1,
-    description: '30px rows, density 1',
-    height: 30,
+    density: 'default',
+    description: '30px rows, 1.0 spacing',
     id: 'trees-density-demo-default',
-    key: 'default',
     label: 'Default',
     viewportHeight: TREE_NEW_VIEWPORT_HEIGHTS.densityDefault,
   },
   {
-    density: 1.2,
-    description: '36px rows, density 1.2',
-    height: 36,
+    density: 'relaxed',
+    description: '36px rows, 1.2 spacing',
     id: 'trees-density-demo-relaxed',
-    key: 'relaxed',
     label: 'Relaxed',
     viewportHeight: TREE_NEW_VIEWPORT_HEIGHTS.densityRelaxed,
   },
 ] as const;
 
-function densityStyle(
-  density: number,
-  height: number,
-  viewportHeight: number
-): CSSProperties {
-  return {
-    colorScheme: 'dark',
-    height: `${String(viewportHeight)}px`,
-    ['--trees-density-override' as string]: density,
-    ['--trees-row-height-override' as string]: `${String(height)}px`,
-  };
-}
-
 function DensityTree({
   density,
-  itemHeight,
   id,
   preloadedData,
   viewportHeight,
 }: {
-  density: number;
-  itemHeight: number;
+  density: FileTreeDensityKeyword;
   id: string;
   preloadedData: FileTreePreloadedData;
   viewportHeight: number;
@@ -79,9 +61,10 @@ function DensityTree({
   const { model } = useFileTree({
     flattenEmptyDirectories: true,
     id,
-    itemHeight,
+    density,
     paths: sampleFileList,
-    initialVisibleRowCount: viewportHeight / itemHeight,
+    initialVisibleRowCount:
+      viewportHeight / FILE_TREE_DENSITY_PRESETS[density].itemHeight,
   });
 
   useEffect(() => {
@@ -94,7 +77,10 @@ function DensityTree({
       className={getDefaultFileTreePanelClass()}
       model={model}
       preloadedData={preloadedData}
-      style={densityStyle(density, itemHeight, viewportHeight)}
+      style={{
+        colorScheme: 'dark',
+        height: `${String(viewportHeight)}px`,
+      }}
     />
   );
 }
@@ -108,7 +94,9 @@ interface DemoDensityClientProps {
 }
 
 export function DemoDensityClient({ preloadedData }: DemoDensityClientProps) {
-  const [mobileView, setMobileView] = useState<string>(DENSITY_PRESETS[0].key);
+  const [mobileView, setMobileView] = useState<string>(
+    DENSITY_PRESETS[0].density
+  );
 
   return (
     <TreeExampleSection>
@@ -117,12 +105,12 @@ export function DemoDensityClient({ preloadedData }: DemoDensityClientProps) {
         title="Adjustable density"
         description={
           <>
-            Pair a row height with a density preset to tune the tree&apos;s
-            proportions. Use <code>--trees-row-height-override</code> for the
-            row size, <code>--trees-density-override</code> for spacing, and
-            keep <code>itemHeight</code> aligned with the chosen row height.
-            Density now scales spacing around the rows rather than height
-            itself. See the{' '}
+            Pass <code>density=&quot;compact&quot;</code>,{' '}
+            <code>&quot;default&quot;</code>, or{' '}
+            <code>&quot;relaxed&quot;</code> (or a custom numeric factor) to{' '}
+            <code>useFileTree</code> to tune the tree&apos;s proportions in one
+            place — the keyword resolves both the row height and the spacing
+            factor. See the{' '}
             <Link
               href={`${PRODUCTS.trees.docsPath}#styling-and-theming`}
               className="inline-link"
@@ -139,7 +127,7 @@ export function DemoDensityClient({ preloadedData }: DemoDensityClientProps) {
         onValueChange={setMobileView}
       >
         {DENSITY_PRESETS.map((preset) => (
-          <ButtonGroupItem key={preset.key} value={preset.key}>
+          <ButtonGroupItem key={preset.density} value={preset.density}>
             {preset.label}
           </ButtonGroupItem>
         ))}
@@ -149,7 +137,7 @@ export function DemoDensityClient({ preloadedData }: DemoDensityClientProps) {
           <div
             key={preset.id}
             className={
-              mobileView === preset.key ? undefined : 'hidden md:block'
+              mobileView === preset.density ? undefined : 'hidden md:block'
             }
           >
             <TreeExampleHeading description={preset.description}>
@@ -158,8 +146,7 @@ export function DemoDensityClient({ preloadedData }: DemoDensityClientProps) {
             <DensityTree
               density={preset.density}
               id={preset.id}
-              itemHeight={preset.height}
-              preloadedData={preloadedData[preset.key]}
+              preloadedData={preloadedData[preset.density]}
               viewportHeight={preset.viewportHeight}
             />
           </div>

--- a/apps/docs/app/trees/DemoTreeApp.tsx
+++ b/apps/docs/app/trees/DemoTreeApp.tsx
@@ -1,4 +1,5 @@
 import { preloadFile } from '@pierre/diffs/ssr';
+import { FILE_TREE_DENSITY_PRESETS } from '@pierre/trees';
 import { preloadFileTree } from '@pierre/trees/ssr';
 
 import { DemoTreeAppClient } from './DemoTreeAppClient';
@@ -13,7 +14,7 @@ import {
 } from './treeAppDemoData';
 
 const TREE_APP_DEMO_TREE_ID = 'tree-app-hero-demo';
-const TREE_APP_DEMO_ITEM_HEIGHT = 24;
+const TREE_APP_DEMO_DENSITY = 'compact' as const;
 
 const TREE_APP_DARK_FILE_OPTIONS = {
   disableFileHeader: true,
@@ -38,12 +39,13 @@ export async function DemoTreeApp() {
     id: TREE_APP_DEMO_TREE_ID,
     initialExpandedPaths: TREE_APP_DEMO_INITIAL_EXPANDED_PATHS,
     initialSelectedPaths: [TREE_APP_DEMO_INITIAL_ACTIVE_PATH],
-    itemHeight: TREE_APP_DEMO_ITEM_HEIGHT,
+    density: TREE_APP_DEMO_DENSITY,
     paths: TREE_APP_DEMO_PATHS,
     search: true,
     unsafeCSS: TREE_APP_DEMO_UNSAFE_CSS,
     initialVisibleRowCount:
-      TREE_NEW_VIEWPORT_HEIGHTS.treeApp / TREE_APP_DEMO_ITEM_HEIGHT,
+      TREE_NEW_VIEWPORT_HEIGHTS.treeApp /
+      FILE_TREE_DENSITY_PRESETS[TREE_APP_DEMO_DENSITY].itemHeight,
   });
 
   // Preload syntax-highlighted HTML for every demo file in parallel, under

--- a/apps/docs/app/trees/DemoTreeAppClient.tsx
+++ b/apps/docs/app/trees/DemoTreeAppClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { FileContents } from '@pierre/diffs';
+import { FILE_TREE_DENSITY_PRESETS } from '@pierre/trees';
 import type { FileTreePreloadedData } from '@pierre/trees/react';
 import { useFileTree } from '@pierre/trees/react';
 import type { CSSProperties } from 'react';
@@ -15,23 +16,19 @@ import { TreeApp } from '@/components/TreeApp';
 import type { TreeAppTheme } from '@/components/TreeApp';
 import type { GitStatusEntry } from '@/lib/treesCompat';
 
-const COMPACT_ITEM_HEIGHT = 24;
-const COMPACT_DENSITY = 0.8;
+const COMPACT_DENSITY = 'compact' as const;
 
 const darkTreePanelStyle = {
   colorScheme: 'dark',
   '--trees-search-bg-override': '#1f2631',
-  '--trees-density-override': COMPACT_DENSITY,
-  '--trees-row-height-override': `${String(COMPACT_ITEM_HEIGHT)}px`,
 } as CSSProperties;
 
 // Light variant drops the dark-specific search background override so the
 // trees stylesheet's `light-dark()` defaults can kick in for the rest of the
-// panel. Density/row-height stay the same since they're visual, not chromatic.
+// panel. Density (row height + spacing factor) lives on the model via the
+// `density` option, so it stays consistent across both themes.
 const lightTreePanelStyle = {
   colorScheme: 'light',
-  '--trees-density-override': COMPACT_DENSITY,
-  '--trees-row-height-override': `${String(COMPACT_ITEM_HEIGHT)}px`,
 } as CSSProperties;
 
 const treeStyleByTheme = {
@@ -233,13 +230,14 @@ export function DemoTreeAppClient({
       id: treeId,
       initialExpandedPaths,
       initialSelectedPaths: [initialActivePath],
-      itemHeight: COMPACT_ITEM_HEIGHT,
+      density: COMPACT_DENSITY,
       paths,
       renaming: true as const,
       search: true as const,
       unsafeCSS: TREE_APP_DEMO_UNSAFE_CSS,
       initialVisibleRowCount:
-        TREE_NEW_VIEWPORT_HEIGHTS.treeApp / COMPACT_ITEM_HEIGHT,
+        TREE_NEW_VIEWPORT_HEIGHTS.treeApp /
+        FILE_TREE_DENSITY_PRESETS[COMPACT_DENSITY].itemHeight,
     }),
     [initialActivePath, initialExpandedPaths, paths, treeId]
   );

--- a/apps/docs/app/trees/docs/Guides/HandleLargeTreesEfficiently/content.mdx
+++ b/apps/docs/app/trees/docs/Guides/HandleLargeTreesEfficiently/content.mdx
@@ -37,7 +37,10 @@ The main rendering knobs are:
   layout
 - `initialVisibleRowCount`, when you want to budget SSR or first-render work
   before measurement
-- `itemHeight`, when your design changes row density enough to matter
+- `density`, when your design changes row density enough to matter — pass
+  `'compact' | 'default' | 'relaxed'` (or a custom numeric factor) to resolve
+  both the row height and the surrounding spacing in one place. Use `itemHeight`
+  only when you need a row height that doesn't match a preset.
 - `overscan`, when you need to trade a little extra work for smoother scrolling
 
 <DocsCodeExample {...LARGE_TREES_VIRTUALIZATION_KNOBS} />

--- a/apps/docs/app/trees/docs/Guides/StyleAndThemeTheTree/content.mdx
+++ b/apps/docs/app/trees/docs/Guides/StyleAndThemeTheTree/content.mdx
@@ -46,6 +46,20 @@ variables the tree already understands.
 That gives you matching panel colors, selection colors, search-field colors, and
 Git-status colors without rebuilding the theme system by hand.
 
+#### Set density with `density`
+
+Pass `density` to `useFileTree` (or `preloadFileTree`) to bundle row height and
+spacing into one option. The keyword form (`'compact'`, `'default'`,
+`'relaxed'`) resolves both at once; a numeric form keeps the default row height
+and supplies a custom spacing factor. The React `<FileTree>` wrapper then paints
+`--trees-item-height` and `--trees-density-override` onto the host so the
+virtualized and painted row heights stay aligned. Set `itemHeight` only when you
+need a row height that doesn't match a preset.
+
+The keyword presets are exported as `FILE_TREE_DENSITY_PRESETS` so SSR helpers
+like `initialVisibleRowCount` can divide by the preset's row height without
+hard-coding it.
+
 #### Choose the right styling layer
 
 Use:

--- a/apps/docs/app/trees/docs/Reference/SharedConcepts/content.mdx
+++ b/apps/docs/app/trees/docs/Reference/SharedConcepts/content.mdx
@@ -58,7 +58,8 @@ runtimes.
 | `gitStatus`               | Built-in Git-style row signals.                                      | Added, modified, deleted, ignored, renamed, and untracked states.            |
 | `icons`                   | Built-in icon set or icon configuration object.                      | Set selection, color mode, remaps, or sprite-sheet extension.                |
 | `renderRowDecoration`     | Custom non-Git row signal renderer.                                  | Generated-file badges, remote markers, validation hints.                     |
-| `itemHeight`              | Row-height hint for the virtualized view.                            | Custom density.                                                              |
+| `density`                 | Density preset or custom spacing factor.                             | Tune row height and spacing in one place.                                    |
+| `itemHeight`              | Explicit row-height override.                                        | Row height that doesn't match a `density` preset.                            |
 | `overscan`                | Extra rows rendered outside the visible window.                      | Smooth scrolling tradeoffs.                                                  |
 | `initialVisibleRowCount`  | Optional first-render row budget before the browser measures height. | Tune SSR and hydration work without pinning steady-state size.               |
 | `unsafeCSS`               | Advanced CSS injection into the tree shadow root.                    | Narrow escape hatch when supported styling surfaces are not enough.          |
@@ -133,9 +134,16 @@ For deeper lookup, jump to [Styling and theming](#styling-and-theming) and
 
 #### Scale and rendering settings
 
-`initialVisibleRowCount`, `itemHeight`, and `overscan` are rendering knobs, not
-onboarding concepts. The rendered container sets steady-state height; these
-options only tune the first-render budget and the virtualized row window.
+`initialVisibleRowCount`, `density`, `itemHeight`, and `overscan` are rendering
+knobs, not onboarding concepts. The rendered container sets steady-state height;
+these options only tune the first-render budget, visual density, and the
+virtualized row window.
+
+For density, prefer the `density` keyword (`'compact' | 'default' | 'relaxed'`)
+or a numeric factor — it resolves both row height and spacing in one place, and
+the React `<FileTree>` wrapper paints `--trees-item-height` and
+`--trees-density-override` for you. Reach for `itemHeight` only when you need a
+row height that doesn't match a preset.
 
 Use [Handle large trees efficiently](#handle-large-trees-efficiently) when scale
 becomes the real problem.

--- a/packages/trees/src/index.ts
+++ b/packages/trees/src/index.ts
@@ -20,6 +20,12 @@ export {
 } from './preparedInput';
 export { FILE_TREE_DEFAULT_ITEM_HEIGHT } from './model/virtualization';
 export {
+  FILE_TREE_DENSITY_PRESETS,
+  type FileTreeDensity,
+  type FileTreeDensityKeyword,
+  type FileTreeDensityPreset,
+} from './model/density';
+export {
   FileTree,
   preloadFileTree,
   serializeFileTreeSsrPayload,

--- a/packages/trees/src/model/density.ts
+++ b/packages/trees/src/model/density.ts
@@ -1,0 +1,40 @@
+export type FileTreeDensityKeyword = 'compact' | 'default' | 'relaxed';
+
+export type FileTreeDensity = FileTreeDensityKeyword | number;
+
+export interface FileTreeDensityPreset {
+  itemHeight: number;
+  factor: number;
+}
+
+export const FILE_TREE_DENSITY_PRESETS: Record<
+  FileTreeDensityKeyword,
+  FileTreeDensityPreset
+> = {
+  compact: { itemHeight: 24, factor: 0.8 },
+  default: { itemHeight: 30, factor: 1 },
+  relaxed: { itemHeight: 36, factor: 1.2 },
+};
+
+// Collapses the public density option (keyword preset or numeric factor) plus
+// an optional explicit itemHeight into the concrete row height + spacing
+// factor used by the model and the React wrapper. An explicit itemHeight
+// always wins for the row size; numeric density keeps the default row height.
+export function resolveFileTreeDensity(
+  density: FileTreeDensity | undefined,
+  explicitItemHeight: number | undefined
+): FileTreeDensityPreset {
+  if (typeof density === 'number') {
+    return {
+      itemHeight:
+        explicitItemHeight ?? FILE_TREE_DENSITY_PRESETS.default.itemHeight,
+      factor: density,
+    };
+  }
+
+  const preset = FILE_TREE_DENSITY_PRESETS[density ?? 'default'];
+  return {
+    itemHeight: explicitItemHeight ?? preset.itemHeight,
+    factor: preset.factor,
+  };
+}

--- a/packages/trees/src/model/types.ts
+++ b/packages/trees/src/model/types.ts
@@ -5,6 +5,7 @@ import type {
   GitStatus,
   GitStatusEntry,
 } from '../types';
+import type { FileTreeDensity } from './density';
 
 /**
  * The provisional public identity stays path-first so later phases can evolve
@@ -225,6 +226,7 @@ export interface FileTreeRenamingConfig {
 
 type FileTreeOptionSurface = FileTreeRenderOptions & {
   composition?: FileTreeCompositionOptions;
+  density?: FileTreeDensity;
   gitStatus?: readonly GitStatusEntry[];
   id?: string;
   icons?: FileTreeIcons;

--- a/packages/trees/src/model/virtualization.ts
+++ b/packages/trees/src/model/virtualization.ts
@@ -1,10 +1,12 @@
+import { FILE_TREE_DENSITY_PRESETS } from './density';
 import type {
   FileTreeRange,
   FileTreeStickyWindowLayout,
   FileTreeViewportMetrics,
 } from './types';
 
-export const FILE_TREE_DEFAULT_ITEM_HEIGHT = 30;
+export const FILE_TREE_DEFAULT_ITEM_HEIGHT =
+  FILE_TREE_DENSITY_PRESETS.default.itemHeight;
 export const FILE_TREE_DEFAULT_OVERSCAN = 10;
 export const FILE_TREE_DEFAULT_VIEWPORT_HEIGHT = 420;
 export const EMPTY_RANGE: FileTreeRange = { start: 0, end: -1 };

--- a/packages/trees/src/react/FileTree.tsx
+++ b/packages/trees/src/react/FileTree.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource react */
 'use client';
 
-import type { HTMLAttributes, ReactNode } from 'react';
+import type { CSSProperties, HTMLAttributes, ReactNode } from 'react';
 import {
   useCallback,
   useEffect,
@@ -250,11 +250,21 @@ export function FileTree({
   );
   const resolvedHostId = id ?? preloadedData?.id;
 
+  // Paint the model's resolved density onto the host so callers don't have to
+  // set `--trees-item-height` and `--trees-density-override` themselves.
+  // Caller-provided `style` keys still win via spread order.
+  const mergedStyle: CSSProperties = {
+    ['--trees-item-height' as string]: `${String(model.getItemHeight())}px`,
+    ['--trees-density-override' as string]: model.getDensityFactor(),
+    ...hostProps.style,
+  };
+
   return (
     <FILE_TREE_TAG_NAME
       {...hostProps}
       id={resolvedHostId}
       ref={handleHostRef}
+      style={mergedStyle}
       suppressHydrationWarning={preloadedData != null}
     >
       {children}

--- a/packages/trees/src/render/FileTree.ts
+++ b/packages/trees/src/render/FileTree.ts
@@ -16,6 +16,10 @@ import {
   HEADER_SLOT_NAME,
 } from '../constants';
 import { normalizeFileTreeIcons } from '../iconConfig';
+import {
+  type FileTreeDensityPreset,
+  resolveFileTreeDensity,
+} from '../model/density';
 import { FileTreeController } from '../model/FileTreeController';
 import {
   type FileTreeGitStatusState,
@@ -172,6 +176,7 @@ export class FileTree
   readonly #searchEnabled: boolean;
   readonly #searchFakeFocus: boolean;
   readonly #slotHost = new FileTreeManagedSlotHost();
+  readonly #density: FileTreeDensityPreset;
   readonly #viewOptions: Pick<
     FileTreeOptions,
     'initialVisibleRowCount' | 'itemHeight' | 'overscan' | 'stickyFolders'
@@ -189,6 +194,7 @@ export class FileTree
   public constructor(options: FileTreeOptions) {
     const {
       composition,
+      density,
       fileTreeSearchMode,
       gitStatus,
       id,
@@ -219,8 +225,9 @@ export class FileTree
     this.#searchBlurBehavior = searchBlurBehavior;
     this.#searchEnabled = search === true;
     this.#searchFakeFocus = searchFakeFocus === true;
+    this.#density = resolveFileTreeDensity(density, itemHeight);
     this.#viewOptions = {
-      itemHeight,
+      itemHeight: this.#density.itemHeight,
       overscan,
       stickyFolders,
       initialVisibleRowCount,
@@ -285,6 +292,14 @@ export class FileTree
 
   public getComposition(): FileTreeCompositionOptions | undefined {
     return this.#composition;
+  }
+
+  public getItemHeight(): number {
+    return this.#density.itemHeight;
+  }
+
+  public getDensityFactor(): number {
+    return this.#density.factor;
   }
 
   public subscribe(listener: FileTreeListener): () => void {
@@ -705,6 +720,7 @@ export class FileTree
 export function preloadFileTree(options: FileTreeOptions): FileTreeSsrPayload {
   const {
     composition,
+    density,
     fileTreeSearchMode,
     gitStatus,
     id,
@@ -724,6 +740,8 @@ export function preloadFileTree(options: FileTreeOptions): FileTreeSsrPayload {
     initialVisibleRowCount,
     ...controllerOptions
   } = options;
+  const resolvedDensity = resolveFileTreeDensity(density, itemHeight);
+  const resolvedItemHeight = resolvedDensity.itemHeight;
   const resolvedId = createServerId(id);
   const controller = new FileTreeController({
     ...controllerOptions,
@@ -734,7 +752,7 @@ export function preloadFileTree(options: FileTreeOptions): FileTreeSsrPayload {
   const gitStatusState = resolveFileTreeGitStatusState(gitStatus);
   const initialViewportHeight = resolveInitialViewportHeight({
     initialVisibleRowCount,
-    itemHeight,
+    itemHeight: resolvedItemHeight,
   });
   const normalizedIcons = normalizeFileTreeIcons(icons);
   const customSpriteSheet = normalizedIcons.spriteSheet?.trim() ?? '';
@@ -759,7 +777,7 @@ export function preloadFileTree(options: FileTreeOptions): FileTreeSsrPayload {
       directoriesWithGitChanges: gitStatusState?.directoriesWithChanges,
       icons,
       instanceId: resolvedId,
-      itemHeight,
+      itemHeight: resolvedItemHeight,
       overscan,
       renamingEnabled: renaming != null && renaming !== false,
       renderRowDecoration,

--- a/packages/trees/src/render/FileTree.ts
+++ b/packages/trees/src/render/FileTree.ts
@@ -119,15 +119,21 @@ function getHeaderSlotHtml(
   return `<div slot="${HEADER_SLOT_NAME}" data-file-tree-managed-slot="${HEADER_SLOT_NAME}">${headerHtml}</div>`;
 }
 
+// Builds the host element opening markup. The optional `hostStyle` string is
+// emitted as an inline `style="..."` so vanilla SSR consumers (who serialize
+// the payload directly) get the resolved density variables on first paint
+// without needing the React wrapper to paint them.
 function getFileTreeOuterStart(
   id: string,
-  mode: 'declarative' | 'dom'
+  mode: 'declarative' | 'dom',
+  hostStyle: string
 ): string {
   const templateAttr =
     mode === 'declarative'
       ? 'shadowrootmode="open"'
       : 'data-file-tree-shadowrootmode="open"';
-  return `<file-tree-container id="${id}" data-file-tree-virtualized="true"><template ${templateAttr}>`;
+  const styleAttr = hostStyle.length === 0 ? '' : ` style="${hostStyle}"`;
+  return `<file-tree-container id="${id}" data-file-tree-virtualized="true"${styleAttr}><template ${templateAttr}>`;
 }
 
 function getFileTreeOuterEnd(headerSlotHtml: string): string {
@@ -792,8 +798,17 @@ export function preloadFileTree(options: FileTreeOptions): FileTreeSsrPayload {
 
   const shadowHtml = `${getBuiltInSpriteSheet(normalizedIcons.set)}${customSpriteSheet}<style ${FILE_TREE_STYLE_ATTRIBUTE}>${wrappedCoreCss}</style>${unsafeCssStyle}<div data-file-tree-id="${resolvedId}" data-file-tree-virtualized-wrapper="true"${coloredIconsAttr}>${bodyHtml}</div>`;
   const headerSlotHtml = getHeaderSlotHtml(composition);
-  const outerStart = getFileTreeOuterStart(resolvedId, 'declarative');
-  const domOuterStart = getFileTreeOuterStart(resolvedId, 'dom');
+  // Inline the resolved density on the host so vanilla SSR consumers get the
+  // same first paint as the React wrapper, where the model paints these vars
+  // for them. The two paths must agree because the SSR shadow body was laid
+  // out using the same resolved itemHeight.
+  const hostStyle = `--trees-item-height:${String(resolvedItemHeight)}px;--trees-density-override:${String(resolvedDensity.factor)}`;
+  const outerStart = getFileTreeOuterStart(
+    resolvedId,
+    'declarative',
+    hostStyle
+  );
+  const domOuterStart = getFileTreeOuterStart(resolvedId, 'dom', hostStyle);
   const outerEnd = getFileTreeOuterEnd(headerSlotHtml);
   return {
     domOuterStart,

--- a/packages/trees/src/style.css
+++ b/packages/trees/src/style.css
@@ -102,9 +102,8 @@
 
       // Density
       //
-      // A unitless scale factor that drives padding, gaps, indentation, and
-      // related spacing. Use --trees-row-height-override to customize row
-      // height separately. Individual layout overrides still take precedence.
+      // A unitless scale factor for padding, gaps, and indentation. Usually
+      // set via `density` on useFileTree. Individual overrides take precedence.
       //
       //   Compact: 0.8
       //   Default: 1
@@ -119,7 +118,6 @@
       --trees-font-size-override
       --trees-font-weight-regular-override
       --trees-font-weight-semibold-override
-      --trees-row-height-override
       --trees-level-gap-override
       --trees-item-padding-x-override
       --trees-item-margin-x-override
@@ -527,7 +525,7 @@
       --trees-icon-nudge-override,
       calc(1px * var(--trees-density))
     );
-    --trees-row-height: var(--trees-row-height-override, 30px);
+    --trees-row-height: var(--trees-item-height, 30px);
     --trees-git-lane-width: var(--trees-git-lane-width-override, 12px);
     --trees-action-lane-width: var(
       --trees-action-lane-width-override,

--- a/packages/trees/test/file-tree-density.test.ts
+++ b/packages/trees/test/file-tree-density.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  FILE_TREE_DENSITY_PRESETS,
+  resolveFileTreeDensity,
+} from '../src/model/density';
+import { FILE_TREE_DEFAULT_ITEM_HEIGHT } from '../src/model/virtualization';
+
+describe('resolveFileTreeDensity', () => {
+  test('returns the default preset when density is undefined', () => {
+    expect(resolveFileTreeDensity(undefined, undefined)).toEqual({
+      itemHeight: FILE_TREE_DENSITY_PRESETS.default.itemHeight,
+      factor: FILE_TREE_DENSITY_PRESETS.default.factor,
+    });
+  });
+
+  test('resolves keyword presets', () => {
+    expect(resolveFileTreeDensity('compact', undefined)).toEqual({
+      itemHeight: FILE_TREE_DENSITY_PRESETS.compact.itemHeight,
+      factor: FILE_TREE_DENSITY_PRESETS.compact.factor,
+    });
+    expect(resolveFileTreeDensity('relaxed', undefined)).toEqual({
+      itemHeight: FILE_TREE_DENSITY_PRESETS.relaxed.itemHeight,
+      factor: FILE_TREE_DENSITY_PRESETS.relaxed.factor,
+    });
+  });
+
+  test('explicit itemHeight overrides the preset row height but not the factor', () => {
+    expect(resolveFileTreeDensity('compact', 28)).toEqual({
+      itemHeight: 28,
+      factor: FILE_TREE_DENSITY_PRESETS.compact.factor,
+    });
+  });
+
+  test('numeric density keeps the default row height by default', () => {
+    expect(resolveFileTreeDensity(0.85, undefined)).toEqual({
+      itemHeight: FILE_TREE_DENSITY_PRESETS.default.itemHeight,
+      factor: 0.85,
+    });
+  });
+
+  test('numeric density still honors an explicit itemHeight', () => {
+    expect(resolveFileTreeDensity(1.5, 40)).toEqual({
+      itemHeight: 40,
+      factor: 1.5,
+    });
+  });
+
+  test('FILE_TREE_DEFAULT_ITEM_HEIGHT is sourced from the default preset', () => {
+    expect(FILE_TREE_DEFAULT_ITEM_HEIGHT).toBe(
+      FILE_TREE_DENSITY_PRESETS.default.itemHeight
+    );
+  });
+});

--- a/packages/trees/test/file-tree-density.test.ts
+++ b/packages/trees/test/file-tree-density.test.ts
@@ -5,6 +5,8 @@ import {
   resolveFileTreeDensity,
 } from '../src/model/density';
 import { FILE_TREE_DEFAULT_ITEM_HEIGHT } from '../src/model/virtualization';
+import { preloadFileTree } from '../src/render/FileTree';
+import { serializeFileTreeSsrPayload } from '../src/ssr';
 
 describe('resolveFileTreeDensity', () => {
   test('returns the default preset when density is undefined', () => {
@@ -49,6 +51,51 @@ describe('resolveFileTreeDensity', () => {
   test('FILE_TREE_DEFAULT_ITEM_HEIGHT is sourced from the default preset', () => {
     expect(FILE_TREE_DEFAULT_ITEM_HEIGHT).toBe(
       FILE_TREE_DENSITY_PRESETS.default.itemHeight
+    );
+  });
+});
+
+describe('preloadFileTree density host style', () => {
+  test('keyword density is inlined on the SSR host element', () => {
+    const payload = preloadFileTree({
+      density: 'compact',
+      paths: ['README.md'],
+    });
+
+    const compact = FILE_TREE_DENSITY_PRESETS.compact;
+    const expectedStyle = `style="--trees-item-height:${String(compact.itemHeight)}px;--trees-density-override:${String(compact.factor)}"`;
+
+    expect(payload.outerStart).toContain(expectedStyle);
+    expect(payload.domOuterStart).toContain(expectedStyle);
+
+    const declarativeHtml = serializeFileTreeSsrPayload(payload);
+    const domHtml = serializeFileTreeSsrPayload(payload, 'dom');
+    expect(declarativeHtml).toContain(expectedStyle);
+    expect(domHtml).toContain(expectedStyle);
+  });
+
+  test('numeric density keeps the default row height and inlines the factor', () => {
+    const payload = preloadFileTree({
+      density: 0.75,
+      paths: ['README.md'],
+    });
+
+    const expectedStyle = `style="--trees-item-height:${String(FILE_TREE_DENSITY_PRESETS.default.itemHeight)}px;--trees-density-override:0.75"`;
+
+    expect(payload.outerStart).toContain(expectedStyle);
+    expect(payload.domOuterStart).toContain(expectedStyle);
+  });
+
+  test('explicit itemHeight overrides the preset row height in the host style', () => {
+    const payload = preloadFileTree({
+      density: 'relaxed',
+      itemHeight: 44,
+      paths: ['README.md'],
+    });
+
+    const relaxed = FILE_TREE_DENSITY_PRESETS.relaxed;
+    expect(payload.outerStart).toContain(
+      `style="--trees-item-height:44px;--trees-density-override:${String(relaxed.factor)}"`
     );
   });
 });


### PR DESCRIPTION
Instead of a mix of CSS variables and `itemHeight`, builds out the system to expect one of three keywords and infer those values. Also provide options to expand the density options for users who need more control.