### PR TITLE
[trees] Fix special case bugs with sticky headers and keyboard nav

### DIFF
--- a/apps/docs/public/trees/llms-full.txt
+++ b/apps/docs/public/trees/llms-full.txt
@@ -793,6 +793,23 @@ variables the tree already understands.
 That gives you matching panel colors, selection colors, search-field colors, and
 Git-status colors without rebuilding the theme system by hand.
 
+#### Set density with `density`
+
+Pass `density` to `useFileTree` (or `preloadFileTree`, or the vanilla `FileTree`
+constructor) to bundle row height and spacing into one option. The keyword form
+(`'compact'`, `'default'`, `'relaxed'`) resolves both at once; a numeric form
+keeps the default row height and supplies a custom spacing factor. Every runtime
+— vanilla CSR, vanilla SSR, React CSR, and React SSR — paints
+`--trees-item-height` and `--trees-density-override` onto the host from the
+resolved density so the virtualized and painted row heights stay aligned.
+Caller-set inline values on the host still win, so you can override either
+variable directly when you need a one-off. Set `itemHeight` only when you need a
+row height that doesn't match a preset.
+
+The keyword presets are exported as `FILE_TREE_DENSITY_PRESETS` so SSR helpers
+like `initialVisibleRowCount` can divide by the preset's row height without
+hard-coding it.
+
 #### Choose the right styling layer
 
 Use:
@@ -1143,7 +1160,10 @@ The main rendering knobs are:
   layout
 - `initialVisibleRowCount`, when you want to budget SSR or first-render work
   before measurement
-- `itemHeight`, when your design changes row density enough to matter
+- `density`, when your design changes row density enough to matter — pass
+  `'compact' | 'default' | 'relaxed'` (or a custom numeric factor) to resolve
+  both the row height and the surrounding spacing in one place. Use `itemHeight`
+  only when you need a row height that doesn't match a preset.
 - `overscan`, when you need to trade a little extra work for smoother scrolling
 
 Give the rendered tree host a real CSS height. The row-count hint only shapes
@@ -1394,7 +1414,8 @@ runtimes.
 | `gitStatus`               | Built-in Git-style row signals.                                      | Added, modified, deleted, ignored, renamed, and untracked states.            |
 | `icons`                   | Built-in icon set or icon configuration object.                      | Set selection, color mode, remaps, or sprite-sheet extension.                |
 | `renderRowDecoration`     | Custom non-Git row signal renderer.                                  | Generated-file badges, remote markers, validation hints.                     |
-| `itemHeight`              | Row-height hint for the virtualized view.                            | Custom density.                                                              |
+| `density`                 | Density preset or custom spacing factor.                             | Tune row height and spacing in one place.                                    |
+| `itemHeight`              | Explicit row-height override.                                        | Row height that doesn't match a `density` preset.                            |
 | `overscan`                | Extra rows rendered outside the visible window.                      | Smooth scrolling tradeoffs.                                                  |
 | `initialVisibleRowCount`  | Optional first-render row budget before the browser measures height. | Tune SSR and hydration work without pinning steady-state size.               |
 | `unsafeCSS`               | Advanced CSS injection into the tree shadow root.                    | Narrow escape hatch when supported styling surfaces are not enough.          |
@@ -1469,9 +1490,16 @@ For deeper lookup, jump to [Styling and theming](#styling-and-theming) and
 
 #### Scale and rendering settings
 
-`initialVisibleRowCount`, `itemHeight`, and `overscan` are rendering knobs, not
-onboarding concepts. The rendered container sets steady-state height; these
-options only tune the first-render budget and the virtualized row window.
+`initialVisibleRowCount`, `density`, `itemHeight`, and `overscan` are rendering
+knobs, not onboarding concepts. The rendered container sets steady-state height;
+these options only tune the first-render budget, visual density, and the
+virtualized row window.
+
+For density, prefer the `density` keyword (`'compact' | 'default' | 'relaxed'`)
+or a numeric factor — it resolves both row height and spacing in one place, and
+the React `<FileTree>` wrapper paints `--trees-item-height` and
+`--trees-density-override` for you. Reach for `itemHeight` only when you need a
+row height that doesn't match a preset.
 
 Use [Handle large trees efficiently](#handle-large-trees-efficiently) when scale
 becomes the real problem.

--- a/packages/trees/src/render/FileTreeView.tsx
+++ b/packages/trees/src/render/FileTreeView.tsx
@@ -546,16 +546,57 @@ function isSearchOpenSeedKey(event: KeyboardEvent): boolean {
   );
 }
 
-// Prefers the live scroll element's measured height once layout has run,
-// falling back to the first-render hint while clientHeight is still zero
-// (SSR, initial mount, detached nodes, jsdom).
-function getMeasuredViewportHeight(
+// Reads the live scroll element's border-box height when an exact viewport
+// height is required. `clientHeight` rounds fractional CSS pixels, which
+// misaligns sticky virtualization in layouts where a slotted header leaves a
+// half-pixel scrollport.
+function readMeasuredViewportHeight(
   scrollElement: HTMLElement | null,
   fallbackViewportHeight: number
 ): number {
-  return scrollElement?.clientHeight != null && scrollElement.clientHeight > 0
+  if (scrollElement == null) {
+    return fallbackViewportHeight;
+  }
+
+  const rectHeight = scrollElement.getBoundingClientRect().height;
+  if (rectHeight > 0) {
+    return rectHeight;
+  }
+
+  return scrollElement.clientHeight > 0
     ? scrollElement.clientHeight
     : fallbackViewportHeight;
+}
+
+function getCachedViewportHeight(
+  cachedViewportHeight: number | null,
+  fallbackViewportHeight: number
+): number {
+  return cachedViewportHeight != null && cachedViewportHeight > 0
+    ? cachedViewportHeight
+    : fallbackViewportHeight;
+}
+
+// ResizeObserver exposes box sizes without forcing an extra layout read. Use
+// that value to refresh the viewport-height cache, falling back to the direct
+// measurement only in environments that omit the border-box size.
+function getResizeObserverViewportHeight(
+  entry: ResizeObserverEntry
+): number | null {
+  const borderBoxSize = entry.borderBoxSize;
+  const firstBorderBoxSize = Array.isArray(borderBoxSize)
+    ? borderBoxSize[0]
+    : borderBoxSize;
+
+  if (
+    firstBorderBoxSize != null &&
+    Number.isFinite(firstBorderBoxSize.blockSize) &&
+    firstBorderBoxSize.blockSize > 0
+  ) {
+    return firstBorderBoxSize.blockSize;
+  }
+
+  return entry.contentRect.height > 0 ? entry.contentRect.height : null;
 }
 
 // Thin imperative wrapper around `computeFocusedRowScrollIntoView`. The numeric
@@ -573,7 +614,7 @@ function scrollFocusedRowIntoView(
     focusedIndex,
     itemHeight,
     topInset,
-    viewportHeight: getMeasuredViewportHeight(
+    viewportHeight: readMeasuredViewportHeight(
       scrollElement,
       fallbackViewportHeight
     ),
@@ -603,7 +644,7 @@ function scrollFocusedRowToViewportOffset(
     itemHeight,
     targetViewportOffset,
     totalHeight,
-    viewportHeight: getMeasuredViewportHeight(
+    viewportHeight: readMeasuredViewportHeight(
       scrollElement,
       fallbackViewportHeight
     ),
@@ -1319,6 +1360,7 @@ export function FileTreeView({
   const rowButtonRefs = useRef(new Map<string, HTMLElement>());
   const stickyRowButtonRefs = useRef(new Map<string, HTMLElement>());
   const updateViewportRef = useRef<() => void>(() => {});
+  const measuredViewportHeightRef = useRef<number | null>(null);
   const domFocusOwnerRef = useRef(false);
   const previousFocusedPathRef = useRef<string | null>(null);
   const previousRenamingPathRef = useRef<string | null>(null);
@@ -1693,7 +1735,7 @@ export function FileTreeView({
 
       if (controller.isSearchOpen()) {
         const scrollElement = scrollRef.current;
-        const viewportHeight = getMeasuredViewportHeight(
+        const viewportHeight = readMeasuredViewportHeight(
           scrollElement,
           resolvedViewportHeight
         );
@@ -1756,7 +1798,7 @@ export function FileTreeView({
         return false;
       }
 
-      const liveViewportHeight = getMeasuredViewportHeight(
+      const liveViewportHeight = readMeasuredViewportHeight(
         scrollElement,
         resolvedViewportHeight
       );
@@ -2235,7 +2277,7 @@ export function FileTreeView({
           controller.selectOnlyPath(currentFocusedPath);
         }
         const scrollElement = scrollRef.current;
-        const viewportHeight = getMeasuredViewportHeight(
+        const viewportHeight = readMeasuredViewportHeight(
           scrollElement,
           resolvedViewportHeight
         );
@@ -2670,10 +2712,15 @@ export function FileTreeView({
       return;
     }
 
+    measuredViewportHeightRef.current = readMeasuredViewportHeight(
+      scrollElement,
+      initialViewportHeight
+    );
+
     const update = (): void => {
       const nextItemCount = controller.getVisibleCount();
-      const nextViewportHeight = getMeasuredViewportHeight(
-        scrollElement,
+      const nextViewportHeight = getCachedViewportHeight(
+        measuredViewportHeightRef.current,
         initialViewportHeight
       );
       const maxScrollTop = Math.max(
@@ -2845,7 +2892,14 @@ export function FileTreeView({
     scrollElement.addEventListener('keydown', onKeyDownPreScroll);
     const resizeObserver =
       typeof ResizeObserver !== 'undefined'
-        ? new ResizeObserver(() => {
+        ? new ResizeObserver((entries) => {
+            const observedViewportHeight =
+              entries[0] == null
+                ? null
+                : getResizeObserverViewportHeight(entries[0]);
+            measuredViewportHeightRef.current =
+              observedViewportHeight ??
+              readMeasuredViewportHeight(scrollElement, initialViewportHeight);
             update();
           })
         : null;
@@ -2876,6 +2930,7 @@ export function FileTreeView({
       // rebinds (e.g. viewportHeight changes) while scrollTop is still 0,
       // because the sync effect only fires when scrollTop itself changes.
       isScrollingRef.current = false;
+      measuredViewportHeightRef.current = null;
       resizeObserver?.disconnect();
     };
   }, [controller, initialViewportHeight, itemHeight, overscan, stickyFolders]);

--- a/packages/trees/src/render/FileTreeView.tsx
+++ b/packages/trees/src/render/FileTreeView.tsx
@@ -1794,6 +1794,7 @@ export function FileTreeView({
 
   const shouldSuppressContextMenu = (): boolean => {
     return (
+      isScrollingRef.current === true ||
       touchLongPressTimerRef.current != null ||
       touchDragActiveRef.current === true
     );
@@ -3543,6 +3544,10 @@ export function FileTreeView({
   );
 
   const openMenuFromTrigger = (): void => {
+    if (isScrollingRef.current) {
+      return;
+    }
+
     if (!contextMenuButtonTriggerEnabled) {
       return;
     }

--- a/packages/trees/src/render/FileTreeView.tsx
+++ b/packages/trees/src/render/FileTreeView.tsx
@@ -768,6 +768,28 @@ function getContextMenuAnchorButton(
   return rowButton?.dataset.itemParked === 'true' ? null : rowButton;
 }
 
+function getMountedStickyRowPaths(rootElement: HTMLElement | null): string[] {
+  if (rootElement == null) {
+    return [];
+  }
+
+  return Array.from(
+    rootElement.querySelectorAll('button[data-file-tree-sticky-row="true"]')
+  )
+    .filter((element): element is HTMLElement => element instanceof HTMLElement)
+    .map((element) => element.dataset.fileTreeStickyPath ?? null)
+    .filter((path): path is string => path != null);
+}
+
+// Sticky keyboard handling runs during the browser event that follows a scroll.
+// Reading the mounted overlay refs keeps that event aligned with the row the
+// user can currently focus, even if the React layout snapshot is one frame old.
+function getMountedStickyRowPathSet(
+  paths: readonly string[]
+): ReadonlySet<string> {
+  return new Set(paths);
+}
+
 function createContextMenuItem(
   row: FileTreeVisibleRow,
   path: string
@@ -1322,6 +1344,11 @@ export function FileTreeView({
   contextMenuStateRef.current = contextMenuState;
 
   const pendingStickyFocusPathRef = useRef<string | null>(null);
+  const pendingStickyKeyboardFocusPathRef = useRef<string | null>(null);
+  const pendingStickyKeyboardViewportOffsetRef = useRef<{
+    path: string;
+    viewportOffset: number;
+  } | null>(null);
   const debugContextMenuTriggerPathRef = useRef<string | null>(null);
   const debugDisableScrollSuppressionRef = useRef(false);
 
@@ -2203,6 +2230,27 @@ export function FileTreeView({
       return;
     }
 
+    const activeTreeElement =
+      rootRef.current == null ? null : getActiveTreeElement(rootRef.current);
+    const mountedStickyRowPaths = getMountedStickyRowPaths(rootRef.current);
+    const mountedStickyRowPathSet = getMountedStickyRowPathSet(
+      mountedStickyRowPaths
+    );
+    const activeStickyFocusPath =
+      activeTreeElement?.dataset.fileTreeStickyPath ?? null;
+    const activeStickyRowOwnsFocus =
+      activeTreeElement?.dataset.fileTreeStickyRow === 'true' &&
+      activeStickyFocusPath != null;
+    if (
+      activeStickyRowOwnsFocus &&
+      activeStickyFocusPath !== focusedPath &&
+      mountedStickyRowPathSet.has(activeStickyFocusPath)
+    ) {
+      controller.focusPath(activeStickyFocusPath);
+    }
+
+    const effectiveFocusedPath = controller.getFocusedPath();
+    const effectiveFocusedIndex = controller.getFocusedIndex();
     const focusedItem = controller.getFocusedItem();
     if (focusedItem == null) {
       return;
@@ -2211,6 +2259,56 @@ export function FileTreeView({
     const focusedDirectoryItem = isFileTreeDirectoryHandle(focusedItem)
       ? focusedItem
       : null;
+    const startedFromStickyRow =
+      effectiveFocusedPath != null &&
+      (stickyRowPathSet.has(effectiveFocusedPath) ||
+        (activeStickyRowOwnsFocus &&
+          activeStickyFocusPath === effectiveFocusedPath &&
+          mountedStickyRowPathSet.has(effectiveFocusedPath)));
+    const shouldPreserveLocalStickyFocusMove =
+      event.key === 'ArrowDown' ||
+      event.key === 'ArrowUp' ||
+      (event.key === 'ArrowRight' &&
+        focusedDirectoryItem != null &&
+        focusedDirectoryItem.isExpanded());
+    const focusedParkedRowElement =
+      rootRef.current == null || effectiveFocusedPath == null
+        ? null
+        : (Array.from(
+            rootRef.current.querySelectorAll(
+              'button[data-item-focused="true"][data-item-parked="true"]'
+            )
+          ).find(
+            (element): element is HTMLElement =>
+              element instanceof HTMLElement &&
+              element.dataset.itemPath === effectiveFocusedPath
+          ) ?? null);
+    const scrollElement = scrollRef.current;
+    const scrollElementRect = scrollElement?.getBoundingClientRect() ?? null;
+    const activeElementTopWithinViewport =
+      scrollElementRect == null || activeTreeElement == null
+        ? null
+        : activeTreeElement.getBoundingClientRect().top - scrollElementRect.top;
+    const parkedElementTopWithinViewport =
+      scrollElementRect == null || focusedParkedRowElement == null
+        ? null
+        : focusedParkedRowElement.getBoundingClientRect().top -
+          scrollElementRect.top;
+    const minimumStickyKeyboardViewportOffset = Math.max(
+      0,
+      stickyOverlayHeight - itemHeight
+    );
+    const stickyKeyboardViewportOffset = Math.max(
+      0,
+      Math.min(
+        parkedElementTopWithinViewport ??
+          Math.max(
+            activeElementTopWithinViewport ?? 0,
+            minimumStickyKeyboardViewportOffset
+          ),
+        Math.max(0, resolvedViewportHeight - itemHeight)
+      )
+    );
     let handled = true;
     if (event.shiftKey && event.key === 'ArrowDown') {
       controller.extendSelectionFromFocused(1);
@@ -2219,16 +2317,20 @@ export function FileTreeView({
     } else if (
       contextMenuEnabled &&
       isContextMenuOpenKey(event) &&
-      focusedPath != null &&
-      focusedIndex >= 0
+      effectiveFocusedPath != null &&
+      effectiveFocusedIndex >= 0
     ) {
       const focusedRow =
-        controller.getVisibleRows(focusedIndex, focusedIndex)[0] ?? null;
-      const focusedButton = rowButtonRefs.current.get(focusedPath) ?? null;
+        controller.getVisibleRows(
+          effectiveFocusedIndex,
+          effectiveFocusedIndex
+        )[0] ?? null;
+      const focusedButton =
+        rowButtonRefs.current.get(effectiveFocusedPath) ?? null;
       if (focusedRow == null || focusedButton == null) {
         handled = false;
       } else {
-        openContextMenuForRow(focusedRow, focusedPath);
+        openContextMenuForRow(focusedRow, effectiveFocusedPath);
       }
     } else if ((event.ctrlKey || event.metaKey) && isSpaceSelectionKey(event)) {
       controller.toggleFocusedSelection();
@@ -2281,6 +2383,41 @@ export function FileTreeView({
     }
 
     setLastContextMenuInteraction('focus');
+    const nextFocusedPath = controller.getFocusedPath();
+    const nextFocusedPathIsMountedSticky =
+      nextFocusedPath != null &&
+      (stickyRowPathSet.has(nextFocusedPath) ||
+        mountedStickyRowPathSet.has(nextFocusedPath));
+    if (
+      shouldPreserveLocalStickyFocusMove &&
+      startedFromStickyRow &&
+      nextFocusedPath != null &&
+      nextFocusedPath !== effectiveFocusedPath &&
+      nextFocusedPathIsMountedSticky
+    ) {
+      pendingStickyKeyboardFocusPathRef.current = nextFocusedPath;
+      pendingStickyKeyboardViewportOffsetRef.current = null;
+      domFocusOwnerRef.current = true;
+      setActiveItemPath((previousPath) =>
+        previousPath === nextFocusedPath ? previousPath : nextFocusedPath
+      );
+    } else {
+      pendingStickyKeyboardFocusPathRef.current = null;
+      if (
+        event.key === 'ArrowUp' &&
+        startedFromStickyRow &&
+        nextFocusedPath != null &&
+        nextFocusedPath !== effectiveFocusedPath
+      ) {
+        pendingStickyKeyboardViewportOffsetRef.current = {
+          path: nextFocusedPath,
+          viewportOffset: stickyKeyboardViewportOffset,
+        };
+        domFocusOwnerRef.current = true;
+      } else {
+        pendingStickyKeyboardViewportOffsetRef.current = null;
+      }
+    }
 
     // Focus-only and selection-only controller updates do not change
     // range/itemCount, so force a render tick before the DOM-focus sync effect
@@ -2816,9 +2953,18 @@ export function FileTreeView({
     const preservedViewportOffset =
       restoreTreeFocusViewportOffsetRef.current ?? 0;
     const pendingStickyFocusPath = pendingStickyFocusPathRef.current;
+    const pendingStickyKeyboardFocusPath =
+      pendingStickyKeyboardFocusPathRef.current;
+    const pendingStickyKeyboardViewportOffset =
+      pendingStickyKeyboardViewportOffsetRef.current;
     const focusWithinTree = activeTreeElement != null;
     const shouldOwnDomFocus = domFocusOwnerRef.current || focusWithinTree;
     const focusedPathChanged = previousFocusedPathRef.current !== focusedPath;
+    const shouldPreserveStickyKeyboardFocusViewport =
+      pendingStickyKeyboardFocusPath != null &&
+      pendingStickyKeyboardFocusPath === focusedPath &&
+      focusedPath != null &&
+      stickyRowPathSet.has(focusedPath);
 
     const shouldRestoreFocusedRowViewportOffset =
       shouldRestoreTreeFocusAfterSearchClose &&
@@ -2841,13 +2987,26 @@ export function FileTreeView({
         totalScrollableHeight,
         stickyOverlayHeight
       );
+    const shouldRestoreStickyKeyboardViewportOffset =
+      pendingStickyKeyboardViewportOffset != null &&
+      pendingStickyKeyboardViewportOffset.path === focusedPath &&
+      scrollFocusedRowToViewportOffset(
+        scrollElement,
+        focusedIndex,
+        itemHeight,
+        resolvedViewportHeight,
+        totalScrollableHeight,
+        pendingStickyKeyboardViewportOffset.viewportOffset
+      );
 
     if (
       shouldRestoreStickyFocusedRowViewportOffset ||
+      shouldRestoreStickyKeyboardViewportOffset ||
       shouldRestoreFocusedRowViewportOffset ||
       (shouldOwnDomFocus &&
         focusedPathChanged &&
         pendingStickyFocusPath !== focusedPath &&
+        !shouldPreserveStickyKeyboardFocusViewport &&
         scrollFocusedRowIntoView(
           scrollElement,
           focusedIndex,
@@ -2894,12 +3053,20 @@ export function FileTreeView({
       focusedPathChanged ||
       shouldRestoreTreeFocusAfterSearchClose ||
       pendingStickyFocusPath === focusedPath ||
+      pendingStickyKeyboardFocusPath === focusedPath ||
+      pendingStickyKeyboardViewportOffset?.path === focusedPath ||
       activeTreeElementPath == null ||
       activeTreeElementPath !== focusedPath
     ) {
       focusElement(focusedButton);
       if (pendingStickyFocusPath === focusedPath) {
         pendingStickyFocusPathRef.current = null;
+      }
+      if (pendingStickyKeyboardFocusPath === focusedPath) {
+        pendingStickyKeyboardFocusPathRef.current = null;
+      }
+      if (pendingStickyKeyboardViewportOffset?.path === focusedPath) {
+        pendingStickyKeyboardViewportOffsetRef.current = null;
       }
       restoreTreeFocusAfterSearchCloseRef.current = false;
       restoreTreeFocusViewportOffsetRef.current = null;
@@ -2917,6 +3084,7 @@ export function FileTreeView({
     resolvedViewportHeight,
     searchEnabled,
     stickyOverlayHeight,
+    stickyRowPathSet,
     totalScrollableHeight,
     visibleRows,
   ]);

--- a/packages/trees/src/render/FileTreeView.tsx
+++ b/packages/trees/src/render/FileTreeView.tsx
@@ -580,7 +580,7 @@ function getCachedViewportHeight(
 // ResizeObserver exposes box sizes without forcing an extra layout read. Use
 // that value to refresh the viewport-height cache, falling back to the direct
 // measurement only in environments that omit the border-box size.
-function getResizeObserverViewportHeight(
+export function getResizeObserverViewportHeight(
   entry: ResizeObserverEntry
 ): number | null {
   const borderBoxSize = entry.borderBoxSize;
@@ -606,7 +606,7 @@ function scrollFocusedRowIntoView(
   scrollElement: HTMLElement,
   focusedIndex: number,
   itemHeight: number,
-  fallbackViewportHeight: number,
+  viewportHeight: number,
   topInset: number = 0
 ): boolean {
   const nextScrollTop = computeFocusedRowScrollIntoView({
@@ -614,10 +614,7 @@ function scrollFocusedRowIntoView(
     focusedIndex,
     itemHeight,
     topInset,
-    viewportHeight: readMeasuredViewportHeight(
-      scrollElement,
-      fallbackViewportHeight
-    ),
+    viewportHeight,
   });
   if (nextScrollTop == null) {
     return false;
@@ -634,7 +631,7 @@ function scrollFocusedRowToViewportOffset(
   scrollElement: HTMLElement,
   focusedIndex: number,
   itemHeight: number,
-  fallbackViewportHeight: number,
+  viewportHeight: number,
   totalHeight: number,
   targetViewportOffset: number
 ): boolean {
@@ -644,10 +641,7 @@ function scrollFocusedRowToViewportOffset(
     itemHeight,
     targetViewportOffset,
     totalHeight,
-    viewportHeight: readMeasuredViewportHeight(
-      scrollElement,
-      fallbackViewportHeight
-    ),
+    viewportHeight,
   });
   if (nextScrollTop == null) {
     return false;
@@ -691,6 +685,29 @@ function getFileTreeGuideStyleText(focusedParentPath: string | null): string {
 
 function isContextMenuOpenKey(event: KeyboardEvent): boolean {
   return (event.shiftKey && event.key === 'F10') || event.key === 'ContextMenu';
+}
+
+// Sticky DOM reads are only needed for keys whose behavior depends on the
+// current focused row. This keeps ordinary keydowns out of the query/measure
+// path while preserving stale-DOM-focus repair for sticky keyboard actions.
+function canKeyUseStickyKeyboardState(
+  event: KeyboardEvent,
+  contextMenuEnabled: boolean
+): boolean {
+  if (contextMenuEnabled && isContextMenuOpenKey(event)) {
+    return true;
+  }
+
+  if ((event.ctrlKey || event.metaKey) && isSpaceSelectionKey(event)) {
+    return true;
+  }
+
+  return (
+    event.key === 'ArrowDown' ||
+    event.key === 'ArrowLeft' ||
+    event.key === 'ArrowRight' ||
+    event.key === 'ArrowUp'
+  );
 }
 
 const BLOCKED_CONTEXT_MENU_NAV_KEYS = new Set([
@@ -851,6 +868,47 @@ function getFocusedParkedRowElement(
   }
 
   return null;
+}
+
+// Sticky keyboard exits use the focused sticky mirror as a proxy for where the
+// canonical row should remain after focus moves or the row collapses. Keeping
+// the layout reads here avoids measuring DOM for ordinary key handling.
+function getStickyKeyboardViewportOffset(
+  rootElement: HTMLElement | null,
+  scrollElement: HTMLElement | null,
+  activeTreeElement: HTMLElement | null,
+  path: string | null,
+  itemHeight: number,
+  stickyOverlayHeight: number,
+  viewportHeight: number
+): number {
+  const minimumStickyKeyboardViewportOffset = Math.max(
+    0,
+    stickyOverlayHeight - itemHeight
+  );
+  const scrollElementRect = scrollElement?.getBoundingClientRect() ?? null;
+  const activeElementTopWithinViewport =
+    scrollElementRect == null || activeTreeElement == null
+      ? null
+      : activeTreeElement.getBoundingClientRect().top - scrollElementRect.top;
+  const focusedParkedRowElement = getFocusedParkedRowElement(rootElement, path);
+  const parkedElementTopWithinViewport =
+    scrollElementRect == null || focusedParkedRowElement == null
+      ? null
+      : focusedParkedRowElement.getBoundingClientRect().top -
+        scrollElementRect.top;
+
+  return Math.max(
+    0,
+    Math.min(
+      parkedElementTopWithinViewport ??
+        Math.max(
+          activeElementTopWithinViewport ?? 0,
+          minimumStickyKeyboardViewportOffset
+        ),
+      Math.max(0, viewportHeight - itemHeight)
+    )
+  );
 }
 
 function createContextMenuItem(
@@ -1420,6 +1478,33 @@ export function FileTreeView({
   const debugContextMenuTriggerPathRef = useRef<string | null>(null);
   const debugDisableScrollSuppressionRef = useRef(false);
 
+  // Keep the coupled sticky-keyboard refs moving together so each transition
+  // leaves exactly one preservation mode active.
+  const clearPendingStickyKeyboardState = (): void => {
+    pendingStickyKeyboardFocusPathRef.current = null;
+    pendingStickyKeyboardViewportOffsetRef.current = null;
+    pendingStickyKeyboardScrollTopRef.current = null;
+  };
+
+  const preserveStickyKeyboardFocusAtScrollTop = (
+    path: string,
+    scrollTop: number | null
+  ): void => {
+    pendingStickyKeyboardFocusPathRef.current = path;
+    pendingStickyKeyboardViewportOffsetRef.current = null;
+    pendingStickyKeyboardScrollTopRef.current =
+      scrollTop == null ? null : { path, scrollTop };
+  };
+
+  const restoreStickyKeyboardViewportOffset = (
+    path: string,
+    viewportOffset: number
+  ): void => {
+    pendingStickyKeyboardFocusPathRef.current = null;
+    pendingStickyKeyboardViewportOffsetRef.current = { path, viewportOffset };
+    pendingStickyKeyboardScrollTopRef.current = null;
+  };
+
   // Trees that mount with an already-open search session (because a caller
   // passed `initialSearchQuery`) should not steal focus from sibling trees
   // during mount when the consumer opted into `'retain'` blur behavior. The
@@ -1701,20 +1786,18 @@ export function FileTreeView({
       const anchorButton = getTriggerAnchorButton(targetPath);
       if (anchorButton?.dataset.fileTreeStickyRow === 'true') {
         const scrollElement = scrollRef.current;
-        pendingStickyKeyboardFocusPathRef.current = targetPath;
-        pendingStickyKeyboardViewportOffsetRef.current = null;
-        pendingStickyKeyboardScrollTopRef.current =
-          scrollElement == null
-            ? null
-            : {
-                path: targetPath,
-                scrollTop: scrollElement.scrollTop,
-              };
+        preserveStickyKeyboardFocusAtScrollTop(
+          targetPath,
+          scrollElement?.scrollTop ?? null
+        );
         domFocusOwnerRef.current = true;
         setActiveItemPath((previousPath) =>
           previousPath === targetPath ? previousPath : targetPath
         );
       }
+      // FileTree item focus is controller focus, not DOM focus. Sticky anchor
+      // preservation relies on this remaining scroll-neutral so the canonical
+      // offscreen row is not revealed before the layout effect restores focus.
       item.focus();
       updateTriggerPosition(anchorButton);
       shouldRestoreContextMenuFocusRef.current = true;
@@ -2316,10 +2399,19 @@ export function FileTreeView({
       return;
     }
 
+    const isKeyboardContextMenuRequest =
+      contextMenuEnabled && isContextMenuOpenKey(event);
+    const shouldInspectStickyKeyboardState = canKeyUseStickyKeyboardState(
+      event,
+      contextMenuEnabled
+    );
     const activeTreeElement =
-      rootRef.current == null ? null : getActiveTreeElement(rootRef.current);
-    const mountedStickyRowPaths = getMountedStickyRowPaths(rootRef.current);
-    const mountedStickyRowPathSet = new Set(mountedStickyRowPaths);
+      shouldInspectStickyKeyboardState && rootRef.current != null
+        ? getActiveTreeElement(rootRef.current)
+        : null;
+    const mountedStickyRowPathSet = shouldInspectStickyKeyboardState
+      ? new Set(getMountedStickyRowPaths(rootRef.current))
+      : new Set<string>();
     const activeStickyFocusPath =
       activeTreeElement?.dataset.fileTreeStickyPath ?? null;
     const activeStickyRowOwnsFocus =
@@ -2335,15 +2427,10 @@ export function FileTreeView({
       // Shift+F10 may also be followed by a native contextmenu event, so this
       // preservation has to be in place before the controller emits.
       const scrollElement = scrollRef.current;
-      pendingStickyKeyboardFocusPathRef.current = activeStickyFocusPath;
-      pendingStickyKeyboardViewportOffsetRef.current = null;
-      pendingStickyKeyboardScrollTopRef.current =
-        scrollElement == null
-          ? null
-          : {
-              path: activeStickyFocusPath,
-              scrollTop: scrollElement.scrollTop,
-            };
+      preserveStickyKeyboardFocusAtScrollTop(
+        activeStickyFocusPath,
+        scrollElement?.scrollTop ?? null
+      );
       controller.focusPath(activeStickyFocusPath);
     }
 
@@ -2374,38 +2461,7 @@ export function FileTreeView({
       startedFromStickyRow &&
       focusedDirectoryItem != null &&
       focusedDirectoryItem.isExpanded();
-    const isKeyboardContextMenuRequest =
-      contextMenuEnabled && isContextMenuOpenKey(event);
-    const focusedParkedRowElement = getFocusedParkedRowElement(
-      rootRef.current,
-      effectiveFocusedPath
-    );
     const scrollElement = scrollRef.current;
-    const scrollElementRect = scrollElement?.getBoundingClientRect() ?? null;
-    const activeElementTopWithinViewport =
-      scrollElementRect == null || activeTreeElement == null
-        ? null
-        : activeTreeElement.getBoundingClientRect().top - scrollElementRect.top;
-    const parkedElementTopWithinViewport =
-      scrollElementRect == null || focusedParkedRowElement == null
-        ? null
-        : focusedParkedRowElement.getBoundingClientRect().top -
-          scrollElementRect.top;
-    const minimumStickyKeyboardViewportOffset = Math.max(
-      0,
-      stickyOverlayHeight - itemHeight
-    );
-    const stickyKeyboardViewportOffset = Math.max(
-      0,
-      Math.min(
-        parkedElementTopWithinViewport ??
-          Math.max(
-            activeElementTopWithinViewport ?? 0,
-            minimumStickyKeyboardViewportOffset
-          ),
-        Math.max(0, resolvedViewportHeight - itemHeight)
-      )
-    );
     let handled = true;
     if (event.shiftKey && event.key === 'ArrowDown') {
       controller.extendSelectionFromFocused(1);
@@ -2504,21 +2560,15 @@ export function FileTreeView({
       nextFocusedPath != null &&
       shouldPreserveStickyKeyboardFocusPath
     ) {
-      pendingStickyKeyboardFocusPathRef.current = nextFocusedPath;
-      pendingStickyKeyboardViewportOffsetRef.current = null;
-      pendingStickyKeyboardScrollTopRef.current =
-        scrollElement == null
-          ? null
-          : {
-              path: nextFocusedPath,
-              scrollTop: scrollElement.scrollTop,
-            };
+      preserveStickyKeyboardFocusAtScrollTop(
+        nextFocusedPath,
+        scrollElement?.scrollTop ?? null
+      );
       domFocusOwnerRef.current = true;
       setActiveItemPath((previousPath) =>
         previousPath === nextFocusedPath ? previousPath : nextFocusedPath
       );
     } else {
-      pendingStickyKeyboardFocusPathRef.current = null;
       const stickyArrowUpExitsStack =
         event.key === 'ArrowUp' &&
         startedFromStickyRow &&
@@ -2530,18 +2580,24 @@ export function FileTreeView({
         nextFocusedPath != null &&
         (stickyArrowUpExitsStack || stickyCollapseStaysOnRow)
       ) {
-        pendingStickyKeyboardViewportOffsetRef.current = {
-          path: nextFocusedPath,
-          viewportOffset: stickyKeyboardViewportOffset,
-        };
-        pendingStickyKeyboardScrollTopRef.current = null;
+        restoreStickyKeyboardViewportOffset(
+          nextFocusedPath,
+          getStickyKeyboardViewportOffset(
+            rootRef.current,
+            scrollElement,
+            activeTreeElement,
+            effectiveFocusedPath,
+            itemHeight,
+            stickyOverlayHeight,
+            resolvedViewportHeight
+          )
+        );
         domFocusOwnerRef.current = true;
         setActiveItemPath((previousPath) =>
           previousPath === nextFocusedPath ? previousPath : nextFocusedPath
         );
       } else {
-        pendingStickyKeyboardViewportOffsetRef.current = null;
-        pendingStickyKeyboardScrollTopRef.current = null;
+        clearPendingStickyKeyboardState();
       }
     }
 

--- a/packages/trees/src/render/FileTreeView.tsx
+++ b/packages/trees/src/render/FileTreeView.tsx
@@ -768,26 +768,48 @@ function getContextMenuAnchorButton(
   return rowButton?.dataset.itemParked === 'true' ? null : rowButton;
 }
 
+// Sticky keyboard handling runs during the browser event that follows a scroll.
+// Reading the mounted overlay mirrors keeps that event aligned with the row the
+// user can currently focus, even if the React layout snapshot is one frame old.
 function getMountedStickyRowPaths(rootElement: HTMLElement | null): string[] {
   if (rootElement == null) {
     return [];
   }
 
-  return Array.from(
-    rootElement.querySelectorAll('button[data-file-tree-sticky-row="true"]')
-  )
-    .filter((element): element is HTMLElement => element instanceof HTMLElement)
-    .map((element) => element.dataset.fileTreeStickyPath ?? null)
-    .filter((path): path is string => path != null);
+  const paths: string[] = [];
+  for (const element of rootElement.querySelectorAll(
+    'button[data-file-tree-sticky-row="true"]'
+  )) {
+    if (!(element instanceof HTMLElement)) {
+      continue;
+    }
+
+    const path = element.dataset.fileTreeStickyPath;
+    if (path != null) {
+      paths.push(path);
+    }
+  }
+
+  return paths;
 }
 
-// Sticky keyboard handling runs during the browser event that follows a scroll.
-// Reading the mounted overlay refs keeps that event aligned with the row the
-// user can currently focus, even if the React layout snapshot is one frame old.
-function getMountedStickyRowPathSet(
-  paths: readonly string[]
-): ReadonlySet<string> {
-  return new Set(paths);
+function getFocusedParkedRowElement(
+  rootElement: HTMLElement | null,
+  path: string | null
+): HTMLElement | null {
+  if (rootElement == null || path == null) {
+    return null;
+  }
+
+  for (const element of rootElement.querySelectorAll(
+    'button[data-item-focused="true"][data-item-parked="true"]'
+  )) {
+    if (element instanceof HTMLElement && element.dataset.itemPath === path) {
+      return element;
+    }
+  }
+
+  return null;
 }
 
 function createContextMenuItem(
@@ -1349,6 +1371,10 @@ export function FileTreeView({
     path: string;
     viewportOffset: number;
   } | null>(null);
+  const pendingStickyKeyboardScrollTopRef = useRef<{
+    path: string;
+    scrollTop: number;
+  } | null>(null);
   const debugContextMenuTriggerPathRef = useRef<string | null>(null);
   const debugDisableScrollSuppressionRef = useRef(false);
 
@@ -1630,8 +1656,25 @@ export function FileTreeView({
         return;
       }
 
+      const anchorButton = getTriggerAnchorButton(targetPath);
+      if (anchorButton?.dataset.fileTreeStickyRow === 'true') {
+        const scrollElement = scrollRef.current;
+        pendingStickyKeyboardFocusPathRef.current = targetPath;
+        pendingStickyKeyboardViewportOffsetRef.current = null;
+        pendingStickyKeyboardScrollTopRef.current =
+          scrollElement == null
+            ? null
+            : {
+                path: targetPath,
+                scrollTop: scrollElement.scrollTop,
+              };
+        domFocusOwnerRef.current = true;
+        setActiveItemPath((previousPath) =>
+          previousPath === targetPath ? previousPath : targetPath
+        );
+      }
       item.focus();
-      updateTriggerPosition(getTriggerAnchorButton(targetPath));
+      updateTriggerPosition(anchorButton);
       shouldRestoreContextMenuFocusRef.current = true;
       setContextMenuState({
         anchorRect: options?.anchorRect ?? null,
@@ -2233,9 +2276,7 @@ export function FileTreeView({
     const activeTreeElement =
       rootRef.current == null ? null : getActiveTreeElement(rootRef.current);
     const mountedStickyRowPaths = getMountedStickyRowPaths(rootRef.current);
-    const mountedStickyRowPathSet = getMountedStickyRowPathSet(
-      mountedStickyRowPaths
-    );
+    const mountedStickyRowPathSet = new Set(mountedStickyRowPaths);
     const activeStickyFocusPath =
       activeTreeElement?.dataset.fileTreeStickyPath ?? null;
     const activeStickyRowOwnsFocus =
@@ -2246,6 +2287,20 @@ export function FileTreeView({
       activeStickyFocusPath !== focusedPath &&
       mountedStickyRowPathSet.has(activeStickyFocusPath)
     ) {
+      // Syncing controller focus to a sticky DOM mirror can otherwise reveal
+      // the offscreen canonical row before the key action decides what to do.
+      // Shift+F10 may also be followed by a native contextmenu event, so this
+      // preservation has to be in place before the controller emits.
+      const scrollElement = scrollRef.current;
+      pendingStickyKeyboardFocusPathRef.current = activeStickyFocusPath;
+      pendingStickyKeyboardViewportOffsetRef.current = null;
+      pendingStickyKeyboardScrollTopRef.current =
+        scrollElement == null
+          ? null
+          : {
+              path: activeStickyFocusPath,
+              scrollTop: scrollElement.scrollTop,
+            };
       controller.focusPath(activeStickyFocusPath);
     }
 
@@ -2276,18 +2331,12 @@ export function FileTreeView({
       startedFromStickyRow &&
       focusedDirectoryItem != null &&
       focusedDirectoryItem.isExpanded();
-    const focusedParkedRowElement =
-      rootRef.current == null || effectiveFocusedPath == null
-        ? null
-        : (Array.from(
-            rootRef.current.querySelectorAll(
-              'button[data-item-focused="true"][data-item-parked="true"]'
-            )
-          ).find(
-            (element): element is HTMLElement =>
-              element instanceof HTMLElement &&
-              element.dataset.itemPath === effectiveFocusedPath
-          ) ?? null);
+    const isKeyboardContextMenuRequest =
+      contextMenuEnabled && isContextMenuOpenKey(event);
+    const focusedParkedRowElement = getFocusedParkedRowElement(
+      rootRef.current,
+      effectiveFocusedPath
+    );
     const scrollElement = scrollRef.current;
     const scrollElementRect = scrollElement?.getBoundingClientRect() ?? null;
     const activeElementTopWithinViewport =
@@ -2320,8 +2369,7 @@ export function FileTreeView({
     } else if (event.shiftKey && event.key === 'ArrowUp') {
       controller.extendSelectionFromFocused(-1);
     } else if (
-      contextMenuEnabled &&
-      isContextMenuOpenKey(event) &&
+      isKeyboardContextMenuRequest &&
       effectiveFocusedPath != null &&
       effectiveFocusedIndex >= 0
     ) {
@@ -2330,8 +2378,11 @@ export function FileTreeView({
           effectiveFocusedIndex,
           effectiveFocusedIndex
         )[0] ?? null;
-      const focusedButton =
-        rowButtonRefs.current.get(effectiveFocusedPath) ?? null;
+      const focusedButton = getContextMenuAnchorButton(
+        effectiveFocusedPath,
+        stickyRowButtonRefs.current,
+        rowButtonRefs.current
+      );
       if (focusedRow == null || focusedButton == null) {
         handled = false;
       } else {
@@ -2393,39 +2444,61 @@ export function FileTreeView({
       nextFocusedPath != null &&
       (stickyRowPathSet.has(nextFocusedPath) ||
         mountedStickyRowPathSet.has(nextFocusedPath));
-    if (
+    const stickyKeyboardMoveLandsOnDifferentStickyRow =
       shouldPreserveLocalStickyFocusMove &&
-      startedFromStickyRow &&
+      nextFocusedPath !== effectiveFocusedPath;
+    const stickyKeyboardMenuStaysOnStickyRow =
+      isKeyboardContextMenuRequest &&
+      activeStickyRowOwnsFocus &&
+      activeStickyFocusPath === effectiveFocusedPath &&
+      nextFocusedPath === effectiveFocusedPath;
+    const shouldPreserveStickyKeyboardFocusPath =
+      (stickyKeyboardMoveLandsOnDifferentStickyRow &&
+        nextFocusedPathIsMountedSticky) ||
+      stickyKeyboardMenuStaysOnStickyRow;
+    if (
+      (startedFromStickyRow || stickyKeyboardMenuStaysOnStickyRow) &&
       nextFocusedPath != null &&
-      nextFocusedPath !== effectiveFocusedPath &&
-      nextFocusedPathIsMountedSticky
+      shouldPreserveStickyKeyboardFocusPath
     ) {
       pendingStickyKeyboardFocusPathRef.current = nextFocusedPath;
       pendingStickyKeyboardViewportOffsetRef.current = null;
+      pendingStickyKeyboardScrollTopRef.current =
+        scrollElement == null
+          ? null
+          : {
+              path: nextFocusedPath,
+              scrollTop: scrollElement.scrollTop,
+            };
       domFocusOwnerRef.current = true;
       setActiveItemPath((previousPath) =>
         previousPath === nextFocusedPath ? previousPath : nextFocusedPath
       );
     } else {
       pendingStickyKeyboardFocusPathRef.current = null;
+      const stickyArrowUpExitsStack =
+        event.key === 'ArrowUp' &&
+        startedFromStickyRow &&
+        nextFocusedPath !== effectiveFocusedPath;
+      const stickyCollapseStaysOnRow =
+        shouldRestoreCollapsedStickyFocusViewport &&
+        nextFocusedPath === effectiveFocusedPath;
       if (
         nextFocusedPath != null &&
-        ((event.key === 'ArrowUp' &&
-          startedFromStickyRow &&
-          nextFocusedPath !== effectiveFocusedPath) ||
-          (shouldRestoreCollapsedStickyFocusViewport &&
-            nextFocusedPath === effectiveFocusedPath))
+        (stickyArrowUpExitsStack || stickyCollapseStaysOnRow)
       ) {
         pendingStickyKeyboardViewportOffsetRef.current = {
           path: nextFocusedPath,
           viewportOffset: stickyKeyboardViewportOffset,
         };
+        pendingStickyKeyboardScrollTopRef.current = null;
         domFocusOwnerRef.current = true;
         setActiveItemPath((previousPath) =>
           previousPath === nextFocusedPath ? previousPath : nextFocusedPath
         );
       } else {
         pendingStickyKeyboardViewportOffsetRef.current = null;
+        pendingStickyKeyboardScrollTopRef.current = null;
       }
     }
 
@@ -2967,14 +3040,15 @@ export function FileTreeView({
       pendingStickyKeyboardFocusPathRef.current;
     const pendingStickyKeyboardViewportOffset =
       pendingStickyKeyboardViewportOffsetRef.current;
+    const pendingStickyKeyboardScrollTop =
+      pendingStickyKeyboardScrollTopRef.current;
     const focusWithinTree = activeTreeElement != null;
     const shouldOwnDomFocus = domFocusOwnerRef.current || focusWithinTree;
     const focusedPathChanged = previousFocusedPathRef.current !== focusedPath;
     const shouldPreserveStickyKeyboardFocusViewport =
       pendingStickyKeyboardFocusPath != null &&
       pendingStickyKeyboardFocusPath === focusedPath &&
-      focusedPath != null &&
-      stickyRowPathSet.has(focusedPath);
+      focusedPath != null;
 
     const shouldRestoreFocusedRowViewportOffset =
       shouldRestoreTreeFocusAfterSearchClose &&
@@ -3008,8 +3082,16 @@ export function FileTreeView({
         totalScrollableHeight,
         pendingStickyKeyboardViewportOffset.viewportOffset
       );
+    const shouldRestoreStickyKeyboardScrollTop =
+      pendingStickyKeyboardScrollTop != null &&
+      pendingStickyKeyboardScrollTop.path === focusedPath &&
+      scrollElement.scrollTop !== pendingStickyKeyboardScrollTop.scrollTop;
+    if (shouldRestoreStickyKeyboardScrollTop) {
+      scrollElement.scrollTop = pendingStickyKeyboardScrollTop.scrollTop;
+    }
 
     if (
+      shouldRestoreStickyKeyboardScrollTop ||
       shouldRestoreStickyFocusedRowViewportOffset ||
       shouldRestoreStickyKeyboardViewportOffset ||
       shouldRestoreFocusedRowViewportOffset ||
@@ -3065,6 +3147,7 @@ export function FileTreeView({
       pendingStickyFocusPath === focusedPath ||
       pendingStickyKeyboardFocusPath === focusedPath ||
       pendingStickyKeyboardViewportOffset?.path === focusedPath ||
+      pendingStickyKeyboardScrollTop?.path === focusedPath ||
       activeTreeElementPath == null ||
       activeTreeElementPath !== focusedPath
     ) {
@@ -3077,6 +3160,9 @@ export function FileTreeView({
       }
       if (pendingStickyKeyboardViewportOffset?.path === focusedPath) {
         pendingStickyKeyboardViewportOffsetRef.current = null;
+      }
+      if (pendingStickyKeyboardScrollTop?.path === focusedPath) {
+        pendingStickyKeyboardScrollTopRef.current = null;
       }
       restoreTreeFocusAfterSearchCloseRef.current = false;
       restoreTreeFocusViewportOffsetRef.current = null;
@@ -3094,7 +3180,6 @@ export function FileTreeView({
     resolvedViewportHeight,
     searchEnabled,
     stickyOverlayHeight,
-    stickyRowPathSet,
     totalScrollableHeight,
     visibleRows,
   ]);

--- a/packages/trees/src/render/FileTreeView.tsx
+++ b/packages/trees/src/render/FileTreeView.tsx
@@ -2271,6 +2271,11 @@ export function FileTreeView({
       (event.key === 'ArrowRight' &&
         focusedDirectoryItem != null &&
         focusedDirectoryItem.isExpanded());
+    const shouldRestoreCollapsedStickyFocusViewport =
+      event.key === 'ArrowLeft' &&
+      startedFromStickyRow &&
+      focusedDirectoryItem != null &&
+      focusedDirectoryItem.isExpanded();
     const focusedParkedRowElement =
       rootRef.current == null || effectiveFocusedPath == null
         ? null
@@ -2404,16 +2409,21 @@ export function FileTreeView({
     } else {
       pendingStickyKeyboardFocusPathRef.current = null;
       if (
-        event.key === 'ArrowUp' &&
-        startedFromStickyRow &&
         nextFocusedPath != null &&
-        nextFocusedPath !== effectiveFocusedPath
+        ((event.key === 'ArrowUp' &&
+          startedFromStickyRow &&
+          nextFocusedPath !== effectiveFocusedPath) ||
+          (shouldRestoreCollapsedStickyFocusViewport &&
+            nextFocusedPath === effectiveFocusedPath))
       ) {
         pendingStickyKeyboardViewportOffsetRef.current = {
           path: nextFocusedPath,
           viewportOffset: stickyKeyboardViewportOffset,
         };
         domFocusOwnerRef.current = true;
+        setActiveItemPath((previousPath) =>
+          previousPath === nextFocusedPath ? previousPath : nextFocusedPath
+        );
       } else {
         pendingStickyKeyboardViewportOffsetRef.current = null;
       }

--- a/packages/trees/src/style.css
+++ b/packages/trees/src/style.css
@@ -872,6 +872,27 @@
     pointer-events: auto;
   }
 
+  /* Sticky rows opt back into pointer events because the overlay wrapper is
+   * inert. During scroll, put them back under the same hover suppression as
+   * the virtualized list so translucent hover states and menu triggers do not
+   * paint over rows moving beneath the sticky stack. */
+  [data-file-tree-virtualized-root='true'][data-is-scrolling]
+    [data-type='item'][data-file-tree-sticky-row='true'] {
+    pointer-events: none;
+  }
+
+  [data-file-tree-virtualized-root='true'][data-is-scrolling]
+    [data-type='item'][data-file-tree-sticky-row='true']:hover:not(
+      [data-item-selected='true']
+    ),
+  [data-file-tree-virtualized-root='true'][data-is-scrolling]
+    [data-type='item'][data-file-tree-sticky-row='true'][data-item-context-hover='true']:not(
+      [data-item-selected='true']
+    ) {
+    background-color: var(--trees-bg);
+    --truncate-marker-background-overlay-color: transparent;
+  }
+
   [data-item-selected='true']:has(+ [data-item-selected='true']) {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;

--- a/packages/trees/test/e2e/file-tree-sticky-context-menu-scroll-drift.pw.ts
+++ b/packages/trees/test/e2e/file-tree-sticky-context-menu-scroll-drift.pw.ts
@@ -134,10 +134,40 @@ type StickyContextMenuMeasurement = {
   steps: StickyContextMenuStep[];
 };
 
+type StickyHoverSuppressionSample = {
+  anchorDisplay: string | null;
+  anchorVisible: boolean;
+  menuPath: string | null;
+  rowBackgroundColor: string | null;
+  rowContextHovered: boolean;
+  rowMatchesHover: boolean;
+  rowMounted: boolean;
+  rowPointerEvents: string | null;
+  rootIsScrolling: boolean;
+  triggerDisplay: string | null;
+  triggerVisible: boolean;
+  virtualizedListIsScrolling: boolean;
+};
+
+type StickyContextMenuDispatchResult = {
+  defaultPrevented: boolean;
+  menuPath: string | null;
+};
+
+type StickyRowRect = {
+  height: number;
+  left: number;
+  top: number;
+  width: number;
+};
+
 declare global {
   interface Window {
     __stickyContextMenuDriftFixtureReady?: boolean;
     __stickyContextMenuDriftProbe?: {
+      dispatchStickyContextMenu: (
+        path: string
+      ) => StickyContextMenuDispatchResult;
       findScenarioCandidate: (options?: {
         maxScrollTop?: number;
         minDepth?: number;
@@ -145,6 +175,7 @@ declare global {
         settleFrames?: number;
         step?: number;
       }) => Promise<StickyContextMenuCandidate | null>;
+      hoverRow: (path: string) => void;
       nextFrames: (count?: number) => Promise<void>;
       runScenario: (
         path: string,
@@ -158,6 +189,7 @@ declare global {
           settled: StickyContextMenuSample;
         }>
       >;
+      sampleHoverSuppression: (path: string) => StickyHoverSuppressionSample;
       setScrollSuppressionDisabled: (disabled: boolean) => void;
       setScrollTop: (scrollTop: number) => void;
       setTriggerPath: (path: string | null) => void;
@@ -194,6 +226,46 @@ const setScrollTop = async (page: Page, scrollTop: number): Promise<void> => {
   await page.evaluate((nextScrollTop) => {
     window.__stickyContextMenuDriftProbe?.setScrollTop(nextScrollTop);
   }, scrollTop);
+};
+
+// Uses real pointer movement for native :hover coverage; the fixture-level
+// hover hook only covers React's context-hover state.
+const getStickyRowRect = async (
+  page: Page,
+  path: string
+): Promise<StickyRowRect> => {
+  const rect = await page.evaluate((nextPath) => {
+    const host = document.querySelector('file-tree-container');
+    const shadowRoot = host?.shadowRoot;
+    const row = Array.from(
+      shadowRoot?.querySelectorAll(
+        'button[data-file-tree-sticky-row="true"]'
+      ) ?? []
+    ).find((button): button is HTMLButtonElement => {
+      return (
+        button instanceof HTMLButtonElement &&
+        button.dataset.fileTreeStickyPath === nextPath
+      );
+    });
+    if (!(row instanceof HTMLButtonElement)) {
+      return null;
+    }
+
+    const rowRect = row.getBoundingClientRect();
+    return {
+      height: rowRect.height,
+      left: rowRect.left,
+      top: rowRect.top,
+      width: rowRect.width,
+    };
+  }, path);
+
+  expect(rect).not.toBeNull();
+  if (rect == null) {
+    throw new Error(`Missing sticky row for ${path}.`);
+  }
+
+  return rect;
 };
 
 const toMeasuredStep = (
@@ -495,6 +567,120 @@ test.describe('sticky context-menu drift fixture @diagnostic', () => {
 });
 
 test.describe('sticky focused row context-menu regressions', () => {
+  test('suppresses sticky hover and context-menu opening while scrolling', async ({
+    page,
+  }) => {
+    await page.goto(
+      '/test/e2e/fixtures/file-tree-sticky-context-menu-scroll-drift.html'
+    );
+    await page.waitForFunction(
+      () => window.__stickyContextMenuDriftFixtureReady === true
+    );
+
+    const candidate = await page.evaluate(async (nextSettleFrames) => {
+      return (
+        (await window.__stickyContextMenuDriftProbe?.findScenarioCandidate({
+          maxScrollTop: 3000,
+          minDepth: 4,
+          minStickyCount: 3,
+          settleFrames: nextSettleFrames,
+          step: 30,
+        })) ?? null
+      );
+    }, settleFrames);
+    expect(candidate).not.toBeNull();
+    if (candidate == null) {
+      return;
+    }
+
+    const hoverPath = candidate.stickyPaths[0];
+    expect(hoverPath).toBeDefined();
+    if (hoverPath == null) {
+      throw new Error('Missing sticky row path to hover.');
+    }
+
+    await setScrollTop(page, candidate.scrollTop);
+    await page.waitForTimeout(80);
+    await nextFrames(page);
+
+    const resting = await page.evaluate((path) => {
+      return (
+        window.__stickyContextMenuDriftProbe?.sampleHoverSuppression(path) ??
+        null
+      );
+    }, hoverPath);
+    expect(resting).not.toBeNull();
+    if (resting == null) {
+      return;
+    }
+    expect(resting.rowMounted).toBe(true);
+    expect(resting.rootIsScrolling).toBe(false);
+    expect(resting.virtualizedListIsScrolling).toBe(false);
+
+    const stickyRect = await getStickyRowRect(page, hoverPath);
+    await page.mouse.move(
+      stickyRect.left + stickyRect.width / 2,
+      stickyRect.top + stickyRect.height / 2
+    );
+    await page.evaluate((path) => {
+      window.__stickyContextMenuDriftProbe?.hoverRow(path);
+    }, hoverPath);
+    await nextFrames(page);
+
+    const hovered = await page.evaluate((path) => {
+      return (
+        window.__stickyContextMenuDriftProbe?.sampleHoverSuppression(path) ??
+        null
+      );
+    }, hoverPath);
+    expect(hovered).not.toBeNull();
+    if (hovered == null) {
+      return;
+    }
+    expect(hovered.rowContextHovered).toBe(true);
+    expect(hovered.rowPointerEvents).toBe('auto');
+    expect(hovered.anchorVisible).toBe(true);
+    expect(hovered.triggerVisible).toBe(true);
+    expect(hovered.rowBackgroundColor).not.toBe(resting.rowBackgroundColor);
+
+    const scrolling = await page.evaluate(
+      ({ path, scrollTop }) => {
+        const probe = window.__stickyContextMenuDriftProbe;
+        probe?.setScrollTop(scrollTop);
+        return probe?.sampleHoverSuppression(path) ?? null;
+      },
+      { path: hoverPath, scrollTop: candidate.scrollTop + 2 }
+    );
+    expect(scrolling).not.toBeNull();
+    if (scrolling == null) {
+      return;
+    }
+    expect(scrolling.rootIsScrolling).toBe(true);
+    expect(scrolling.virtualizedListIsScrolling).toBe(true);
+    expect(scrolling.rowPointerEvents).toBe('none');
+    expect(scrolling.rowBackgroundColor).toBe(resting.rowBackgroundColor);
+    expect(scrolling.anchorDisplay).toBe('none');
+
+    const contextMenuAttempt = await page.evaluate((path) => {
+      return (
+        window.__stickyContextMenuDriftProbe?.dispatchStickyContextMenu(path) ??
+        null
+      );
+    }, hoverPath);
+    expect(contextMenuAttempt).not.toBeNull();
+    expect(contextMenuAttempt?.defaultPrevented).toBe(true);
+    await nextFrames(page);
+
+    const afterContextMenuAttempt = await page.evaluate((path) => {
+      return (
+        window.__stickyContextMenuDriftProbe?.sampleHoverSuppression(path) ??
+        null
+      );
+    }, hoverPath);
+    expect(afterContextMenuAttempt?.menuPath).toBeNull();
+    expect(contextMenuAttempt?.menuPath).toBeNull();
+  });
+
   test('does not restore the trigger to a parked focused row after hover clears', async ({
     page,
   }) => {

--- a/packages/trees/test/e2e/file-tree-sticky-keyboard-navigation.pw.ts
+++ b/packages/trees/test/e2e/file-tree-sticky-keyboard-navigation.pw.ts
@@ -202,6 +202,14 @@ const getFocusedKeyboardProxyTop = (snapshot: StickyKeyboardSample): number => {
   return proxyRow.topWithinScroll;
 };
 
+const getMountedFlowRow = (
+  snapshot: StickyKeyboardSample,
+  path: string
+): StickyKeyboardRowSnapshot | null =>
+  snapshot.rows.find(
+    (row) => row.path === path && !row.isSticky && !row.isParked
+  ) ?? null;
+
 test.describe('sticky keyboard navigation fixture', () => {
   test('ArrowDown from a non-first sticky folder focuses the next sticky folder without shifting the list', async ({
     page,
@@ -421,6 +429,94 @@ test.describe('sticky keyboard navigation fixture', () => {
       baseline,
       'a1/b2/c1/'
     );
+  });
+
+  test('ArrowRight from the deepest synthetic sticky folder reveals its first file below the overlay', async ({
+    page,
+  }) => {
+    await prepareSyntheticBranchStickyStack(page, 'a1/b2/c1/d2/');
+
+    await page.keyboard.press('ArrowRight');
+    await nextFrames(page);
+
+    const after = await sample(page);
+    const targetPath = 'a1/b2/c1/d2/file_1';
+    const targetRow = getMountedFlowRow(after, targetPath);
+    expect(after.focusedPath).toBe(targetPath);
+    expect(after.activeElementPath).toBe(targetPath);
+    expect(after.activeElementIsSticky).toBe(false);
+    expect(after.stickyPaths).toEqual([...syntheticBranchStickyPaths]);
+    expect(after.mountedFlowPaths[0]).toBe(targetPath);
+    expect(targetRow).not.toBeNull();
+    expect(targetRow?.topWithinScroll).toBeGreaterThanOrEqual(
+      after.stickyOverlayBottomWithinScroll
+    );
+  });
+
+  test('ArrowLeft from an expanded sticky folder collapses it without leaving child rows above focus', async ({
+    page,
+  }) => {
+    const baseline = await prepareSyntheticBranchStickyStack(page, 'a1/b2/');
+    const sourceProxyTop = getFocusedKeyboardProxyTop(baseline);
+
+    await page.keyboard.press('ArrowLeft');
+    await nextFrames(page);
+
+    const after = await sample(page);
+    const targetRow = getMountedFlowRow(after, 'a1/b2/');
+    expect(after.focusedPath).toBe('a1/b2/');
+    expect(after.activeElementPath).toBe('a1/b2/');
+    expect(after.activeElementIsSticky).toBe(false);
+    expect(after.stickyPaths).not.toContain('a1/b2/');
+    expect(after.stickyPaths).not.toContain('a1/b2/c1/');
+    expect(after.mountedFlowPaths).not.toContain('a1/b2/c1/');
+    expect(after.mountedFlowPaths).not.toContain('a1/b2/c1/d2/file_5');
+    expect(targetRow).not.toBeNull();
+    expect(targetRow?.topWithinScroll).toBeCloseTo(sourceProxyTop, 1);
+  });
+
+  test('ArrowLeft from a nested expanded sticky folder drops descendant sticky rows without hiding focus', async ({
+    page,
+  }) => {
+    const baseline = await prepareSyntheticBranchStickyStack(page, 'a1/b2/c1/');
+    const sourceProxyTop = getFocusedKeyboardProxyTop(baseline);
+
+    await page.keyboard.press('ArrowLeft');
+    await nextFrames(page);
+
+    const after = await sample(page);
+    const targetRow = getMountedFlowRow(after, 'a1/b2/c1/');
+    expect(after.focusedPath).toBe('a1/b2/c1/');
+    expect(after.activeElementPath).toBe('a1/b2/c1/');
+    expect(after.activeElementIsSticky).toBe(false);
+    expect(after.stickyPaths).toContain('a1/');
+    expect(after.stickyPaths).not.toContain('a1/b2/c1/');
+    expect(after.stickyPaths).not.toContain('a1/b2/c1/d2/');
+    expect(after.mountedFlowPaths).not.toContain('a1/b2/c1/d2/');
+    expect(after.mountedFlowPaths).not.toContain('a1/b2/c1/d2/file_5');
+    expect(targetRow).not.toBeNull();
+    expect(targetRow?.topWithinScroll).toBeCloseTo(sourceProxyTop, 1);
+  });
+
+  test('second ArrowLeft after collapsing a sticky folder follows parent navigation', async ({
+    page,
+  }) => {
+    await prepareSyntheticBranchStickyStack(page, 'a1/b2/');
+
+    await page.keyboard.press('ArrowLeft');
+    await nextFrames(page);
+    const afterCollapse = await sample(page);
+    expect(afterCollapse.focusedPath).toBe('a1/b2/');
+    expect(afterCollapse.activeElementPath).toBe('a1/b2/');
+    expect(afterCollapse.activeElementIsSticky).toBe(false);
+
+    await page.keyboard.press('ArrowLeft');
+    await nextFrames(page);
+
+    const afterParent = await sample(page);
+    expect(afterParent.focusedPath).toBe('a1/');
+    expect(afterParent.activeElementPath).toBe('a1/');
+    expect(afterParent.stickyPaths).not.toContain('a1/b2/');
   });
 
   test('Shift+ArrowDown from a synthetic sticky folder preserves the sticky viewport while extending selection', async ({

--- a/packages/trees/test/e2e/file-tree-sticky-keyboard-navigation.pw.ts
+++ b/packages/trees/test/e2e/file-tree-sticky-keyboard-navigation.pw.ts
@@ -159,9 +159,10 @@ const prepareLinuxArcIncludeStickyStack = async (
 
 const prepareSyntheticBranchStickyStack = async (
   page: Page,
-  focusedPath: string
+  focusedPath: string,
+  query: string = '?scenario=synthetic-branch'
 ): Promise<StickyKeyboardSample> => {
-  await gotoFixture(page, '?scenario=synthetic-branch');
+  await gotoFixture(page, query);
   await setScrollTop(page, syntheticBranchScrollTop);
   await focusStickyPath(page, focusedPath);
   const baseline = await sample(page);
@@ -202,6 +203,12 @@ const getFocusedKeyboardProxyTop = (snapshot: StickyKeyboardSample): number => {
 
   return proxyRow.topWithinScroll;
 };
+
+const getStickyRow = (
+  snapshot: StickyKeyboardSample,
+  path: string
+): StickyKeyboardRowSnapshot | null =>
+  snapshot.rows.find((row) => row.path === path && row.isSticky) ?? null;
 
 const getMountedFlowRow = (
   snapshot: StickyKeyboardSample,
@@ -597,6 +604,72 @@ test.describe('sticky keyboard navigation fixture', () => {
     expect(targetRow).toBeDefined();
     expect(targetRow?.topWithinScroll).toBeGreaterThanOrEqual(
       after.stickyOverlayBottomWithinScroll
+    );
+  });
+
+  test('clicking a non-root sticky folder collapses it at the same visual top with a fractional scrollport', async ({
+    page,
+  }) => {
+    const baseline = await prepareSyntheticBranchStickyStack(
+      page,
+      'a1/b2/',
+      '?scenario=synthetic-branch&fractional-header=true'
+    );
+    const sourceStickyRow = getStickyRow(baseline, 'a1/b2/');
+    expect(sourceStickyRow).not.toBeNull();
+    if (sourceStickyRow == null) {
+      throw new Error('Missing source sticky row for a1/b2/.');
+    }
+
+    await page.waitForTimeout(80);
+    await page
+      .locator(
+        'file-tree-container button[data-file-tree-sticky-row="true"][data-file-tree-sticky-path="a1/b2/"]'
+      )
+      .click();
+    await nextFrames(page);
+
+    const after = await sample(page);
+    const targetRow = getMountedFlowRow(after, 'a1/b2/');
+    expect(after.focusedPath).toBe('a1/b2/');
+    expect(after.activeElementPath).toBe('a1/b2/');
+    expect(after.activeElementIsSticky).toBe(false);
+    expect(after.stickyPaths).not.toContain('a1/b2/');
+    expect(targetRow).not.toBeNull();
+    expect(targetRow?.topWithinScroll).toBeCloseTo(
+      sourceStickyRow.topWithinScroll,
+      2
+    );
+  });
+
+  test('clicking a linux non-root sticky folder collapses it at the same visual top', async ({
+    page,
+  }) => {
+    const baseline = await prepareLinuxArcStickyStack(page, 'arch/arc/');
+    const sourceStickyRow = getStickyRow(baseline, 'arch/arc/');
+    expect(sourceStickyRow).not.toBeNull();
+    if (sourceStickyRow == null) {
+      throw new Error('Missing source sticky row for arch/arc/.');
+    }
+
+    await page.waitForTimeout(80);
+    await page
+      .locator(
+        'file-tree-container button[data-file-tree-sticky-row="true"][data-file-tree-sticky-path="arch/arc/"]'
+      )
+      .click();
+    await nextFrames(page);
+
+    const after = await sample(page);
+    const targetRow = getMountedFlowRow(after, 'arch/arc/');
+    expect(after.focusedPath).toBe('arch/arc/');
+    expect(after.activeElementPath).toBe('arch/arc/');
+    expect(after.activeElementIsSticky).toBe(false);
+    expect(after.stickyPaths).not.toContain('arch/arc/');
+    expect(targetRow).not.toBeNull();
+    expect(targetRow?.topWithinScroll).toBeCloseTo(
+      sourceStickyRow.topWithinScroll,
+      2
     );
   });
 });

--- a/packages/trees/test/e2e/file-tree-sticky-keyboard-navigation.pw.ts
+++ b/packages/trees/test/e2e/file-tree-sticky-keyboard-navigation.pw.ts
@@ -1,0 +1,481 @@
+import { expect, type Page, test } from '@playwright/test';
+
+type StickyKeyboardRowSnapshot = {
+  bottomWithinScroll: number;
+  isFocused: boolean;
+  isParked: boolean;
+  isSticky: boolean;
+  path: string;
+  topWithinScroll: number;
+};
+
+type StickyKeyboardSample = {
+  activeElementPath: string | null;
+  activeElementIsParked: boolean;
+  activeElementIsSticky: boolean;
+  focusedPath: string | null;
+  focusedRows: StickyKeyboardRowSnapshot[];
+  mountedFlowPaths: string[];
+  rows: StickyKeyboardRowSnapshot[];
+  scrollTop: number;
+  stickyOverlayBottomWithinScroll: number;
+  stickyPaths: string[];
+};
+
+declare global {
+  interface Window {
+    __stickyKeyboardNavigationFixtureReady?: boolean;
+    __stickyKeyboardNavigationProbe?: {
+      focusStickyDomOnly: (path: string) => Promise<void>;
+      focusStickyPath: (path: string) => Promise<void>;
+      nextFrames: (count?: number) => Promise<void>;
+      sample: () => StickyKeyboardSample;
+      setScrollTop: (scrollTop: number) => void;
+    };
+  }
+}
+
+const fixturePath =
+  '/test/e2e/fixtures/file-tree-sticky-keyboard-navigation.html';
+const linuxArcScrollTop = 9_000;
+const linuxArcStickyPaths = [
+  'arch/',
+  'arch/arc/',
+  'arch/arc/boot/',
+  'arch/arc/boot/dts/',
+] as const;
+const linuxArcIncludeScrollTop = 10_080;
+const linuxArcIncludeStickyPaths = [
+  'arch/',
+  'arch/arc/',
+  'arch/arc/include/',
+  'arch/arc/include/asm/',
+] as const;
+const syntheticBranchScrollTop = 4_210;
+const syntheticBranchStickyPaths = [
+  'a1/',
+  'a1/b2/',
+  'a1/b2/c1/',
+  'a1/b2/c1/d2/',
+] as const;
+
+const gotoFixture = async (page: Page, query: string = ''): Promise<void> => {
+  const browserErrors: string[] = [];
+  page.on('pageerror', (error) => {
+    browserErrors.push(error.message);
+  });
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      browserErrors.push(message.text());
+    }
+  });
+
+  await page.goto(`${fixturePath}${query}`);
+  try {
+    await page.waitForFunction(
+      () => window.__stickyKeyboardNavigationFixtureReady === true,
+      undefined,
+      { timeout: 5_000 }
+    );
+  } catch (error) {
+    throw new Error(
+      `Sticky keyboard fixture did not become ready. Browser errors: ${browserErrors.join(
+        '\n'
+      )}`,
+      { cause: error }
+    );
+  }
+};
+
+const nextFrames = async (page: Page, count: number = 2): Promise<void> => {
+  await page.evaluate((nextCount) => {
+    return window.__stickyKeyboardNavigationProbe?.nextFrames(nextCount);
+  }, count);
+};
+
+const setScrollTop = async (page: Page, scrollTop: number): Promise<void> => {
+  await page.evaluate((nextScrollTop) => {
+    window.__stickyKeyboardNavigationProbe?.setScrollTop(nextScrollTop);
+  }, scrollTop);
+  await nextFrames(page);
+};
+
+const focusStickyPath = async (page: Page, path: string): Promise<void> => {
+  await page.evaluate((nextPath) => {
+    return window.__stickyKeyboardNavigationProbe?.focusStickyPath(nextPath);
+  }, path);
+  await nextFrames(page);
+};
+
+const focusStickyDomOnly = async (page: Page, path: string): Promise<void> => {
+  await page.evaluate((nextPath) => {
+    return window.__stickyKeyboardNavigationProbe?.focusStickyDomOnly(nextPath);
+  }, path);
+  await nextFrames(page);
+};
+
+const sample = async (page: Page): Promise<StickyKeyboardSample> => {
+  const result = await page.evaluate(() => {
+    return window.__stickyKeyboardNavigationProbe?.sample() ?? null;
+  });
+  expect(result).not.toBeNull();
+  if (result == null) {
+    throw new Error('Missing sticky keyboard navigation sample.');
+  }
+  return result;
+};
+
+const prepareLinuxArcStickyStack = async (
+  page: Page,
+  focusedPath: string
+): Promise<StickyKeyboardSample> => {
+  await gotoFixture(page);
+  await setScrollTop(page, linuxArcScrollTop);
+  await focusStickyPath(page, focusedPath);
+  const baseline = await sample(page);
+  expect(baseline.scrollTop).toBe(linuxArcScrollTop);
+  expect(baseline.stickyPaths).toEqual([...linuxArcStickyPaths]);
+  expect(baseline.focusedPath).toBe(focusedPath);
+  expect(baseline.activeElementPath).toBe(focusedPath);
+  expect(baseline.activeElementIsSticky).toBe(true);
+  return baseline;
+};
+
+const prepareLinuxArcIncludeStickyStack = async (
+  page: Page,
+  focusedPath: string
+): Promise<StickyKeyboardSample> => {
+  await gotoFixture(page);
+  await setScrollTop(page, linuxArcIncludeScrollTop);
+  await focusStickyPath(page, focusedPath);
+  const baseline = await sample(page);
+  expect(baseline.scrollTop).toBe(linuxArcIncludeScrollTop);
+  expect(baseline.stickyPaths).toEqual([...linuxArcIncludeStickyPaths]);
+  expect(baseline.focusedPath).toBe(focusedPath);
+  expect(baseline.activeElementPath).toBe(focusedPath);
+  return baseline;
+};
+
+const prepareSyntheticBranchStickyStack = async (
+  page: Page,
+  focusedPath: string
+): Promise<StickyKeyboardSample> => {
+  await gotoFixture(page, '?scenario=synthetic-branch');
+  await setScrollTop(page, syntheticBranchScrollTop);
+  await focusStickyPath(page, focusedPath);
+  const baseline = await sample(page);
+  expect(baseline.scrollTop).toBe(syntheticBranchScrollTop);
+  expect(baseline.stickyPaths).toEqual([...syntheticBranchStickyPaths]);
+  expect(baseline.focusedPath).toBe(focusedPath);
+  expect(baseline.activeElementPath).toBe(focusedPath);
+  expect(baseline.activeElementIsSticky).toBe(true);
+  expect(baseline.mountedFlowPaths[0]).toBe('a1/b2/c1/d2/file_5');
+  return baseline;
+};
+
+const expectSyntheticBranchStickyStackPreserved = (
+  after: StickyKeyboardSample,
+  baseline: StickyKeyboardSample,
+  focusedPath: string
+): void => {
+  expect(after.focusedPath).toBe(focusedPath);
+  expect(after.activeElementPath).toBe(focusedPath);
+  expect(after.stickyPaths).toEqual([...syntheticBranchStickyPaths]);
+  expect(after.stickyPaths[1]).toBe('a1/b2/');
+  expect(after.scrollTop).toBe(baseline.scrollTop);
+  expect(after.mountedFlowPaths).toEqual(baseline.mountedFlowPaths);
+  expect(after.mountedFlowPaths[0]).toBe('a1/b2/c1/d2/file_5');
+  expect(after.mountedFlowPaths).not.toContain('a1/b1/');
+  expect(after.mountedFlowPaths).not.toContain('a1/b1/c2/d2/file_16');
+};
+
+const getFocusedKeyboardProxyTop = (snapshot: StickyKeyboardSample): number => {
+  const proxyRow =
+    snapshot.focusedRows.find((row) => row.isParked) ??
+    snapshot.focusedRows.find((row) => row.isSticky) ??
+    null;
+  expect(proxyRow).not.toBeNull();
+  if (proxyRow == null) {
+    throw new Error('Missing focused sticky keyboard proxy row.');
+  }
+
+  return proxyRow.topWithinScroll;
+};
+
+test.describe('sticky keyboard navigation fixture', () => {
+  test('ArrowDown from a non-first sticky folder focuses the next sticky folder without shifting the list', async ({
+    page,
+  }) => {
+    const baseline = await prepareLinuxArcStickyStack(page, 'arch/arc/');
+
+    await page.keyboard.press('ArrowDown');
+    await nextFrames(page);
+
+    const after = await sample(page);
+    expect(after.focusedPath).toBe('arch/arc/boot/');
+    expect(after.activeElementPath).toBe('arch/arc/boot/');
+    expect(after.scrollTop).toBe(baseline.scrollTop);
+    expect(after.stickyPaths).toEqual(baseline.stickyPaths);
+    expect(after.mountedFlowPaths).toEqual(baseline.mountedFlowPaths);
+    expect(after.focusedRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          isFocused: true,
+          isSticky: true,
+          path: 'arch/arc/boot/',
+        }),
+      ])
+    );
+  });
+
+  test('ArrowDown from a focused sticky DOM mirror syncs focus before moving in the linux workload', async ({
+    page,
+  }) => {
+    await gotoFixture(page);
+    await setScrollTop(page, linuxArcScrollTop);
+    await focusStickyDomOnly(page, 'arch/arc/');
+
+    const baseline = await sample(page);
+    expect(baseline.scrollTop).toBe(linuxArcScrollTop);
+    expect(baseline.stickyPaths).toEqual([...linuxArcStickyPaths]);
+    expect(baseline.activeElementPath).toBe('arch/arc/');
+    expect(baseline.activeElementIsSticky).toBe(true);
+
+    await page.keyboard.press('ArrowDown');
+    await nextFrames(page);
+
+    const after = await sample(page);
+    expect(after.focusedPath).toBe('arch/arc/boot/');
+    expect(after.activeElementPath).toBe('arch/arc/boot/');
+    expect(after.scrollTop).toBe(baseline.scrollTop);
+    expect(after.stickyPaths).toEqual(baseline.stickyPaths);
+    expect(after.mountedFlowPaths).toEqual(baseline.mountedFlowPaths);
+  });
+
+  test('ArrowDown from a first sticky folder at its depth keeps the sticky stack stable', async ({
+    page,
+  }) => {
+    const baseline = await prepareLinuxArcStickyStack(page, 'arch/arc/boot/');
+
+    await page.keyboard.press('ArrowDown');
+    await nextFrames(page);
+
+    const after = await sample(page);
+    expect(after.focusedPath).toBe('arch/arc/boot/dts/');
+    expect(after.activeElementPath).toBe('arch/arc/boot/dts/');
+    expect(after.scrollTop).toBe(baseline.scrollTop);
+    expect(after.stickyPaths).toEqual(baseline.stickyPaths);
+    expect(after.mountedFlowPaths).toEqual(baseline.mountedFlowPaths);
+    expect(after.focusedRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          isFocused: true,
+          isSticky: true,
+          path: 'arch/arc/boot/dts/',
+        }),
+      ])
+    );
+  });
+
+  test('ArrowUp from a sticky folder focuses the previous sticky folder without shifting the list', async ({
+    page,
+  }) => {
+    const baseline = await prepareLinuxArcStickyStack(page, 'arch/arc/boot/');
+
+    await page.keyboard.press('ArrowUp');
+    await nextFrames(page);
+
+    const after = await sample(page);
+    expect(after.focusedPath).toBe('arch/arc/');
+    expect(after.activeElementPath).toBe('arch/arc/');
+    expect(after.scrollTop).toBe(baseline.scrollTop);
+    expect(after.stickyPaths).toEqual(baseline.stickyPaths);
+    expect(after.mountedFlowPaths).toEqual(baseline.mountedFlowPaths);
+    expect(after.focusedRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          isFocused: true,
+          isSticky: true,
+          path: 'arch/arc/',
+        }),
+      ])
+    );
+  });
+
+  test('ArrowUp from a sticky folder whose previous list item is outside the sticky stack follows logical row order', async ({
+    page,
+  }) => {
+    const baseline = await prepareLinuxArcIncludeStickyStack(page, 'arch/arc/');
+    const sourceProxyTop = getFocusedKeyboardProxyTop(baseline);
+
+    await page.keyboard.press('ArrowUp');
+    await nextFrames(page);
+
+    const after = await sample(page);
+    const targetPath = 'arch/alpha/Makefile';
+    const targetRow = after.rows.find(
+      (row) => row.path === targetPath && !row.isSticky && !row.isParked
+    );
+    expect(after.focusedPath).toBe(targetPath);
+    expect(after.activeElementPath).toBe(targetPath);
+    expect(after.activeElementIsSticky).toBe(false);
+    expect(after.stickyPaths).not.toContain('arch/arc/');
+    expect(after.mountedFlowPaths).toContain(targetPath);
+    expect(targetRow).toBeDefined();
+    expect(targetRow?.topWithinScroll).toBeCloseTo(sourceProxyTop, 1);
+  });
+
+  test('ArrowDown from the deepest sticky folder reveals its first child below the overlay', async ({
+    page,
+  }) => {
+    await prepareLinuxArcStickyStack(page, 'arch/arc/boot/dts/');
+
+    await page.keyboard.press('ArrowDown');
+    await nextFrames(page);
+
+    const after = await sample(page);
+    const targetPath = 'arch/arc/boot/dts/abilis_tb10x.dtsi';
+    const targetRow = after.rows.find(
+      (row) => row.path === targetPath && !row.isSticky && !row.isParked
+    );
+    expect(after.focusedPath).toBe(targetPath);
+    expect(after.mountedFlowPaths[0]).toBe(targetPath);
+    expect(targetRow).toBeDefined();
+    expect(targetRow?.topWithinScroll).toBeGreaterThanOrEqual(
+      after.stickyOverlayBottomWithinScroll
+    );
+    expect(after.mountedFlowPaths).not.toContain('arch/alpha/Makefile');
+    expect(after.mountedFlowPaths).not.toContain('arch/arc/');
+  });
+
+  test('ArrowDown from the synthetic b2 sticky folder keeps b2 in the second sticky slot', async ({
+    page,
+  }) => {
+    const baseline = await prepareSyntheticBranchStickyStack(page, 'a1/b2/');
+
+    await page.keyboard.press('ArrowDown');
+    await nextFrames(page);
+
+    const after = await sample(page);
+    expectSyntheticBranchStickyStackPreserved(after, baseline, 'a1/b2/c1/');
+  });
+
+  test('ArrowUp from the synthetic b2 sticky folder follows previous branch content instead of the visual parent', async ({
+    page,
+  }) => {
+    const baseline = await prepareSyntheticBranchStickyStack(page, 'a1/b2/');
+    const sourceProxyTop = getFocusedKeyboardProxyTop(baseline);
+
+    await page.keyboard.press('ArrowUp');
+    await nextFrames(page);
+
+    const after = await sample(page);
+    const focusedPath = after.focusedPath;
+    expect(focusedPath).not.toBeNull();
+    expect(focusedPath?.startsWith('a1/b1/')).toBe(true);
+    expect(focusedPath).not.toBe('a1/');
+    expect(after.activeElementPath).toBe(focusedPath);
+    expect(after.activeElementIsSticky).toBe(false);
+    expect(after.stickyPaths).not.toContain('a1/b2/');
+    const targetRow = after.rows.find(
+      (row) => row.path === focusedPath && !row.isSticky && !row.isParked
+    );
+    expect(targetRow).toBeDefined();
+    expect(targetRow?.topWithinScroll).toBeCloseTo(sourceProxyTop, 1);
+  });
+
+  test('ArrowDown from a focused synthetic sticky DOM mirror keeps b2 in the second sticky slot', async ({
+    page,
+  }) => {
+    await gotoFixture(page, '?scenario=synthetic-branch');
+    await setScrollTop(page, syntheticBranchScrollTop);
+    await focusStickyDomOnly(page, 'a1/b2/');
+
+    const baseline = await sample(page);
+    expect(baseline.scrollTop).toBe(syntheticBranchScrollTop);
+    expect(baseline.stickyPaths).toEqual([...syntheticBranchStickyPaths]);
+    expect(baseline.activeElementPath).toBe('a1/b2/');
+    expect(baseline.activeElementIsSticky).toBe(true);
+    expect(baseline.mountedFlowPaths[0]).toBe('a1/b2/c1/d2/file_5');
+
+    await page.keyboard.press('ArrowDown');
+    await nextFrames(page);
+
+    expectSyntheticBranchStickyStackPreserved(
+      await sample(page),
+      baseline,
+      'a1/b2/c1/'
+    );
+  });
+
+  test('ArrowRight from an expanded synthetic sticky folder preserves the sticky viewport', async ({
+    page,
+  }) => {
+    const baseline = await prepareSyntheticBranchStickyStack(page, 'a1/b2/');
+
+    await page.keyboard.press('ArrowRight');
+    await nextFrames(page);
+
+    expectSyntheticBranchStickyStackPreserved(
+      await sample(page),
+      baseline,
+      'a1/b2/c1/'
+    );
+  });
+
+  test('Shift+ArrowDown from a synthetic sticky folder preserves the sticky viewport while extending selection', async ({
+    page,
+  }) => {
+    const baseline = await prepareSyntheticBranchStickyStack(page, 'a1/b2/');
+
+    await page.keyboard.down('Shift');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.up('Shift');
+    await nextFrames(page);
+
+    expectSyntheticBranchStickyStackPreserved(
+      await sample(page),
+      baseline,
+      'a1/b2/c1/'
+    );
+  });
+
+  test('Shift+ArrowUp from a synthetic sticky folder preserves the sticky viewport while extending selection', async ({
+    page,
+  }) => {
+    const baseline = await prepareSyntheticBranchStickyStack(page, 'a1/b2/c1/');
+
+    await page.keyboard.down('Shift');
+    await page.keyboard.press('ArrowUp');
+    await page.keyboard.up('Shift');
+    await nextFrames(page);
+
+    expectSyntheticBranchStickyStackPreserved(
+      await sample(page),
+      baseline,
+      'a1/b2/'
+    );
+  });
+
+  test('ArrowDown from the deepest synthetic sticky folder still reveals its first file below the overlay', async ({
+    page,
+  }) => {
+    await prepareSyntheticBranchStickyStack(page, 'a1/b2/c1/d2/');
+
+    await page.keyboard.press('ArrowDown');
+    await nextFrames(page);
+
+    const after = await sample(page);
+    const targetPath = 'a1/b2/c1/d2/file_1';
+    const targetRow = after.rows.find(
+      (row) => row.path === targetPath && !row.isSticky && !row.isParked
+    );
+    expect(after.focusedPath).toBe(targetPath);
+    expect(after.stickyPaths).toEqual([...syntheticBranchStickyPaths]);
+    expect(after.mountedFlowPaths[0]).toBe(targetPath);
+    expect(targetRow).toBeDefined();
+    expect(targetRow?.topWithinScroll).toBeGreaterThanOrEqual(
+      after.stickyOverlayBottomWithinScroll
+    );
+  });
+});

--- a/packages/trees/test/e2e/file-tree-sticky-keyboard-navigation.pw.ts
+++ b/packages/trees/test/e2e/file-tree-sticky-keyboard-navigation.pw.ts
@@ -13,6 +13,7 @@ type StickyKeyboardSample = {
   activeElementPath: string | null;
   activeElementIsParked: boolean;
   activeElementIsSticky: boolean;
+  contextMenuPath: string | null;
   focusedPath: string | null;
   focusedRows: StickyKeyboardRowSnapshot[];
   mountedFlowPaths: string[];
@@ -258,6 +259,30 @@ test.describe('sticky keyboard navigation fixture', () => {
     expect(after.scrollTop).toBe(baseline.scrollTop);
     expect(after.stickyPaths).toEqual(baseline.stickyPaths);
     expect(after.mountedFlowPaths).toEqual(baseline.mountedFlowPaths);
+  });
+
+  test('Shift+F10 from a focused sticky DOM mirror opens the menu for that sticky path', async ({
+    page,
+  }) => {
+    await gotoFixture(page, '?scenario=synthetic-branch');
+    await setScrollTop(page, syntheticBranchScrollTop);
+    await focusStickyDomOnly(page, 'a1/b2/');
+
+    const baseline = await sample(page);
+    expect(baseline.contextMenuPath).toBeNull();
+    expect(baseline.scrollTop).toBe(syntheticBranchScrollTop);
+    expect(baseline.activeElementPath).toBe('a1/b2/');
+    expect(baseline.activeElementIsSticky).toBe(true);
+
+    await page.keyboard.down('Shift');
+    await page.keyboard.press('F10');
+    await page.keyboard.up('Shift');
+    await nextFrames(page);
+
+    const after = await sample(page);
+    expect(after.contextMenuPath).toBe('a1/b2/');
+    expect(after.focusedPath).toBe('a1/b2/');
+    expect(after.scrollTop).toBe(baseline.scrollTop);
   });
 
   test('ArrowDown from a first sticky folder at its depth keeps the sticky stack stable', async ({

--- a/packages/trees/test/e2e/fixtures/file-tree-sticky-context-menu-scroll-drift.ts
+++ b/packages/trees/test/e2e/fixtures/file-tree-sticky-context-menu-scroll-drift.ts
@@ -122,8 +122,29 @@ type StickyContextMenuScenarioCandidate = {
   stickyPaths: string[];
 };
 
+type StickyHoverSuppressionSample = {
+  anchorDisplay: string | null;
+  anchorVisible: boolean;
+  menuPath: string | null;
+  rowBackgroundColor: string | null;
+  rowContextHovered: boolean;
+  rowMatchesHover: boolean;
+  rowMounted: boolean;
+  rowPointerEvents: string | null;
+  rootIsScrolling: boolean;
+  triggerDisplay: string | null;
+  triggerVisible: boolean;
+  virtualizedListIsScrolling: boolean;
+};
+
+type StickyContextMenuDispatchResult = {
+  defaultPrevented: boolean;
+  menuPath: string | null;
+};
+
 type StickyContextMenuDriftProbe = {
   clearTrigger: () => void;
+  dispatchStickyContextMenu: (path: string) => StickyContextMenuDispatchResult;
   findScenarioCandidate: (options?: {
     maxScrollTop?: number;
     minDepth?: number;
@@ -139,6 +160,7 @@ type StickyContextMenuDriftProbe = {
     settleFrames?: number
   ) => Promise<StickyContextMenuScenarioStep[]>;
   sample: (path: string) => StickyContextMenuSample;
+  sampleHoverSuppression: (path: string) => StickyHoverSuppressionSample;
   setScrollSuppressionDisabled: (disabled: boolean) => void;
   setScrollTop: (scrollTop: number) => void;
   setTriggerPath: (path: string | null) => void;
@@ -449,6 +471,67 @@ const hoverRow = (path: string): void => {
   );
 };
 
+const getRenderedMenuPath = (): string | null => {
+  const menu = document.querySelector('[data-test-sticky-drift-menu]');
+  return menu instanceof HTMLElement
+    ? (menu.dataset.testStickyDriftMenu ?? null)
+    : null;
+};
+
+// Samples the sticky row, root scroll-suppression flags, and floating trigger
+// together so the test can catch one-frame disagreements between them.
+const sampleHoverSuppression = (path: string): StickyHoverSuppressionSample => {
+  const row = getRowButton(path);
+  const rowStyle = row == null ? null : getComputedStyle(row);
+  const anchor = getAnchorElement();
+  const anchorStyle = anchor == null ? null : getComputedStyle(anchor);
+  const trigger = getTriggerElement();
+  const triggerStyle = trigger == null ? null : getComputedStyle(trigger);
+  const virtualizedList = getVirtualizedListElement();
+
+  return {
+    anchorDisplay: emptyStringToNull(anchorStyle?.display ?? ''),
+    anchorVisible: anchor?.dataset.visible === 'true',
+    menuPath: getRenderedMenuPath(),
+    rowBackgroundColor: emptyStringToNull(rowStyle?.backgroundColor ?? ''),
+    rowContextHovered: row?.dataset.itemContextHover === 'true',
+    rowMatchesHover: row?.matches(':hover') === true,
+    rowMounted: row instanceof HTMLButtonElement,
+    rowPointerEvents: emptyStringToNull(rowStyle?.pointerEvents ?? ''),
+    rootIsScrolling: getRootElement().dataset.isScrolling != null,
+    triggerDisplay: emptyStringToNull(triggerStyle?.display ?? ''),
+    triggerVisible: trigger?.dataset.visible === 'true',
+    virtualizedListIsScrolling: virtualizedList?.dataset.isScrolling != null,
+  };
+};
+
+// Bypasses browser hit-testing to prove late contextmenu events still cannot
+// open a sticky-row menu while the tree is suppressing scroll interactions.
+const dispatchStickyContextMenu = (
+  path: string
+): StickyContextMenuDispatchResult => {
+  const row = getRowButton(path);
+  if (!(row instanceof HTMLButtonElement)) {
+    throw new Error(`Expected visible row for ${path}`);
+  }
+
+  const rect = row.getBoundingClientRect();
+  const event = new MouseEvent('contextmenu', {
+    bubbles: true,
+    button: 2,
+    cancelable: true,
+    clientX: rect.left + rect.width / 2,
+    clientY: rect.top + rect.height / 2,
+    composed: true,
+  });
+  const dispatched = row.dispatchEvent(event);
+
+  return {
+    defaultPrevented: event.defaultPrevented || !dispatched,
+    menuPath: getRenderedMenuPath(),
+  };
+};
+
 const setScrollSuppressionDisabled = (disabled: boolean): void => {
   getRootElement().dispatchEvent(
     new CustomEvent('file-tree-debug-set-scroll-suppression', {
@@ -674,11 +757,13 @@ const stickyContextMenuDriftWindow = window as StickyContextMenuDriftWindow;
 
 stickyContextMenuDriftWindow.__stickyContextMenuDriftProbe = {
   clearTrigger,
+  dispatchStickyContextMenu,
   findScenarioCandidate,
   hoverRow,
   nextFrames,
   runScenario,
   sample,
+  sampleHoverSuppression,
   setScrollSuppressionDisabled,
   setScrollTop,
   setTriggerPath,

--- a/packages/trees/test/e2e/fixtures/file-tree-sticky-keyboard-navigation.html
+++ b/packages/trees/test/e2e/fixtures/file-tree-sticky-keyboard-navigation.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>file-tree sticky keyboard navigation fixture</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 16px;
+        font-family: system-ui, sans-serif;
+        background: #f7f7f8;
+      }
+
+      [data-sticky-keyboard-shell] {
+        display: grid;
+        gap: 16px;
+        grid-template-columns: minmax(0, 440px) minmax(320px, 1fr);
+        align-items: start;
+      }
+
+      [data-sticky-keyboard-frame] {
+        overflow: hidden;
+        border: 1px solid #d4d4d8;
+        border-radius: 12px;
+        background: white;
+        padding: 12px;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+      }
+
+      [data-sticky-keyboard-mount] {
+        width: 420px;
+        height: 700px;
+      }
+
+      [data-sticky-keyboard-report] {
+        margin: 0;
+        min-height: 700px;
+        overflow: auto;
+        border: 1px solid #d4d4d8;
+        border-radius: 12px;
+        background: #111827;
+        color: #e5e7eb;
+        padding: 12px;
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+        line-height: 1.5;
+        white-space: pre-wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <div data-sticky-keyboard-shell>
+      <div data-sticky-keyboard-frame>
+        <div data-sticky-keyboard-mount></div>
+      </div>
+      <pre data-sticky-keyboard-report>Waiting for fixture...</pre>
+    </div>
+    <script
+      type="module"
+      src="./file-tree-sticky-keyboard-navigation.ts"
+    ></script>
+  </body>
+</html>

--- a/packages/trees/test/e2e/fixtures/file-tree-sticky-keyboard-navigation.ts
+++ b/packages/trees/test/e2e/fixtures/file-tree-sticky-keyboard-navigation.ts
@@ -1,0 +1,277 @@
+import { getVirtualizationWorkload } from '@pierre/tree-test-data';
+
+const fileTreeRuntimePath: string = '/dist/index.js';
+const { FileTree, preparePresortedFileTreeInput } = (await import(
+  /* @vite-ignore */ fileTreeRuntimePath
+)) as typeof import('../../../src/index');
+
+type StickyKeyboardRowSnapshot = {
+  bottomWithinScroll: number;
+  isFocused: boolean;
+  isParked: boolean;
+  isSticky: boolean;
+  path: string;
+  topWithinScroll: number;
+};
+
+type StickyKeyboardSample = {
+  activeElementPath: string | null;
+  activeElementIsParked: boolean;
+  activeElementIsSticky: boolean;
+  focusedPath: string | null;
+  focusedRows: StickyKeyboardRowSnapshot[];
+  mountedFlowPaths: string[];
+  rows: StickyKeyboardRowSnapshot[];
+  scrollTop: number;
+  stickyOverlayBottomWithinScroll: number;
+  stickyPaths: string[];
+};
+
+type StickyKeyboardNavigationProbe = {
+  focusStickyDomOnly: (path: string) => Promise<void>;
+  focusStickyPath: (path: string) => Promise<void>;
+  nextFrames: (count?: number) => Promise<void>;
+  sample: () => StickyKeyboardSample;
+  setScrollTop: (scrollTop: number) => void;
+};
+
+type StickyKeyboardNavigationWindow = Window & {
+  __stickyKeyboardNavigationFixtureReady?: boolean;
+  __stickyKeyboardNavigationProbe?: StickyKeyboardNavigationProbe;
+};
+
+type SyntheticBranchWorkload = {
+  expandedFolders: string[];
+  paths: string[];
+};
+
+const createSyntheticBranchWorkload = (): SyntheticBranchWorkload => {
+  const letters = ['a', 'b', 'c', 'd'] as const;
+  const expandedFolders = new Set<string>();
+  const paths: string[] = [];
+
+  const addFiles = (folderPath: string): void => {
+    for (let index = 1; index <= 16; index += 1) {
+      paths.push(`${folderPath}/file_${String(index)}`);
+    }
+  };
+
+  const addFolder = (folderPath: string, depth: number): void => {
+    expandedFolders.add(`${folderPath}/`);
+    addFiles(folderPath);
+
+    const nextLetter = letters[depth + 1];
+    if (nextLetter == null) {
+      return;
+    }
+
+    addFolder(`${folderPath}/${nextLetter}1`, depth + 1);
+    addFolder(`${folderPath}/${nextLetter}2`, depth + 1);
+  };
+
+  addFolder('a1', 0);
+  addFolder('a2', 0);
+
+  return {
+    expandedFolders: [...expandedFolders],
+    paths,
+  };
+};
+
+const mount = document.querySelector('[data-sticky-keyboard-mount]');
+const report = document.querySelector('[data-sticky-keyboard-report]');
+if (!(mount instanceof HTMLDivElement) || !(report instanceof HTMLPreElement)) {
+  throw new Error('Missing sticky keyboard navigation fixture shell.');
+}
+
+const scenario = new URL(window.location.href).searchParams.get('scenario');
+const workload = getVirtualizationWorkload('linux-1x');
+const syntheticBranchWorkload = createSyntheticBranchWorkload();
+const fileTree =
+  scenario === 'synthetic-branch'
+    ? new FileTree({
+        fileTreeSearchMode: 'hide-non-matches',
+        flattenEmptyDirectories: true,
+        initialExpandedPaths: syntheticBranchWorkload.expandedFolders,
+        paths: syntheticBranchWorkload.paths,
+        search: true,
+        stickyFolders: true,
+        initialVisibleRowCount: 700 / 30,
+      })
+    : new FileTree({
+        fileTreeSearchMode: 'hide-non-matches',
+        flattenEmptyDirectories: true,
+        initialExpandedPaths: workload.expandedFolders,
+        preparedInput: preparePresortedFileTreeInput(workload.presortedFiles),
+        search: true,
+        stickyFolders: true,
+        initialVisibleRowCount: 700 / 30,
+      });
+fileTree.render({ containerWrapper: mount });
+
+const nextFrames = async (count: number = 2): Promise<void> => {
+  for (let index = 0; index < count; index += 1) {
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+};
+
+const waitForTree = async (): Promise<HTMLElement> => {
+  const started = performance.now();
+  while (true) {
+    const host = mount.querySelector('file-tree-container');
+    if (
+      host instanceof HTMLElement &&
+      host.shadowRoot?.querySelector('button[data-type="item"]') != null
+    ) {
+      return host;
+    }
+
+    if (performance.now() - started > 5_000) {
+      throw new Error(
+        'Timed out waiting for sticky keyboard navigation fixture tree.'
+      );
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 16));
+  }
+};
+
+const host = await waitForTree();
+const getShadow = (): ShadowRoot => {
+  if (!(host.shadowRoot instanceof ShadowRoot)) {
+    throw new Error(
+      'Expected open shadow root on sticky keyboard navigation fixture host.'
+    );
+  }
+  return host.shadowRoot;
+};
+
+const getScrollElement = (): HTMLElement => {
+  const scrollElement = getShadow().querySelector(
+    '[data-file-tree-virtualized-scroll="true"]'
+  );
+  if (!(scrollElement instanceof HTMLElement)) {
+    throw new Error('Missing sticky keyboard navigation scroll element.');
+  }
+  return scrollElement;
+};
+
+const getStickyOverlayContentElement = (): HTMLElement | null => {
+  const overlayContent = getShadow().querySelector(
+    '[data-file-tree-sticky-overlay-content="true"]'
+  );
+  return overlayContent instanceof HTMLElement ? overlayContent : null;
+};
+
+const getStickyRowButton = (path: string): HTMLButtonElement => {
+  const button = getShadow().querySelector(
+    `button[data-file-tree-sticky-row="true"][data-file-tree-sticky-path="${path}"]`
+  );
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Missing sticky keyboard row for ${path}`);
+  }
+  return button;
+};
+
+const getRows = (): HTMLButtonElement[] =>
+  Array.from(getShadow().querySelectorAll('button[data-type="item"]')).filter(
+    (button): button is HTMLButtonElement => button instanceof HTMLButtonElement
+  );
+
+const getStickyPaths = (): string[] =>
+  Array.from(
+    getShadow().querySelectorAll('button[data-file-tree-sticky-row="true"]')
+  )
+    .map((element) =>
+      element instanceof HTMLElement ? element.dataset.fileTreeStickyPath : null
+    )
+    .filter((path): path is string => path != null);
+
+const writeReport = (value: unknown): void => {
+  report.textContent = JSON.stringify(value, null, 2);
+};
+
+const setScrollTop = (scrollTop: number): void => {
+  const scrollElement = getScrollElement();
+  scrollElement.scrollTop = scrollTop;
+  scrollElement.dispatchEvent(new Event('scroll'));
+};
+
+const focusStickyPath: StickyKeyboardNavigationProbe['focusStickyPath'] =
+  async (path) => {
+    fileTree.focusPath(path);
+    await nextFrames(1);
+    getStickyRowButton(path).focus({ preventScroll: true });
+    await nextFrames(1);
+  };
+
+const focusStickyDomOnly: StickyKeyboardNavigationProbe['focusStickyDomOnly'] =
+  async (path) => {
+    getStickyRowButton(path).focus({ preventScroll: true });
+    await nextFrames(1);
+  };
+
+const getRowPath = (element: HTMLElement): string | null =>
+  element.dataset.fileTreeStickyPath ?? element.dataset.itemPath ?? null;
+
+const sample = (): StickyKeyboardSample => {
+  const scrollElement = getScrollElement();
+  const scrollRect = scrollElement.getBoundingClientRect();
+  const overlayRect = getStickyOverlayContentElement()?.getBoundingClientRect();
+  const activeElement = getShadow().activeElement;
+  const activeHtmlElement =
+    activeElement instanceof HTMLElement ? activeElement : null;
+  const rows = getRows()
+    .map((button): StickyKeyboardRowSnapshot | null => {
+      const path = getRowPath(button);
+      if (path == null) {
+        return null;
+      }
+
+      const rect = button.getBoundingClientRect();
+      return {
+        bottomWithinScroll: rect.bottom - scrollRect.top,
+        isFocused: button.dataset.itemFocused === 'true',
+        isParked: button.dataset.itemParked === 'true',
+        isSticky: button.dataset.fileTreeStickyRow === 'true',
+        path,
+        topWithinScroll: rect.top - scrollRect.top,
+      };
+    })
+    .filter((row): row is StickyKeyboardRowSnapshot => row != null);
+  const focusedRows = rows.filter((row) => row.isFocused);
+  const mountedFlowPaths = rows
+    .filter((row) => !row.isSticky && !row.isParked)
+    .map((row) => row.path);
+  const result = {
+    activeElementPath:
+      activeHtmlElement == null ? null : getRowPath(activeHtmlElement),
+    activeElementIsParked:
+      activeHtmlElement?.dataset.itemParked === 'true' ? true : false,
+    activeElementIsSticky:
+      activeHtmlElement?.dataset.fileTreeStickyRow === 'true' ? true : false,
+    focusedPath: fileTree.getFocusedPath(),
+    focusedRows,
+    mountedFlowPaths,
+    rows,
+    scrollTop: scrollElement.scrollTop,
+    stickyOverlayBottomWithinScroll:
+      overlayRect == null ? 0 : overlayRect.bottom - scrollRect.top,
+    stickyPaths: getStickyPaths(),
+  } satisfies StickyKeyboardSample;
+  writeReport(result);
+  return result;
+};
+
+const stickyKeyboardNavigationWindow = window as StickyKeyboardNavigationWindow;
+stickyKeyboardNavigationWindow.__stickyKeyboardNavigationProbe = {
+  focusStickyDomOnly,
+  focusStickyPath,
+  nextFrames,
+  sample,
+  setScrollTop,
+};
+stickyKeyboardNavigationWindow.__stickyKeyboardNavigationFixtureReady = true;
+writeReport({ ready: true, scenario: scenario ?? 'linux-1x' });

--- a/packages/trees/test/e2e/fixtures/file-tree-sticky-keyboard-navigation.ts
+++ b/packages/trees/test/e2e/fixtures/file-tree-sticky-keyboard-navigation.ts
@@ -88,6 +88,9 @@ if (!(mount instanceof HTMLDivElement) || !(report instanceof HTMLPreElement)) {
 }
 
 const scenario = new URL(window.location.href).searchParams.get('scenario');
+const hasFractionalHeader =
+  new URL(window.location.href).searchParams.get('fractional-header') ===
+  'true';
 const workload = getVirtualizationWorkload('linux-1x');
 const syntheticBranchWorkload = createSyntheticBranchWorkload();
 const renderContextMenu = (item: ContextMenuItem): HTMLElement => {
@@ -96,6 +99,11 @@ const renderContextMenu = (item: ContextMenuItem): HTMLElement => {
   menu.textContent = `Menu for ${item.path}`;
   return menu;
 };
+const headerComposition = hasFractionalHeader
+  ? {
+      html: '<div data-sticky-keyboard-fractional-header style="height:77.5px">Fractional header</div>',
+    }
+  : undefined;
 const fileTree =
   scenario === 'synthetic-branch'
     ? new FileTree({
@@ -105,6 +113,7 @@ const fileTree =
             render: renderContextMenu,
             triggerMode: 'both',
           },
+          header: headerComposition,
         },
         fileTreeSearchMode: 'hide-non-matches',
         flattenEmptyDirectories: true,
@@ -121,6 +130,7 @@ const fileTree =
             render: renderContextMenu,
             triggerMode: 'both',
           },
+          header: headerComposition,
         },
         fileTreeSearchMode: 'hide-non-matches',
         flattenEmptyDirectories: true,

--- a/packages/trees/test/e2e/fixtures/file-tree-sticky-keyboard-navigation.ts
+++ b/packages/trees/test/e2e/fixtures/file-tree-sticky-keyboard-navigation.ts
@@ -1,5 +1,7 @@
 import { getVirtualizationWorkload } from '@pierre/tree-test-data';
 
+import type { ContextMenuItem } from '../../../src/index';
+
 const fileTreeRuntimePath: string = '/dist/index.js';
 const { FileTree, preparePresortedFileTreeInput } = (await import(
   /* @vite-ignore */ fileTreeRuntimePath
@@ -18,6 +20,7 @@ type StickyKeyboardSample = {
   activeElementPath: string | null;
   activeElementIsParked: boolean;
   activeElementIsSticky: boolean;
+  contextMenuPath: string | null;
   focusedPath: string | null;
   focusedRows: StickyKeyboardRowSnapshot[];
   mountedFlowPaths: string[];
@@ -87,9 +90,22 @@ if (!(mount instanceof HTMLDivElement) || !(report instanceof HTMLPreElement)) {
 const scenario = new URL(window.location.href).searchParams.get('scenario');
 const workload = getVirtualizationWorkload('linux-1x');
 const syntheticBranchWorkload = createSyntheticBranchWorkload();
+const renderContextMenu = (item: ContextMenuItem): HTMLElement => {
+  const menu = document.createElement('div');
+  menu.dataset.testStickyKeyboardMenu = item.path;
+  menu.textContent = `Menu for ${item.path}`;
+  return menu;
+};
 const fileTree =
   scenario === 'synthetic-branch'
     ? new FileTree({
+        composition: {
+          contextMenu: {
+            enabled: true,
+            render: renderContextMenu,
+            triggerMode: 'both',
+          },
+        },
         fileTreeSearchMode: 'hide-non-matches',
         flattenEmptyDirectories: true,
         initialExpandedPaths: syntheticBranchWorkload.expandedFolders,
@@ -99,6 +115,13 @@ const fileTree =
         initialVisibleRowCount: 700 / 30,
       })
     : new FileTree({
+        composition: {
+          contextMenu: {
+            enabled: true,
+            render: renderContextMenu,
+            triggerMode: 'both',
+          },
+        },
         fileTreeSearchMode: 'hide-non-matches',
         flattenEmptyDirectories: true,
         initialExpandedPaths: workload.expandedFolders,
@@ -223,6 +246,7 @@ const sample = (): StickyKeyboardSample => {
   const activeElement = getShadow().activeElement;
   const activeHtmlElement =
     activeElement instanceof HTMLElement ? activeElement : null;
+  const contextMenu = host.querySelector('[data-test-sticky-keyboard-menu]');
   const rows = getRows()
     .map((button): StickyKeyboardRowSnapshot | null => {
       const path = getRowPath(button);
@@ -252,6 +276,10 @@ const sample = (): StickyKeyboardSample => {
       activeHtmlElement?.dataset.itemParked === 'true' ? true : false,
     activeElementIsSticky:
       activeHtmlElement?.dataset.fileTreeStickyRow === 'true' ? true : false,
+    contextMenuPath:
+      contextMenu instanceof HTMLElement
+        ? (contextMenu.dataset.testStickyKeyboardMenu ?? null)
+        : null,
     focusedPath: fileTree.getFocusedPath(),
     focusedRows,
     mountedFlowPaths,

--- a/packages/trees/test/file-tree-composition-surfaces.test.ts
+++ b/packages/trees/test/file-tree-composition-surfaces.test.ts
@@ -867,7 +867,7 @@ describe('file-tree composition surfaces', () => {
       await flushDom();
       expect(openedPath.current).toBeNull();
 
-      await new Promise((resolve) => setTimeout(resolve, 60));
+      await new Promise((resolve) => setTimeout(resolve, 80));
       await flushDom();
 
       triggerButton.dispatchEvent(

--- a/packages/trees/test/file-tree-composition-surfaces.test.ts
+++ b/packages/trees/test/file-tree-composition-surfaces.test.ts
@@ -865,6 +865,18 @@ describe('file-tree composition surfaces', () => {
         })
       );
       await flushDom();
+      expect(openedPath.current).toBeNull();
+
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      await flushDom();
+
+      triggerButton.dispatchEvent(
+        new dom.window.MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+      await flushDom();
 
       expect(openedPath.current).toBe('src/index.ts');
 

--- a/packages/trees/test/file-tree-render-scroll.test.ts
+++ b/packages/trees/test/file-tree-render-scroll.test.ts
@@ -14,6 +14,7 @@ import {
   FILE_TREE_DEFAULT_OVERSCAN,
   FILE_TREE_DEFAULT_VIEWPORT_HEIGHT,
 } from '../src/model/virtualization';
+import { getResizeObserverViewportHeight } from '../src/render/FileTreeView';
 import { serializeFileTreeSsrPayload } from '../src/ssr';
 
 function installDom() {
@@ -82,6 +83,16 @@ function installDom() {
 
 async function flushDom(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createResizeObserverEntry(
+  borderBoxSize: unknown,
+  contentRectHeight: number
+): ResizeObserverEntry {
+  return {
+    borderBoxSize,
+    contentRect: { height: contentRectHeight },
+  } as unknown as ResizeObserverEntry;
 }
 
 function getFocusedTreeElement(
@@ -423,6 +434,30 @@ async function loadPreloadFileTree(): Promise<
 }
 
 describe('file-tree render + scroll', () => {
+  test('reads viewport height from ResizeObserver border box entries', () => {
+    expect(
+      getResizeObserverViewportHeight(
+        createResizeObserverEntry([{ blockSize: 123.5, inlineSize: 10 }], 90)
+      )
+    ).toBe(123.5);
+
+    expect(
+      getResizeObserverViewportHeight(
+        createResizeObserverEntry({ blockSize: 88.25, inlineSize: 10 }, 90)
+      )
+    ).toBe(88.25);
+
+    expect(
+      getResizeObserverViewportHeight(
+        createResizeObserverEntry([{ blockSize: 0, inlineSize: 10 }], 64.5)
+      )
+    ).toBe(64.5);
+
+    expect(
+      getResizeObserverViewportHeight(createResizeObserverEntry(undefined, 0))
+    ).toBeNull();
+  });
+
   test('controller exposes path-first visible rows without leaking numeric ids', async () => {
     const FileTreeController = await loadFileTreeController();
 


### PR DESCRIPTION
Hitting up and down and left and right were doing unexpected things from a sticky folder, this attempts to smooth those cases.