### PR TITLE
[trees] Avoid full projection rebuild on expand-collapse

### DIFF
--- a/packages/path-store/src/child-index.ts
+++ b/packages/path-store/src/child-index.ts
@@ -229,6 +229,47 @@ export function selectChildIndexByVisibleIndex(
   );
 }
 
+// Returns the number of visible rows contributed by siblings before a child.
+// Wide directories use the same chunk sums as visible-index selection so path
+// lookups do not need to scan thousands of siblings one by one.
+export function getVisibleChildPrefixCount(
+  nodes: readonly PathStoreNode[],
+  index: DirectoryChildIndex,
+  childPosition: number
+): number {
+  let visibleCount = 0;
+  const chunkSums = index.childVisibleChunkSums;
+  let scanStart = 0;
+
+  if (chunkSums != null) {
+    const chunkIndex = childPosition >> PATH_STORE_CHILD_INDEX_CHUNK_SHIFT;
+    for (let chunkOffset = 0; chunkOffset < chunkIndex; chunkOffset += 1) {
+      visibleCount += chunkSums[chunkOffset] ?? 0;
+    }
+    scanStart = chunkIndex << PATH_STORE_CHILD_INDEX_CHUNK_SHIFT;
+  }
+
+  for (
+    let childIndex = scanStart;
+    childIndex < childPosition;
+    childIndex += 1
+  ) {
+    const childId = index.childIds[childIndex];
+    if (childId == null) {
+      continue;
+    }
+
+    const childNode = nodes[childId];
+    if (childNode == null) {
+      continue;
+    }
+
+    visibleCount += childNode.visibleSubtreeCount;
+  }
+
+  return visibleCount;
+}
+
 export function rebuildVisibleChildChunks(
   nodes: readonly PathStoreNode[],
   index: DirectoryChildIndex

--- a/packages/path-store/src/projection.ts
+++ b/packages/path-store/src/projection.ts
@@ -8,6 +8,7 @@ import {
 } from './canonical';
 import {
   ensureChildPositions,
+  getVisibleChildPrefixCount,
   selectChildIndexByVisibleIndex,
 } from './child-index';
 import { createCollapseEvent, createExpandEvent } from './events';
@@ -380,6 +381,70 @@ export function getVisibleTreeProjection(
   return createVisibleTreeProjectionFromData(
     getVisibleTreeProjectionData(state)
   );
+}
+
+// Resolves one canonical path to its current visible row index using stored
+// subtree counts rather than materializing the whole path-to-index map.
+export function getVisibleIndexByPath(
+  state: PathStoreState,
+  path: string
+): number | null {
+  const nodeId = findNodeId(state, path);
+  if (nodeId == null || nodeId === state.snapshot.rootId) {
+    return null;
+  }
+
+  const node = requireNode(state, nodeId);
+  if (
+    isDirectoryNode(node) &&
+    getFlattenedTerminalDirectoryId(state, nodeId) !== nodeId
+  ) {
+    return null;
+  }
+
+  let visibleIndex = 0;
+  let currentNodeId = nodeId;
+  const { nodes, rootId } = state.snapshot;
+
+  while (currentNodeId !== rootId) {
+    const currentNode = requireNode(state, currentNodeId);
+    const parentId = currentNode.parentId;
+    const parentIndex = getDirectoryIndex(state, parentId);
+    const childPosition = ensureChildPositions(parentIndex).get(currentNodeId);
+    if (childPosition == null) {
+      throw new Error(
+        `Child ${String(currentNodeId)} was not found in its parent index`
+      );
+    }
+
+    visibleIndex += getVisibleChildPrefixCount(
+      nodes,
+      parentIndex,
+      childPosition
+    );
+
+    if (parentId !== rootId) {
+      const parentNode = requireNode(state, parentId);
+      const flattenedChildDirectoryId = getFlattenedChildDirectoryId(
+        state,
+        parentId
+      );
+      if (
+        !isDirectoryExpanded(state, parentId, parentNode) &&
+        flattenedChildDirectoryId !== currentNodeId
+      ) {
+        return null;
+      }
+
+      if (getFlattenedTerminalDirectoryId(state, parentId) === parentId) {
+        visibleIndex += 1;
+      }
+    }
+
+    currentNodeId = parentId;
+  }
+
+  return visibleIndex;
 }
 
 export function expandPath(

--- a/packages/path-store/src/store.ts
+++ b/packages/path-store/src/store.ts
@@ -51,6 +51,7 @@ import {
   collapsePath,
   expandPath,
   getVisibleCount,
+  getVisibleIndexByPath,
   getVisibleRowContext,
   getVisibleSlice,
   getVisibleTreeProjectionData as getVisibleTreeProjectionDataFromState,
@@ -474,6 +475,18 @@ export class PathStore {
     maxRows?: number
   ): PathStoreVisibleTreeProjectionData {
     return getVisibleTreeProjectionDataFromState(this.#state, maxRows);
+  }
+
+  /**
+   * Resolves a path to its visible row index without building a full projection
+   * index. Returns null when the path is unknown or currently hidden.
+   */
+  public getVisibleIndex(path: string): number | null {
+    return withBenchmarkPhase(
+      this.#state.instrumentation,
+      'store.getVisibleIndex',
+      () => getVisibleIndexByPath(this.#state, path)
+    );
   }
 
   /**

--- a/packages/trees/src/model/FileTreeController.ts
+++ b/packages/trees/src/model/FileTreeController.ts
@@ -2199,7 +2199,7 @@ export class FileTreeController
   }
 
   #setFocusedIndex(index: number, emit: boolean = true): void {
-    const nextPath = this.#getCurrentVisiblePaths()[index];
+    const nextPath = this.#resolveVisiblePathAtIndex(index);
     if (nextPath == null) {
       return;
     }

--- a/packages/trees/src/model/FileTreeController.ts
+++ b/packages/trees/src/model/FileTreeController.ts
@@ -53,8 +53,6 @@ interface FileTreeVisibleProjection {
   paths: readonly string[];
   posInSetByIndex: ProjectionIndexBuffer;
   setSizeByIndex: ProjectionIndexBuffer;
-  visibleIndexByPath: Map<string, number> | null;
-  visibleIndexByPathFactory: () => Map<string, number>;
 }
 
 type MutationListener = (event: FileTreeMutationEvent) => void;
@@ -126,21 +124,6 @@ function getAncestorDirectoryPaths(path: string): readonly string[] {
   return segments
     .slice(0, -1)
     .map((_, index) => `${segments.slice(0, index + 1).join('/')}/`);
-}
-
-function findNearestVisibleAncestorPath(
-  visibleIndexByPath: ReadonlyMap<string, number>,
-  path: string
-): string | null {
-  const ancestorPaths = getAncestorDirectoryPaths(path);
-  for (let index = ancestorPaths.length - 1; index >= 0; index -= 1) {
-    const ancestorPath = ancestorPaths[index];
-    if (ancestorPath != null && visibleIndexByPath.has(ancestorPath)) {
-      return ancestorPath;
-    }
-  }
-
-  return null;
 }
 
 function getImmediateParentPath(path: string): string | null {
@@ -421,11 +404,11 @@ function toTreesMutationEvent(
   }
 }
 
-// Keeps logical focus on a visible row. When a focused descendant disappears,
-// this falls back to the nearest visible ancestor before defaulting to row 0.
-function resolveFocusedIndex(
+// Keeps focus resolution cheap after expand/collapse by asking for only the
+// candidate path and its ancestors instead of forcing a full visible-index map.
+function resolveFocusedIndexByLookup(
   rowCount: number,
-  visibleIndexByPath: ReadonlyMap<string, number>,
+  getVisibleIndex: (path: string) => number | null,
   candidatePath: string | null
 ): number {
   if (rowCount === 0) {
@@ -433,17 +416,22 @@ function resolveFocusedIndex(
   }
 
   if (candidatePath != null) {
-    const directIndex = visibleIndexByPath.get(candidatePath);
+    const directIndex = getVisibleIndex(candidatePath);
     if (directIndex != null) {
       return directIndex;
     }
 
-    const ancestorPath = findNearestVisibleAncestorPath(
-      visibleIndexByPath,
-      candidatePath
-    );
-    if (ancestorPath != null) {
-      return visibleIndexByPath.get(ancestorPath) ?? 0;
+    const ancestorPaths = getAncestorDirectoryPaths(candidatePath);
+    for (let index = ancestorPaths.length - 1; index >= 0; index -= 1) {
+      const ancestorPath = ancestorPaths[index];
+      if (ancestorPath == null) {
+        continue;
+      }
+
+      const ancestorIndex = getVisibleIndex(ancestorPath);
+      if (ancestorIndex != null) {
+        return ancestorIndex;
+      }
     }
   }
 
@@ -456,7 +444,8 @@ function resolveFocusedIndex(
 // treeitem ARIA attrs without exposing PathStore's numeric row identities.
 function createVisibleProjection(
   projection: PathStoreVisibleTreeProjectionData,
-  focusedPathCandidate: string | null
+  focusedPathCandidate: string | null,
+  resolveVisibleIndexByPath?: (path: string) => number | null
 ): FileTreeVisibleProjection {
   if (projection.paths.length === 0) {
     return {
@@ -465,8 +454,6 @@ function createVisibleProjection(
       paths: projection.paths,
       posInSetByIndex: projection.posInSetByIndex,
       setSizeByIndex: projection.setSizeByIndex,
-      visibleIndexByPath: null,
-      visibleIndexByPathFactory: () => projection.visibleIndexByPath,
     };
   }
 
@@ -477,24 +464,23 @@ function createVisibleProjection(
       paths: projection.paths,
       posInSetByIndex: projection.posInSetByIndex,
       setSizeByIndex: projection.setSizeByIndex,
-      visibleIndexByPath: null,
-      visibleIndexByPathFactory: () => projection.visibleIndexByPath,
     };
   }
 
-  const visibleIndexByPath = projection.visibleIndexByPath;
+  const getVisibleIndex =
+    resolveVisibleIndexByPath ??
+    ((path: string): number | null =>
+      projection.visibleIndexByPath.get(path) ?? null);
   return {
-    focusedIndex: resolveFocusedIndex(
+    focusedIndex: resolveFocusedIndexByLookup(
       projection.paths.length,
-      visibleIndexByPath,
+      getVisibleIndex,
       focusedPathCandidate
     ),
     getParentIndex: projection.getParentIndex,
     paths: projection.paths,
     posInSetByIndex: projection.posInSetByIndex,
     setSizeByIndex: projection.setSizeByIndex,
-    visibleIndexByPath,
-    visibleIndexByPathFactory: () => visibleIndexByPath,
   };
 }
 
@@ -553,8 +539,6 @@ export class FileTreeController
   #suppressStoreNotifications = false;
   #visibleCount = 0;
   #unsubscribe: (() => void) | null;
-  #visibleIndexByPath: Map<string, number> | null = null;
-  #visibleIndexByPathFactory: (() => Map<string, number>) | null = null;
 
   public constructor(options: FileTreeControllerOptions) {
     const {
@@ -1528,13 +1512,6 @@ export class FileTreeController
     } satisfies FileTreeResetEvent);
   }
 
-  #ensureVisibleIndexByPath(): ReadonlyMap<string, number> {
-    this.#visibleIndexByPath ??=
-      this.#visibleIndexByPathFactory?.() ?? new Map();
-
-    return this.#visibleIndexByPath;
-  }
-
   #findNearestVisibleSiblingPath(path: string): string | null {
     this.#ensureFullProjection();
     const parentPath = getImmediateParentPath(path);
@@ -1568,12 +1545,17 @@ export class FileTreeController
       return directIndex;
     }
 
-    const ancestorPath = findNearestVisibleAncestorPath(
-      this.#searchVisibleIndexByPath ?? this.#ensureVisibleIndexByPath(),
-      path
-    );
-    if (ancestorPath != null) {
-      return this.#getVisibleIndexByPath(ancestorPath);
+    const ancestorPaths = getAncestorDirectoryPaths(path);
+    for (let index = ancestorPaths.length - 1; index >= 0; index -= 1) {
+      const ancestorPath = ancestorPaths[index];
+      if (ancestorPath == null) {
+        continue;
+      }
+
+      const ancestorIndex = this.#getVisibleIndexByPath(ancestorPath);
+      if (ancestorIndex !== -1) {
+        return ancestorIndex;
+      }
     }
 
     return this.#getCurrentVisiblePaths().length > 0 ? 0 : -1;
@@ -1961,11 +1943,12 @@ export class FileTreeController
   }
 
   #getVisibleIndexByPath(path: string): number {
-    return (
-      this.#searchVisibleIndexByPath?.get(path) ??
-      this.#ensureVisibleIndexByPath().get(path) ??
-      -1
-    );
+    const searchIndex = this.#searchVisibleIndexByPath?.get(path);
+    if (searchIndex != null) {
+      return searchIndex;
+    }
+
+    return this.#store.getVisibleIndex(path) ?? -1;
   }
 
   #focusRelativeSearchMatch(direction: -1 | 1): void {
@@ -2159,13 +2142,13 @@ export class FileTreeController
   ): void {
     const rawVisibleCount = this.#store.getVisibleCount();
     this.#storeVisibleCount = rawVisibleCount;
+    const projectionData = this.#store.getVisibleTreeProjectionData(
+      full ? undefined : Math.min(rawVisibleCount, INITIAL_PROJECTION_ROW_LIMIT)
+    );
     const projection = createVisibleProjection(
-      this.#store.getVisibleTreeProjectionData(
-        full
-          ? undefined
-          : Math.min(rawVisibleCount, INITIAL_PROJECTION_ROW_LIMIT)
-      ),
-      focusedPathCandidate
+      projectionData,
+      focusedPathCandidate,
+      full ? (path) => this.#store.getVisibleIndex(path) : undefined
     );
     this.#ancestorIndicesByIndex.clear();
     this.#ancestorPathsByIndex.clear();
@@ -2174,8 +2157,6 @@ export class FileTreeController
     this.#projectionPaths = projection.paths;
     this.#projectionPosInSetByIndex = projection.posInSetByIndex;
     this.#projectionSetSizeByIndex = projection.setSizeByIndex;
-    this.#visibleIndexByPath = projection.visibleIndexByPath;
-    this.#visibleIndexByPathFactory = projection.visibleIndexByPathFactory;
     this.#syncSearchVisibilityState();
     this.#focusedIndex =
       focusedPathCandidate == null
@@ -2186,7 +2167,20 @@ export class FileTreeController
     this.#focusedPath =
       this.#focusedIndex < 0
         ? null
-        : (this.#getCurrentVisiblePaths()[this.#focusedIndex] ?? null);
+        : this.#resolveVisiblePathAtIndex(this.#focusedIndex);
+  }
+
+  #resolveVisiblePathAtIndex(index: number): string | null {
+    const projectedPath = this.#getCurrentVisiblePaths()[index];
+    if (projectedPath != null) {
+      return projectedPath;
+    }
+
+    if (this.#searchVisibleIndices != null) {
+      return null;
+    }
+
+    return this.#store.getVisibleRowContext(index)?.row.path ?? null;
   }
 
   #resolveSelectionPath(path: string): string | null {
@@ -2298,7 +2292,13 @@ export class FileTreeController
           : this.#searchValue === ''
             ? this.#focusedPath
             : focusPathCandidate;
-      this.#rebuildVisibleProjection(searchFocusCandidate, true);
+      const shouldBuildFullProjection =
+        this.#searchValue != null ||
+        (event.operation !== 'expand' && event.operation !== 'collapse');
+      this.#rebuildVisibleProjection(
+        searchFocusCandidate,
+        shouldBuildFullProjection
+      );
       this.#emit();
       const mutationEvent = toTreesMutationEvent(event);
       if (mutationEvent != null) {

--- a/packages/trees/test/file-tree-render-scroll.test.ts
+++ b/packages/trees/test/file-tree-render-scroll.test.ts
@@ -579,6 +579,42 @@ describe('file-tree render + scroll', () => {
     controller.destroy();
   });
 
+  test('controller focus parent works after toggling with focus beyond the initial projection', async () => {
+    const FileTreeController = await loadFileTreeController();
+    const paths = Array.from(
+      { length: 700 },
+      (_, index) => `dir-${String(index).padStart(3, '0')}/child.txt`
+    );
+    const controller = new FileTreeController({
+      flattenEmptyDirectories: false,
+      initialExpansion: 'open',
+      paths,
+    });
+
+    controller.focusPath('dir-650/child.txt');
+    expect(controller.getFocusedPath()).toBe('dir-650/child.txt');
+    expect(controller.getFocusedIndex()).toBeGreaterThan(512);
+
+    const firstDirectory = controller.getItem('dir-000/');
+    if (
+      firstDirectory == null ||
+      !firstDirectory.isDirectory() ||
+      !('collapse' in firstDirectory)
+    ) {
+      throw new Error('missing first directory');
+    }
+    firstDirectory.collapse();
+
+    expect(controller.getFocusedPath()).toBe('dir-650/child.txt');
+    expect(controller.getFocusedIndex()).toBeGreaterThan(512);
+
+    controller.focusParentItem();
+    expect(controller.getFocusedPath()).toBe('dir-650/');
+    expect(controller.getFocusedIndex()).toBeGreaterThan(512);
+
+    controller.destroy();
+  });
+
   test('resetPaths prunes stale selections and resets a hidden range anchor', async () => {
     const FileTreeController = await loadFileTreeController();
 


### PR DESCRIPTION
Adds a targeted PathStore visible-index lookup backed by node lookup, ancestor visibility checks, subtree counts, and child chunk sums. FileTreeController uses that lookup for focus resolution instead of forcing visibleIndexByPath construction, and ordinary non-search expand/collapse events rebuild only the limited projection needed for the viewport.

Experiments: #2, #3
Metric: controller_toggle_p50_ms 639.68ms → 0.134667ms (-99.98%)