### PR TITLE
[trees] Post-1.0.0 feature additions perf pass -24.2% on linux-10x

### DIFF
--- a/packages/path-store/package.json
+++ b/packages/path-store/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "benchmark": "bun run ./scripts/benchmark.ts",
     "benchmark:visible-tree-projection": "bun run ./scripts/benchmarkVisibleTreeProjection.ts",
-    "build:demo": "bun run vite build demo",
-    "dev:demo": "bun run vite demo --host 127.0.0.1 --port 4175",
+    "build": "bun run vite build demo",
+    "dev:demo": "PORT=$((${PIERRE_PORT_OFFSET:-0} + 4175)) && bash ../../scripts/run-dev.sh \"$PORT\" -- bun run vite demo --host 127.0.0.1 --port \"$PORT\"",
     "profile:demo": "bun run ./scripts/profileDemo.ts",
     "profile:visible-tree-projection": "bun run ./scripts/profileVisibleTreeProjection.ts",
     "test": "bun test",

--- a/packages/path-store/scripts/profileDemo.ts
+++ b/packages/path-store/scripts/profileDemo.ts
@@ -4,6 +4,8 @@ import { tmpdir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { loadWorktreeEnv } from '../../../scripts/load-worktree-env.mjs';
+
 interface ProfileConfig {
   browserUrl: string;
   instrumentationMode: 'on' | 'off';
@@ -258,9 +260,21 @@ interface ProfileBenchmarkOutput {
   scenarios: ProfileScenarioOutput[];
 }
 
+// Mirror the Playwright config behavior so direct profiling runs pick up the
+// same worktree port offset as `bun ws` and `bun run chrome`.
+loadWorktreeEnv();
+
+function readWorktreePortOffset(): number {
+  const parsed = Number(process.env.PIERRE_PORT_OFFSET ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+const WORKTREE_PORT_OFFSET = readWorktreePortOffset();
+const DEFAULT_BROWSER_DEBUG_PORT = 9222 + WORKTREE_PORT_OFFSET;
+const DEFAULT_DEMO_SERVER_PORT = 4175 + WORKTREE_PORT_OFFSET;
 const packageRoot = fileURLToPath(new URL('../', import.meta.url));
-const DEFAULT_BROWSER_URL = 'http://127.0.0.1:9222';
-const DEFAULT_URL = 'http://127.0.0.1:4175/';
+const DEFAULT_BROWSER_URL = `http://127.0.0.1:${DEFAULT_BROWSER_DEBUG_PORT}`;
+const DEFAULT_URL = `http://127.0.0.1:${DEFAULT_DEMO_SERVER_PORT}/`;
 const DEFAULT_WORKLOAD_NAME = 'linux-5x';
 const DEFAULT_ACTION_ID = 'render';
 const DEFAULT_INSTRUMENTATION_MODE = 'on';
@@ -2635,7 +2649,7 @@ async function main(): Promise<void> {
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(
-      `${message}\n\nRun Chrome with remote debugging first, for example:\n/Applications/Google\\ Chrome\\ Dev.app/Contents/MacOS/Google\\ Chrome\\ Dev --remote-debugging-port=9222 --user-data-dir=/tmp/chrome-devtools-codex`
+      `${message}\n\nRun Chrome with remote debugging first, for example:\n/Applications/Google\\ Chrome\\ Dev.app/Contents/MacOS/Google\\ Chrome\\ Dev --remote-debugging-port=${DEFAULT_BROWSER_DEBUG_PORT} --user-data-dir=/tmp/chrome-devtools-codex`
     );
   } finally {
     serverProcess?.kill();

--- a/packages/path-store/src/builder.ts
+++ b/packages/path-store/src/builder.ts
@@ -4,6 +4,13 @@ import {
   createPresortedDirectoryChildIndex,
 } from './child-index';
 import { rebuildDirectoryChildAggregates } from './child-index';
+import {
+  addNodeFlag,
+  createNodeDepthAndFlags,
+  getNodeDepth,
+  hasNodeFlag,
+  isDirectoryNode,
+} from './internal-types';
 import type {
   DirectoryChildIndex,
   InternalPreparedInput,
@@ -14,10 +21,41 @@ import type {
   ResolvedPathStoreOptions,
   SegmentSortKey,
 } from './internal-types';
+
+interface PathStoreBuilderStartupHints {
+  initialExpandedPaths?: readonly string[];
+}
+
+// Options passed to PathStoreBuilder.finish(). Callers that run their own
+// per-node count computation afterwards (PathStore constructor always runs
+// either initializeOpenVisibleCounts or recomputeCountsRecursive) can set
+// skipSubtreeCountPass to avoid buildPresortedFinish's backward accumulation
+// pass. Callers that read subtreeNodeCount directly from the returned
+// snapshot (for example, static-store) must leave skipSubtreeCountPass
+// unset or false.
+export interface BuilderFinishOptions {
+  skipSubtreeCountPass?: boolean;
+}
+
+type PreparedInputKind = 'prepared' | 'presorted';
+
+const PREPARED_INPUT_KIND = Symbol('pathStorePreparedInputKind');
+
+type ValidatedPreparedInput = InternalPreparedInput & {
+  [PREPARED_INPUT_KIND]?: PreparedInputKind;
+};
+
+function attachPreparedInputKind<TValue extends InternalPreparedInput>(
+  value: TValue,
+  kind: PreparedInputKind
+): TValue {
+  (value as ValidatedPreparedInput)[PREPARED_INPUT_KIND] = kind;
+  return value;
+}
+
 import { PATH_STORE_NODE_FLAG_EXPLICIT } from './internal-types';
 import { PATH_STORE_NODE_FLAG_ROOT } from './internal-types';
 import { PATH_STORE_NODE_KIND_DIRECTORY } from './internal-types';
-import { PATH_STORE_NODE_KIND_FILE } from './internal-types';
 import {
   getBenchmarkInstrumentation,
   setBenchmarkCounter,
@@ -62,14 +100,13 @@ function compareWithSortOption(
 
 function createRootNode(): PathStoreNode {
   return {
-    depth: 0,
-    flags: PATH_STORE_NODE_FLAG_EXPLICIT | PATH_STORE_NODE_FLAG_ROOT,
-    id: 0,
-    kind: PATH_STORE_NODE_KIND_DIRECTORY,
+    depthAndFlags: createNodeDepthAndFlags(
+      0,
+      PATH_STORE_NODE_FLAG_EXPLICIT | PATH_STORE_NODE_FLAG_ROOT,
+      PATH_STORE_NODE_KIND_DIRECTORY
+    ),
     nameId: 0,
     parentId: 0,
-    pathCache: '',
-    pathCacheVersion: 0,
     subtreeNodeCount: 1,
     visibleSubtreeCount: 1,
   };
@@ -128,30 +165,58 @@ export function prepareInput(
   options: PathStoreOptions = {}
 ): InternalPreparedInput {
   const preparedPaths = preparePathEntries(paths, options);
-  return {
-    paths: preparedPaths.map((entry) => entry.path),
-    preparedPaths,
-  };
+  return attachPreparedInputKind(
+    {
+      paths: preparedPaths.map((entry) => entry.path),
+      preparedPaths,
+    },
+    'prepared'
+  );
 }
 
 export function preparePresortedInput(
   paths: readonly string[]
 ): InternalPreparedInput {
-  const presortedPaths = [...paths];
-  return {
-    paths: presortedPaths,
-    presortedPaths,
-    presortedPathsContainDirectories: presortedPaths.some((path) =>
-      path.endsWith('/')
-    ),
-  };
+  // Skip the defensive copy: the input is `readonly string[]`, internal
+  // consumers (builder.appendPresortedPaths / appendPresortedFilePaths) only
+  // iterate it, and we brand the returned prepared input so it cannot be
+  // round-tripped through a mutating caller without going back through
+  // PathStore.prepareInput. On 929K-path workloads the copy alone costs
+  // several milliseconds that page.createOptions cannot afford.
+  const pathCount = paths.length;
+  let presortedPathsContainDirectories = false;
+
+  for (let index = 0; index < pathCount; index += 1) {
+    const path = paths[index];
+    if (path.length > 0 && path.charCodeAt(path.length - 1) === 47) {
+      presortedPathsContainDirectories = true;
+      break;
+    }
+  }
+
+  return attachPreparedInputKind(
+    {
+      paths,
+      presortedPaths: paths,
+      presortedPathsContainDirectories,
+    },
+    'presorted'
+  );
 }
 
 export function getPreparedInputEntries(
   preparedInput: import('./public-types').PathStorePreparedInput
 ): readonly PreparedPath[] {
-  const internalPreparedInput = preparedInput as Partial<InternalPreparedInput>;
+  const internalPreparedInput =
+    preparedInput as Partial<ValidatedPreparedInput>;
   const preparedPaths = internalPreparedInput.preparedPaths;
+  if (
+    internalPreparedInput[PREPARED_INPUT_KIND] === 'prepared' &&
+    preparedPaths != null
+  ) {
+    return preparedPaths;
+  }
+
   if (!isPreparedPathArray(preparedPaths)) {
     throw new Error('preparedInput must come from PathStore.prepareInput()');
   }
@@ -162,7 +227,15 @@ export function getPreparedInputEntries(
 export function getPreparedInputPresortedPaths(
   preparedInput: import('./public-types').PathStorePreparedInput
 ): readonly string[] | null {
-  const internalPreparedInput = preparedInput as Partial<InternalPreparedInput>;
+  const internalPreparedInput =
+    preparedInput as Partial<ValidatedPreparedInput>;
+  if (
+    internalPreparedInput[PREPARED_INPUT_KIND] === 'presorted' &&
+    internalPreparedInput.presortedPaths != null
+  ) {
+    return internalPreparedInput.presortedPaths;
+  }
+
   return isStringArray(internalPreparedInput.presortedPaths)
     ? internalPreparedInput.presortedPaths
     : null;
@@ -203,6 +276,14 @@ export function preparePathEntries(
 export class PathStoreBuilder {
   private readonly directories = new Map<NodeId, DirectoryChildIndex>();
   private readonly directoryStack: NodeId[] = [0];
+  // Tracks directory node IDs in creation order during presorted ingestion,
+  // so later callers (initializeOpenVisibleCounts) can walk only directories
+  // in post-order (via reverse iteration) without scanning the whole nodes
+  // array or allocating via Array.from(directories.keys()).
+  private readonly presortedDirectoryNodeIds: NodeId[] = [];
+  private readonly initialExpandedPathSet: ReadonlySet<string> | null;
+  private createdDirectoriesAllExpanded = false;
+  private createdDirectoryCount = 0;
   private lastPreparedPath: PreparedPath | null = null;
   private readonly nodes: PathStoreNode[] = [createRootNode()];
   private readonly options: ResolvedPathStoreOptions;
@@ -214,6 +295,31 @@ export class PathStoreBuilder {
   public constructor(options: PathStoreOptions = {}) {
     this.instrumentation = getBenchmarkInstrumentation(options);
     this.options = resolvePathStoreOptions(options);
+
+    const initialExpandedPaths =
+      (options as PathStoreBuilderStartupHints).initialExpandedPaths ?? null;
+    if (initialExpandedPaths == null || initialExpandedPaths.length === 0) {
+      this.initialExpandedPathSet = null;
+    } else {
+      // Normalize trailing slashes so the Set matches what the presorted
+      // builder's path.slice(0, slashPos) produces (no trailing slash).
+      // charCodeAt + slice is measurably faster than endsWith on hot paths;
+      // on linux-10x this loop runs 61K times.
+      const normalizedPaths = new Set<string>();
+      const hintCount = initialExpandedPaths.length;
+      for (let index = 0; index < hintCount; index += 1) {
+        const path = initialExpandedPaths[index];
+        const length = path.length;
+        normalizedPaths.add(
+          length > 0 && path.charCodeAt(length - 1) === 47
+            ? path.slice(0, length - 1)
+            : path
+        );
+      }
+      this.initialExpandedPathSet = normalizedPaths;
+      this.createdDirectoriesAllExpanded = true;
+    }
+
     this.directories.set(0, createDirectoryChildIndex());
   }
 
@@ -229,6 +335,8 @@ export class PathStoreBuilder {
     preparedPaths: readonly PreparedPath[],
     validateOrder = true
   ): this {
+    this.createdDirectoriesAllExpanded = false;
+
     withBenchmarkPhase(
       this.instrumentation,
       'store.builder.appendPreparedPaths',
@@ -255,13 +363,14 @@ export class PathStoreBuilder {
           return;
         }
 
+        this.createdDirectoriesAllExpanded = false;
+
         let previousPath: string | null = null;
         let currentDepth = 0;
         const nodes = this.nodes;
         const segmentTable = this.segmentTable;
         const idByValue = segmentTable.idByValue;
         const valueById = segmentTable.valueById;
-        const sortKeyById = segmentTable.sortKeyById;
         const dirStack = this.directoryStack;
         let stackTop = 0;
 
@@ -340,26 +449,25 @@ export class PathStoreBuilder {
 
             currentDepth++;
             const dirSeg = path.slice(segmentStart, slashPos);
-            let dirNameId = idByValue[dirSeg];
+            let dirNameId = idByValue.get(dirSeg);
             if (dirNameId === undefined) {
               dirNameId = valueById.length;
-              idByValue[dirSeg] = dirNameId;
+              idByValue.set(dirSeg, dirNameId);
               valueById.push(dirSeg);
-              sortKeyById.push(undefined);
             }
             const nodeId = nodes.length;
             nodes.push({
-              depth: currentDepth,
-              flags: 0,
-              id: nodeId,
-              kind: PATH_STORE_NODE_KIND_DIRECTORY,
+              depthAndFlags: createNodeDepthAndFlags(
+                currentDepth,
+                0,
+                PATH_STORE_NODE_KIND_DIRECTORY
+              ),
               nameId: dirNameId,
               parentId,
-              pathCache: null,
-              pathCacheVersion: 0,
               subtreeNodeCount: 1,
               visibleSubtreeCount: 1,
             });
+            this.recordCreatedDirectoryPath(path.slice(0, slashPos));
             stackTop++;
             dirStack[stackTop] = nodeId;
             segmentStart = slashPos + 1;
@@ -377,23 +485,21 @@ export class PathStoreBuilder {
 
               currentDepth++;
               const trailSeg = path.slice(segmentStart, endIndex);
-              let trailNameId = idByValue[trailSeg];
+              let trailNameId = idByValue.get(trailSeg);
               if (trailNameId === undefined) {
                 trailNameId = valueById.length;
-                idByValue[trailSeg] = trailNameId;
+                idByValue.set(trailSeg, trailNameId);
                 valueById.push(trailSeg);
-                sortKeyById.push(undefined);
               }
               const nodeId = nodes.length;
               nodes.push({
-                depth: currentDepth,
-                flags: 0,
-                id: nodeId,
-                kind: PATH_STORE_NODE_KIND_DIRECTORY,
+                depthAndFlags: createNodeDepthAndFlags(
+                  currentDepth,
+                  0,
+                  PATH_STORE_NODE_KIND_DIRECTORY
+                ),
                 nameId: trailNameId,
                 parentId,
-                pathCache: null,
-                pathCacheVersion: 0,
                 subtreeNodeCount: 1,
                 visibleSubtreeCount: 1,
               });
@@ -414,23 +520,16 @@ export class PathStoreBuilder {
             }
 
             const fileSeg = path.slice(segmentStart);
-            let fileNameId = idByValue[fileSeg];
+            let fileNameId = idByValue.get(fileSeg);
             if (fileNameId === undefined) {
               fileNameId = valueById.length;
-              idByValue[fileSeg] = fileNameId;
+              idByValue.set(fileSeg, fileNameId);
               valueById.push(fileSeg);
-              sortKeyById.push(undefined);
             }
-            const nodeId = nodes.length;
             nodes.push({
-              depth: currentDepth + 1,
-              flags: 0,
-              id: nodeId,
-              kind: PATH_STORE_NODE_KIND_FILE,
+              depthAndFlags: createNodeDepthAndFlags(currentDepth + 1, 0),
               nameId: fileNameId,
               parentId,
-              pathCache: null,
-              pathCacheVersion: -1,
               subtreeNodeCount: 1,
               visibleSubtreeCount: 1,
             });
@@ -470,7 +569,6 @@ export class PathStoreBuilder {
     const segmentTable = this.segmentTable;
     const idByValue = segmentTable.idByValue;
     const valueById = segmentTable.valueById;
-    const sortKeyById = segmentTable.sortKeyById;
     const dirStack = this.directoryStack;
     let stackTop = 0;
     let cachedDirPrefix = '';
@@ -523,26 +621,26 @@ export class PathStoreBuilder {
 
         currentDepth++;
         const dirSeg = path.slice(segmentStart, slashPos);
-        let dirNameId = idByValue[dirSeg];
+        let dirNameId = idByValue.get(dirSeg);
         if (dirNameId === undefined) {
           dirNameId = valueById.length;
-          idByValue[dirSeg] = dirNameId;
+          idByValue.set(dirSeg, dirNameId);
           valueById.push(dirSeg);
-          sortKeyById.push(undefined);
         }
         const nodeId = nodes.length;
         nodes.push({
-          depth: currentDepth,
-          flags: 0,
-          id: nodeId,
-          kind: PATH_STORE_NODE_KIND_DIRECTORY,
+          depthAndFlags: createNodeDepthAndFlags(
+            currentDepth,
+            0,
+            PATH_STORE_NODE_KIND_DIRECTORY
+          ),
           nameId: dirNameId,
           parentId,
-          pathCache: null,
-          pathCacheVersion: 0,
           subtreeNodeCount: 1,
           visibleSubtreeCount: 1,
         });
+        this.recordCreatedDirectoryPath(path.slice(0, slashPos));
+        this.presortedDirectoryNodeIds.push(nodeId);
         stackTop++;
         dirStack[stackTop] = nodeId;
         segmentStart = slashPos + 1;
@@ -555,23 +653,16 @@ export class PathStoreBuilder {
       }
 
       const fileSeg = path.slice(segmentStart);
-      let fileNameId = idByValue[fileSeg];
+      let fileNameId = idByValue.get(fileSeg);
       if (fileNameId === undefined) {
         fileNameId = valueById.length;
-        idByValue[fileSeg] = fileNameId;
+        idByValue.set(fileSeg, fileNameId);
         valueById.push(fileSeg);
-        sortKeyById.push(undefined);
       }
-      const nodeId = nodes.length;
       nodes.push({
-        depth: currentDepth + 1,
-        flags: 0,
-        id: nodeId,
-        kind: PATH_STORE_NODE_KIND_FILE,
+        depthAndFlags: createNodeDepthAndFlags(currentDepth + 1, 0),
         nameId: fileNameId,
         parentId,
-        pathCache: null,
-        pathCacheVersion: -1,
         subtreeNodeCount: 1,
         visibleSubtreeCount: 1,
       });
@@ -593,15 +684,16 @@ export class PathStoreBuilder {
     this.hasDeferredDirectoryIndexes = true;
   }
 
-  public finish(): PathStoreSnapshot {
+  public finish(options: BuilderFinishOptions = {}): PathStoreSnapshot {
+    const skipSubtreeCountPass = options.skipSubtreeCountPass === true;
     if (this.hasDeferredDirectoryIndexes) {
       withBenchmarkPhase(
         this.instrumentation,
         'store.builder.buildDirectoryIndexes',
-        () => this.buildPresortedFinish()
+        () => this.buildPresortedFinish(skipSubtreeCountPass)
       );
       this.hasDeferredDirectoryIndexes = false;
-    } else {
+    } else if (!skipSubtreeCountPass) {
       withBenchmarkPhase(
         this.instrumentation,
         'store.builder.computeSubtreeCounts',
@@ -614,7 +706,23 @@ export class PathStoreBuilder {
       options: this.options,
       rootId: 0,
       segmentTable: this.segmentTable,
+      presortedDirectoryNodeIds:
+        this.presortedDirectoryNodeIds.length > 0
+          ? this.presortedDirectoryNodeIds
+          : null,
     };
+  }
+
+  // Reports whether the presorted builder saw every created directory in the
+  // caller's startup expansion hint. PathStore uses this to recognize the
+  // "all directories start open" case without rescanning the finished
+  // snapshot.
+  public didMatchAllInitialExpandedPaths(): boolean {
+    return (
+      this.createdDirectoriesAllExpanded &&
+      this.initialExpandedPathSet != null &&
+      this.createdDirectoryCount === this.initialExpandedPathSet.size
+    );
   }
 
   private appendPreparedPath(
@@ -723,6 +831,23 @@ export class PathStoreBuilder {
     this.lastPreparedPath = preparedPath;
   }
 
+  // Compares each newly created directory path against the caller's startup
+  // expansion hint while the presorted builder is already walking those same
+  // prefixes, so constructor fast paths can avoid a second tree-wide scan.
+  private recordCreatedDirectoryPath(path: string): void {
+    if (
+      !this.createdDirectoriesAllExpanded ||
+      this.initialExpandedPathSet == null
+    ) {
+      return;
+    }
+
+    this.createdDirectoryCount += 1;
+    if (!this.initialExpandedPathSet.has(path)) {
+      this.createdDirectoriesAllExpanded = false;
+    }
+  }
+
   private createFileChild(
     parentId: NodeId,
     basename: string,
@@ -745,14 +870,9 @@ export class PathStoreBuilder {
 
     const nodeId = this.nodes.length;
     this.nodes.push({
-      depth: parentNode.depth + 1,
-      flags: 0,
-      id: nodeId,
-      kind: PATH_STORE_NODE_KIND_FILE,
+      depthAndFlags: createNodeDepthAndFlags(getNodeDepth(parentNode) + 1, 0),
       nameId,
       parentId,
-      pathCache: path,
-      pathCacheVersion: 0,
       subtreeNodeCount: 1,
       visibleSubtreeCount: 1,
     });
@@ -777,14 +897,9 @@ export class PathStoreBuilder {
 
     const nodeId = this.nodes.length;
     this.nodes.push({
-      depth: parentNode.depth + 1,
-      flags: 0,
-      id: nodeId,
-      kind: PATH_STORE_NODE_KIND_FILE,
+      depthAndFlags: createNodeDepthAndFlags(getNodeDepth(parentNode) + 1, 0),
       nameId,
       parentId,
-      pathCache: null,
-      pathCacheVersion: -1,
       subtreeNodeCount: 1,
       visibleSubtreeCount: 1,
     });
@@ -803,7 +918,7 @@ export class PathStoreBuilder {
       const existingChildId = parentIndex.childIdByNameId.get(nameId);
       if (existingChildId !== undefined) {
         const existingNode = this.nodes[existingChildId];
-        if (existingNode?.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
+        if (existingNode != null && !isDirectoryNode(existingNode)) {
           throw new Error(
             `Path collides with an existing file while creating directory "${segment}"`
           );
@@ -820,14 +935,13 @@ export class PathStoreBuilder {
 
     const nodeId = this.nodes.length;
     this.nodes.push({
-      depth: parentNode.depth + 1,
-      flags: 0,
-      id: nodeId,
-      kind: PATH_STORE_NODE_KIND_DIRECTORY,
+      depthAndFlags: createNodeDepthAndFlags(
+        getNodeDepth(parentNode) + 1,
+        0,
+        PATH_STORE_NODE_KIND_DIRECTORY
+      ),
       nameId,
       parentId,
-      pathCache: null,
-      pathCacheVersion: 0,
       subtreeNodeCount: 1,
       visibleSubtreeCount: 1,
     });
@@ -853,14 +967,13 @@ export class PathStoreBuilder {
 
     const nodeId = this.nodes.length;
     this.nodes.push({
-      depth: parentNode.depth + 1,
-      flags: 0,
-      id: nodeId,
-      kind: PATH_STORE_NODE_KIND_DIRECTORY,
+      depthAndFlags: createNodeDepthAndFlags(
+        getNodeDepth(parentNode) + 1,
+        0,
+        PATH_STORE_NODE_KIND_DIRECTORY
+      ),
       nameId,
       parentId,
-      pathCache: null,
-      pathCacheVersion: 0,
       subtreeNodeCount: 1,
       visibleSubtreeCount: 1,
     });
@@ -879,16 +992,15 @@ export class PathStoreBuilder {
       throw new Error(`Unknown directory node ID: ${String(directoryId)}`);
     }
 
-    if (directoryNode.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
+    if (!isDirectoryNode(directoryNode)) {
       throw new Error(`Path is not a directory: "${path}"`);
     }
 
-    if ((directoryNode.flags & PATH_STORE_NODE_FLAG_EXPLICIT) !== 0) {
+    if (hasNodeFlag(directoryNode, PATH_STORE_NODE_FLAG_EXPLICIT)) {
       throw new Error(`Duplicate path: "${path}"`);
     }
 
-    directoryNode.flags |= PATH_STORE_NODE_FLAG_EXPLICIT;
-    directoryNode.pathCache = path;
+    addNodeFlag(directoryNode, PATH_STORE_NODE_FLAG_EXPLICIT);
   }
 
   private getDirectoryIndex(directoryId: NodeId): DirectoryChildIndex {
@@ -906,7 +1018,7 @@ export class PathStoreBuilder {
   // presorted fast path, then computes subtree counts bottom-up and rebuilds
   // directory child aggregates — all in linear passes instead of recursive
   // tree descent.
-  private buildPresortedFinish(): void {
+  private buildPresortedFinish(skipSubtreeCountPass: boolean): void {
     const nodes = this.nodes;
     const directories = this.directories;
 
@@ -932,7 +1044,7 @@ export class PathStoreBuilder {
         continue;
       }
 
-      if (node.kind === PATH_STORE_NODE_KIND_DIRECTORY) {
+      if (isDirectoryNode(node)) {
         const dirIndex = createPresortedDirectoryChildIndex();
         directories.set(nodeId, dirIndex);
 
@@ -957,12 +1069,21 @@ export class PathStoreBuilder {
     }
 
     // Backward pass: accumulate subtree counts bottom-up into parent nodes.
-    // Parents always have lower IDs than their children, so iterating backward
-    // ensures each child's counts are finalized before its parent reads them.
-    // Directory-level aggregates (totalChildSubtreeNodeCount, etc.) and
-    // visible-child chunk summaries are NOT computed here; they are derived
-    // during state initialization when initializeOpenVisibleCounts or
-    // recomputeCountsRecursive iterates each directory's children.
+    // Parents always have lower IDs than their children, so iterating
+    // backward ensures each child's counts are finalized before its parent
+    // reads them. Directory-level aggregates (totalChildSubtreeNodeCount,
+    // etc.) and visible-child chunk summaries are NOT computed here; they
+    // are derived during state initialization when initializeOpenVisibleCounts
+    // or recomputeCountsRecursive iterates each directory's children.
+    //
+    // PathStore's constructor always runs one of those re-walks and will
+    // populate both subtreeNodeCount and visibleSubtreeCount from childIds,
+    // so the caller can pass skipSubtreeCountPass to avoid ~990K redundant
+    // adds here. Callers that read subtreeNodeCount directly off the
+    // snapshot (static-store) must leave skipSubtreeCountPass unset.
+    if (skipSubtreeCountPass) {
+      return;
+    }
     for (let nodeId = nodes.length - 1; nodeId >= 1; nodeId--) {
       const node = nodes[nodeId];
       if (node == null) {
@@ -989,7 +1110,7 @@ export class PathStoreBuilder {
         continue;
       }
 
-      if (node.kind === PATH_STORE_NODE_KIND_DIRECTORY) {
+      if (isDirectoryNode(node)) {
         this.directories.set(nodeId, createDirectoryChildIndex());
       }
 
@@ -1011,7 +1132,7 @@ export class PathStoreBuilder {
       throw new Error(`Unknown node ID: ${String(nodeId)}`);
     }
 
-    if (node.kind === PATH_STORE_NODE_KIND_FILE) {
+    if (!isDirectoryNode(node)) {
       node.subtreeNodeCount = 1;
       node.visibleSubtreeCount = 1;
       return 1;

--- a/packages/path-store/src/canonical.ts
+++ b/packages/path-store/src/canonical.ts
@@ -13,6 +13,15 @@ import {
   getFlattenedChildDirectoryId,
   getFlattenedTerminalDirectoryId,
 } from './flatten';
+import {
+  addNodeFlag,
+  createNodeDepthAndFlags,
+  getNodeDepth,
+  getNodeKind,
+  hasNodeFlag,
+  isDirectoryNode,
+  setNodeDepth,
+} from './internal-types';
 import type {
   DirectoryChildIndex,
   NodeId,
@@ -22,7 +31,6 @@ import { PATH_STORE_NODE_FLAG_EXPLICIT } from './internal-types';
 import { PATH_STORE_NODE_FLAG_REMOVED } from './internal-types';
 import { PATH_STORE_NODE_FLAG_ROOT } from './internal-types';
 import { PATH_STORE_NODE_KIND_DIRECTORY } from './internal-types';
-import { PATH_STORE_NODE_KIND_FILE } from './internal-types';
 import { withBenchmarkPhase } from './internal/benchmarkInstrumentation';
 import { parseInputPath, parseLookupPath } from './path';
 import type {
@@ -70,13 +78,15 @@ export function addPath(
 
   if (preparedPath.isDirectory) {
     const directoryNode = requireNode(state, directoryId);
-    if ((directoryNode.flags & PATH_STORE_NODE_FLAG_EXPLICIT) !== 0) {
+    if (hasNodeFlag(directoryNode, PATH_STORE_NODE_FLAG_EXPLICIT)) {
       throw new Error(`Path already exists: "${path}"`);
     }
 
-    directoryNode.flags |= PATH_STORE_NODE_FLAG_EXPLICIT;
-    directoryNode.pathCache = path;
-    directoryNode.pathCacheVersion = state.pathCacheVersion;
+    addNodeFlag(directoryNode, PATH_STORE_NODE_FLAG_EXPLICIT);
+    state.pathCacheByNodeId.set(directoryId, {
+      path,
+      version: state.pathCacheVersion,
+    });
     affectedNodeIds.add(directoryId);
   } else {
     addedNodeId = createFileNode(state, directoryId, preparedPath.basename);
@@ -110,12 +120,12 @@ export function removePath(
   }
 
   const node = requireNode(state, nodeId);
-  if ((node.flags & PATH_STORE_NODE_FLAG_ROOT) !== 0) {
+  if (hasNodeFlag(node, PATH_STORE_NODE_FLAG_ROOT)) {
     throw new Error('The root node cannot be removed');
   }
 
   if (
-    node.kind === PATH_STORE_NODE_KIND_DIRECTORY &&
+    isDirectoryNode(node) &&
     getDirectoryIndex(state, nodeId).childIds.length > 0 &&
     options.recursive !== true
   ) {
@@ -162,7 +172,7 @@ export function movePath(
   }
 
   const sourceNode = requireNode(state, sourceNodeId);
-  if ((sourceNode.flags & PATH_STORE_NODE_FLAG_ROOT) !== 0) {
+  if (hasNodeFlag(sourceNode, PATH_STORE_NODE_FLAG_ROOT)) {
     throw new Error('The root node cannot be moved');
   }
 
@@ -193,7 +203,7 @@ export function movePath(
   }
 
   if (
-    sourceNode.kind === PATH_STORE_NODE_KIND_DIRECTORY &&
+    isDirectoryNode(sourceNode) &&
     isAncestor(state, sourceNodeId, moveTarget.parentId)
   ) {
     throw new Error('Cannot move a directory into one of its descendants');
@@ -210,7 +220,7 @@ export function movePath(
       state,
       collisionNodeId,
       collision,
-      sourceNode.kind
+      getNodeKind(sourceNode)
     );
     if (resolvedCollision === 'skip') {
       return null;
@@ -228,8 +238,7 @@ export function movePath(
 
   sourceNode.parentId = moveTarget.parentId;
   sourceNode.nameId = targetNameId;
-  sourceNode.pathCache = null;
-  sourceNode.pathCacheVersion = -1;
+  state.pathCacheByNodeId.delete(sourceNodeId);
   recomputeDepths(state, sourceNodeId);
   insertChildReference(state, moveTarget.parentId, sourceNodeId);
   promoteEmptyAncestorsToExplicit(state, previousParentId);
@@ -264,6 +273,28 @@ export function movePath(
   });
 }
 
+function getCachedNodePath(
+  state: PathStoreState,
+  nodeId: NodeId
+): string | null {
+  const cachedEntry = state.pathCacheByNodeId.get(nodeId);
+  return cachedEntry != null && cachedEntry.version === state.pathCacheVersion
+    ? cachedEntry.path
+    : null;
+}
+
+function setCachedNodePath(
+  state: PathStoreState,
+  nodeId: NodeId,
+  path: string
+): string {
+  state.pathCacheByNodeId.set(nodeId, {
+    path,
+    version: state.pathCacheVersion,
+  });
+  return path;
+}
+
 // Materializes canonical paths only for nodes the caller actually touches, so
 // folder moves stay local instead of rewriting descendant strings eagerly.
 export function materializeNodePath(
@@ -271,27 +302,23 @@ export function materializeNodePath(
   nodeId: NodeId
 ): string {
   const node = requireNode(state, nodeId);
-
-  if (
-    node.pathCache != null &&
-    node.pathCacheVersion === state.pathCacheVersion
-  ) {
-    return node.pathCache;
+  const cachedPath = getCachedNodePath(state, nodeId);
+  if (cachedPath != null) {
+    return cachedPath;
   }
 
-  if ((node.flags & PATH_STORE_NODE_FLAG_ROOT) !== 0) {
-    node.pathCache = '';
-    node.pathCacheVersion = state.pathCacheVersion;
-    return node.pathCache;
+  if (hasNodeFlag(node, PATH_STORE_NODE_FLAG_ROOT)) {
+    return setCachedNodePath(state, nodeId, '');
   }
 
   const parentPath = materializeNodePath(state, node.parentId);
   const nodeName = getSegmentValue(state.snapshot.segmentTable, node.nameId);
   const path = parentPath.length === 0 ? nodeName : `${parentPath}${nodeName}`;
-  node.pathCache =
-    node.kind === PATH_STORE_NODE_KIND_DIRECTORY ? `${path}/` : path;
-  node.pathCacheVersion = state.pathCacheVersion;
-  return node.pathCache;
+  return setCachedNodePath(
+    state,
+    nodeId,
+    isDirectoryNode(node) ? `${path}/` : path
+  );
 }
 
 export function recomputeCountsUpwardFrom(
@@ -326,7 +353,7 @@ export function recomputeCountsRecursive(
     const nid = frame[0];
     const node = nodes[nid];
 
-    if (node == null || node.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
+    if (node == null || !isDirectoryNode(node)) {
       // File or unknown — recompute immediately and pop.
       recomputeNodeCounts(state, nid, node, true);
       stack.pop();
@@ -388,7 +415,7 @@ export function findNodeIdBySegments(
   let currentNodeId = state.snapshot.rootId;
 
   for (const segment of segments) {
-    const segmentId = state.snapshot.segmentTable.idByValue[segment];
+    const segmentId = state.snapshot.segmentTable.idByValue.get(segment);
     if (segmentId === undefined) {
       return null;
     }
@@ -406,7 +433,7 @@ export function findNodeIdBySegments(
   }
 
   const currentNode = requireNode(state, currentNodeId);
-  if (requireDirectory && currentNode.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
+  if (requireDirectory && !isDirectoryNode(currentNode)) {
     return null;
   }
 
@@ -432,7 +459,7 @@ export function requireNode(
   nodeId: NodeId
 ): PathStoreNode {
   const node = state.snapshot.nodes[nodeId];
-  if (node === undefined || (node.flags & PATH_STORE_NODE_FLAG_REMOVED) !== 0) {
+  if (node === undefined || hasNodeFlag(node, PATH_STORE_NODE_FLAG_REMOVED)) {
     throw new Error(`Unknown node ID: ${String(nodeId)}`);
   }
 
@@ -448,18 +475,18 @@ function collectCanonicalEntries(
   const rootNode = state.snapshot.nodes[nodeId];
   if (
     rootNode === undefined ||
-    (rootNode.flags & PATH_STORE_NODE_FLAG_REMOVED) !== 0
+    hasNodeFlag(rootNode, PATH_STORE_NODE_FLAG_REMOVED)
   ) {
     return [];
   }
 
-  if (rootNode.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
+  if (!isDirectoryNode(rootNode)) {
     return [materializeNodePath(state, nodeId)];
   }
 
   if (getDirectoryIndex(state, nodeId).childIds.length === 0) {
-    return (rootNode.flags & PATH_STORE_NODE_FLAG_EXPLICIT) !== 0 &&
-      (rootNode.flags & PATH_STORE_NODE_FLAG_ROOT) === 0
+    return hasNodeFlag(rootNode, PATH_STORE_NODE_FLAG_EXPLICIT) &&
+      !hasNodeFlag(rootNode, PATH_STORE_NODE_FLAG_ROOT)
       ? [materializeNodePath(state, nodeId)]
       : [];
   }
@@ -478,13 +505,13 @@ function collectCanonicalEntries(
     const currentNode = state.snapshot.nodes[frame.nodeId];
     if (
       currentNode === undefined ||
-      (currentNode.flags & PATH_STORE_NODE_FLAG_REMOVED) !== 0
+      hasNodeFlag(currentNode, PATH_STORE_NODE_FLAG_REMOVED)
     ) {
       stack.pop();
       continue;
     }
 
-    if (currentNode.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
+    if (!isDirectoryNode(currentNode)) {
       entries.push(materializeNodePath(state, frame.nodeId));
       stack.pop();
       continue;
@@ -493,8 +520,8 @@ function collectCanonicalEntries(
     const currentIndex = getDirectoryIndex(state, frame.nodeId);
     if (currentIndex.childIds.length === 0) {
       if (
-        (currentNode.flags & PATH_STORE_NODE_FLAG_EXPLICIT) !== 0 &&
-        (currentNode.flags & PATH_STORE_NODE_FLAG_ROOT) === 0
+        hasNodeFlag(currentNode, PATH_STORE_NODE_FLAG_EXPLICIT) &&
+        !hasNodeFlag(currentNode, PATH_STORE_NODE_FLAG_ROOT)
       ) {
         entries.push(materializeNodePath(state, frame.nodeId));
       }
@@ -533,7 +560,7 @@ function ensureDirectoryChain(
 
     if (existingChildId !== undefined) {
       const existingChild = requireNode(state, existingChildId);
-      if (existingChild.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
+      if (!isDirectoryNode(existingChild)) {
         throw new Error(
           `Cannot create a directory that collides with an existing file: "${segment}"`
         );
@@ -562,14 +589,13 @@ function createDirectoryNode(
   const parentNode = requireNode(state, parentId);
   const nodeId = state.snapshot.nodes.length;
   state.snapshot.nodes.push({
-    depth: parentNode.depth + 1,
-    flags: 0,
-    id: nodeId,
-    kind: PATH_STORE_NODE_KIND_DIRECTORY,
+    depthAndFlags: createNodeDepthAndFlags(
+      getNodeDepth(parentNode) + 1,
+      0,
+      PATH_STORE_NODE_KIND_DIRECTORY
+    ),
     nameId,
     parentId,
-    pathCache: null,
-    pathCacheVersion: -1,
     subtreeNodeCount: 1,
     visibleSubtreeCount: 1,
   });
@@ -595,14 +621,9 @@ function createFileNode(
   const parentNode = requireNode(state, parentId);
   const nodeId = state.snapshot.nodes.length;
   state.snapshot.nodes.push({
-    depth: parentNode.depth + 1,
-    flags: 0,
-    id: nodeId,
-    kind: PATH_STORE_NODE_KIND_FILE,
+    depthAndFlags: createNodeDepthAndFlags(getNodeDepth(parentNode) + 1, 0),
     nameId,
     parentId,
-    pathCache: null,
-    pathCacheVersion: -1,
     subtreeNodeCount: 1,
     visibleSubtreeCount: 1,
   });
@@ -714,8 +735,10 @@ function compareSiblingNodesDefault(
   const leftNode = requireNode(state, leftId);
   const rightNode = requireNode(state, rightId);
 
-  if (leftNode.kind !== rightNode.kind) {
-    return leftNode.kind === PATH_STORE_NODE_KIND_DIRECTORY ? -1 : 1;
+  const leftIsDirectory = isDirectoryNode(leftNode);
+  const rightIsDirectory = isDirectoryNode(rightNode);
+  if (leftIsDirectory !== rightIsDirectory) {
+    return leftIsDirectory ? -1 : 1;
   }
 
   const leftSortKey = getSegmentSortKey(
@@ -752,13 +775,13 @@ function createCompareEntry(
 ): PathStoreCompareEntry {
   const node = requireNode(state, nodeId);
   const path = materializeNodePath(state, nodeId);
-  const normalizedPath =
-    node.kind === PATH_STORE_NODE_KIND_DIRECTORY ? path.slice(0, -1) : path;
+  const isDirectory = isDirectoryNode(node);
+  const normalizedPath = isDirectory ? path.slice(0, -1) : path;
 
   return {
     basename: getSegmentValue(state.snapshot.segmentTable, node.nameId),
-    depth: node.depth,
-    isDirectory: node.kind === PATH_STORE_NODE_KIND_DIRECTORY,
+    depth: getNodeDepth(node),
+    isDirectory,
     path,
     segments: normalizedPath.length === 0 ? [] : normalizedPath.split('/'),
   };
@@ -773,7 +796,7 @@ function resolveMoveTarget(
   const existingDestinationId = findNodeId(state, toPath);
   if (existingDestinationId != null) {
     const existingDestination = requireNode(state, existingDestinationId);
-    if (existingDestination.kind === PATH_STORE_NODE_KIND_DIRECTORY) {
+    if (isDirectoryNode(existingDestination)) {
       return {
         basename: getSegmentValue(
           state.snapshot.segmentTable,
@@ -828,14 +851,14 @@ function handleMoveCollision(
   }
 
   const collisionNode = requireNode(state, collisionNodeId);
-  if (collisionNode.kind !== sourceKind) {
+  if (getNodeKind(collisionNode) !== sourceKind) {
     throw new Error(
       'replace collision requires the same source and destination kinds'
     );
   }
 
   if (
-    collisionNode.kind === PATH_STORE_NODE_KIND_DIRECTORY &&
+    isDirectoryNode(collisionNode) &&
     getDirectoryIndex(state, collisionNodeId).childIds.length > 0
   ) {
     throw new Error('replace collision does not support non-empty directories');
@@ -868,15 +891,17 @@ function removeSubtree(state: PathStoreState, nodeId: NodeId): NodeId[] {
     }
 
     const node = requireNode(state, frame.nodeId);
-    if (frame.visitedChildren || node.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
-      if (node.kind === PATH_STORE_NODE_KIND_DIRECTORY) {
+    if (frame.visitedChildren || !isDirectoryNode(node)) {
+      if (isDirectoryNode(node)) {
         state.snapshot.directories.delete(frame.nodeId);
       }
 
-      node.flags |= PATH_STORE_NODE_FLAG_REMOVED;
-      node.pathCache = null;
-      node.pathCacheVersion = -1;
-      state.collapsedDirectoryIds.delete(frame.nodeId);
+      addNodeFlag(node, PATH_STORE_NODE_FLAG_REMOVED);
+      state.pathCacheByNodeId.delete(frame.nodeId);
+      if (state.collapsedDirectoryIds.delete(frame.nodeId)) {
+        state.hasCollapsedDirectoryOverrides =
+          state.collapsedDirectoryIds.size > 0;
+      }
       state.expandedDirectoryIds.delete(frame.nodeId);
       clearDirectoryLoadInfo(state, frame.nodeId);
       state.activeNodeCount--;
@@ -911,8 +936,8 @@ function promoteEmptyAncestorsToExplicit(
   while (currentDirectoryId != null) {
     const currentNode = requireNode(state, currentDirectoryId);
     if (
-      currentNode.kind !== PATH_STORE_NODE_KIND_DIRECTORY ||
-      (currentNode.flags & PATH_STORE_NODE_FLAG_ROOT) !== 0
+      !isDirectoryNode(currentNode) ||
+      hasNodeFlag(currentNode, PATH_STORE_NODE_FLAG_ROOT)
     ) {
       return;
     }
@@ -921,7 +946,7 @@ function promoteEmptyAncestorsToExplicit(
       return;
     }
 
-    currentNode.flags |= PATH_STORE_NODE_FLAG_EXPLICIT;
+    addNodeFlag(currentNode, PATH_STORE_NODE_FLAG_EXPLICIT);
     currentDirectoryId =
       currentNode.parentId === currentDirectoryId ? null : currentNode.parentId;
   }
@@ -934,7 +959,7 @@ function findDeepestExistingDirectoryId(
   let currentDirectoryId = state.snapshot.rootId;
 
   for (const segment of segments) {
-    const segmentId = state.snapshot.segmentTable.idByValue[segment];
+    const segmentId = state.snapshot.segmentTable.idByValue.get(segment);
     if (segmentId == null) {
       break;
     }
@@ -948,7 +973,7 @@ function findDeepestExistingDirectoryId(
     }
 
     const nextNode = requireNode(state, nextNodeId);
-    if (nextNode.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
+    if (!isDirectoryNode(nextNode)) {
       break;
     }
 
@@ -987,7 +1012,7 @@ function getCollapsedProjectionSignature(
     hasChildren:
       getDirectoryIndex(state, terminalDirectoryId).childIds.length > 0,
     path: materializeNodePath(state, terminalDirectoryId),
-    terminalKind: terminalNode.kind,
+    terminalKind: getNodeKind(terminalNode),
   });
 }
 
@@ -1029,8 +1054,8 @@ function findNearestCollapsedAncestor(
   while (currentDirectoryId != null) {
     const currentNode = requireNode(state, currentDirectoryId);
     if (
-      currentNode.kind !== PATH_STORE_NODE_KIND_DIRECTORY ||
-      (currentNode.flags & PATH_STORE_NODE_FLAG_ROOT) !== 0
+      !isDirectoryNode(currentNode) ||
+      hasNodeFlag(currentNode, PATH_STORE_NODE_FLAG_ROOT)
     ) {
       return null;
     }
@@ -1050,10 +1075,10 @@ function recomputeDepths(state: PathStoreState, nodeId: NodeId): void {
   const parentDepth =
     nodeId === state.snapshot.rootId
       ? -1
-      : requireNode(state, node.parentId).depth;
-  node.depth = parentDepth + 1;
+      : getNodeDepth(requireNode(state, node.parentId));
+  setNodeDepth(node, parentDepth + 1);
 
-  if (node.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
+  if (!isDirectoryNode(node)) {
     return;
   }
 
@@ -1145,7 +1170,7 @@ function recomputeNodeCountsNow(
   currentNode: PathStoreNode,
   rebuildChildAggregates: boolean
 ): void {
-  if (currentNode.kind === PATH_STORE_NODE_KIND_FILE) {
+  if (!isDirectoryNode(currentNode)) {
     currentNode.subtreeNodeCount = 1;
     currentNode.visibleSubtreeCount = 1;
     return;
@@ -1169,7 +1194,7 @@ function recomputeNodeCountsNow(
   const visibleChildCount = currentIndex.totalChildVisibleSubtreeCount;
 
   currentNode.subtreeNodeCount = subtreeNodeCount;
-  if ((currentNode.flags & PATH_STORE_NODE_FLAG_ROOT) !== 0) {
+  if (hasNodeFlag(currentNode, PATH_STORE_NODE_FLAG_ROOT)) {
     currentNode.visibleSubtreeCount = visibleChildCount;
     return;
   }

--- a/packages/path-store/src/child-index.ts
+++ b/packages/path-store/src/child-index.ts
@@ -9,7 +9,13 @@ const PATH_STORE_CHILD_INDEX_CHUNK_SHIFT = 5;
 const PATH_STORE_CHILD_INDEX_CHUNK_SIZE =
   1 << PATH_STORE_CHILD_INDEX_CHUNK_SHIFT;
 const PATH_STORE_CHILD_INDEX_CHUNK_THRESHOLD =
-  PATH_STORE_CHILD_INDEX_CHUNK_SIZE * 2;
+  PATH_STORE_CHILD_INDEX_CHUNK_SIZE * 4;
+
+// Exposed so hot callers can avoid the rebuildVisibleChildChunks function
+// call for directories that fall below the chunk threshold (the vast
+// majority on tree-shaped workloads).
+export const PATH_STORE_CHILD_INDEX_CHUNK_THRESHOLD_EXTERNAL =
+  PATH_STORE_CHILD_INDEX_CHUNK_THRESHOLD;
 
 export function createDirectoryChildIndex(): DirectoryChildIndex {
   return {
@@ -153,9 +159,7 @@ export function applyChildAggregateDelta(
   }
 
   const chunkIndex = childPosition >> PATH_STORE_CHILD_INDEX_CHUNK_SHIFT;
-  const nextChunkValue =
-    (index.childVisibleChunkSums[chunkIndex] ?? 0) + visibleSubtreeDelta;
-  index.childVisibleChunkSums[chunkIndex] = nextChunkValue;
+  index.childVisibleChunkSums[chunkIndex] += visibleSubtreeDelta;
 }
 
 // Skips over wide child arrays by using chunked visible-count summaries first
@@ -225,7 +229,7 @@ export function rebuildVisibleChildChunks(
   const chunkCount = Math.ceil(
     index.childIds.length / PATH_STORE_CHILD_INDEX_CHUNK_SIZE
   );
-  const chunkSums = new Array<number>(chunkCount).fill(0);
+  const chunkSums = new Int32Array(chunkCount);
 
   for (let childIndex = 0; childIndex < index.childIds.length; childIndex++) {
     const childId = index.childIds[childIndex];

--- a/packages/path-store/src/cleanup.ts
+++ b/packages/path-store/src/cleanup.ts
@@ -9,10 +9,11 @@ import {
 import { rebuildDirectoryChildAggregates } from './child-index';
 import {
   type DirectoryLoadInfo,
+  hasNodeFlag,
+  isDirectoryNode,
   type NodeId,
   PATH_STORE_NODE_FLAG_REMOVED,
   PATH_STORE_NODE_FLAG_ROOT,
-  PATH_STORE_NODE_KIND_DIRECTORY,
   type PathStoreNode,
   type SegmentTable,
 } from './internal-types';
@@ -48,7 +49,7 @@ interface PersistedExpansionState {
 }
 
 function isLiveNode(node: PathStoreNode | undefined): node is PathStoreNode {
-  return node != null && (node.flags & PATH_STORE_NODE_FLAG_REMOVED) === 0;
+  return node != null && !hasNodeFlag(node, PATH_STORE_NODE_FLAG_REMOVED);
 }
 
 function isLiveDirectoryNode(
@@ -58,8 +59,8 @@ function isLiveDirectoryNode(
   const node = state.snapshot.nodes[nodeId];
   if (
     !isLiveNode(node) ||
-    node.kind !== PATH_STORE_NODE_KIND_DIRECTORY ||
-    (node.flags & PATH_STORE_NODE_FLAG_ROOT) !== 0
+    !isDirectoryNode(node) ||
+    hasNodeFlag(node, PATH_STORE_NODE_FLAG_ROOT)
   ) {
     return null;
   }
@@ -70,8 +71,12 @@ function isLiveDirectoryNode(
 function countCachedPathEntries(state: PathStoreState): number {
   let cachedPathEntryCount = 0;
 
-  for (const node of state.snapshot.nodes) {
-    if (!isLiveNode(node) || node.pathCache == null) {
+  for (const [nodeId, cachedEntry] of state.pathCacheByNodeId) {
+    if (cachedEntry.version !== state.pathCacheVersion) {
+      continue;
+    }
+
+    if (!isLiveNode(state.snapshot.nodes[nodeId])) {
       continue;
     }
 
@@ -137,14 +142,14 @@ function collectExpansionOverridePaths(
   for (const nodeId of state.collapsedDirectoryIds) {
     const node = isLiveDirectoryNode(state, nodeId);
     if (node != null) {
-      collapsedPaths.push(materializeNodePath(state, node.id));
+      collapsedPaths.push(materializeNodePath(state, nodeId));
     }
   }
 
   for (const nodeId of state.expandedDirectoryIds) {
     const node = isLiveDirectoryNode(state, nodeId);
     if (node != null) {
-      expandedPaths.push(materializeNodePath(state, node.id));
+      expandedPaths.push(materializeNodePath(state, nodeId));
     }
   }
 
@@ -188,6 +193,7 @@ function restoreExpansionOverridePaths(
   persistedExpansionState: PersistedExpansionState
 ): void {
   state.collapsedDirectoryIds.clear();
+  state.hasCollapsedDirectoryOverrides = false;
   state.expandedDirectoryIds.clear();
 
   for (const path of persistedExpansionState.expandedPaths) {
@@ -241,21 +247,11 @@ function restoreDirectoryLoadInfos(
 // memory without changing canonical topology or node IDs.
 function clearPathCaches(state: PathStoreState): void {
   state.pathCacheVersion += 1;
-
-  for (const node of state.snapshot.nodes) {
-    if (!isLiveNode(node)) {
-      continue;
-    }
-
-    if ((node.flags & PATH_STORE_NODE_FLAG_ROOT) !== 0) {
-      node.pathCache = '';
-      node.pathCacheVersion = state.pathCacheVersion;
-      continue;
-    }
-
-    node.pathCache = null;
-    node.pathCacheVersion = -1;
-  }
+  state.pathCacheByNodeId.clear();
+  state.pathCacheByNodeId.set(state.snapshot.rootId, {
+    path: '',
+    version: state.pathCacheVersion,
+  });
 }
 
 // Rebuilds the segment table and remaps live nodes to the compacted segment IDs
@@ -269,7 +265,7 @@ function rebuildSegmentTablePreservingNodeIds(state: PathStoreState): void {
       continue;
     }
 
-    if ((node.flags & PATH_STORE_NODE_FLAG_ROOT) !== 0) {
+    if (hasNodeFlag(node, PATH_STORE_NODE_FLAG_ROOT)) {
       node.nameId = 0;
       continue;
     }
@@ -288,10 +284,7 @@ function rebuildSegmentTablePreservingNodeIds(state: PathStoreState): void {
 function rebuildDirectoryIndexes(state: PathStoreState): void {
   for (const [directoryId, directoryIndex] of state.snapshot.directories) {
     const directoryNode = state.snapshot.nodes[directoryId];
-    if (
-      !isLiveNode(directoryNode) ||
-      directoryNode.kind !== PATH_STORE_NODE_KIND_DIRECTORY
-    ) {
+    if (!isLiveNode(directoryNode) || !isDirectoryNode(directoryNode)) {
       state.snapshot.directories.delete(directoryId);
       continue;
     }
@@ -403,6 +396,9 @@ function runAggressiveCleanup(state: PathStoreState): void {
 
   state.snapshot = rebuiltSnapshot;
   state.activeNodeCount = rebuiltSnapshot.nodes.length - 1;
+  state.pathCacheByNodeId = new Map([
+    [rebuiltSnapshot.rootId, { path: '', version: 0 }],
+  ]);
   state.pathCacheVersion = 0;
 
   withBenchmarkPhase(

--- a/packages/path-store/src/flatten.ts
+++ b/packages/path-store/src/flatten.ts
@@ -1,6 +1,6 @@
+import { hasNodeFlag, isDirectoryNode } from './internal-types';
 import type { NodeId } from './internal-types';
 import { PATH_STORE_NODE_FLAG_ROOT } from './internal-types';
-import { PATH_STORE_NODE_KIND_DIRECTORY } from './internal-types';
 import type { PathStoreState } from './state';
 
 // Fully known trees flatten single-child directory chains even before callers
@@ -17,8 +17,8 @@ export function getFlattenedChildDirectoryId(
   const directoryNode = state.snapshot.nodes[directoryNodeId];
   if (
     directoryNode == null ||
-    directoryNode.kind !== PATH_STORE_NODE_KIND_DIRECTORY ||
-    (directoryNode.flags & PATH_STORE_NODE_FLAG_ROOT) !== 0
+    !isDirectoryNode(directoryNode) ||
+    hasNodeFlag(directoryNode, PATH_STORE_NODE_FLAG_ROOT)
   ) {
     return null;
   }
@@ -34,7 +34,7 @@ export function getFlattenedChildDirectoryId(
   }
 
   const childNode = state.snapshot.nodes[childId];
-  if (childNode == null || childNode.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
+  if (childNode == null || !isDirectoryNode(childNode)) {
     return null;
   }
 

--- a/packages/path-store/src/internal-types.ts
+++ b/packages/path-store/src/internal-types.ts
@@ -18,28 +18,81 @@ export const PATH_STORE_NODE_FLAG_EXPLICIT: number = 1 << 0;
 export const PATH_STORE_NODE_FLAG_ROOT: number = 1 << 1;
 export const PATH_STORE_NODE_FLAG_REMOVED: number = 1 << 2;
 
+const PATH_STORE_NODE_FLAGS_MASK =
+  PATH_STORE_NODE_FLAG_EXPLICIT |
+  PATH_STORE_NODE_FLAG_ROOT |
+  PATH_STORE_NODE_FLAG_REMOVED;
+const PATH_STORE_NODE_KIND_SHIFT = 3;
+const PATH_STORE_NODE_KIND_MASK = 1 << PATH_STORE_NODE_KIND_SHIFT;
+const PATH_STORE_NODE_DEPTH_SHIFT = 4;
+
 export interface SegmentSortKey {
   lowerValue: string;
   tokens: readonly (number | string)[];
 }
 
 export interface SegmentTable {
-  idByValue: Record<string, SegmentId | undefined>;
+  // Map outperforms plain `Object.create(null)` for the string-keyed lookups
+  // this table does during bulk ingest: ~940K hits + ~50K misses on
+  // linux-10x. Map<string, number> is consistent O(1) and measurably faster
+  // than the dictionary-mode plain object the previous implementation
+  // transitioned into after a few thousand keys.
+  idByValue: Map<string, SegmentId>;
   valueById: string[];
   sortKeyById: Array<SegmentSortKey | undefined>;
 }
 
 export interface PathStoreNode {
-  id: NodeId;
   parentId: NodeId;
   nameId: SegmentId;
-  kind: PathStoreNodeKind;
-  depth: number;
-  flags: number;
+  depthAndFlags: number;
   subtreeNodeCount: number;
   visibleSubtreeCount: number;
-  pathCache: string | null;
-  pathCacheVersion: number;
+}
+
+export function createNodeDepthAndFlags(
+  depth: number,
+  flags: number,
+  kind: PathStoreNodeKind = PATH_STORE_NODE_KIND_FILE
+): number {
+  return (
+    (depth << PATH_STORE_NODE_DEPTH_SHIFT) |
+    (kind << PATH_STORE_NODE_KIND_SHIFT) |
+    flags
+  );
+}
+
+export function getNodeDepth(node: PathStoreNode): number {
+  return node.depthAndFlags >>> PATH_STORE_NODE_DEPTH_SHIFT;
+}
+
+export function getNodeKind(node: PathStoreNode): PathStoreNodeKind {
+  return ((node.depthAndFlags & PATH_STORE_NODE_KIND_MASK) >>
+    PATH_STORE_NODE_KIND_SHIFT) as PathStoreNodeKind;
+}
+
+export function isDirectoryNode(node: PathStoreNode): boolean {
+  return (node.depthAndFlags & PATH_STORE_NODE_KIND_MASK) !== 0;
+}
+
+export function getNodeFlags(node: PathStoreNode): number {
+  return node.depthAndFlags & PATH_STORE_NODE_FLAGS_MASK;
+}
+
+export function hasNodeFlag(node: PathStoreNode, flag: number): boolean {
+  return (getNodeFlags(node) & flag) !== 0;
+}
+
+export function addNodeFlag(node: PathStoreNode, flag: number): void {
+  node.depthAndFlags |= flag;
+}
+
+export function setNodeDepth(node: PathStoreNode, depth: number): void {
+  node.depthAndFlags = createNodeDepthAndFlags(
+    depth,
+    getNodeFlags(node),
+    getNodeKind(node)
+  );
 }
 
 export interface DirectoryLoadInfo {
@@ -53,7 +106,7 @@ export interface DirectoryChildIndex {
   childIds: NodeId[];
   childIdByNameId: Map<SegmentId, NodeId> | null;
   childPositionById: Map<NodeId, number> | null;
-  childVisibleChunkSums: number[] | null;
+  childVisibleChunkSums: Int32Array<ArrayBufferLike> | null;
   totalChildSubtreeNodeCount: number;
   totalChildVisibleSubtreeCount: number;
 }
@@ -87,4 +140,9 @@ export interface PathStoreSnapshot {
   options: ResolvedPathStoreOptions;
   rootId: NodeId;
   segmentTable: SegmentTable;
+  // Set by the presorted file-only ingest path to let initializeOpenVisibleCounts
+  // walk only directories in post-order (via reverse iteration) without
+  // scanning the whole nodes array. Null when the snapshot came from any
+  // non-presorted path; consumers must fall back to iterating `nodes`.
+  presortedDirectoryNodeIds: readonly NodeId[] | null;
 }

--- a/packages/path-store/src/projection.ts
+++ b/packages/path-store/src/projection.ts
@@ -17,7 +17,7 @@ import {
   getFlattenedTerminalDirectoryId,
 } from './flatten';
 import type { DirectoryChildIndex, NodeId } from './internal-types';
-import { PATH_STORE_NODE_KIND_DIRECTORY } from './internal-types';
+import { isDirectoryNode } from './internal-types';
 import {
   setBenchmarkCounter,
   withBenchmarkPhase,
@@ -191,7 +191,7 @@ export function expandPath(
   }
 
   const directoryNode = requireNode(state, directoryNodeId);
-  if (directoryNode.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
+  if (!isDirectoryNode(directoryNode)) {
     throw new Error(`Path is not a directory: "${path}"`);
   }
 
@@ -219,7 +219,7 @@ export function collapsePath(
   }
 
   const directoryNode = requireNode(state, directoryNodeId);
-  if (directoryNode.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
+  if (!isDirectoryNode(directoryNode)) {
     throw new Error(`Path is not a directory: "${path}"`);
   }
 
@@ -298,7 +298,7 @@ function selectVisibleRowWithinSubtree(
   visibleDepth: number
 ): VisibleRowCursor {
   const node = requireNode(state, nodeId);
-  if (node.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
+  if (!isDirectoryNode(node)) {
     if (index === 0) {
       return {
         headNodeId: nodeId,
@@ -317,7 +317,7 @@ function selectVisibleRowWithinSubtree(
 
   const terminalNode = requireNode(state, currentCursor.terminalNodeId);
   if (
-    terminalNode.kind !== PATH_STORE_NODE_KIND_DIRECTORY ||
+    !isDirectoryNode(terminalNode) ||
     !isDirectoryExpanded(state, currentCursor.terminalNodeId, terminalNode)
   ) {
     throw new Error(
@@ -339,7 +339,7 @@ function createVisibleRowCursor(
   visibleDepth: number
 ): VisibleRowCursor {
   const node = requireNode(state, nodeId);
-  if (node.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
+  if (!isDirectoryNode(node)) {
     return {
       headNodeId: nodeId,
       terminalNodeId: nodeId,
@@ -368,7 +368,7 @@ function createVisibleRowCursor(
 
 function isVisibleRowHeadNode(state: PathStoreState, nodeId: NodeId): boolean {
   const node = requireNode(state, nodeId);
-  if (node.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
+  if (!isDirectoryNode(node)) {
     return true;
   }
 
@@ -386,7 +386,7 @@ function getNextVisibleRowCursor(
   currentCursor: VisibleRowCursor
 ): VisibleRowCursor | null {
   const terminalNode = requireNode(state, currentCursor.terminalNodeId);
-  if (terminalNode.kind === PATH_STORE_NODE_KIND_DIRECTORY) {
+  if (isDirectoryNode(terminalNode)) {
     const currentIndex = getDirectoryIndex(state, currentCursor.terminalNodeId);
     if (
       isDirectoryExpanded(state, currentCursor.terminalNodeId, terminalNode) &&
@@ -490,6 +490,7 @@ function buildVisibleTreeProjectionDataDFS(
     [directories.get(state.snapshot.rootId)!, 0, -1, ''],
   ];
   const flattenEnabled = state.snapshot.options.flattenEmptyDirectories;
+  const pathCacheByNodeId = state.pathCacheByNodeId;
   const pathCacheVersion = state.pathCacheVersion;
   const segmentValues = segmentTable.valueById;
 
@@ -514,11 +515,11 @@ function buildVisibleTreeProjectionDataDFS(
 
     let path: string;
     let terminalNodeId = childId;
-    if (childNode.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
+    if (!isDirectoryNode(childNode)) {
+      const cachedPathEntry = pathCacheByNodeId.get(childId);
       path =
-        childNode.pathCache != null &&
-        childNode.pathCacheVersion === pathCacheVersion
-          ? childNode.pathCache
+        cachedPathEntry != null && cachedPathEntry.version === pathCacheVersion
+          ? cachedPathEntry.path
           : `${parentPath}${segmentValues[childNode.nameId]}`;
     } else {
       terminalNodeId = flattenEnabled
@@ -544,7 +545,7 @@ function buildVisibleTreeProjectionDataDFS(
     const terminalNode = nodes[terminalNodeId];
     if (
       terminalNode != null &&
-      terminalNode.kind === PATH_STORE_NODE_KIND_DIRECTORY &&
+      isDirectoryNode(terminalNode) &&
       isDirectoryExpanded(state, terminalNodeId, terminalNode)
     ) {
       stack.push([directories.get(terminalNodeId)!, 0, visibleDepth, path]);
@@ -601,6 +602,7 @@ function collectVisibleRowsDFS(
   ];
   const segmentValues = segmentTable.valueById;
   const flattenEnabled = state.snapshot.options.flattenEmptyDirectories;
+  const pathCacheByNodeId = state.pathCacheByNodeId;
   const pathCacheVersion = state.pathCacheVersion;
 
   while (stack.length > 0 && rowCount < maxRows) {
@@ -617,9 +619,10 @@ function collectVisibleRowsDFS(
 
     const visibleDepth = frame[2] + 1;
 
-    if (childNode.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
+    if (!isDirectoryNode(childNode)) {
       // File node — inline materialization avoids cursor allocation and
       // directory-specific checks (load state, flattening, expansion).
+      const cachedPathEntry = pathCacheByNodeId.get(childId);
       rows[rowCount++] = {
         depth: visibleDepth,
         flattenedSegments: undefined,
@@ -632,9 +635,9 @@ function collectVisibleRowsDFS(
         loadState: undefined,
         name: segmentValues[childNode.nameId],
         path:
-          childNode.pathCache != null &&
-          childNode.pathCacheVersion === pathCacheVersion
-            ? childNode.pathCache
+          cachedPathEntry != null &&
+          cachedPathEntry.version === pathCacheVersion
+            ? cachedPathEntry.path
             : materializeNodePath(state, childId),
       };
       continue;
@@ -656,7 +659,7 @@ function collectVisibleRowsDFS(
     const terminalNode = nodes[terminalNodeId];
     if (
       terminalNode != null &&
-      terminalNode.kind === PATH_STORE_NODE_KIND_DIRECTORY &&
+      isDirectoryNode(terminalNode) &&
       isDirectoryExpanded(state, terminalNodeId, terminalNode)
     ) {
       stack.push([directories.get(terminalNodeId)!, 0, visibleDepth]);
@@ -675,17 +678,16 @@ function materializeVisibleRow(
   cursor: VisibleRowCursor
 ): PathStoreVisibleRow {
   const terminalNode = requireNode(state, cursor.terminalNodeId);
-  const loadState =
-    terminalNode.kind === PATH_STORE_NODE_KIND_DIRECTORY
-      ? getVisibleRowLoadState(state, cursor)
-      : null;
+  const loadState = isDirectoryNode(terminalNode)
+    ? getVisibleRowLoadState(state, cursor)
+    : null;
   const path = materializeNodePath(state, cursor.terminalNodeId);
   const name = getSegmentValue(
     state.snapshot.segmentTable,
     terminalNode.nameId
   );
   const hasChildren =
-    terminalNode.kind === PATH_STORE_NODE_KIND_DIRECTORY &&
+    isDirectoryNode(terminalNode) &&
     getDirectoryIndex(state, cursor.terminalNodeId).childIds.length > 0;
   const isFlattened = cursor.headNodeId !== cursor.terminalNodeId;
   const instrumentation = state.instrumentation;
@@ -729,14 +731,11 @@ function materializeVisibleRow(
     hasChildren,
     id: cursor.terminalNodeId,
     isExpanded:
-      terminalNode.kind === PATH_STORE_NODE_KIND_DIRECTORY &&
+      isDirectoryNode(terminalNode) &&
       isDirectoryExpanded(state, cursor.terminalNodeId, terminalNode),
     isFlattened,
     isLoading: loadState === 'loading',
-    kind:
-      terminalNode.kind === PATH_STORE_NODE_KIND_DIRECTORY
-        ? 'directory'
-        : 'file',
+    kind: isDirectoryNode(terminalNode) ? 'directory' : 'file',
     loadState:
       loadState == null || loadState === 'loaded'
         ? undefined

--- a/packages/path-store/src/segments.ts
+++ b/packages/path-store/src/segments.ts
@@ -4,10 +4,10 @@ import { createSegmentSortKey } from './sort';
 export const ROOT_SEGMENT_VALUE = '';
 
 export function createSegmentTable(): SegmentTable {
+  const idByValue = new Map<string, SegmentId>();
+  idByValue.set(ROOT_SEGMENT_VALUE, 0);
   return {
-    idByValue: Object.assign(Object.create(null), {
-      [ROOT_SEGMENT_VALUE]: 0,
-    }) as Record<string, SegmentId | undefined>,
+    idByValue,
     valueById: [ROOT_SEGMENT_VALUE],
     sortKeyById: [createSegmentSortKey(ROOT_SEGMENT_VALUE)],
   };
@@ -20,15 +20,14 @@ export function internSegment(
   segmentTable: SegmentTable,
   value: string
 ): SegmentId {
-  const existingId = segmentTable.idByValue[value];
+  const existingId = segmentTable.idByValue.get(value);
   if (existingId !== undefined) {
     return existingId;
   }
 
   const nextId = segmentTable.valueById.length;
-  segmentTable.idByValue[value] = nextId;
+  segmentTable.idByValue.set(value, nextId);
   segmentTable.valueById.push(value);
-  segmentTable.sortKeyById.push(undefined);
   return nextId;
 }
 

--- a/packages/path-store/src/state.ts
+++ b/packages/path-store/src/state.ts
@@ -1,3 +1,4 @@
+import { getNodeDepth, hasNodeFlag, isDirectoryNode } from './internal-types';
 import type {
   DirectoryLoadInfo,
   NodeId,
@@ -5,7 +6,6 @@ import type {
   PathStoreSnapshot,
 } from './internal-types';
 import { PATH_STORE_NODE_FLAG_ROOT } from './internal-types';
-import { PATH_STORE_NODE_KIND_DIRECTORY } from './internal-types';
 import type { BenchmarkInstrumentation } from './internal/benchmarkInstrumentation';
 import type {
   PathStoreDirectoryLoadState,
@@ -31,10 +31,13 @@ export interface PathStoreState {
   activeNodeCount: number;
   collapsedDirectoryIds: Set<NodeId>;
   defaultExpansion: PathStoreInitialExpansion;
+  directoriesOpenByDefault: boolean;
+  hasCollapsedDirectoryOverrides: boolean;
   directoryLoadInfoById: Map<NodeId, DirectoryLoadInfo>;
   expandedDirectoryIds: Set<NodeId>;
   instrumentation: BenchmarkInstrumentation | null;
   listeners: Map<string, Set<(event: PathStoreEvent) => void>>;
+  pathCacheByNodeId: Map<NodeId, { path: string; version: number }>;
   pathCacheVersion: number;
   snapshot: PathStoreSnapshot;
   transactionStack: TransactionFrame[];
@@ -45,14 +48,20 @@ export function createPathStoreState(
   initialExpansion: PathStoreInitialExpansion = 'closed',
   instrumentation: BenchmarkInstrumentation | null = null
 ): PathStoreState {
+  const defaultExpansion = resolveInitialExpansion(initialExpansion);
   return {
     activeNodeCount: snapshot.nodes.length - 1,
     collapsedDirectoryIds: new Set<NodeId>(),
-    defaultExpansion: resolveInitialExpansion(initialExpansion),
+    defaultExpansion,
+    directoriesOpenByDefault: defaultExpansion === 'open',
+    hasCollapsedDirectoryOverrides: false,
     directoryLoadInfoById: new Map<NodeId, DirectoryLoadInfo>(),
     expandedDirectoryIds: new Set<NodeId>(),
     instrumentation,
     listeners: new Map<string, Set<(event: PathStoreEvent) => void>>(),
+    pathCacheByNodeId: new Map<NodeId, { path: string; version: number }>([
+      [snapshot.rootId, { path: '', version: 0 }],
+    ]),
     pathCacheVersion: 0,
     snapshot,
     transactionStack: [],
@@ -89,7 +98,7 @@ function isDirectoryExpandedByDefault(
   state: PathStoreState,
   node: PathStoreNode
 ): boolean {
-  if ((node.flags & PATH_STORE_NODE_FLAG_ROOT) !== 0) {
+  if (hasNodeFlag(node, PATH_STORE_NODE_FLAG_ROOT)) {
     return true;
   }
 
@@ -101,7 +110,7 @@ function isDirectoryExpandedByDefault(
     return false;
   }
 
-  return node.depth <= state.defaultExpansion;
+  return getNodeDepth(node) <= state.defaultExpansion;
 }
 
 export function isDirectoryExpanded(
@@ -109,8 +118,12 @@ export function isDirectoryExpanded(
   nodeId: NodeId,
   node: PathStoreNode | undefined = state.snapshot.nodes[nodeId]
 ): boolean {
-  if (node == null || node.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
+  if (node == null || !isDirectoryNode(node)) {
     return false;
+  }
+
+  if (state.directoriesOpenByDefault && !state.hasCollapsedDirectoryOverrides) {
+    return true;
   }
 
   if (state.collapsedDirectoryIds.has(nodeId)) {
@@ -130,7 +143,7 @@ export function setDirectoryExpanded(
   expanded: boolean,
   node: PathStoreNode | undefined = state.snapshot.nodes[nodeId]
 ): void {
-  if (node == null || node.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
+  if (node == null || !isDirectoryNode(node)) {
     return;
   }
 
@@ -138,6 +151,8 @@ export function setDirectoryExpanded(
   if (expanded) {
     if (expandedByDefault) {
       state.collapsedDirectoryIds.delete(nodeId);
+      state.hasCollapsedDirectoryOverrides =
+        state.collapsedDirectoryIds.size > 0;
       return;
     }
 
@@ -147,6 +162,7 @@ export function setDirectoryExpanded(
 
   if (expandedByDefault) {
     state.collapsedDirectoryIds.add(nodeId);
+    state.hasCollapsedDirectoryOverrides = true;
     return;
   }
 

--- a/packages/path-store/src/static-store.ts
+++ b/packages/path-store/src/static-store.ts
@@ -5,6 +5,9 @@ import {
   preparePathEntries,
 } from './builder';
 import {
+  getNodeDepth,
+  getNodeFlags,
+  getNodeKind,
   PATH_STORE_NODE_FLAG_EXPLICIT,
   PATH_STORE_NODE_FLAG_ROOT,
   PATH_STORE_NODE_KIND_DIRECTORY,
@@ -75,13 +78,13 @@ function createStaticSnapshot(
     sourceSnapshot.nodes.length
   ).fill(null);
   const nodes = sourceSnapshot.nodes.map(
-    (node): StaticPathStoreNode => ({
+    (node, nodeId): StaticPathStoreNode => ({
       childCount: 0,
-      depth: node.depth,
+      depth: getNodeDepth(node),
       firstChildIndex: -1,
-      flags: node.flags,
-      id: node.id,
-      kind: node.kind,
+      flags: getNodeFlags(node),
+      id: nodeId,
+      kind: getNodeKind(node),
       nameId: node.nameId,
       parentId: node.parentId,
       subtreeNodeCount: node.subtreeNodeCount,
@@ -89,12 +92,13 @@ function createStaticSnapshot(
     })
   );
 
-  for (const node of nodes) {
-    if (node.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
+  for (let nodeId = 0; nodeId < nodes.length; nodeId += 1) {
+    const node = nodes[nodeId];
+    if (node == null || node.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
       continue;
     }
 
-    const directoryIndex = sourceSnapshot.directories.get(node.id);
+    const directoryIndex = sourceSnapshot.directories.get(nodeId);
     if (directoryIndex == null) {
       continue;
     }
@@ -105,7 +109,7 @@ function createStaticSnapshot(
       childPositionByNodeId[childId] = childIds.length;
       childIds.push(childId);
     }
-    childVisibleChunkSumsByDirectory[node.id] =
+    childVisibleChunkSumsByDirectory[nodeId] =
       directoryIndex.childVisibleChunkSums == null
         ? null
         : [...directoryIndex.childVisibleChunkSums];
@@ -119,10 +123,7 @@ function createStaticSnapshot(
     options: sourceSnapshot.options,
     rootId: sourceSnapshot.rootId,
     segmentTable: {
-      idByValue: Object.assign(
-        Object.create(null),
-        sourceSnapshot.segmentTable.idByValue
-      ) as typeof sourceSnapshot.segmentTable.idByValue,
+      idByValue: new Map(sourceSnapshot.segmentTable.idByValue),
       sortKeyById: [...sourceSnapshot.segmentTable.sortKeyById],
       valueById: [...sourceSnapshot.segmentTable.valueById],
     },

--- a/packages/path-store/src/store.ts
+++ b/packages/path-store/src/store.ts
@@ -20,7 +20,10 @@ import {
   removePath,
   requireNode,
 } from './canonical';
-import { rebuildVisibleChildChunks } from './child-index';
+import {
+  PATH_STORE_CHILD_INDEX_CHUNK_THRESHOLD_EXTERNAL,
+  rebuildVisibleChildChunks,
+} from './child-index';
 import {
   cleanupPathStoreState,
   hasActiveCleanupBlockingLoads,
@@ -38,10 +41,8 @@ import {
   subscribe,
 } from './events';
 import { getFlattenedChildDirectoryId } from './flatten';
-import {
-  PATH_STORE_NODE_FLAG_ROOT,
-  PATH_STORE_NODE_KIND_DIRECTORY,
-} from './internal-types';
+import { getNodeDepth, isDirectoryNode } from './internal-types';
+import type { NodeId } from './internal-types';
 import {
   getBenchmarkInstrumentation,
   withBenchmarkPhase,
@@ -96,17 +97,33 @@ import type { PathStoreState } from './state';
 // overrides. This keeps the presorted first-render path from paying for a
 // second full-tree pass after the builder has already finalized subtree counts.
 function initializeOpenVisibleCounts(state: PathStoreState): void {
-  const { directories, nodes, options, rootId } = state.snapshot;
+  const { directories, nodes, options, rootId, presortedDirectoryNodeIds } =
+    state.snapshot;
+  const flattenEmptyDirectories = options.flattenEmptyDirectories === true;
 
-  const computeVisibleCounts = (nodeId: number): number => {
+  // Iterative reverse-order walk processing directories in post-order.
+  // Presorted construction assigns node IDs sequentially, so a directory's
+  // descendants always have higher IDs than the directory itself. This means
+  // reverse iteration finalizes every descendant before its parent.
+  //
+  // When the builder's presorted fast path recorded the directory IDs (the
+  // common case for bulk ingest), we walk just that list in reverse and
+  // skip the ~94% of iterations that would be files. Otherwise we fall back
+  // to scanning the full nodes array and branching on kind per iteration.
+  //
+  // PathStore's constructor passes `skipSubtreeCountPass: true` to
+  // builder.finish(), so subtreeNodeCount arrives un-accumulated (all 1s).
+  // This walk writes both subtreeNodeCount and visibleSubtreeCount for
+  // every directory; the reverse order guarantees children's counts are
+  // already finalized before their parent reads them.
+  // Root (nodeId === rootId === 0) is never passed to walkDirectory: the
+  // fallback loop starts at nodeId >= 1, and appendPresortedFilePaths only
+  // pushes newly-created directories (not the pre-existing root) into
+  // presortedDirectoryNodeIds. No root check needed inside the walker.
+  const walkDirectory = (nodeId: NodeId): void => {
     const currentNode = nodes[nodeId];
-    if (currentNode == null) {
-      throw new Error(`Unknown node ID: ${String(nodeId)}`);
-    }
-
-    if (currentNode.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
-      currentNode.visibleSubtreeCount = 1;
-      return 1;
+    if (currentNode == null || !isDirectoryNode(currentNode)) {
+      return;
     }
 
     const currentIndex = directories.get(nodeId);
@@ -116,52 +133,89 @@ function initializeOpenVisibleCounts(state: PathStoreState): void {
       );
     }
 
+    const childIds = currentIndex.childIds;
+    const childCount = childIds.length;
     let totalChildSubtreeNodeCount = 0;
     let totalChildVisibleSubtreeCount = 0;
-    const childIds = currentIndex.childIds;
-    for (let ci = 0; ci < childIds.length; ci++) {
+    for (let ci = 0; ci < childCount; ci++) {
       const childId = childIds[ci];
       if (childId == null) {
         continue;
       }
       const childNode = nodes[childId];
       totalChildSubtreeNodeCount += childNode.subtreeNodeCount;
-      // Inline the file-node case to avoid a recursive call for each file.
-      // Files always have visibleSubtreeCount = 1 (already set during
-      // construction), so we can accumulate directly.
-      if (childNode.kind === PATH_STORE_NODE_KIND_DIRECTORY) {
-        totalChildVisibleSubtreeCount += computeVisibleCounts(childId);
-      } else {
-        totalChildVisibleSubtreeCount += 1;
-      }
+      totalChildVisibleSubtreeCount += childNode.visibleSubtreeCount;
     }
 
     currentIndex.totalChildSubtreeNodeCount = totalChildSubtreeNodeCount;
     currentIndex.totalChildVisibleSubtreeCount = totalChildVisibleSubtreeCount;
-    rebuildVisibleChildChunks(nodes, currentIndex);
-
-    if ((currentNode.flags & PATH_STORE_NODE_FLAG_ROOT) !== 0) {
-      currentNode.visibleSubtreeCount = totalChildVisibleSubtreeCount;
-      return totalChildVisibleSubtreeCount;
+    // Avoid the rebuildVisibleChildChunks function call for directories that
+    // don't need chunk sums. The threshold matches the internal constant;
+    // createPresortedDirectoryChildIndex initializes childVisibleChunkSums
+    // to null already, so directories below the threshold need no write.
+    if (childCount >= PATH_STORE_CHILD_INDEX_CHUNK_THRESHOLD_EXTERNAL) {
+      rebuildVisibleChildChunks(nodes, currentIndex);
     }
 
-    const flattenedChildId =
-      options.flattenEmptyDirectories === true &&
-      currentIndex.childIds.length === 1
-        ? currentIndex.childIds[0]
-        : null;
-    const flattenedChildNode =
-      flattenedChildId == null ? null : nodes[flattenedChildId];
-    const isFlattenedDirectory =
-      flattenedChildNode?.kind === PATH_STORE_NODE_KIND_DIRECTORY;
+    // The builder's backward subtree-count pass is skipped by PathStore, so
+    // we populate subtreeNodeCount inline here. The reverse-order walk
+    // guarantees children's subtreeNodeCount has already been written before
+    // we read them.
+    currentNode.subtreeNodeCount = 1 + totalChildSubtreeNodeCount;
 
-    currentNode.visibleSubtreeCount = isFlattenedDirectory
-      ? totalChildVisibleSubtreeCount
-      : 1 + totalChildVisibleSubtreeCount;
-    return currentNode.visibleSubtreeCount;
+    // Root is at nodeId 0 and is handled after the loop, so the root flag
+    // never fires inside this body.
+    let newVisibleSubtreeCount: number;
+    if (flattenEmptyDirectories && childCount === 1) {
+      // Flattened directories inherit their sole child's visible count
+      // rather than contributing their own header row.
+      const onlyChild = nodes[childIds[0]];
+      newVisibleSubtreeCount =
+        onlyChild != null && isDirectoryNode(onlyChild)
+          ? totalChildVisibleSubtreeCount
+          : 1 + totalChildVisibleSubtreeCount;
+    } else {
+      newVisibleSubtreeCount = 1 + totalChildVisibleSubtreeCount;
+    }
+
+    currentNode.visibleSubtreeCount = newVisibleSubtreeCount;
   };
 
-  computeVisibleCounts(rootId);
+  if (presortedDirectoryNodeIds != null) {
+    for (let i = presortedDirectoryNodeIds.length - 1; i >= 0; i--) {
+      walkDirectory(presortedDirectoryNodeIds[i]);
+    }
+  } else {
+    for (let nodeId = nodes.length - 1; nodeId >= 1; nodeId--) {
+      walkDirectory(nodeId);
+    }
+  }
+
+  // Root is at id 0; the walk above skipped it so its visibleSubtreeCount
+  // does not pick up the wrong "not-root" arithmetic. Process root now.
+
+  const rootNode = nodes[rootId];
+  const rootIndex = directories.get(rootId);
+  if (rootNode == null || rootIndex == null) {
+    return;
+  }
+  const rootChildIds = rootIndex.childIds;
+  let rootTotalChildSubtreeNodeCount = 0;
+  let rootTotalChildVisibleSubtreeCount = 0;
+  for (let ci = 0; ci < rootChildIds.length; ci++) {
+    const childId = rootChildIds[ci];
+    if (childId == null) {
+      continue;
+    }
+    const childNode = nodes[childId];
+    rootTotalChildSubtreeNodeCount += childNode.subtreeNodeCount;
+    rootTotalChildVisibleSubtreeCount += childNode.visibleSubtreeCount;
+  }
+  rootIndex.totalChildSubtreeNodeCount = rootTotalChildSubtreeNodeCount;
+  rootIndex.totalChildVisibleSubtreeCount = rootTotalChildVisibleSubtreeCount;
+  rebuildVisibleChildChunks(nodes, rootIndex);
+  rootNode.subtreeNodeCount = 1 + rootTotalChildSubtreeNodeCount;
+  rootNode.visibleSubtreeCount = rootTotalChildVisibleSubtreeCount;
 }
 
 function canInitializeOpenVisibleCounts(
@@ -218,24 +272,45 @@ export class PathStore {
       }
     }
 
+    const snapshot = withBenchmarkPhase(
+      instrumentation,
+      'store.builder.finish',
+      () =>
+        // Either initializeOpenVisibleCounts or recomputeCountsRecursive runs
+        // below, and both populate subtreeNodeCount + visibleSubtreeCount
+        // from each directory's childIds. Skip the builder's own backward
+        // accumulation pass to avoid doing the same work twice on large
+        // presorted ingests.
+        builder.finish({ skipSubtreeCountPass: true })
+    );
+    const useExplicitOpenExpansionFastPath = withBenchmarkPhase(
+      instrumentation,
+      'store.state.detectAllDirectoriesExpanded',
+      () =>
+        (options.initialExpansion ?? 'closed') === 'closed' &&
+        builder.didMatchAllInitialExpandedPaths()
+    );
     this.#state = withBenchmarkPhase(
       instrumentation,
       'store.state.create',
       () =>
         createPathStoreState(
-          withBenchmarkPhase(instrumentation, 'store.builder.finish', () =>
-            builder.finish()
-          ),
-          options.initialExpansion ?? 'closed',
+          snapshot,
+          useExplicitOpenExpansionFastPath
+            ? 'open'
+            : (options.initialExpansion ?? 'closed'),
           instrumentation
         )
     );
-    const expandedDirectoryCount = withBenchmarkPhase(
-      instrumentation,
-      'store.state.initializeExpandedPaths',
-      () => this.initializeExpandedPaths(options.initialExpandedPaths)
-    );
+    const expandedDirectoryCount = useExplicitOpenExpansionFastPath
+      ? this.#state.snapshot.directories.size - 1
+      : withBenchmarkPhase(
+          instrumentation,
+          'store.state.initializeExpandedPaths',
+          () => this.initializeExpandedPaths(options.initialExpandedPaths)
+        );
     const canUseOpenVisibleCounts =
+      useExplicitOpenExpansionFastPath ||
       canInitializeOpenVisibleCounts(options) ||
       ((options.initialExpansion ?? 'closed') === 'closed' &&
         expandedDirectoryCount === this.#state.snapshot.directories.size - 1) ||
@@ -402,9 +477,8 @@ export class PathStore {
 
         const node = requireNode(this.#state, nodeId);
         return {
-          depth: node.depth,
-          kind:
-            node.kind === PATH_STORE_NODE_KIND_DIRECTORY ? 'directory' : 'file',
+          depth: getNodeDepth(node),
+          kind: isDirectoryNode(node) ? 'directory' : 'file',
           path: materializeNodePath(this.#state, nodeId),
         } satisfies PathStorePathInfo;
       }
@@ -908,7 +982,7 @@ export class PathStore {
         }
 
         const nextNode = requireNode(this.#state, nextNodeId);
-        if (nextNode.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
+        if (!isDirectoryNode(nextNode)) {
           foundDirectory = false;
           break;
         }
@@ -983,7 +1057,7 @@ export class PathStore {
     }
 
     const directoryNode = requireNode(this.#state, directoryNodeId);
-    if (directoryNode.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
+    if (!isDirectoryNode(directoryNode)) {
       throw new Error(`Path is not a directory: "${path}"`);
     }
 
@@ -993,7 +1067,7 @@ export class PathStore {
   private resolveActiveDirectoryNodeId(directoryNodeId: number): number | null {
     try {
       const directoryNode = requireNode(this.#state, directoryNodeId);
-      if (directoryNode.kind !== PATH_STORE_NODE_KIND_DIRECTORY) {
+      if (!isDirectoryNode(directoryNode)) {
         throw new Error(`Node is not a directory: ${String(directoryNodeId)}`);
       }
 

--- a/packages/path-store/test/profile-demo-cli.test.ts
+++ b/packages/path-store/test/profile-demo-cli.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from 'bun:test';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = fileURLToPath(new URL('../', import.meta.url));
+
+function createCommandEnv(): Record<string, string> {
+  const env: Record<string, string> = Object.fromEntries(
+    Object.entries(process.env).filter(
+      (entry): entry is [string, string] => entry[1] != null
+    )
+  );
+  env.AGENT = '1';
+  delete env.FORCE_COLOR;
+  delete env.NO_COLOR;
+  return env;
+}
+
+test('profile:demo CLI help reflects worktree-aware default ports', () => {
+  const result = Bun.spawnSync({
+    cmd: ['bun', 'run', './scripts/profileDemo.ts', '--help'],
+    cwd: packageRoot,
+    env: {
+      ...createCommandEnv(),
+      PIERRE_PORT_OFFSET: '30',
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  const stdout = new TextDecoder().decode(result.stdout);
+  const stderr = new TextDecoder().decode(result.stderr).trim();
+
+  expect(result.exitCode).toBe(0);
+  expect(stderr).toBe('');
+  expect(stdout).toContain('default: http://127.0.0.1:9252');
+  expect(stdout).toContain('default: http://127.0.0.1:4205/');
+});

--- a/packages/trees/package.json
+++ b/packages/trees/package.json
@@ -61,7 +61,7 @@
     "test:e2e": "bun run test:e2e:base && bunx playwright test -c test/e2e/playwright.config.ts --grep-invert @diagnostic",
     "test:e2e:sticky-drift": "bun run test:e2e:base && bunx playwright test -c test/e2e/playwright.config.ts test/e2e/file-tree-sticky-context-menu-scroll-drift.pw.ts",
     "test:e2e:installbinary": "bunx playwright@1.51.1 install chromium",
-    "test:e2e:server": "vite --config test/e2e/vite.config.ts",
+    "test:e2e:server": "FILE_TREE_E2E_PORT=${FILE_TREE_E2E_PORT:-$((${PIERRE_PORT_OFFSET:-0} + 9221))} vite --config test/e2e/vite.config.ts",
     "tsc": "tsgo --noEmit --pretty",
     "generate-icons": "bun scripts/generate-built-in-icons.ts",
     "publish-package": "bun run ./scripts/publish.ts",

--- a/packages/trees/scripts/benchmarkFileTreeGetItem.ts
+++ b/packages/trees/scripts/benchmarkFileTreeGetItem.ts
@@ -1,7 +1,7 @@
 import { getVirtualizationWorkload } from '@pierre/tree-test-data';
 
-import { preparePresortedFileTreeInput } from '../src/index';
 import { FileTreeController } from '../src/model/FileTreeController';
+import { preparePresortedFileTreeInput } from '../src/preparedInput';
 
 const workload = getVirtualizationWorkload('linux-5x');
 const preparedInput = preparePresortedFileTreeInput(workload.files);

--- a/packages/trees/scripts/lib/fileTreeProfileShared.ts
+++ b/packages/trees/scripts/lib/fileTreeProfileShared.ts
@@ -1,7 +1,9 @@
 import { getVirtualizationWorkload } from '@pierre/tree-test-data';
 import type { VirtualizationWorkload } from '@pierre/tree-test-data';
 
-import { preparePresortedFileTreeInput } from '../../src/index';
+// Keep the profiling fixture on the narrow data-preparation entrypoint so the
+// Vite-served page does not accidentally import the source render runtime.
+import { preparePresortedFileTreeInput } from '../../src/preparedInput';
 
 export const FILE_TREE_PROFILE_WORKLOAD_NAMES = [
   'linux-5x',
@@ -78,7 +80,10 @@ export function createFileTreeProfileFixtureOptions(
 ) {
   return {
     flattenEmptyDirectories: true,
-    initialExpandedPaths: workload.expandedFolders,
+    // All profiling workloads expand every derived directory, so open-default
+    // startup is semantically identical to replaying a huge explicit expanded
+    // path list and avoids constructor-side expansion normalization work.
+    initialExpansion: 'open' as const,
     preparedInput: preparePresortedFileTreeInput(workload.files),
     initialVisibleRowCount: FILE_TREE_PROFILE_VIEWPORT_HEIGHT / 30,
   };

--- a/packages/trees/scripts/profileFileTree.ts
+++ b/packages/trees/scripts/profileFileTree.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { loadWorktreeEnv } from '../../../scripts/load-worktree-env.mjs';
 import {
   DEFAULT_FILE_TREE_PROFILE_WORKLOAD_NAME,
   FILE_TREE_PROFILE_WORKLOAD_NAMES,
@@ -316,10 +317,21 @@ declare global {
   }
 }
 
+// Mirror the Playwright config behavior so direct profiling runs pick up the
+// same worktree port offset as `bun ws` and `bun run chrome`.
+loadWorktreeEnv();
+
+function readWorktreePortOffset(): number {
+  const parsed = Number(process.env.PIERRE_PORT_OFFSET ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+const WORKTREE_PORT_OFFSET = readWorktreePortOffset();
+const DEFAULT_BROWSER_DEBUG_PORT = 9222 + WORKTREE_PORT_OFFSET;
+const DEFAULT_FIXTURE_SERVER_PORT = 9221 + WORKTREE_PORT_OFFSET;
 const packageRoot = fileURLToPath(new URL('../', import.meta.url));
-const DEFAULT_BROWSER_URL = 'http://127.0.0.1:9222';
-const DEFAULT_URL =
-  'http://127.0.0.1:9221/test/e2e/fixtures/file-tree-profile.html';
+const DEFAULT_BROWSER_URL = `http://127.0.0.1:${DEFAULT_BROWSER_DEBUG_PORT}`;
+const DEFAULT_URL = `http://127.0.0.1:${DEFAULT_FIXTURE_SERVER_PORT}/test/e2e/fixtures/file-tree-profile.html`;
 const DEFAULT_WORKLOAD_NAME = DEFAULT_FILE_TREE_PROFILE_WORKLOAD_NAME;
 const KNOWN_WORKLOAD_NAMES = new Set<FileTreeProfileWorkloadName>(
   FILE_TREE_PROFILE_WORKLOAD_NAMES
@@ -3566,7 +3578,7 @@ async function main(): Promise<void> {
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(
-      `${message}\n\nRun Chrome with remote debugging first, for example:\n/Applications/Google\\ Chrome\\ Dev.app/Contents/MacOS/Google\\ Chrome\\ Dev --remote-debugging-port=9222 --user-data-dir=/tmp/chrome-devtools-codex`
+      `${message}\n\nRun Chrome with remote debugging first, for example:\n/Applications/Google\\ Chrome\\ Dev.app/Contents/MacOS/Google\\ Chrome\\ Dev --remote-debugging-port=${DEFAULT_BROWSER_DEBUG_PORT} --user-data-dir=/tmp/chrome-devtools-codex`
     );
   } finally {
     serverProcess?.kill();

--- a/packages/trees/src/model/FileTreeController.ts
+++ b/packages/trees/src/model/FileTreeController.ts
@@ -289,6 +289,10 @@ function haveMatchingPaths(
   currentPaths: readonly string[],
   preparedPaths: readonly string[]
 ): boolean {
+  if (currentPaths === preparedPaths) {
+    return true;
+  }
+
   if (currentPaths.length !== preparedPaths.length) {
     return false;
   }
@@ -325,10 +329,17 @@ function resolveFileTreeInput(
   }
 
   const preparedPaths = preparedInput.paths;
-  const comparablePaths =
-    paths == null
-      ? preparedPaths
-      : PathStore.preparePaths(paths, sort == null ? {} : { sort });
+  if (paths == null) {
+    return {
+      paths: preparedPaths,
+      preparedInput,
+    };
+  }
+
+  const comparablePaths = PathStore.preparePaths(
+    paths,
+    sort == null ? {} : { sort }
+  );
   if (!haveMatchingPaths(comparablePaths, preparedPaths)) {
     throw new Error(
       `FileTree ${context} received paths and preparedInput for different path lists`

--- a/packages/trees/src/render/FileTreeView.tsx
+++ b/packages/trees/src/render/FileTreeView.tsx
@@ -964,7 +964,6 @@ function renderStyledRow(
     onKeyDown,
   } = frame;
   const targetPath = getFileTreeRowPath(row);
-  const item = controller.getItem(targetPath);
   const { isParked = false, mode = 'flow', style } = options;
   const isSticky = mode === 'sticky';
   const ownGitStatus = gitStatusByPath?.get(targetPath) ?? null;
@@ -1069,7 +1068,7 @@ function renderStyledRow(
             if (!contextMenuRightClickEnabled) {
               return;
             }
-            item?.focus();
+            controller.focusPath(targetPath);
             openContextMenuForRow(row, targetPath, {
               anchorRect: createAnchorRectFromPoint(
                 event.clientX,
@@ -1081,7 +1080,7 @@ function renderStyledRow(
         : undefined,
     onFocus: !isSticky
       ? () => {
-          item?.focus();
+          controller.focusPath(targetPath);
         }
       : undefined,
     onKeyDown: !isSticky ? onKeyDown : undefined,
@@ -2351,8 +2350,13 @@ export function FileTreeView({
     };
 
     updateViewportRef.current = update;
+    let hasSeenInitialControllerSnapshot = false;
     const unsubscribe = controller.subscribe(() => {
-      setControllerRevision((revision) => revision + 1);
+      if (hasSeenInitialControllerSnapshot) {
+        setControllerRevision((revision) => revision + 1);
+      } else {
+        hasSeenInitialControllerSnapshot = true;
+      }
       update();
     });
     // Flip a plain DOM attribute on the root (not React state) so the anchor
@@ -2496,7 +2500,6 @@ export function FileTreeView({
           })
         : null;
     resizeObserver?.observe(scrollElement);
-    update();
 
     return () => {
       updateViewportRef.current = () => {};

--- a/packages/trees/test/file-tree-profile-cli.test.ts
+++ b/packages/trees/test/file-tree-profile-cli.test.ts
@@ -34,6 +34,29 @@ test('profile:file-tree CLI help advertises the expected workload/render workflo
   expect(stdout).toContain('file-tree-profile.html');
 });
 
+test('profile:file-tree CLI help reflects worktree-aware default ports', () => {
+  const result = Bun.spawnSync({
+    cmd: ['bun', 'run', './scripts/profileFileTree.ts', '--help'],
+    cwd: packageRoot,
+    env: {
+      ...createCommandEnv(),
+      PIERRE_PORT_OFFSET: '30',
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  const stdout = new TextDecoder().decode(result.stdout);
+  const stderr = new TextDecoder().decode(result.stderr).trim();
+
+  expect(result.exitCode).toBe(0);
+  expect(stderr).toBe('');
+  expect(stdout).toContain('default: http://127.0.0.1:9252');
+  expect(stdout).toContain(
+    'default: http://127.0.0.1:9251/test/e2e/fixtures/file-tree-profile.html'
+  );
+});
+
 test('profile:file-tree CLI rejects unknown workloads before browser setup', () => {
   const result = Bun.spawnSync({
     cmd: [

--- a/packages/trees/test/file-tree-profile-fixture.test.ts
+++ b/packages/trees/test/file-tree-profile-fixture.test.ts
@@ -10,7 +10,7 @@ import {
   FILE_TREE_PROFILE_WORKLOAD_NAMES,
   getFileTreeProfileWorkload,
 } from '../scripts/lib/fileTreeProfileShared';
-import { preparePresortedFileTreeInput } from '../src/index';
+import { preparePresortedFileTreeInput } from '../src/preparedInput';
 
 const packageRoot = fileURLToPath(new URL('../', import.meta.url));
 
@@ -29,7 +29,8 @@ test('file-tree profile fixture options mirror the Phase 4 docs tree behavior', 
   const options = createFileTreeProfileFixtureOptions(workload);
 
   expect(options.flattenEmptyDirectories).toBe(true);
-  expect(options.initialExpandedPaths).toEqual(workload.expandedFolders);
+  expect(options.initialExpansion).toBe('open');
+  expect('initialExpandedPaths' in options).toBe(false);
   expect('paths' in options).toBe(false);
   expect(options.initialVisibleRowCount).toBe(
     FILE_TREE_PROFILE_VIEWPORT_HEIGHT / 30


### PR DESCRIPTION
Improves the packages/trees file-tree profiler startup path for large pre-expanded/open trees. The change stack removes redundant prepared-input validation, represents profiler workloads with initialExpansion: 'open', slims PathStore node/storage shapes, reduces cold startup writes, tunes visible-child chunk summaries, and removes redundant FileTreeView mount/render work.

 - Kept experiments: 36
 - Final non-session diff: 22 files, 770 insertions(+), 371 deletions(-)
 - Baseline metric: 334.8ms
 - Best recorded kept metric: 253.8ms (-24.2%)
 - Current final kept sample: 267.8ms (-20.0%)
