### PR TITLE
[trees] Fix negative interaction with focus, virtualization, and sticky folders

### DIFF
--- a/packages/trees/src/render/FileTreeView.tsx
+++ b/packages/trees/src/render/FileTreeView.tsx
@@ -759,7 +759,13 @@ function getContextMenuAnchorButton(
     return null;
   }
 
-  return stickyButtonRefs.get(path) ?? rowButtonRefs.get(path) ?? null;
+  const stickyButton = stickyButtonRefs.get(path) ?? null;
+  if (stickyButton != null) {
+    return stickyButton;
+  }
+
+  const rowButton = rowButtonRefs.get(path) ?? null;
+  return rowButton?.dataset.itemParked === 'true' ? null : rowButton;
 }
 
 function createContextMenuItem(
@@ -1305,6 +1311,7 @@ export function FileTreeView({
   const [lastContextMenuInteraction, setLastContextMenuInteraction] = useState<
     'focus' | 'pointer' | null
   >(null);
+  const [scrollSettledRevision, setScrollSettledRevision] = useState(0);
   const [contextMenuState, setContextMenuState] = useState<{
     anchorRect: FileTreeContextMenuOpenContext['anchorRect'] | null;
     item: FileTreeContextMenuItem;
@@ -2345,6 +2352,16 @@ export function FileTreeView({
     if (rootElement == null) {
       return;
     }
+    let nullFocusOutTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const clearNullFocusOutTimer = (): void => {
+      if (nullFocusOutTimer == null) {
+        return;
+      }
+
+      clearTimeout(nullFocusOutTimer);
+      nullFocusOutTimer = null;
+    };
 
     const updateActiveItemPath = (): void => {
       const activeTreeElement = getActiveTreeElement(rootElement);
@@ -2355,6 +2372,7 @@ export function FileTreeView({
     };
 
     const onFocusIn = (): void => {
+      clearNullFocusOutTimer();
       domFocusOwnerRef.current = true;
       updateActiveItemPath();
     };
@@ -2362,22 +2380,43 @@ export function FileTreeView({
       const nextTarget = event.relatedTarget;
       if (nextTarget == null) {
         // Virtualization can swap the focused row between rendered and parked
-        // states before the replacement element receives focus.
+        // states before the replacement element receives focus. Defer the
+        // ownership check so a true blur to the page can still clear visual
+        // focus once the browser has finished moving focus.
+        clearNullFocusOutTimer();
+        nullFocusOutTimer = setTimeout(() => {
+          nullFocusOutTimer = null;
+          if (getActiveTreeElement(rootElement) != null) {
+            updateActiveItemPath();
+            return;
+          }
+
+          domFocusOwnerRef.current = false;
+          setActiveItemPath(null);
+        }, 0);
         return;
       }
 
       if (!(nextTarget instanceof Node) || !rootElement.contains(nextTarget)) {
+        clearNullFocusOutTimer();
         domFocusOwnerRef.current = false;
         setActiveItemPath(null);
         return;
       }
 
-      updateActiveItemPath();
+      const nextActiveItemPath =
+        nextTarget instanceof HTMLElement
+          ? (nextTarget.dataset.itemPath ?? null)
+          : null;
+      setActiveItemPath((previousPath) =>
+        previousPath === nextActiveItemPath ? previousPath : nextActiveItemPath
+      );
     };
 
     rootElement.addEventListener('focusin', onFocusIn);
     rootElement.addEventListener('focusout', onFocusOut);
     return () => {
+      clearNullFocusOutTimer();
       rootElement.removeEventListener('focusin', onFocusIn);
       rootElement.removeEventListener('focusout', onFocusOut);
     };
@@ -2475,6 +2514,7 @@ export function FileTreeView({
           delete rootElement.dataset.isScrolling;
         }
         isScrollingRef.current = false;
+        setScrollSettledRevision((revision) => revision + 1);
         scrollTimer = null;
       }, 50);
     };
@@ -2881,8 +2921,18 @@ export function FileTreeView({
     visibleRows,
   ]);
 
+  const focusedRowIsVisible =
+    focusedIndex >= 0 &&
+    focusedIndex >= layoutSnapshot.visible.startIndex &&
+    focusedIndex <= layoutSnapshot.visible.endIndex;
+  const focusedRowIsSticky =
+    focusedPath != null &&
+    stickyRows.some((entry) => getFileTreeRowPath(entry.row) === focusedPath);
+  const focusedRowHasVisibleAnchor = focusedRowIsVisible || focusedRowIsSticky;
   const focusTriggerPath =
-    contextMenuButtonTriggerEnabled && domFocusOwnerRef.current === true
+    contextMenuButtonTriggerEnabled &&
+    domFocusOwnerRef.current === true &&
+    focusedRowHasVisibleAnchor
       ? focusedPath
       : null;
   const pointerTriggerPath =
@@ -2896,11 +2946,17 @@ export function FileTreeView({
   const isPointerContextMenuOpen = contextMenuState?.source === 'right-click';
 
   useLayoutEffect(() => {
+    if (isScrollingRef.current && contextMenuState == null) {
+      return;
+    }
+
     updateTriggerPosition(getTriggerAnchorButton(triggerPath));
   }, [
+    contextMenuState,
     getTriggerAnchorButton,
     range,
     resolvedViewportHeight,
+    scrollSettledRevision,
     stickyRows,
     triggerPath,
     updateTriggerPosition,

--- a/packages/trees/test/e2e/file-tree-sticky-context-menu-scroll-drift.pw.ts
+++ b/packages/trees/test/e2e/file-tree-sticky-context-menu-scroll-drift.pw.ts
@@ -493,3 +493,185 @@ test.describe('sticky context-menu drift fixture @diagnostic', () => {
     expect(reportText).toContain('down-2');
   });
 });
+
+test.describe('sticky focused row context-menu regressions', () => {
+  test('does not restore the trigger to a parked focused row after hover clears', async ({
+    page,
+  }) => {
+    await page.goto(
+      '/test/e2e/fixtures/file-tree-sticky-context-menu-scroll-drift.html'
+    );
+    await page.waitForFunction(
+      () => window.__stickyContextMenuDriftFixtureReady === true
+    );
+
+    const focusedPath = await page.evaluate(() => {
+      const host = document.querySelector('file-tree-container');
+      const shadowRoot = host?.shadowRoot;
+      const row = Array.from(
+        shadowRoot?.querySelectorAll('button[data-type="item"]') ?? []
+      ).find((button) => {
+        return (
+          button instanceof HTMLButtonElement &&
+          button.dataset.fileTreeStickyRow !== 'true' &&
+          button.dataset.itemParked !== 'true' &&
+          button.dataset.itemType === 'file'
+        );
+      });
+      if (!(row instanceof HTMLButtonElement) || row.dataset.itemPath == null) {
+        throw new Error('Expected a visible file row to focus.');
+      }
+
+      row.click();
+      return row.dataset.itemPath;
+    });
+    await nextFrames(page);
+
+    await page.evaluate(
+      ({ scrollTop }) => {
+        window.__stickyContextMenuDriftProbe?.setScrollTop(scrollTop);
+      },
+      { scrollTop: 1500 }
+    );
+    await nextFrames(page);
+    await page.waitForFunction((path) => {
+      const host = document.querySelector('file-tree-container');
+      const parkedRow = host?.shadowRoot?.querySelector<HTMLButtonElement>(
+        `button[data-item-path="${path}"][data-item-parked="true"]`
+      );
+      return parkedRow instanceof HTMLButtonElement;
+    }, focusedPath);
+    await page.waitForTimeout(80);
+    await nextFrames(page);
+
+    const hoveredPath = await page.evaluate((path) => {
+      const host = document.querySelector('file-tree-container');
+      const shadowRoot = host?.shadowRoot;
+      const row = Array.from(
+        shadowRoot?.querySelectorAll('button[data-type="item"]') ?? []
+      ).find((button) => {
+        return (
+          button instanceof HTMLButtonElement &&
+          button.dataset.fileTreeStickyRow !== 'true' &&
+          button.dataset.itemParked !== 'true' &&
+          button.dataset.itemPath !== path
+        );
+      });
+      if (!(row instanceof HTMLButtonElement) || row.dataset.itemPath == null) {
+        throw new Error('Expected a visible row to hover.');
+      }
+
+      row.dispatchEvent(
+        new PointerEvent('pointerover', { bubbles: true, composed: true })
+      );
+      return row.dataset.itemPath;
+    }, focusedPath);
+    await nextFrames(page);
+
+    await expect(
+      page.locator(
+        'file-tree-container button[data-type="context-menu-trigger"]'
+      )
+    ).toHaveAttribute('data-visible', 'true');
+
+    await page.evaluate(() => {
+      const host = document.querySelector('file-tree-container');
+      const root = host?.shadowRoot?.querySelector(
+        '[data-file-tree-virtualized-root="true"]'
+      );
+      root?.dispatchEvent(new PointerEvent('pointerleave', { bubbles: true }));
+    });
+    await nextFrames(page);
+
+    await expect(
+      page.locator(
+        'file-tree-container button[data-type="context-menu-trigger"]'
+      )
+    ).toHaveAttribute('data-visible', 'false');
+    await expect(
+      page.locator('file-tree-container [data-type="context-menu-anchor"]')
+    ).toHaveAttribute('data-visible', 'false');
+
+    expect(hoveredPath).not.toBe(focusedPath);
+  });
+
+  test('clears visual focus after a focused row is parked and restored', async ({
+    page,
+  }) => {
+    await page.goto(
+      '/test/e2e/fixtures/file-tree-sticky-context-menu-scroll-drift.html'
+    );
+    await page.waitForFunction(
+      () => window.__stickyContextMenuDriftFixtureReady === true
+    );
+
+    const focusedPath = await page.evaluate(() => {
+      const outsideButton = document.createElement('button');
+      outsideButton.dataset.testOutsideFocus = 'true';
+      outsideButton.type = 'button';
+      outsideButton.textContent = 'Outside focus';
+      document.body.append(outsideButton);
+
+      const host = document.querySelector('file-tree-container');
+      const shadowRoot = host?.shadowRoot;
+      const row = Array.from(
+        shadowRoot?.querySelectorAll('button[data-type="item"]') ?? []
+      ).find((button) => {
+        return (
+          button instanceof HTMLButtonElement &&
+          button.dataset.fileTreeStickyRow !== 'true' &&
+          button.dataset.itemParked !== 'true' &&
+          button.dataset.itemType === 'file'
+        );
+      });
+      if (!(row instanceof HTMLButtonElement) || row.dataset.itemPath == null) {
+        throw new Error('Expected a visible file row to focus.');
+      }
+
+      row.click();
+      return row.dataset.itemPath;
+    });
+    await nextFrames(page);
+
+    await page.evaluate(
+      ({ scrollTop }) => {
+        window.__stickyContextMenuDriftProbe?.setScrollTop(scrollTop);
+      },
+      { scrollTop: 1500 }
+    );
+    await nextFrames(page);
+    await page.waitForFunction((path) => {
+      const host = document.querySelector('file-tree-container');
+      const parkedRow = host?.shadowRoot?.querySelector<HTMLButtonElement>(
+        `button[data-item-path="${path}"][data-item-parked="true"]`
+      );
+      return parkedRow instanceof HTMLButtonElement;
+    }, focusedPath);
+    await page.waitForTimeout(80);
+    await nextFrames(page);
+
+    await page.evaluate(() => {
+      window.__stickyContextMenuDriftProbe?.setScrollTop(0);
+    });
+    await page.waitForTimeout(80);
+    await nextFrames(page);
+
+    await expect(
+      page.locator(
+        `file-tree-container button[data-item-path="${focusedPath}"][data-item-focused="true"]`
+      )
+    ).toHaveCount(1);
+
+    await page.locator('[data-test-outside-focus="true"]').focus();
+    await nextFrames(page);
+
+    await expect(
+      page.locator('file-tree-container button[data-item-focused="true"]')
+    ).toHaveCount(0);
+    await expect(
+      page.locator(
+        'file-tree-container button[data-type="context-menu-trigger"]'
+      )
+    ).toHaveAttribute('data-visible', 'false');
+  });
+});

--- a/packages/trees/test/file-tree-composition-surfaces.test.ts
+++ b/packages/trees/test/file-tree-composition-surfaces.test.ts
@@ -874,6 +874,205 @@ describe('file-tree composition surfaces', () => {
     }
   });
 
+  test('hides the focused trigger when the retained focused row is parked offscreen', async () => {
+    const { cleanup, dom } = installDom();
+    try {
+      const { FileTree } = await import('../src/render/FileTree');
+      const mount = dom.window.document.createElement('div');
+      dom.window.document.body.appendChild(mount);
+
+      const fileTree = new FileTree({
+        composition: {
+          contextMenu: {
+            enabled: true,
+            triggerMode: 'button',
+          },
+        },
+        flattenEmptyDirectories: false,
+        initialExpansion: 'open',
+        initialVisibleRowCount: 90 / 30,
+        overscan: 0,
+        paths: [
+          'README.md',
+          ...Array.from({ length: 20 }, (_unused, index) => {
+            return `src/generated/file-${String(index).padStart(2, '0')}.ts`;
+          }),
+        ],
+        stickyFolders: true,
+      });
+
+      fileTree.render({ containerWrapper: mount });
+      await flushDom();
+
+      const shadowRoot = fileTree.getFileTreeContainer()?.shadowRoot;
+      const root = getTreeRoot(shadowRoot, dom);
+      const scrollElement = shadowRoot?.querySelector(
+        '[data-file-tree-virtualized-scroll="true"]'
+      );
+      const firstRow = shadowRoot?.querySelector(
+        'button[data-type="item"][data-item-type="file"]'
+      );
+      const trigger = shadowRoot?.querySelector(
+        '[data-type="context-menu-trigger"]'
+      );
+
+      if (
+        !(firstRow instanceof dom.window.HTMLButtonElement) ||
+        !(scrollElement instanceof dom.window.HTMLElement) ||
+        !(trigger instanceof dom.window.HTMLButtonElement)
+      ) {
+        throw new Error('expected virtualized tree elements');
+      }
+      const focusedPath = firstRow.dataset.itemPath;
+      if (focusedPath == null) {
+        throw new Error('expected focused row path');
+      }
+
+      firstRow.dispatchEvent(
+        new dom.window.MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+      await flushDom();
+      expect(fileTree.getFocusedPath()).toBe(focusedPath);
+      expect(trigger.dataset.visible).toBe('true');
+
+      scrollElement.scrollTop = 240;
+      scrollElement.dispatchEvent(new dom.window.Event('scroll'));
+      await flushDom();
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      await flushDom();
+
+      const parkedFirstRow = getItemButton(shadowRoot, dom, focusedPath);
+      expect(parkedFirstRow.dataset.itemParked).toBe('true');
+
+      const visibleHoverRow = Array.from(
+        shadowRoot?.querySelectorAll('button[data-type="item"]') ?? []
+      ).find((button) => {
+        return (
+          button instanceof dom.window.HTMLButtonElement &&
+          button.dataset.itemParked !== 'true' &&
+          button.dataset.fileTreeStickyRow !== 'true' &&
+          button.dataset.itemPath !== focusedPath
+        );
+      });
+      if (!(visibleHoverRow instanceof dom.window.HTMLButtonElement)) {
+        throw new Error('expected a visible hover row');
+      }
+
+      visibleHoverRow.dispatchEvent(
+        new dom.window.Event('pointerover', { bubbles: true, composed: true })
+      );
+      await flushDom();
+      expect(trigger.dataset.visible).toBe('true');
+
+      root.dispatchEvent(new dom.window.Event('pointerleave'));
+      await flushDom();
+
+      expect(trigger.dataset.visible).toBe('false');
+
+      fileTree.cleanUp();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('clears visual focus after a null-target blur from a row restored after parking', async () => {
+    const { cleanup, dom } = installDom();
+    try {
+      const { FileTree } = await import('../src/render/FileTree');
+      const mount = dom.window.document.createElement('div');
+      dom.window.document.body.appendChild(mount);
+
+      const fileTree = new FileTree({
+        composition: {
+          contextMenu: {
+            enabled: true,
+            triggerMode: 'button',
+          },
+        },
+        flattenEmptyDirectories: false,
+        initialExpansion: 'open',
+        initialVisibleRowCount: 90 / 30,
+        overscan: 0,
+        paths: [
+          'README.md',
+          ...Array.from({ length: 20 }, (_unused, index) => {
+            return `src/generated/file-${String(index).padStart(2, '0')}.ts`;
+          }),
+        ],
+        stickyFolders: true,
+      });
+
+      fileTree.render({ containerWrapper: mount });
+      await flushDom();
+
+      const shadowRoot = fileTree.getFileTreeContainer()?.shadowRoot;
+      const scrollElement = shadowRoot?.querySelector(
+        '[data-file-tree-virtualized-scroll="true"]'
+      );
+      const trigger = shadowRoot?.querySelector(
+        '[data-type="context-menu-trigger"]'
+      );
+      const firstRow = shadowRoot?.querySelector(
+        'button[data-type="item"][data-item-type="file"]'
+      );
+
+      if (
+        !(firstRow instanceof dom.window.HTMLButtonElement) ||
+        !(scrollElement instanceof dom.window.HTMLElement) ||
+        !(trigger instanceof dom.window.HTMLButtonElement)
+      ) {
+        throw new Error('expected virtualized tree elements');
+      }
+      const focusedPath = firstRow.dataset.itemPath;
+      if (focusedPath == null) {
+        throw new Error('expected focused row path');
+      }
+
+      firstRow.dispatchEvent(
+        new dom.window.MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+      await flushDom();
+
+      scrollElement.scrollTop = 240;
+      scrollElement.dispatchEvent(new dom.window.Event('scroll'));
+      await flushDom();
+      expect(
+        getItemButton(shadowRoot, dom, focusedPath).dataset.itemParked
+      ).toBe('true');
+
+      scrollElement.scrollTop = 0;
+      scrollElement.dispatchEvent(new dom.window.Event('scroll'));
+      await flushDom();
+      await flushDom();
+
+      const restoredFirstRow = getItemButton(shadowRoot, dom, focusedPath);
+      expect(restoredFirstRow.dataset.itemParked).toBeUndefined();
+      expect(restoredFirstRow.dataset.itemFocused).toBe('true');
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      await flushDom();
+      expect(trigger.dataset.visible).toBe('true');
+
+      restoredFirstRow.blur();
+      await flushDom();
+      await flushDom();
+
+      expect(
+        shadowRoot?.querySelector('button[data-item-focused="true"]')
+      ).toBeNull();
+      expect(trigger.dataset.visible).toBe('false');
+
+      fileTree.cleanUp();
+    } finally {
+      cleanup();
+    }
+  });
+
   test('button-capable modes reserve the action lane and keep lane attrs stable', async () => {
     const { cleanup, dom } = installDom();
     try {


### PR DESCRIPTION
we were overlaying the context menu button on top of the sticky folders because the parked focused item was hiding behind there (on purpose). visually you just had a random context menu.