### PR TITLE
11th hour edits and fixes

### DIFF
--- a/apps/docs/app/Hero.tsx
+++ b/apps/docs/app/Hero.tsx
@@ -38,7 +38,7 @@ export function Hero({ productId }: HeroProps) {
     <section className="flex max-w-3xl flex-col gap-3 pt-20 pb-10 md:pb-20 lg:max-w-4xl">
       <HeroIcon productId={productId} />
 
-      <h1 className="text-4xl font-semibold tracking-tight md:text-5xl lg:text-6xl">
+      <h1 className="text-4xl font-semibold tracking-tight text-balance md:text-5xl lg:text-6xl">
         {product.tagline}
       </h1>
       <p className="text-md text-muted-foreground mb-2 max-w-[740px] text-pretty md:text-lg lg:text-xl">

--- a/apps/docs/app/docs/DocsSidebar.tsx
+++ b/apps/docs/app/docs/DocsSidebar.tsx
@@ -1,45 +1,19 @@
 'use client';
 
-import { IconArrowUpRightCircle } from '@pierre/icons';
-import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import NavLink from '../../components/NavLink';
 import {
+  DIFFS_THEME_PATH,
   getExternalUrl,
   getProductFromPathname,
   PRODUCTS,
 } from '@/app/product-config';
-import { cn } from '@/lib/utils';
+import { MobileNavLink } from '@/components/MobileNavLink';
 
 const siteProduct = process.env.NEXT_PUBLIC_SITE ?? 'diffs';
 const isTrees = siteProduct === 'trees';
-
-function MobileNavLink({
-  href,
-  children,
-  external,
-}: {
-  href: string;
-  children: React.ReactNode;
-  external?: boolean;
-}) {
-  return (
-    <Link
-      href={href}
-      className={cn(
-        'text-foreground flex items-center gap-1.5 rounded-md px-3 py-2 text-base transition-colors',
-        'hover:bg-muted active:bg-muted/70'
-      )}
-    >
-      {children}
-      {external === true && (
-        <IconArrowUpRightCircle className="text-muted-foreground" />
-      )}
-    </Link>
-  );
-}
 
 interface DocsSidebarProps {
   isMobileOpen?: boolean;
@@ -167,7 +141,7 @@ export function DocsSidebar({
 
       <nav
         ref={navRef}
-        className={`docs-sidebar ${isMobileOpen ? 'is-open' : ''}`}
+        className={`mobile-popover docs-sidebar ${isMobileOpen ? 'is-open' : ''}`}
         onClick={onMobileClose}
       >
         {isMobileOpen && (
@@ -178,9 +152,6 @@ export function DocsSidebar({
               Home
             </MobileNavLink>
             <MobileNavLink href={product.docsPath}>Docs</MobileNavLink>
-            {product.themePath != null && (
-              <MobileNavLink href={product.themePath}>Theme</MobileNavLink>
-            )}
             {product.id === 'diffs' && (
               <MobileNavLink
                 href={
@@ -199,6 +170,16 @@ export function DocsSidebar({
                 Diffs
               </MobileNavLink>
             )}
+            <MobileNavLink
+              href={
+                isTrees
+                  ? `${getExternalUrl('diffs')}${DIFFS_THEME_PATH}`
+                  : DIFFS_THEME_PATH
+              }
+              external={isTrees}
+            >
+              Theme
+            </MobileNavLink>
           </div>
         )}
         {headings.map((heading) => (

--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -212,20 +212,24 @@
   @apply border-foreground/10;
 }
 
-/* Docs sidebar */
-.docs-sidebar {
-  /* Mobile popover menu */
+/* Shared mobile popover surface (docs sidebar, header menu, playground drawer) */
+.mobile-popover {
   @apply bg-background fixed top-16 right-4 left-4 z-[60];
   @apply max-h-[80dvh] overflow-y-auto;
   @apply -translate-y-2;
-  @apply rounded-xl border border-[rgb(0_0_0_/_0.15)] bg-clip-padding p-4;
+  @apply rounded-xl border border-[rgb(0_0_0_/_0.15)] dark:border-[rgb(255_255_255_/_0.1)] bg-clip-padding p-4;
   @apply opacity-0 shadow-2xl;
   @apply pointer-events-none transition-all duration-200 ease-out;
-
-  /* Shared scrollbar styles */
   @apply [scrollbar-color:transparent_transparent] [scrollbar-gutter:stable] [scrollbar-width:thin];
   @apply hover:[scrollbar-color:auto];
 
+  &.is-open {
+    @apply pointer-events-auto translate-y-0 opacity-100;
+  }
+}
+
+/* Docs sidebar: shares mobile popover styles, adds desktop sticky overrides */
+.docs-sidebar {
   /* Desktop sticky sidebar */
   @apply md:pointer-events-auto md:relative md:z-auto;
   @apply md:top-auto md:right-auto md:left-auto;
@@ -233,24 +237,4 @@
   @apply md:rounded-none md:border-none md:bg-transparent;
   @apply md:p-0 md:opacity-100 md:shadow-none md:transition-none;
   @apply md:sticky md:top-22 md:max-h-[calc(100vh-112px)];
-
-  &.is-open {
-    @apply pointer-events-auto translate-y-0 opacity-100;
-  }
-}
-
-/* Playground controls drawer (mobile only, same pattern as docs sidebar) */
-.playground-controls-drawer {
-  @apply bg-background fixed top-16 right-4 left-4 z-[60];
-  @apply max-h-[80dvh] overflow-y-auto;
-  @apply -translate-y-2;
-  @apply rounded-xl border border-[rgb(0_0_0_/_0.15)] bg-clip-padding p-4;
-  @apply opacity-0 shadow-2xl;
-  @apply pointer-events-none transition-all duration-200 ease-out;
-  @apply [scrollbar-color:transparent_transparent] [scrollbar-gutter:stable] [scrollbar-width:thin];
-  @apply hover:[scrollbar-color:auto];
-
-  &.is-open {
-    @apply pointer-events-auto translate-y-0 opacity-100;
-  }
 }

--- a/apps/docs/app/playground/PlaygroundClient.tsx
+++ b/apps/docs/app/playground/PlaygroundClient.tsx
@@ -789,7 +789,7 @@ export function PlaygroundClient({ prerenderedDiff }: PlaygroundClientProps) {
             />
           )}
           <div
-            className={`playground-controls-drawer ${isControlsOpen ? 'is-open' : ''}`}
+            className={`mobile-popover ${isControlsOpen ? 'is-open' : ''}`}
             onClick={(e) => e.stopPropagation()}
           >
             <div className="mb-4 flex items-center justify-between">

--- a/apps/docs/app/product-config.ts
+++ b/apps/docs/app/product-config.ts
@@ -56,6 +56,12 @@ const EXTERNAL_URLS: Record<ProductId, string> = {
 };
 
 /**
+ * Theme lives only on the diffs site, so this path is the single source of
+ * truth whether we link to it cross-site (trees) or in-site (diffs).
+ */
+export const DIFFS_THEME_PATH = PRODUCTS.diffs.themePath ?? '/theme';
+
+/**
  * Return the external base URL for the given product.
  * Useful for cross-site links when two products live on separate domains.
  */

--- a/apps/docs/app/trees/docs/Guides/ChooseYourIntegration/content.mdx
+++ b/apps/docs/app/trees/docs/Guides/ChooseYourIntegration/content.mdx
@@ -1,50 +1,38 @@
+`@pierre/trees` exposes one path-first model and two primary runtime entries: a
+thin React layer in [`@pierre/trees/react`](#get-started-with-react) and the
+vanilla class in [`@pierre/trees`](#get-started-with-vanilla).
+
 ### Choose your integration
 
-Start here if you are deciding how `@pierre/trees` fits into your app. Trees
-exposes one path-first model and two primary runtime entries: a thin React layer
-in `@pierre/trees/react`, and the vanilla class in `@pierre/trees`.
-
-#### Start with path-first identity
+#### 1. Path-first identity
 
 Treat canonical path strings as the public identity for every item in the tree.
-Selection, focus, search matches, rename events, drag and drop, Git status, and
-row annotations all talk about paths.
-
-That means `src/components/Button.tsx` is not just a label on screen. It is also
+For example, `src/components/Button.tsx` is not just a label on screen. It is
 the value you read from selection state, the path you focus programmatically,
-and the target you rename or move later. For the shared vocabulary behind that
-rule, jump to [Shared concepts](#shared-concepts).
+and the target you rename or move later.
 
-#### Choose React when your app already lives in React
+For the shared vocabulary behind that rule, jump to
+[Shared concepts](#shared-concepts).
 
-Pick the React entry point when the surrounding UI, data loading, and state
-management already live in React. The hook creates the model once, and the
-component mounts it.
+#### 2. React vs Vanilla JS
+
+Pick the React entry point when the surrounding UI already lives in React. Jump
+to the [getting started with React](#get-started-with-react) guide for more
+info.
 
 <DocsCodeExample {...CHOOSE_INTEGRATION_REACT_EXAMPLE} />
 
-Read [Get started with React](#get-started-with-react) next if that is your
-runtime.
-
-#### Choose vanilla when you want the model directly
-
 Pick the vanilla class when your app is not React-based, or when another
-framework will own lifecycle around an imperative model. The class instance is
-both the entry point and the state surface.
+framework will own lifecycle around an imperative model. Jump to the
+[getting started with vanilla JS](#get-started-with-vanilla) for more.
 
 <DocsCodeExample {...CHOOSE_INTEGRATION_VANILLA_EXAMPLE} />
 
-Read [Get started with vanilla](#get-started-with-vanilla) next if you want the
-class-first runtime.
-
-#### Read the tree-shape guide next
+#### 3. Understand tree-shape
 
 Both runtimes consume the same tree data. Small examples can start with raw
 `paths`, but real application trees should move to prepared input before the
-client pays that shaping work on every load.
-
-After your runtime quickstart, continue with
-[Shape tree data for fast rendering](#shape-tree-data-for-fast-rendering). That
-guide explains when `paths` is enough, when to switch to
-`prepareFileTreeInput(...)`, and when `preparePresortedFileTreeInput(...)` is
-the better fit.
+client pays that shaping work on every load. Regardless of your runtime being
+React or vanilla JS, be sure to read
+[Shape tree data for fast rendering](#shape-tree-data-for-fast-rendering) after
+your runtime quickstart.

--- a/apps/docs/app/trees/docs/Overview/constants.ts
+++ b/apps/docs/app/trees/docs/Overview/constants.ts
@@ -1,0 +1,25 @@
+import type { FileTreeOptions } from '@/lib/treesCompatShared';
+
+export const OVERVIEW_TREE_ID = 'trees-docs-overview';
+
+export const OVERVIEW_FILES: string[] = [
+  'README.md',
+  'package.json',
+  '.gitignore',
+  'src/index.ts',
+  'src/components/Button.tsx',
+  'src/components/Card.tsx',
+  'src/components/Header.tsx',
+  'src/lib/utils.ts',
+  'src/styles/globals.css',
+  'public/favicon.ico',
+];
+
+export const OVERVIEW_INITIAL_EXPANDED_ITEMS: string[] = [
+  'src',
+  'src/components',
+];
+
+export const OVERVIEW_OPTIONS: FileTreeOptions = {
+  id: OVERVIEW_TREE_ID,
+};

--- a/apps/docs/app/trees/docs/Overview/content.mdx
+++ b/apps/docs/app/trees/docs/Overview/content.mdx
@@ -15,7 +15,7 @@ all work in terms of canonical paths.
   initialExpandedItems={OVERVIEW_INITIAL_EXPANDED_ITEMS}
   prerenderedHTML={overviewPrerenderedHTML}
   className="py-4 rounded-lg border-1"
-  style={{ height: 394 }}
+  style={{ height: 394, maxWidth: 400 }}
 />
 
 These docs stay guide-first. Pick your runtime, shape tree data before it

--- a/apps/docs/app/trees/docs/Overview/content.mdx
+++ b/apps/docs/app/trees/docs/Overview/content.mdx
@@ -1,0 +1,23 @@
+## Overview
+
+<Notice variant="warning" icon={<IconFlagFill />}>
+  **Trees is in beta.** Start from the public React, vanilla, and SSR entry
+  points on this page. Expect polish and small API shifts between beta releases.
+</Notice>
+
+**Trees** keeps one path-first model across React, vanilla, and SSR hydration.
+Selection, focus, search, rename, drag and drop, Git status, and row annotations
+all work in terms of canonical paths.
+
+<FileTree
+  files={OVERVIEW_FILES}
+  options={OVERVIEW_OPTIONS}
+  initialExpandedItems={OVERVIEW_INITIAL_EXPANDED_ITEMS}
+  prerenderedHTML={overviewPrerenderedHTML}
+  className="py-4 rounded-lg border-1"
+  style={{ height: 394 }}
+/>
+
+These docs stay guide-first. Pick your runtime, shape tree data before it
+reaches the UI, and then add search, item actions, styling, icons, row signals,
+or SSR as needed.

--- a/apps/docs/app/trees/docs/page.tsx
+++ b/apps/docs/app/trees/docs/page.tsx
@@ -17,13 +17,18 @@ import * as shapeTreeDataForFastRenderingConstants from './Guides/ShapeTreeDataF
 import * as showGitStatusAndRowAnnotationsConstants from './Guides/ShowGitStatusAndRowAnnotations/constants';
 import * as ssrGuideConstants from './Guides/SSR/constants';
 import * as styleAndThemeTheTreeConstants from './Guides/StyleAndThemeTheTree/constants';
+import {
+  OVERVIEW_FILES,
+  OVERVIEW_INITIAL_EXPANDED_ITEMS,
+  OVERVIEW_OPTIONS,
+} from './Overview/constants';
 import * as reactApiConstants from './Reference/ReactAPI/constants';
 import * as ssrApiConstants from './Reference/SSRAPI/constants';
 import * as stylingAndThemingConstants from './Reference/StylingAndTheming/constants';
 import * as vanillaApiConstants from './Reference/VanillaAPI/constants';
 import Footer from '@/components/Footer';
-import { Notice } from '@/components/ui/notice';
 import { renderMDX, renderMDXWithPreloadedFiles } from '@/lib/mdx';
+import { preloadFileTree } from '@/lib/treesCompat';
 
 interface DocsSection {
   filePath: string;
@@ -125,7 +130,7 @@ export default function TreesDocsPage() {
       <DocsLayout>
         <div className="min-w-0 space-y-10">
           <HeadingAnchors />
-          <IntroSection />
+          <OverviewSection />
           <DocsSectionGroup
             id="guides"
             title="Guides"
@@ -143,27 +148,21 @@ export default function TreesDocsPage() {
   );
 }
 
-function IntroSection() {
-  return (
-    <ProseWrapper>
-      <h1>Trees docs</h1>
-      <Notice variant="warning">
-        Trees is in beta. Start from the public React, vanilla, and SSR entry
-        points on this page. Expect polish and small API shifts between beta
-        releases.
-      </Notice>
-      <p>
-        These docs stay guide-first. Pick your runtime, shape tree data before
-        it reaches the UI, and then add search, item actions, styling, icons,
-        row signals, or SSR as needed.
-      </p>
-      <p>
-        Trees keeps one path-first model across React, vanilla, and hydration.
-        Selection, focus, search, rename, drag and drop, Git status, and row
-        annotations all work in terms of canonical paths.
-      </p>
-    </ProseWrapper>
+async function OverviewSection() {
+  const ssrPayload = preloadFileTree(
+    { ...OVERVIEW_OPTIONS, initialFiles: OVERVIEW_FILES },
+    { initialExpandedItems: OVERVIEW_INITIAL_EXPANDED_ITEMS }
   );
+  const content = await renderMDX({
+    filePath: 'trees/docs/Overview/content.mdx',
+    scope: {
+      OVERVIEW_FILES,
+      OVERVIEW_INITIAL_EXPANDED_ITEMS,
+      OVERVIEW_OPTIONS,
+      overviewPrerenderedHTML: ssrPayload.shadowHtml,
+    },
+  });
+  return <ProseWrapper>{content}</ProseWrapper>;
 }
 
 // Render each section, preloading its code snippets in parallel when the

--- a/apps/docs/components/Header.tsx
+++ b/apps/docs/components/Header.tsx
@@ -11,6 +11,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
+import { HeaderMobileMenu } from './HeaderMobileMenu';
 import { Button } from './ui/button';
 import { getProductFromPathname } from '@/app/product-config';
 import { cn } from '@/lib/utils';
@@ -77,6 +78,7 @@ function IconLink({ href, label, children }: IconLinkProps) {
 export function Header({ onMobileMenuToggle, className }: HeaderProps) {
   const pathname = usePathname();
   const [isStuck, setIsStuck] = useState(false);
+  const [internalMenuOpen, setInternalMenuOpen] = useState(false);
   const product = getProductFromPathname(pathname);
 
   useEffect(() => {
@@ -98,9 +100,13 @@ export function Header({ onMobileMenuToggle, className }: HeaderProps) {
   }, []);
 
   const homeHref = product.basePath !== '' ? product.basePath : '/';
-  const showMobileMenu =
-    pathname === product.docsPath ||
-    (product.themePath != null && pathname === product.themePath);
+  // When no parent-managed handler is provided, the Header owns its own
+  // mobile popover (used on home, playground, ssr). Docs/theme pages pass a
+  // handler so the existing DocsSidebar popover can be opened instead.
+  const ownsPopover = onMobileMenuToggle == null;
+  const handleMobileToggle = ownsPopover
+    ? () => setInternalMenuOpen((v) => !v)
+    : onMobileMenuToggle;
 
   return (
     <header
@@ -131,57 +137,65 @@ export function Header({ onMobileMenuToggle, className }: HeaderProps) {
         </span>
       </div>
 
-      {showMobileMenu && (
-        <div className="mr-auto flex items-center gap-1 md:hidden">
-          <IconChevronFlat size={16} className="text-border" />
-          <Button variant="ghost" size="icon" onClick={onMobileMenuToggle}>
-            <IconParagraph />
-          </Button>
-        </div>
+      <div className="mr-auto flex items-center gap-1 md:hidden">
+        <IconChevronFlat size={16} className="text-border" />
+        <Button variant="ghost" size="icon" onClick={handleMobileToggle}>
+          <IconParagraph />
+        </Button>
+      </div>
+
+      {ownsPopover && (
+        <HeaderMobileMenu
+          isOpen={internalMenuOpen}
+          onClose={() => setInternalMenuOpen(false)}
+          product={product}
+        />
       )}
 
       <nav className="flex items-center">
-        <NavLink href="/" basePath={product.basePath}>
-          Home
-        </NavLink>
-        <NavLink href="/docs" basePath={product.basePath}>
-          Docs
-        </NavLink>
-        {product.id === 'diffs' ? (
-          <Button
-            variant="ghost"
-            size="sm"
-            asChild
-            className="text-muted-foreground gap-0.5 px-2 font-normal"
-          >
-            <Link
-              href="https://trees.software"
-              target="_blank"
-              rel="noopener noreferrer"
+        <div className="hidden items-center md:flex">
+          <NavLink href="/" basePath={product.basePath}>
+            Home
+          </NavLink>
+          <NavLink href="/docs" basePath={product.basePath}>
+            Docs
+          </NavLink>
+          {product.id === 'diffs' ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              asChild
+              className="text-muted-foreground gap-0.5 px-2 font-normal"
             >
-              Trees
-              <IconArrowUpRight />
-            </Link>
-          </Button>
-        ) : (
-          <Button
-            variant="ghost"
-            size="sm"
-            asChild
-            className="text-muted-foreground gap-0.5 px-2 font-normal"
-          >
-            <Link
-              href="https://diffs.com"
-              target="_blank"
-              rel="noopener noreferrer"
+              <Link
+                href="https://trees.software"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Trees
+                <IconArrowUpRight />
+              </Link>
+            </Button>
+          ) : (
+            <Button
+              variant="ghost"
+              size="sm"
+              asChild
+              className="text-muted-foreground gap-0.5 px-2 font-normal"
             >
-              Diffs
-              <IconArrowUpRight />
-            </Link>
-          </Button>
-        )}
+              <Link
+                href="https://diffs.com"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Diffs
+                <IconArrowUpRight />
+              </Link>
+            </Button>
+          )}
 
-        <div className="border-border mx-2 h-5 w-px border-l" />
+          <div className="border-border mx-2 h-5 w-px border-l" />
+        </div>
 
         <IconLink href="https://discord.gg/pierre" label="Discord">
           <IconBrandDiscord />

--- a/apps/docs/components/HeaderMobileMenu.tsx
+++ b/apps/docs/components/HeaderMobileMenu.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { MobileNavLink } from './MobileNavLink';
+import {
+  DIFFS_THEME_PATH,
+  getExternalUrl,
+  type ProductConfig,
+  PRODUCTS,
+} from '@/app/product-config';
+
+const siteProduct = process.env.NEXT_PUBLIC_SITE ?? 'diffs';
+const isTrees = siteProduct === 'trees';
+
+export interface HeaderMobileMenuProps {
+  isOpen: boolean;
+  onClose: () => void;
+  product: ProductConfig;
+}
+
+/**
+ * Self-contained mobile popover used by the Header on pages that don't
+ * already render a docs-style sidebar (home, playground, ssr). On docs/theme
+ * pages the DocsSidebar popover is used instead and includes a TOC section.
+ */
+export function HeaderMobileMenu({
+  isOpen,
+  onClose,
+  product,
+}: HeaderMobileMenuProps) {
+  useEffect(() => {
+    if (isOpen) {
+      document.body.classList.add('overflow-hidden');
+    } else {
+      document.body.classList.remove('overflow-hidden');
+    }
+    return () => {
+      document.body.classList.remove('overflow-hidden');
+    };
+  }, [isOpen]);
+
+  return (
+    <>
+      {isOpen && (
+        <div
+          className="bg-background/50 fixed inset-0 z-[50] backdrop-blur-sm transition-opacity duration-200 md:hidden"
+          onClick={onClose}
+          aria-hidden
+        />
+      )}
+
+      <nav
+        className={`mobile-popover md:hidden ${isOpen ? 'is-open' : ''}`}
+        onClick={onClose}
+      >
+        <MobileNavLink href={product.basePath !== '' ? product.basePath : '/'}>
+          Home
+        </MobileNavLink>
+        <MobileNavLink href={product.docsPath}>Docs</MobileNavLink>
+        {product.themePath != null && (
+          <MobileNavLink href={product.themePath}>Theme</MobileNavLink>
+        )}
+        {product.id === 'diffs' && (
+          <MobileNavLink
+            href={isTrees ? PRODUCTS.trees.basePath : getExternalUrl('trees')}
+            external={!isTrees}
+          >
+            Trees
+          </MobileNavLink>
+        )}
+        {product.id === 'trees' && (
+          <MobileNavLink
+            href={isTrees ? getExternalUrl('diffs') : '/'}
+            external={isTrees}
+          >
+            Diffs
+          </MobileNavLink>
+        )}
+        <MobileNavLink
+          href={
+            isTrees
+              ? `${getExternalUrl('diffs')}${DIFFS_THEME_PATH}`
+              : DIFFS_THEME_PATH
+          }
+          external={isTrees}
+        >
+          Theme
+        </MobileNavLink>
+      </nav>
+    </>
+  );
+}
+
+export default HeaderMobileMenu;

--- a/apps/docs/components/MobileNavLink.tsx
+++ b/apps/docs/components/MobileNavLink.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { IconArrowUpRightCircle } from '@pierre/icons';
+import Link from 'next/link';
+
+import { cn } from '@/lib/utils';
+
+interface MobileNavLinkProps {
+  href: string;
+  children: React.ReactNode;
+  external?: boolean;
+  onClick?: () => void;
+}
+
+export function MobileNavLink({
+  href,
+  children,
+  external,
+  onClick,
+}: MobileNavLinkProps) {
+  return (
+    <Link
+      href={href}
+      onClick={onClick}
+      className={cn(
+        'text-foreground flex items-center gap-1.5 rounded-md px-3 py-2 text-base transition-colors',
+        'hover:bg-muted active:bg-muted/70'
+      )}
+    >
+      {children}
+      {external === true && (
+        <IconArrowUpRightCircle className="text-muted-foreground" />
+      )}
+    </Link>
+  );
+}
+
+export default MobileNavLink;

--- a/apps/docs/lib/mdx.tsx
+++ b/apps/docs/lib/mdx.tsx
@@ -4,6 +4,7 @@ import {
   IconArrowRight,
   IconBulbFill,
   IconCiWarningFill,
+  IconFlagFill,
   IconInfoFill,
 } from '@pierre/icons';
 import { compileMDX } from 'next-mdx-remote/rsc';
@@ -58,6 +59,7 @@ const defaultComponents = {
   IconCiWarningFill,
   IconInfoFill,
   IconBulbFill,
+  IconFlagFill,
   DocsCodeExample,
   CustomHunkSeparators,
   FileTree,


### PR DESCRIPTION
- New responsive header on homepage—our nav links were causing the header to break out on iPhone Pro size devices.
- Balanced h1 text
- Tweaked overview section of Trees docs
- Revamped intro bits of the Guides section in Trees docs

Goal on the content was to make it feel a little more human, show off the Tree component on docs near top, and make the whole docs page more usable. This will need to be deployed on Diffs.com too at some point, if not automatically done.