### PR TITLE
[trees] attempt to fix ios drag and drop weirdness

### DIFF
--- a/packages/trees/src/render/FileTreeView.tsx
+++ b/packages/trees/src/render/FileTreeView.tsx
@@ -270,7 +270,40 @@ function getPointElement(
     pointRoot.elementFromPoint?.(clientX, clientY) ??
     documentElementFromPoint?.(clientX, clientY) ??
     null;
+  if (
+    rootNode instanceof ShadowRoot &&
+    (element == null || !rootNode.contains(element))
+  ) {
+    return getShadowPointElementByGeometry(rootNode, clientX, clientY);
+  }
+
   return element instanceof HTMLElement ? element : null;
+}
+
+function getShadowPointElementByGeometry(
+  rootNode: ShadowRoot,
+  clientX: number,
+  clientY: number
+): HTMLElement | null {
+  const candidates = Array.from(
+    rootNode.querySelectorAll<HTMLElement>(
+      '[data-type="item"], [data-item-flattened-subitem]'
+    )
+  );
+  for (let index = candidates.length - 1; index >= 0; index--) {
+    const candidate = candidates[index];
+    const rect = candidate.getBoundingClientRect();
+    if (
+      clientX >= rect.left &&
+      clientX <= rect.right &&
+      clientY >= rect.top &&
+      clientY <= rect.bottom
+    ) {
+      return candidate;
+    }
+  }
+
+  return null;
 }
 
 function resolveDropTargetFromElement(
@@ -1888,7 +1921,11 @@ export function FileTreeView({
     touchSourceElementRef.current = dragSource;
     dragSource.setAttribute('draggable', 'false');
 
-    const clearPendingTouchStart = (): void => {
+    const clearPendingTouchStart = (
+      options: { restoreNativeDraggable?: boolean } = {}
+    ): void => {
+      const restoreNativeDraggable =
+        options.restoreNativeDraggable ?? !touchDragActiveRef.current;
       if (touchLongPressTimerRef.current != null) {
         clearTimeout(touchLongPressTimerRef.current);
         touchLongPressTimerRef.current = null;
@@ -1899,7 +1936,7 @@ export function FileTreeView({
       if (touchCleanupRef.current === clearPendingTouchStart) {
         touchCleanupRef.current = null;
       }
-      if (!touchDragActiveRef.current) {
+      if (restoreNativeDraggable) {
         dragSource.setAttribute('draggable', 'true');
         if (touchSourceElementRef.current === dragSource) {
           touchSourceElementRef.current = null;
@@ -1938,7 +1975,10 @@ export function FileTreeView({
     document.addEventListener('touchcancel', handlePendingTouchEnd);
     touchCleanupRef.current = clearPendingTouchStart;
     touchLongPressTimerRef.current = setTimeout(() => {
-      clearPendingTouchStart();
+      // Keep native draggable disabled while the custom touch drag activates.
+      // iOS Safari can otherwise promote the same long press into its native
+      // HTML drag flow before the touch-specific listeners take over.
+      clearPendingTouchStart({ restoreNativeDraggable: false });
       if (controller.startDrag(targetPath) === false) {
         dragSource.setAttribute('draggable', 'true');
         if (touchSourceElementRef.current === dragSource) {

--- a/packages/trees/test/file-tree-drag-and-drop.test.ts
+++ b/packages/trees/test/file-tree-drag-and-drop.test.ts
@@ -139,6 +139,32 @@ function dispatchDragEvent(
   element.dispatchEvent(event);
 }
 
+function dispatchTouchEvent(
+  target: EventTarget,
+  dom: JSDOM,
+  type: string,
+  init: {
+    changedTouches?: readonly { clientX: number; clientY: number }[];
+    touches?: readonly { clientX: number; clientY: number }[];
+  }
+): void {
+  const event = new dom.window.Event(type, {
+    bubbles: true,
+    cancelable: true,
+  });
+  Object.defineProperties(event, {
+    changedTouches: {
+      configurable: true,
+      value: init.changedTouches ?? init.touches ?? [],
+    },
+    touches: {
+      configurable: true,
+      value: init.touches ?? [],
+    },
+  });
+  target.dispatchEvent(event);
+}
+
 function getTreeRoot(
   shadowRoot: ShadowRoot | null | undefined,
   dom: JSDOM
@@ -377,24 +403,154 @@ describe('file-tree drag and drop', () => {
         rendered.dom,
         'README.md'
       );
-      const touchStartEvent = new rendered.dom.window.Event('touchstart', {
-        bubbles: true,
-        cancelable: true,
-      });
-      Object.defineProperty(touchStartEvent, 'touches', {
-        configurable: true,
-        value: [{ clientX: 12, clientY: 12 }],
-      });
 
-      sourceButton.dispatchEvent(touchStartEvent);
+      dispatchTouchEvent(sourceButton, rendered.dom, 'touchstart', {
+        touches: [{ clientX: 12, clientY: 12 }],
+      });
       await flushDom();
       expect(sourceButton.getAttribute('draggable')).toBe('false');
 
-      rendered.dom.window.document.dispatchEvent(
-        new rendered.dom.window.Event('touchend', { bubbles: true })
+      dispatchTouchEvent(
+        rendered.dom.window.document,
+        rendered.dom,
+        'touchend',
+        {
+          changedTouches: [{ clientX: 12, clientY: 12 }],
+        }
       );
       await flushDom();
       expect(sourceButton.getAttribute('draggable')).toBe('true');
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  test('touch drag activation keeps native draggable disabled', async () => {
+    const rendered = await renderFileTree({
+      dragAndDrop: true,
+      flattenEmptyDirectories: true,
+      initialExpandedPaths: ['src/'],
+      paths: ['README.md', 'src/index.ts'],
+      initialVisibleRowCount: 180 / 30,
+    });
+
+    try {
+      const sourceButton = getItemButton(
+        rendered.shadowRoot,
+        rendered.dom,
+        'README.md'
+      );
+      const draggableWrites: string[] = [];
+      const setAttribute = sourceButton.setAttribute.bind(sourceButton);
+      sourceButton.setAttribute = (name: string, value: string): void => {
+        if (name === 'draggable') {
+          draggableWrites.push(value);
+        }
+        setAttribute(name, value);
+      };
+
+      dispatchTouchEvent(sourceButton, rendered.dom, 'touchstart', {
+        touches: [{ clientX: 12, clientY: 12 }],
+      });
+      await new Promise((resolve) => setTimeout(resolve, 450));
+      await flushDom();
+
+      expect(draggableWrites).not.toContain('true');
+      expect(sourceButton.getAttribute('draggable')).toBe('false');
+      expect(getDraggingPaths(rendered.shadowRoot)).toEqual(['README.md']);
+
+      dispatchTouchEvent(
+        rendered.dom.window.document,
+        rendered.dom,
+        'touchcancel',
+        {
+          changedTouches: [{ clientX: 12, clientY: 12 }],
+        }
+      );
+      await flushDom();
+      expect(sourceButton.getAttribute('draggable')).toBe('true');
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  test('touch drag resolves drop targets when shadow hit-testing retargets to the host', async () => {
+    const rendered = await renderFileTree({
+      dragAndDrop: true,
+      flattenEmptyDirectories: true,
+      initialExpandedPaths: ['src/'],
+      paths: ['README.md', 'src/index.ts'],
+      initialVisibleRowCount: 180 / 30,
+    });
+
+    try {
+      const host = rendered.fileTree.getFileTreeContainer();
+      if (!(host instanceof rendered.dom.window.HTMLElement)) {
+        throw new Error('missing file tree host');
+      }
+      const sourceButton = getItemButton(
+        rendered.shadowRoot,
+        rendered.dom,
+        'README.md'
+      );
+      const targetButton = getItemButton(
+        rendered.shadowRoot,
+        rendered.dom,
+        'src/'
+      );
+      sourceButton.getBoundingClientRect = () =>
+        ({
+          bottom: 30,
+          height: 30,
+          left: 0,
+          right: 240,
+          top: 0,
+          width: 240,
+          x: 0,
+          y: 0,
+        }) as DOMRect;
+      targetButton.getBoundingClientRect = () =>
+        ({
+          bottom: 70,
+          height: 30,
+          left: 0,
+          right: 240,
+          top: 40,
+          width: 240,
+          x: 0,
+          y: 40,
+        }) as DOMRect;
+      rendered.dom.window.document.elementFromPoint = () => host;
+
+      dispatchTouchEvent(sourceButton, rendered.dom, 'touchstart', {
+        touches: [{ clientX: 12, clientY: 12 }],
+      });
+      await new Promise((resolve) => setTimeout(resolve, 450));
+      await flushDom();
+      dispatchTouchEvent(
+        rendered.dom.window.document,
+        rendered.dom,
+        'touchmove',
+        {
+          touches: [{ clientX: 12, clientY: 52 }],
+        }
+      );
+      await flushDom();
+      expect(getDragTargetPaths(rendered.shadowRoot)).toEqual(['src/']);
+
+      dispatchTouchEvent(
+        rendered.dom.window.document,
+        rendered.dom,
+        'touchend',
+        {
+          changedTouches: [{ clientX: 12, clientY: 52 }],
+        }
+      );
+      await flushDom();
+
+      expect(rendered.fileTree.getItem('src/README.md')).not.toBeNull();
+      expect(getDraggingPaths(rendered.shadowRoot)).toEqual([]);
+      expect(getDragTargetPaths(rendered.shadowRoot)).toEqual([]);
     } finally {
       rendered.cleanup();
     }


### PR DESCRIPTION
Root cause looked like two related issues:

  1. During long-press activation, we briefly restored draggable="true" before switching into the custom touch drag path.
     On iOS Safari that can race into the native HTML drag path.
  2. The custom touch path could miss targets when hit-testing retargeted out of the shadow root, so drops could complete
     with no target.

  Changes:

  - Kept native draggable disabled during touch-drag activation: packages/trees/src/render/FileTreeView.tsx:1924
  - Added a shadow-root geometry fallback for touch hit-testing: packages/trees/src/render/FileTreeView.tsx:259
  - Added regression coverage for both the draggable race and host-retargeted touch hit-testing: packages/trees/test/file-
    tree-drag-and-drop.test.ts:428

  Verified:

  - bun run format
  - bun test packages/trees/test/file-tree-drag-and-drop.test.ts
  - bun ws trees tsc
  - bun ws trees test:e2e test/e2e/file-tree-drag-and-drop.pw.ts
  - bun run lint exits 0; repo still has 10 pre-existing warnings
  - bun run wt clean completed after E2E.