### PR TITLE
WS TTY Fix Round 2

### DIFF
--- a/scripts/ws.ts
+++ b/scripts/ws.ts
@@ -68,10 +68,12 @@ const FORWARDED_SIGNALS: NodeJS.Signals[] = ['SIGINT', 'SIGTERM', 'SIGHUP'];
 
 // Some dev tools ask the terminal for state during shutdown. Their replies can
 // arrive after the child exits, so briefly drain stdin until it has gone quiet.
-const TTY_MIN_DRAIN_MS = 300;
 const TTY_QUIET_MS = 25;
-const TTY_MAX_DRAIN_MS = 750;
+const TTY_MAX_DRAIN_MS = 250;
 const TTY_DRAIN_POLL_MS = 5;
+
+const CHILD_TREE_MAX_WAIT_MS = 1_000;
+const CHILD_TREE_POLL_MS = 25;
 
 let isExiting = false;
 
@@ -129,10 +131,7 @@ async function drainTTYInput() {
       const now = Date.now();
       if (sawInput) {
         lastInputAt = now;
-      } else if (
-        now - startedAt >= TTY_MIN_DRAIN_MS &&
-        now - lastInputAt >= TTY_QUIET_MS
-      ) {
+      } else if (now - lastInputAt >= TTY_QUIET_MS) {
         break;
       }
 
@@ -160,11 +159,91 @@ async function exitCleanly(code: number) {
   process.exit(code);
 }
 
+function collectDescendantPids(rootPid: number) {
+  const result = spawnSync('ps', ['-axo', 'pid=,ppid='], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  if (result.status !== 0) {
+    return [];
+  }
+
+  const childrenByParent = new Map<number, number[]>();
+  for (const line of result.stdout.split('\n')) {
+    const parts = line.trim().split(/\s+/);
+    if (parts.length !== 2) {
+      continue;
+    }
+
+    const pid = Number(parts[0]);
+    const ppid = Number(parts[1]);
+    if (!Number.isInteger(pid) || !Number.isInteger(ppid)) {
+      continue;
+    }
+
+    const children = childrenByParent.get(ppid);
+    if (children) {
+      children.push(pid);
+    } else {
+      childrenByParent.set(ppid, [pid]);
+    }
+  }
+
+  const descendants: number[] = [];
+  const stack = [...(childrenByParent.get(rootPid) ?? [])];
+  while (stack.length > 0) {
+    const pid = stack.pop();
+    if (pid === undefined) {
+      continue;
+    }
+
+    descendants.push(pid);
+    stack.push(...(childrenByParent.get(pid) ?? []));
+  }
+
+  return descendants;
+}
+
+function isProcessAlive(pid: number) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForProcessesToExit(pids: Set<number>) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < CHILD_TREE_MAX_WAIT_MS) {
+    let hasAliveProcess = false;
+    for (const pid of pids) {
+      if (isProcessAlive(pid)) {
+        hasAliveProcess = true;
+        break;
+      }
+    }
+
+    if (!hasAliveProcess) {
+      return;
+    }
+
+    await Bun.sleep(CHILD_TREE_POLL_MS);
+  }
+}
+
 function handleChildExit(proc: ChildProcess) {
   const listeners = new Map<NodeJS.Signals, () => void>();
+  const signaledDescendants = new Set<number>();
 
   for (const signal of FORWARDED_SIGNALS) {
     const handler = () => {
+      if (proc.pid !== undefined) {
+        for (const pid of collectDescendantPids(proc.pid)) {
+          signaledDescendants.add(pid);
+        }
+      }
+
       if (proc.exitCode === null && proc.signalCode === null) {
         proc.kill(signal);
       }
@@ -179,7 +258,12 @@ function handleChildExit(proc: ChildProcess) {
       process.off(forwardedSignal, handler);
     }
 
-    void exitCleanly(signal ? (SIGNAL_EXIT_CODES[signal] ?? 1) : (code ?? 0));
+    void (async () => {
+      await waitForProcessesToExit(signaledDescendants);
+      await exitCleanly(
+        signal ? (SIGNAL_EXIT_CODES[signal] ?? 1) : (code ?? 0)
+      );
+    })();
   });
 }
 

--- a/scripts/ws.ts
+++ b/scripts/ws.ts
@@ -72,6 +72,9 @@ const TTY_QUIET_MS = 25;
 const TTY_MAX_DRAIN_MS = 250;
 const TTY_DRAIN_POLL_MS = 5;
 
+// After Ctrl+C, the wrapper process can close before grandchildren like
+// `next dev` finish their own shutdown output. Wait briefly for the descendants
+// we signaled so their final terminal writes happen before we restore the shell.
 const CHILD_TREE_MAX_WAIT_MS = 1_000;
 const CHILD_TREE_POLL_MS = 25;
 
@@ -159,6 +162,9 @@ async function exitCleanly(code: number) {
   process.exit(code);
 }
 
+// Snapshot the child process tree immediately before forwarding a signal.
+// Shell scripts often spawn grandchildren, and those descendants can still be
+// writing to the inherited terminal after the direct child has closed.
 function collectDescendantPids(rootPid: number) {
   const result = spawnSync('ps', ['-axo', 'pid=,ppid='], {
     encoding: 'utf8',
@@ -204,6 +210,8 @@ function collectDescendantPids(rootPid: number) {
   return descendants;
 }
 
+// `kill(pid, 0)` checks whether a process still exists without sending it a
+// signal. This lets shutdown wait for descendants without disturbing them again.
 function isProcessAlive(pid: number) {
   try {
     process.kill(pid, 0);
@@ -213,6 +221,8 @@ function isProcessAlive(pid: number) {
   }
 }
 
+// Wait for signaled descendants to exit before returning control to the user's
+// shell. The timeout is only a safety cap for stuck children, not a TTY delay.
 async function waitForProcessesToExit(pids: Set<number>) {
   const startedAt = Date.now();
   while (Date.now() - startedAt < CHILD_TREE_MAX_WAIT_MS) {
@@ -234,6 +244,8 @@ async function waitForProcessesToExit(pids: Set<number>) {
 
 function handleChildExit(proc: ChildProcess) {
   const listeners = new Map<NodeJS.Signals, () => void>();
+  // Record descendants before forwarding SIGINT/SIGTERM/SIGHUP, because the
+  // direct child may close before slower grandchildren finish their cleanup.
   const signaledDescendants = new Set<number>();
 
   for (const signal of FORWARDED_SIGNALS) {

--- a/scripts/ws.ts
+++ b/scripts/ws.ts
@@ -68,8 +68,9 @@ const FORWARDED_SIGNALS: NodeJS.Signals[] = ['SIGINT', 'SIGTERM', 'SIGHUP'];
 
 // Some dev tools ask the terminal for state during shutdown. Their replies can
 // arrive after the child exits, so briefly drain stdin until it has gone quiet.
+const TTY_MIN_DRAIN_MS = 300;
 const TTY_QUIET_MS = 25;
-const TTY_MAX_DRAIN_MS = 250;
+const TTY_MAX_DRAIN_MS = 750;
 const TTY_DRAIN_POLL_MS = 5;
 
 let isExiting = false;
@@ -128,7 +129,10 @@ async function drainTTYInput() {
       const now = Date.now();
       if (sawInput) {
         lastInputAt = now;
-      } else if (now - lastInputAt >= TTY_QUIET_MS) {
+      } else if (
+        now - startedAt >= TTY_MIN_DRAIN_MS &&
+        now - lastInputAt >= TTY_QUIET_MS
+      ) {
         break;
       }
 


### PR DESCRIPTION
Soo, my previous fix at #570 only worked initially if you hadn't loaded any routes.

Initially the AI extended the timeout to wait for child processes, but then I told it to go back to first principles and figure out how to better solve this. 

Anyways, it came up with this, it does appear to work even after a route loads and I hope it's much more stable than before.