### PR TITLE
smol: fix a wee lint error in `getResizeObserverViewportHeight`

### DIFF
--- a/packages/trees/src/render/FileTreeView.tsx
+++ b/packages/trees/src/render/FileTreeView.tsx
@@ -584,7 +584,7 @@ export function getResizeObserverViewportHeight(
   entry: ResizeObserverEntry
 ): number | null {
   const borderBoxSize = entry.borderBoxSize;
-  const firstBorderBoxSize = Array.isArray(borderBoxSize)
+  const firstBorderBoxSize: ResizeObserverSize = Array.isArray(borderBoxSize)
     ? borderBoxSize[0]
     : borderBoxSize;
 


### PR DESCRIPTION
Smol bun run lint warning fix