### PR TITLE
[trees] Add AOSP file-tree action profiling workload

### DIFF
--- a/apps/demo/src/main.ts
+++ b/apps/demo/src/main.ts
@@ -441,7 +441,7 @@ export function workerRenderDiff(parsedPatches: ParsedPatch[]) {
 }
 
 function handlePreload() {
-  if (!isHighlighterNull()) return;
+  if (isHighlighterNull() !== true) return;
   const langs: SupportedLanguages[] = [];
   const themes: DiffsThemeNames[] = [];
   for (const item of FileStreamCodeConfigs) {

--- a/apps/docs/app/diff-examples/Annotations/Annotations.tsx
+++ b/apps/docs/app/diff-examples/Annotations/Annotations.tsx
@@ -49,7 +49,9 @@ export function Annotations({ prerenderedDiff }: AnnotationsProps) {
     []
   );
 
-  const hasOpenCommentForm = annotations.some((ann) => !ann.metadata.isThread);
+  const hasOpenCommentForm = annotations.some(
+    (ann) => ann.metadata.isThread !== true
+  );
   const [selectedRange, setSelectedRange] = useState<SelectedLineRange | null>(
     null
   );
@@ -112,7 +114,7 @@ export function Annotations({ prerenderedDiff }: AnnotationsProps) {
         }}
         lineAnnotations={annotations}
         renderAnnotation={(annotation) =>
-          annotation.metadata.isThread ? (
+          annotation.metadata.isThread === true ? (
             <Thread />
           ) : (
             <CommentForm

--- a/apps/docs/app/diff-examples/DiffStyles/DiffStyles.tsx
+++ b/apps/docs/app/diff-examples/DiffStyles/DiffStyles.tsx
@@ -66,8 +66,8 @@ export function DiffStyles({
   const [overflow, setOverflow] = useState<'wrap' | 'scroll'>(
     options?.overflow ?? 'wrap'
   );
-  const [disableLineNumbers, setDisableLineNumbers] = useState(
-    options?.disableLineNumbers ?? false
+  const [disableLineNumbers, setDisableLineNumbers] = useState<boolean>(
+    options?.disableLineNumbers === true
   );
 
   return (

--- a/apps/docs/app/diff-examples/LineSelection/LineSelection.tsx
+++ b/apps/docs/app/diff-examples/LineSelection/LineSelection.tsx
@@ -28,8 +28,8 @@ export function LineSelection({ prerenderedDiff }: LineSelectionProps) {
   const [themeType, setThemeType] = useState<'dark' | 'light'>(
     prerenderedDiff.options?.themeType === 'light' ? 'light' : 'dark'
   );
-  const [disableBackground, setDisableBackground] = useState(
-    prerenderedDiff.options?.disableBackground ?? false
+  const [disableBackground, setDisableBackground] = useState<boolean>(
+    prerenderedDiff.options?.disableBackground === true
   );
   const [diffStyle, setDiffStyle] = useState<'split' | 'unified'>(
     prerenderedDiff.options?.diffStyle ?? 'split'

--- a/apps/docs/app/playground/PlaygroundClient.tsx
+++ b/apps/docs/app/playground/PlaygroundClient.tsx
@@ -699,7 +699,9 @@ export function PlaygroundClient({ prerenderedDiff }: PlaygroundClientProps) {
     []
   );
 
-  const hasOpenCommentForm = annotations.some((ann) => !ann.metadata.isThread);
+  const hasOpenCommentForm = annotations.some(
+    (ann) => ann.metadata.isThread !== true
+  );
 
   // Hover comments and line selection conflict on click targets.
   // Give hover comments precedence when both toggles are on.
@@ -833,7 +835,7 @@ export function PlaygroundClient({ prerenderedDiff }: PlaygroundClientProps) {
         renderAnnotation={
           showAnnotations
             ? (annotation) =>
-                annotation.metadata.isThread ? (
+                annotation.metadata.isThread === true ? (
                   <ExampleThread />
                 ) : (
                   <CommentForm

--- a/apps/docs/app/theme/ThemeDemo.tsx
+++ b/apps/docs/app/theme/ThemeDemo.tsx
@@ -409,7 +409,7 @@ export function ThemeDemo() {
   );
 
   const activeDiffs = useMemo(
-    () => fileDiffs.filter((fd) => fd.hasChanges),
+    () => fileDiffs.filter((fd) => fd.hasChanges === true),
     [fileDiffs]
   );
 
@@ -621,7 +621,7 @@ export function ThemeDemo() {
             </div>
             <div className="divide-y divide-neutral-200 dark:divide-neutral-700">
               {fileDiffs.map((fileData) => {
-                if (fileData.hasChanges) {
+                if (fileData.hasChanges === true) {
                   return (
                     <FileDiff
                       key={fileData.id}

--- a/packages/trees/scripts/lib/fileTreeProfileShared.ts
+++ b/packages/trees/scripts/lib/fileTreeProfileShared.ts
@@ -1,5 +1,4 @@
 import { getVirtualizationWorkload } from '@pierre/tree-test-data';
-import type { VirtualizationWorkload } from '@pierre/tree-test-data';
 
 // Keep the profiling fixture on the narrow data-preparation entrypoint so the
 // Vite-served page does not accidentally import the source render runtime.
@@ -9,6 +8,7 @@ export const FILE_TREE_PROFILE_WORKLOAD_NAMES = [
   'linux-5x',
   'linux-10x',
   'linux',
+  'aosp',
   'demo-small',
 ] as const;
 
@@ -23,6 +23,43 @@ export interface FileTreeProfileWorkloadSummary {
   fileCount: number;
   label: string;
   name: FileTreeProfileWorkloadName;
+}
+
+export interface FileTreeProfileWorkload {
+  expandedFolders: string[];
+  files: string[];
+  label: string;
+  name: FileTreeProfileWorkloadName;
+}
+
+export type FileTreeProfileActionOperation = 'collapse' | 'expand';
+export type FileTreeProfileActionInitialExpansion = 'closed' | 'open';
+export type FileTreeProfileActionDispatch = 'api' | 'dom-click';
+export type FileTreeProfileActionTargetVisibility =
+  | 'hidden'
+  | 'offscreen'
+  | 'sticky'
+  | 'visible';
+
+export interface FileTreeProfileActionSetupOperation {
+  operation: FileTreeProfileActionOperation;
+  path: string;
+}
+
+export interface FileTreeProfileActionSummary {
+  dispatch: FileTreeProfileActionDispatch;
+  id: string;
+  initialExpansion: FileTreeProfileActionInitialExpansion;
+  label: string;
+  operation: FileTreeProfileActionOperation;
+  renderedItemCountAfter?: number;
+  renderedItemCountBefore?: number;
+  setupOperations: FileTreeProfileActionSetupOperation[];
+  targetDepth: number;
+  targetIsExpandedAfter?: boolean;
+  targetPath: string;
+  targetVisibility: FileTreeProfileActionTargetVisibility;
+  targetWasExpandedBefore?: boolean;
 }
 
 export interface FileTreeProfilePhaseSummary {
@@ -47,10 +84,13 @@ export interface FileTreeProfileInstrumentationSummary {
 }
 
 export interface FileTreeProfilePageSummary {
+  action?: FileTreeProfileActionSummary;
+  actionDurationMs?: number;
   instrumentation: FileTreeProfileInstrumentationSummary | null;
   longTaskCount: number;
   longTaskTotalMs: number;
   longestLongTaskMs: number;
+  profileKind?: 'action' | 'render';
   renderDurationMs: number;
   renderedItemCount: number;
   resultText: string | null;
@@ -68,34 +108,51 @@ export function isFileTreeProfileWorkloadName(
 
 export function getFileTreeProfileWorkload(
   value: string | null | undefined
-): VirtualizationWorkload {
-  const workloadName = isFileTreeProfileWorkloadName(value ?? '')
-    ? value
+): FileTreeProfileWorkload {
+  const requestedWorkloadName = value ?? '';
+  const workloadName = isFileTreeProfileWorkloadName(requestedWorkloadName)
+    ? requestedWorkloadName
     : DEFAULT_FILE_TREE_PROFILE_WORKLOAD_NAME;
-  return getVirtualizationWorkload(workloadName);
+  if (workloadName === 'aosp') {
+    throw new Error(
+      'The AOSP file-tree profile workload is loaded asynchronously from the browser fixture.'
+    );
+  }
+  const workload = getVirtualizationWorkload(workloadName);
+  return {
+    expandedFolders: workload.expandedFolders,
+    files: workload.files,
+    label: workload.label,
+    name: workloadName,
+  };
 }
 
 export function createFileTreeProfileFixtureOptions(
-  workload: VirtualizationWorkload
+  workload: FileTreeProfileWorkload,
+  options: {
+    initialExpansion?: FileTreeProfileActionInitialExpansion;
+  } = {}
 ) {
+  const initialExpansion = options.initialExpansion ?? 'open';
   return {
     flattenEmptyDirectories: true,
     // All profiling workloads expand every derived directory, so open-default
     // startup is semantically identical to replaying a huge explicit expanded
     // path list and avoids constructor-side expansion normalization work.
-    initialExpansion: 'open' as const,
+    initialExpansion,
     preparedInput: preparePresortedFileTreeInput(workload.files),
     initialVisibleRowCount: FILE_TREE_PROFILE_VIEWPORT_HEIGHT / 30,
+    stickyFolders: true,
   };
 }
 
 export function createFileTreeProfileWorkloadSummary(
-  workload: VirtualizationWorkload
+  workload: FileTreeProfileWorkload
 ): FileTreeProfileWorkloadSummary {
   return {
     expandedFolderCount: workload.expandedFolders.length,
     fileCount: workload.files.length,
     label: workload.label,
-    name: workload.name as FileTreeProfileWorkloadName,
+    name: workload.name,
   };
 }

--- a/packages/trees/scripts/profileFileTree.ts
+++ b/packages/trees/scripts/profileFileTree.ts
@@ -8,11 +8,15 @@ import { loadWorktreeEnv } from '../../../scripts/load-worktree-env.mjs';
 import {
   DEFAULT_FILE_TREE_PROFILE_WORKLOAD_NAME,
   FILE_TREE_PROFILE_WORKLOAD_NAMES,
+  type FileTreeProfileActionSummary,
   type FileTreeProfilePageSummary,
   type FileTreeProfileWorkloadName,
 } from './lib/fileTreeProfileShared';
 
+type ProfileActionsMode = 'expansion' | 'off';
+
 interface ProfileConfig {
+  actionsMode: ProfileActionsMode;
   browserUrl: string;
   url: string;
   workloads: FileTreeProfileWorkloadName[];
@@ -24,6 +28,7 @@ interface ProfileConfig {
   showDominantTraceEvents: boolean;
   outputJson: boolean;
   comparePath?: string;
+  profileRender: boolean;
   traceOutputPath: string;
   ensureBuild: boolean;
   ensureServer: boolean;
@@ -127,6 +132,8 @@ interface HeapSummary {
 }
 
 interface ProfileResult {
+  action: FileTreeProfileActionSummary | null;
+  actionDurationMs: number | null;
   runNumber: number;
   browserUrl: string;
   url: string;
@@ -157,6 +164,7 @@ interface AggregateMetricSummary {
 }
 
 type AggregateMetricKey =
+  | 'actionDurationMs'
   | 'visibleRowsReadyMs'
   | 'postPaintReadyMs'
   | 'clickDispatchMs'
@@ -172,12 +180,21 @@ interface JsonAggregateSummary {
 }
 
 interface ProfileWorkloadOutput {
+  actionProfiles: ProfileActionOutput[];
+  actionSummary: JsonAggregateSummary | null;
   workload: PageWorkloadSummary;
   runs: ProfileResult[];
   summary: JsonAggregateSummary;
 }
 
+interface ProfileActionOutput {
+  action: FileTreeProfileActionSummary;
+  runs: ProfileResult[];
+  summary: JsonAggregateSummary;
+}
+
 interface ProfileConfigSummary {
+  actionsMode: ProfileActionsMode;
   browserUrl: string;
   url: string;
   workloads: string[];
@@ -186,6 +203,7 @@ interface ProfileConfigSummary {
   warmupRuns: number;
   instrumentationMode: 'on' | 'off';
   includeCallCounts: boolean;
+  profileRender: boolean;
   showDominantTraceEvents: boolean;
 }
 
@@ -314,6 +332,7 @@ declare global {
   interface Window {
     __treesFileTreeFixtureReady?: boolean;
     __treesFileTreeProfile?: PageRenderSummary;
+    __treesFileTreeProfileError?: string;
   }
 }
 
@@ -330,6 +349,7 @@ const WORKTREE_PORT_OFFSET = readWorktreePortOffset();
 const DEFAULT_BROWSER_DEBUG_PORT = 9222 + WORKTREE_PORT_OFFSET;
 const DEFAULT_FIXTURE_SERVER_PORT = 9221 + WORKTREE_PORT_OFFSET;
 const packageRoot = fileURLToPath(new URL('../', import.meta.url));
+const repoRoot = resolve(packageRoot, '../..');
 const DEFAULT_BROWSER_URL = `http://127.0.0.1:${DEFAULT_BROWSER_DEBUG_PORT}`;
 const DEFAULT_URL = `http://127.0.0.1:${DEFAULT_FIXTURE_SERVER_PORT}/test/e2e/fixtures/file-tree-profile.html`;
 const DEFAULT_WORKLOAD_NAME = DEFAULT_FILE_TREE_PROFILE_WORKLOAD_NAME;
@@ -426,6 +446,11 @@ const AGGREGATE_METRIC_DEFINITIONS: Array<{
   select: (result: ProfileResult) => number | null;
 }> = [
   {
+    key: 'actionDurationMs',
+    label: 'API action dispatch',
+    select: (result) => result.actionDurationMs,
+  },
+  {
     key: 'visibleRowsReadyMs',
     label: 'Visible rows ready',
     select: (result) => result.visibleRowsReadyMs,
@@ -480,6 +505,9 @@ function printHelpAndExit(): never {
     `  --browser-url <url>    Chrome remote debugging base URL (default: ${DEFAULT_BROWSER_URL})`
   );
   console.log(
+    '                         If the local debug port is closed, the profiler starts `bun run chrome` automatically'
+  );
+  console.log(
     `  --url <url>            Page to profile (default: ${DEFAULT_URL})`
   );
   console.log(
@@ -502,6 +530,12 @@ function printHelpAndExit(): never {
   );
   console.log(
     '  --dominant-trace-events Show the lower-signal dominant trace event table in human output'
+  );
+  console.log(
+    '  --actions <mode>      Run action profiles: off or expansion (default: off)'
+  );
+  console.log(
+    '  --actions-only        Run expansion action profiles without the standalone render profile'
   );
   console.log(
     `  --trace-out <path>     Where to save the Chrome trace JSON when tracing succeeds (default: ${DEFAULT_TRACE_OUTPUT_EXAMPLE_PATH})`
@@ -545,6 +579,16 @@ function parseInstrumentationMode(value: string): 'on' | 'off' {
   );
 }
 
+function parseActionsMode(value: string): ProfileActionsMode {
+  if (value === 'off' || value === 'expansion') {
+    return value;
+  }
+
+  throw new Error(
+    `Invalid --actions value '${value}'. Expected 'off' or 'expansion'.`
+  );
+}
+
 function parseWorkloadName(value: string): FileTreeProfileWorkloadName {
   if (KNOWN_WORKLOAD_NAMES.has(value as FileTreeProfileWorkloadName)) {
     return value as FileTreeProfileWorkloadName;
@@ -571,6 +615,15 @@ function createDefaultTraceOutputPath(): string {
   );
 }
 
+function slugifyTracePart(value: string): string {
+  const slug = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug.length > 0 ? slug : 'item';
+}
+
 function createRunTraceOutputPath(
   traceOutputPath: string,
   workloadName: string,
@@ -580,12 +633,7 @@ function createRunTraceOutputPath(
 ): string {
   const suffixParts: string[] = [];
   if (workloadCount > 1) {
-    const workloadSlug = workloadName
-      .trim()
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-+|-+$/g, '');
-    suffixParts.push(workloadSlug.length > 0 ? workloadSlug : 'workload');
+    suffixParts.push(slugifyTracePart(workloadName));
   }
 
   if (totalRuns > 1) {
@@ -605,6 +653,19 @@ function createRunTraceOutputPath(
   }
 
   return `${traceOutputPath.slice(0, extensionIndex)}${runSuffix}${traceOutputPath.slice(extensionIndex)}`;
+}
+
+function createActionTraceOutputPath(
+  traceOutputPath: string,
+  actionId: string
+): string {
+  const actionSuffix = `-${slugifyTracePart(actionId)}`;
+  const extensionIndex = traceOutputPath.lastIndexOf('.');
+  if (extensionIndex <= 0) {
+    return `${traceOutputPath}${actionSuffix}`;
+  }
+
+  return `${traceOutputPath.slice(0, extensionIndex)}${actionSuffix}${traceOutputPath.slice(extensionIndex)}`;
 }
 
 function isFileTreeProfileFixtureUrl(url: string): boolean {
@@ -639,6 +700,7 @@ function createProfileUrl(
 
 function parseArgs(argv: string[]): ProfileConfig {
   const config: ProfileConfig = {
+    actionsMode: 'off',
     browserUrl: DEFAULT_BROWSER_URL,
     url: DEFAULT_URL,
     workloads: [DEFAULT_WORKLOAD_NAME],
@@ -649,6 +711,7 @@ function parseArgs(argv: string[]): ProfileConfig {
     includeCallCounts: false,
     showDominantTraceEvents: false,
     outputJson: false,
+    profileRender: true,
     traceOutputPath: createDefaultTraceOutputPath(),
     ensureBuild: true,
     ensureServer: true,
@@ -675,6 +738,12 @@ function parseArgs(argv: string[]): ProfileConfig {
       continue;
     }
 
+    if (rawArg === '--actions-only') {
+      config.actionsMode = 'expansion';
+      config.profileRender = false;
+      continue;
+    }
+
     if (rawArg === '--no-build') {
       config.ensureBuild = false;
       continue;
@@ -694,6 +763,7 @@ function parseArgs(argv: string[]): ProfileConfig {
       flag === '--runs' ||
       flag === '--warmup-runs' ||
       flag === '--instrumentation' ||
+      flag === '--actions' ||
       flag === '--trace-out' ||
       flag === '--compare'
     ) {
@@ -725,6 +795,8 @@ function parseArgs(argv: string[]): ProfileConfig {
         config.warmupRuns = parseNonNegativeInteger(value, '--warmup-runs');
       } else if (flag === '--instrumentation') {
         config.instrumentationMode = parseInstrumentationMode(value);
+      } else if (flag === '--actions') {
+        config.actionsMode = parseActionsMode(value);
       } else if (flag === '--compare') {
         config.comparePath = resolve(process.cwd(), value);
       } else {
@@ -737,6 +809,9 @@ function parseArgs(argv: string[]): ProfileConfig {
   }
 
   config.workloads = [...new Set(config.workloads)];
+  if (!config.profileRender && config.actionsMode === 'off') {
+    throw new Error('--actions-only requires action profiling.');
+  }
   return config;
 }
 
@@ -877,6 +952,7 @@ function createProfileConfigSummary(
   config: ProfileConfig
 ): ProfileConfigSummary {
   return {
+    actionsMode: config.actionsMode,
     browserUrl: config.browserUrl,
     url: config.url,
     workloads: [...config.workloads],
@@ -885,19 +961,28 @@ function createProfileConfigSummary(
     warmupRuns: config.warmupRuns,
     instrumentationMode: config.instrumentationMode,
     includeCallCounts: config.includeCallCounts,
+    profileRender: config.profileRender,
     showDominantTraceEvents: config.showDominantTraceEvents,
   };
 }
 
-function createWorkloadOutput(results: ProfileResult[]): ProfileWorkloadOutput {
-  if (results.length === 0) {
+function createWorkloadOutput(
+  workload: PageWorkloadSummary,
+  results: ProfileResult[],
+  actionProfiles: ProfileActionOutput[]
+): ProfileWorkloadOutput {
+  if (results.length === 0 && actionProfiles.length === 0) {
     throw new Error('Cannot summarize an empty workload result set.');
   }
 
+  const actionRuns = actionProfiles.flatMap((profile) => profile.runs);
   return {
-    workload: results[0].workload,
+    actionProfiles,
+    actionSummary:
+      actionRuns.length === 0 ? null : createJsonAggregateSummary(actionRuns),
     runs: results,
     summary: createJsonAggregateSummary(results),
+    workload,
   };
 }
 
@@ -1063,6 +1148,110 @@ function ensureProductionDistBuild(): void {
         .join('\n\n')
     );
   }
+}
+
+function createBrowserVersionUrl(browserUrl: string): string {
+  try {
+    return new URL('/json/version', browserUrl).toString();
+  } catch {
+    return `${browserUrl.replace(/\/$/, '')}/json/version`;
+  }
+}
+
+async function isChromeDebugEndpointAvailable(
+  browserUrl: string,
+  timeoutMs: number
+): Promise<boolean> {
+  try {
+    const version = await fetchJson<Partial<InspectVersionResponse>>(
+      createBrowserVersionUrl(browserUrl),
+      undefined,
+      timeoutMs
+    );
+    return (
+      typeof version.webSocketDebuggerUrl === 'string' &&
+      version.webSocketDebuggerUrl !== ''
+    );
+  } catch {
+    return false;
+  }
+}
+
+function readLocalBrowserDebugPort(browserUrl: string): number | null {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(browserUrl);
+  } catch {
+    return null;
+  }
+
+  const localHosts = new Set(['127.0.0.1', '::1', '[::1]', 'localhost']);
+  if (
+    parsedUrl.protocol !== 'http:' ||
+    !localHosts.has(parsedUrl.hostname) ||
+    parsedUrl.port === ''
+  ) {
+    return null;
+  }
+
+  const port = Number.parseInt(parsedUrl.port, 10);
+  return Number.isInteger(port) && port > 0 ? port : null;
+}
+
+function launchChromeDebugPort(browserUrl: string): void {
+  const browserDebugPort = readLocalBrowserDebugPort(browserUrl);
+  if (browserDebugPort == null) {
+    throw new Error(
+      `Chrome debug endpoint ${createBrowserVersionUrl(
+        browserUrl
+      )} is not reachable. Automatic launch is only supported for localhost browser URLs with an explicit port.`
+    );
+  }
+
+  const launchResult = Bun.spawnSync({
+    cmd: ['bun', 'run', 'chrome'],
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      AGENT: '1',
+      PIERRE_PORT_OFFSET: String(browserDebugPort - 9222),
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  if (launchResult.exitCode !== 0) {
+    const stdout = decodeOutput(launchResult.stdout);
+    const stderr = decodeOutput(launchResult.stderr);
+    throw new Error(
+      [
+        `Failed to launch Chrome debug port ${browserDebugPort}.`,
+        stdout !== '' ? `stdout:\n${stdout}` : null,
+        stderr !== '' ? `stderr:\n${stderr}` : null,
+      ]
+        .filter((value): value is string => value != null)
+        .join('\n\n')
+    );
+  }
+}
+
+async function ensureChromeDebugPort(config: ProfileConfig): Promise<void> {
+  if (await isChromeDebugEndpointAvailable(config.browserUrl, 1_000)) {
+    return;
+  }
+
+  launchChromeDebugPort(config.browserUrl);
+  if (
+    await isChromeDebugEndpointAvailable(config.browserUrl, config.timeoutMs)
+  ) {
+    return;
+  }
+
+  throw new Error(
+    `Chrome debug endpoint ${createBrowserVersionUrl(
+      config.browserUrl
+    )} is still not reachable after launching Chrome.`
+  );
 }
 
 async function waitForUrl(url: string, timeoutMs: number): Promise<void> {
@@ -2355,7 +2544,9 @@ function createNestedPhaseRows(phases: InstrumentedPhaseSummary[]): Array<{
   return rows;
 }
 
-function startTrace(cdp: CdpClient): Promise<TraceFile> {
+async function startTrace(cdp: CdpClient): Promise<{
+  traceComplete: Promise<TraceFile>;
+}> {
   const traceEvents: TraceEvent[] = [];
   const removeListener = cdp.on('Tracing.dataCollected', (params) => {
     const payload = params as { value?: TraceEvent[] };
@@ -2371,15 +2562,12 @@ function startTrace(cdp: CdpClient): Promise<TraceFile> {
       return { traceEvents };
     });
 
-  return cdp
-    .send('Tracing.start', {
-      categories: TRACE_CATEGORIES,
-      transferMode: 'ReportEvents',
-    })
-    .then(async () => {
-      await Bun.sleep(TRACE_START_SETTLE_MS);
-      return traceComplete;
-    });
+  await cdp.send('Tracing.start', {
+    categories: TRACE_CATEGORIES,
+    transferMode: 'ReportEvents',
+  });
+  await Bun.sleep(TRACE_START_SETTLE_MS);
+  return { traceComplete };
 }
 
 async function startCpuProfile(cdp: CdpClient): Promise<void> {
@@ -2483,12 +2671,20 @@ async function waitForProfileSummary(
 ): Promise<PageRenderSummary> {
   const summary = await evaluateJson<{
     done: boolean;
+    error?: string;
     profile: PageRenderSummary | null;
   }>(
     cdp,
     `(async () => {
       const started = performance.now();
       while (performance.now() - started < ${timeoutMs}) {
+        if (window.__treesFileTreeProfileError != null) {
+          return {
+            done: true,
+            error: window.__treesFileTreeProfileError,
+            profile: window.__treesFileTreeProfile ?? null,
+          };
+        }
         if (window.__treesFileTreeProfile != null) {
           return { done: true, profile: window.__treesFileTreeProfile };
         }
@@ -2501,11 +2697,48 @@ async function waitForProfileSummary(
     })()`
   );
 
+  if (summary.error != null) {
+    throw new Error(summary.error);
+  }
+
   if (!summary.done || summary.profile == null) {
     throw new Error('Timed out waiting for the file-tree render summary.');
   }
 
   return summary.profile;
+}
+
+async function dispatchMouseClick(
+  cdp: CdpClient,
+  x: number,
+  y: number
+): Promise<void> {
+  await cdp.send('Input.dispatchMouseEvent', {
+    type: 'mouseMoved',
+    x,
+    y,
+    button: 'none',
+    pointerType: 'mouse',
+  });
+  await cdp.send('Input.dispatchMouseEvent', {
+    type: 'mousePressed',
+    x,
+    y,
+    button: 'left',
+    buttons: 1,
+    clickCount: 1,
+    pointerType: 'mouse',
+  });
+  await Bun.sleep(16);
+  await cdp.send('Input.dispatchMouseEvent', {
+    type: 'mouseReleased',
+    x,
+    y,
+    button: 'left',
+    buttons: 0,
+    clickCount: 1,
+    pointerType: 'mouse',
+  });
 }
 
 async function clickRenderButton(cdp: CdpClient): Promise<void> {
@@ -2534,32 +2767,96 @@ async function clickRenderButton(cdp: CdpClient): Promise<void> {
     throw new Error(result.reason ?? 'Failed to click the render button.');
   }
 
-  await cdp.send('Input.dispatchMouseEvent', {
-    type: 'mouseMoved',
-    x: result.x,
-    y: result.y,
-    button: 'none',
-    pointerType: 'mouse',
-  });
-  await cdp.send('Input.dispatchMouseEvent', {
-    type: 'mousePressed',
-    x: result.x,
-    y: result.y,
-    button: 'left',
-    buttons: 1,
-    clickCount: 1,
-    pointerType: 'mouse',
-  });
-  await Bun.sleep(16);
-  await cdp.send('Input.dispatchMouseEvent', {
-    type: 'mouseReleased',
-    x: result.x,
-    y: result.y,
-    button: 'left',
-    buttons: 0,
-    clickCount: 1,
-    pointerType: 'mouse',
-  });
+  await dispatchMouseClick(cdp, result.x, result.y);
+}
+
+async function listExpansionActionScenarios(
+  cdp: CdpClient
+): Promise<FileTreeProfileActionSummary[]> {
+  return await evaluateJson<FileTreeProfileActionSummary[]>(
+    cdp,
+    `(async () => {
+      const api = window.treesFileTreeProfile;
+      if (api == null) {
+        throw new Error('Missing treesFileTreeProfile fixture API.');
+      }
+      return await api.listExpansionActionScenarios();
+    })()`
+  );
+}
+
+async function prepareActionProfile(
+  cdp: CdpClient,
+  actionId: string
+): Promise<FileTreeProfileActionSummary> {
+  return await evaluateJson<FileTreeProfileActionSummary>(
+    cdp,
+    `(async () => {
+      const api = window.treesFileTreeProfile;
+      if (api == null) {
+        throw new Error('Missing treesFileTreeProfile fixture API.');
+      }
+      return await api.prepareActionProfile(${JSON.stringify(actionId)});
+    })()`
+  );
+}
+
+async function profilePreparedAction(
+  cdp: CdpClient
+): Promise<PageRenderSummary> {
+  return await evaluateJson<PageRenderSummary>(
+    cdp,
+    `(async () => {
+      const api = window.treesFileTreeProfile;
+      if (api == null) {
+        throw new Error('Missing treesFileTreeProfile fixture API.');
+      }
+      return await api.profilePreparedAction();
+    })()`
+  );
+}
+
+async function beginPreparedActionClickProfile(cdp: CdpClient): Promise<{
+  x: number;
+  y: number;
+}> {
+  return await evaluateJson<{ x: number; y: number }>(
+    cdp,
+    `(async () => {
+      const api = window.treesFileTreeProfile;
+      if (api == null) {
+        throw new Error('Missing treesFileTreeProfile fixture API.');
+      }
+      return await api.beginPreparedActionClickProfile();
+    })()`
+  );
+}
+
+async function clickPreparedActionAndWaitForSummary(
+  cdp: CdpClient,
+  timeoutMs: number
+): Promise<PageRenderSummary> {
+  const target = await beginPreparedActionClickProfile(cdp);
+  await dispatchMouseClick(cdp, target.x, target.y);
+  return await waitForProfileSummary(cdp, timeoutMs);
+}
+
+async function profilePreparedActionForScenario(
+  cdp: CdpClient,
+  scenario: FileTreeProfileActionSummary,
+  timeoutMs: number
+): Promise<PageRenderSummary> {
+  return scenario.dispatch === 'dom-click'
+    ? await clickPreparedActionAndWaitForSummary(cdp, timeoutMs)
+    : await profilePreparedAction(cdp);
+}
+
+async function clickAndWaitForRenderSummary(
+  cdp: CdpClient,
+  timeoutMs: number
+): Promise<PageRenderSummary> {
+  await clickRenderButton(cdp);
+  return await waitForProfileSummary(cdp, timeoutMs);
 }
 
 async function collectProfilingArtifacts(
@@ -2575,7 +2872,7 @@ async function collectProfilingArtifacts(
   let cpuProfileStarted = false;
 
   try {
-    tracePromise = startTrace(cdp);
+    tracePromise = (await startTrace(cdp)).traceComplete;
   } catch {
     tracePromise = null;
   }
@@ -2628,13 +2925,13 @@ async function collectProfilingArtifacts(
 async function collectFunctionCallCounts(
   cdp: CdpClient,
   url: string,
-  timeoutMs: number
+  timeoutMs: number,
+  action: () => Promise<unknown>
 ): Promise<Map<string, number | null> | null> {
   try {
     await navigateToFixture(cdp, url, timeoutMs);
     await startPreciseCoverage(cdp);
-    await clickRenderButton(cdp);
-    await waitForProfileSummary(cdp, timeoutMs);
+    await action();
     const coverage = await stopPreciseCoverage(cdp);
     if (coverage == null) {
       return null;
@@ -2658,6 +2955,57 @@ function writeTraceIfAvailable(
   mkdirSync(dirname(traceOutputPath), { recursive: true });
   writeFileSync(traceOutputPath, JSON.stringify(trace));
   return traceOutputPath;
+}
+
+function createProfileResult({
+  browserUrl,
+  callCountsByFunction,
+  cpuProfile,
+  pageSummary,
+  runNumber,
+  trace,
+  traceOutputPath,
+  url,
+}: {
+  browserUrl: string;
+  callCountsByFunction: Map<string, number | null> | null;
+  cpuProfile: CpuProfile | null;
+  pageSummary: PageRenderSummary;
+  runNumber: number;
+  trace: TraceFile | null;
+  traceOutputPath: string | null;
+  url: string;
+}): ProfileResult {
+  return {
+    action: pageSummary.action ?? null,
+    actionDurationMs:
+      pageSummary.actionDurationMs == null
+        ? null
+        : Number(pageSummary.actionDurationMs.toFixed(3)),
+    runNumber,
+    browserUrl,
+    url,
+    workload: getPageWorkloadSummary(pageSummary, url),
+    traceOutputPath: writeTraceIfAvailable(trace, traceOutputPath),
+    renderedItemCount: pageSummary.renderedItemCount,
+    visibleRowsReadyMs:
+      pageSummary.visibleRowsReadyMs == null
+        ? null
+        : Number(pageSummary.visibleRowsReadyMs.toFixed(3)),
+    renderDurationMs: Number(pageSummary.renderDurationMs.toFixed(3)),
+    longTaskCount: pageSummary.longTaskCount ?? null,
+    longTaskTotalMs:
+      pageSummary.longTaskTotalMs == null
+        ? null
+        : Number(pageSummary.longTaskTotalMs.toFixed(3)),
+    longestLongTaskMs:
+      pageSummary.longestLongTaskMs == null
+        ? null
+        : Number(pageSummary.longestLongTaskMs.toFixed(3)),
+    instrumentation: summarizeInstrumentation(pageSummary),
+    trace: summarizeTrace(trace, pageSummary),
+    cpuProfile: summarizeCpuProfile(cpuProfile, callCountsByFunction),
+  };
 }
 
 async function profileFileTreeRender(
@@ -2700,40 +3048,130 @@ async function profileFileTreeRender(
     const { pageSummary, trace, cpuProfile } = await collectProfilingArtifacts(
       cdp,
       config.timeoutMs,
-      async () => {
-        await clickRenderButton(cdp);
-        return await waitForProfileSummary(cdp, config.timeoutMs);
-      }
+      () => clickAndWaitForRenderSummary(cdp, config.timeoutMs)
     );
     const callCountsByFunction = config.includeCallCounts
-      ? await collectFunctionCallCounts(cdp, profileUrl, config.timeoutMs)
+      ? await collectFunctionCallCounts(cdp, profileUrl, config.timeoutMs, () =>
+          clickAndWaitForRenderSummary(cdp, config.timeoutMs)
+        )
       : null;
 
-    return {
-      runNumber,
+    return createProfileResult({
       browserUrl: config.browserUrl,
+      callCountsByFunction,
+      cpuProfile,
+      pageSummary,
+      runNumber,
+      trace,
+      traceOutputPath,
       url: profileUrl,
-      workload: getPageWorkloadSummary(pageSummary, profileUrl),
-      traceOutputPath: writeTraceIfAvailable(trace, traceOutputPath),
-      renderedItemCount: pageSummary.renderedItemCount,
-      visibleRowsReadyMs:
-        pageSummary.visibleRowsReadyMs == null
+    });
+  } finally {
+    cdp.close();
+    await closePageTarget(config.browserUrl, target.id, config.timeoutMs);
+  }
+}
+
+async function collectActionFunctionCallCounts(
+  cdp: CdpClient,
+  profileUrl: string,
+  timeoutMs: number,
+  scenario: FileTreeProfileActionSummary
+): Promise<Map<string, number | null> | null> {
+  return await collectFunctionCallCounts(
+    cdp,
+    profileUrl,
+    timeoutMs,
+    async () => {
+      const preparedScenario = await prepareActionProfile(cdp, scenario.id);
+      await profilePreparedActionForScenario(cdp, preparedScenario, timeoutMs);
+    }
+  );
+}
+
+async function profileFileTreeExpansionActions(
+  config: ProfileConfig,
+  workloadName: string,
+  runNumber: number,
+  traceOutputPath: string | null
+): Promise<ProfileResult[]> {
+  const profileUrl = createProfileUrl(
+    config.url,
+    config.instrumentationMode,
+    workloadName
+  );
+  const version = await fetchJson<InspectVersionResponse>(
+    `${config.browserUrl}/json/version`,
+    undefined,
+    config.timeoutMs
+  );
+  if (version.webSocketDebuggerUrl === '') {
+    throw new Error(
+      `Chrome at ${config.browserUrl} did not expose a browser WebSocket URL.`
+    );
+  }
+
+  const target = await createPageTarget(
+    config.browserUrl,
+    profileUrl,
+    config.timeoutMs
+  );
+  const cdp = await CdpClient.connect(
+    target.webSocketDebuggerUrl,
+    config.timeoutMs
+  );
+
+  try {
+    await cdp.send('Page.enable');
+    await cdp.send('Runtime.enable');
+    await navigateToFixture(cdp, profileUrl, config.timeoutMs);
+
+    const scenarios = await listExpansionActionScenarios(cdp);
+    if (scenarios.length === 0) {
+      throw new Error(
+        `No expansion action scenarios were available for workload ${workloadName}.`
+      );
+    }
+
+    const results: ProfileResult[] = [];
+    for (const scenario of scenarios) {
+      const preparedScenario = await prepareActionProfile(cdp, scenario.id);
+      const actionTraceOutputPath =
+        traceOutputPath == null
           ? null
-          : Number(pageSummary.visibleRowsReadyMs.toFixed(3)),
-      renderDurationMs: Number(pageSummary.renderDurationMs.toFixed(3)),
-      longTaskCount: pageSummary.longTaskCount ?? null,
-      longTaskTotalMs:
-        pageSummary.longTaskTotalMs == null
-          ? null
-          : Number(pageSummary.longTaskTotalMs.toFixed(3)),
-      longestLongTaskMs:
-        pageSummary.longestLongTaskMs == null
-          ? null
-          : Number(pageSummary.longestLongTaskMs.toFixed(3)),
-      instrumentation: summarizeInstrumentation(pageSummary),
-      trace: summarizeTrace(trace, pageSummary),
-      cpuProfile: summarizeCpuProfile(cpuProfile, callCountsByFunction),
-    };
+          : createActionTraceOutputPath(traceOutputPath, scenario.id);
+      const { pageSummary, trace, cpuProfile } =
+        await collectProfilingArtifacts(cdp, config.timeoutMs, () =>
+          profilePreparedActionForScenario(
+            cdp,
+            preparedScenario,
+            config.timeoutMs
+          )
+        );
+      const callCountsByFunction = config.includeCallCounts
+        ? await collectActionFunctionCallCounts(
+            cdp,
+            profileUrl,
+            config.timeoutMs,
+            preparedScenario
+          )
+        : null;
+
+      results.push(
+        createProfileResult({
+          browserUrl: config.browserUrl,
+          callCountsByFunction,
+          cpuProfile,
+          pageSummary,
+          runNumber,
+          trace,
+          traceOutputPath: actionTraceOutputPath,
+          url: profileUrl,
+        })
+      );
+    }
+
+    return results;
   } finally {
     cdp.close();
     await closePageTarget(config.browserUrl, target.id, config.timeoutMs);
@@ -2746,6 +3184,12 @@ function printRunHumanSummary(
   showDominantTraceEvents: boolean
 ): void {
   const summaryRows = [['Visible rows', String(result.renderedItemCount)]];
+  if (result.actionDurationMs != null) {
+    summaryRows.push([
+      'API action dispatch',
+      formatMs(result.actionDurationMs),
+    ]);
+  }
 
   if (result.visibleRowsReadyMs != null) {
     summaryRows.push([
@@ -2795,6 +3239,35 @@ function printRunHumanSummary(
   }
 
   console.log(`Run ${result.runNumber}/${totalRuns}`);
+  if (result.action != null) {
+    console.log(
+      createTable(
+        ['Action', 'Value'],
+        [
+          ['Scenario', result.action.label],
+          ['Operation', result.action.operation],
+          ['Dispatch', result.action.dispatch],
+          ['Initial expansion', result.action.initialExpansion],
+          ['Target visibility', result.action.targetVisibility],
+          ['Target depth', String(result.action.targetDepth)],
+          ['Target path', result.action.targetPath],
+          [
+            'Target expanded',
+            `${String(result.action.targetWasExpandedBefore ?? 'n/a')} -> ${String(result.action.targetIsExpandedAfter ?? 'n/a')}`,
+          ],
+          [
+            'Rendered rows',
+            `${String(result.action.renderedItemCountBefore ?? 'n/a')} -> ${String(result.action.renderedItemCountAfter ?? 'n/a')}`,
+          ],
+        ],
+        {
+          alignments: ['left', 'left'],
+          maxWidths: [22, 78],
+        }
+      )
+    );
+    console.log('');
+  }
   console.log(
     createTable(['Metric', 'Value'], summaryRows, {
       alignments: ['left', 'right'],
@@ -2967,6 +3440,36 @@ function createJsonAggregateSummary(
   };
 }
 
+function createActionOutputs(results: ProfileResult[]): ProfileActionOutput[] {
+  const outputs: ProfileActionOutput[] = [];
+  const outputById = new Map<string, ProfileActionOutput>();
+
+  for (const result of results) {
+    if (result.action == null) {
+      continue;
+    }
+
+    let output = outputById.get(result.action.id);
+    if (output == null) {
+      output = {
+        action: result.action,
+        runs: [],
+        summary: createJsonAggregateSummary([]),
+      };
+      outputById.set(result.action.id, output);
+      outputs.push(output);
+    }
+
+    output.runs.push(result);
+    output.action = result.action;
+  }
+
+  return outputs.map((output) => ({
+    ...output,
+    summary: createJsonAggregateSummary(output.runs),
+  }));
+}
+
 function printAggregateHumanSummary(
   summary: JsonAggregateSummary,
   measuredRuns: number
@@ -2993,6 +3496,72 @@ function printAggregateHumanSummary(
       }
     )
   );
+}
+
+function printActionProfilesHumanSummary(
+  actionProfiles: ProfileActionOutput[],
+  actionSummary: JsonAggregateSummary | null,
+  measuredRuns: number
+): void {
+  if (actionProfiles.length === 0) {
+    return;
+  }
+
+  console.log('Action Profile Summary');
+  console.log(
+    createTable(
+      [
+        'Action',
+        'Op',
+        'State',
+        'Input',
+        'Visibility',
+        'Depth',
+        'API med',
+        'Click med',
+        'Ready med',
+        'Paint med',
+        'CPU med',
+        'Runs',
+      ],
+      actionProfiles.map((profile) => [
+        profile.action.label,
+        profile.action.operation,
+        profile.action.initialExpansion,
+        profile.action.dispatch,
+        profile.action.targetVisibility,
+        String(profile.action.targetDepth),
+        formatMs(profile.summary.metrics.actionDurationMs.medianMs),
+        formatMs(profile.summary.metrics.clickDispatchMs.medianMs),
+        formatMs(profile.summary.metrics.visibleRowsReadyMs.medianMs),
+        formatMs(profile.summary.metrics.postPaintReadyMs.medianMs),
+        formatMs(profile.summary.metrics.sampledCpuTimeMs.medianMs),
+        `${profile.summary.measuredRuns}/${measuredRuns}`,
+      ]),
+      {
+        alignments: [
+          'left',
+          'left',
+          'left',
+          'left',
+          'left',
+          'right',
+          'right',
+          'right',
+          'right',
+          'right',
+          'right',
+          'right',
+        ],
+        maxWidths: [32, 8, 8, 9, 10, 7, 12, 12, 12, 12, 12, 8],
+      }
+    )
+  );
+
+  if (actionSummary != null) {
+    console.log('');
+    printAggregateHumanSummary(actionSummary, actionSummary.measuredRuns);
+  }
 }
 
 function formatSignedNumber(
@@ -3115,6 +3684,7 @@ function createLegacyConfigSummaryFromRuns(
   });
 
   return {
+    actionsMode: 'off',
     browserUrl: firstRun?.browserUrl ?? DEFAULT_BROWSER_URL,
     url: normalizeComparableUrl(firstRun?.url ?? DEFAULT_URL),
     workloads:
@@ -3124,6 +3694,7 @@ function createLegacyConfigSummaryFromRuns(
     warmupRuns: 0,
     instrumentationMode: inferInstrumentationModeFromUrl(firstRun?.url ?? ''),
     includeCallCounts,
+    profileRender: true,
     showDominantTraceEvents: false,
   };
 }
@@ -3152,7 +3723,16 @@ function normalizeProfileBenchmarkOutput(
   if (Array.isArray(rawValue.workloads)) {
     const workloads = (rawValue.workloads as ProfileWorkloadOutput[]).map(
       (workloadOutput) => {
+        const actionProfiles = workloadOutput.actionProfiles ?? [];
         return {
+          actionProfiles,
+          actionSummary:
+            workloadOutput.actionSummary ??
+            (actionProfiles.length === 0
+              ? null
+              : createJsonAggregateSummary(
+                  actionProfiles.flatMap((profile) => profile.runs)
+                )),
           workload: workloadOutput.workload,
           runs: workloadOutput.runs,
           summary: createJsonAggregateSummary(workloadOutput.runs),
@@ -3181,10 +3761,12 @@ function normalizeProfileBenchmarkOutput(
         ),
         runs: rawConfig.runs ?? workloads[0].runs.length,
         warmupRuns: rawConfig.warmupRuns ?? fallbackConfig.warmupRuns,
+        actionsMode: rawConfig.actionsMode ?? fallbackConfig.actionsMode,
         instrumentationMode:
           rawConfig.instrumentationMode ?? fallbackConfig.instrumentationMode,
         includeCallCounts:
           rawConfig.includeCallCounts ?? fallbackConfig.includeCallCounts,
+        profileRender: rawConfig.profileRender ?? fallbackConfig.profileRender,
         showDominantTraceEvents:
           rawConfig.showDominantTraceEvents ??
           fallbackConfig.showDominantTraceEvents,
@@ -3199,7 +3781,7 @@ function normalizeProfileBenchmarkOutput(
       throw new Error(`No benchmark runs found in ${sourcePath}.`);
     }
 
-    const workloadOutput = createWorkloadOutput(runs);
+    const workloadOutput = createWorkloadOutput(runs[0].workload, runs, []);
     return {
       benchmark: 'treesFileTreeProfile',
       config: createLegacyConfigSummaryFromRuns(runs),
@@ -3327,7 +3909,8 @@ function printWorkloadHumanSummary(
       'Expanded folders',
       formatCount(workloadOutput.workload.expandedFolderCount),
     ],
-    ['Measured runs', String(workloadOutput.runs.length)],
+    ['Render runs', String(workloadOutput.runs.length)],
+    ['Action scenarios', String(workloadOutput.actionProfiles.length)],
     ['Warmup runs', String(config.warmupRuns)],
   ];
 
@@ -3355,6 +3938,17 @@ function printWorkloadHumanSummary(
     printAggregateHumanSummary(
       workloadOutput.summary,
       workloadOutput.runs.length
+    );
+  }
+
+  if (workloadOutput.actionProfiles.length > 0) {
+    if (workloadOutput.runs.length > 0) {
+      console.log('');
+    }
+    printActionProfilesHumanSummary(
+      workloadOutput.actionProfiles,
+      workloadOutput.actionSummary,
+      config.runs
     );
   }
 }
@@ -3473,6 +4067,8 @@ function printRunsHumanSummary(output: ProfileBenchmarkOutput): void {
     ['Measured runs/workload', String(output.config.runs)],
     ['Warmup runs/workload', String(output.config.warmupRuns)],
     ['Instrumentation', output.config.instrumentationMode],
+    ['Render profile', output.config.profileRender ? 'on' : 'off'],
+    ['Action profiles', output.config.actionsMode],
     ['Call counts', output.config.includeCallCounts ? 'on' : 'off'],
     [
       'Dominant trace events',
@@ -3506,21 +4102,33 @@ async function runWorkloadProfile(
   workloadName: string
 ): Promise<ProfileWorkloadOutput> {
   const results: ProfileResult[] = [];
+  const actionResults: ProfileResult[] = [];
 
   for (
     let warmupRunNumber = 1;
     warmupRunNumber <= config.warmupRuns;
     warmupRunNumber += 1
   ) {
-    await profileFileTreeRender(
-      {
-        ...config,
-        includeCallCounts: false,
-      },
-      workloadName,
-      warmupRunNumber,
-      null
-    );
+    const warmupConfig = {
+      ...config,
+      includeCallCounts: false,
+    };
+    if (config.profileRender) {
+      await profileFileTreeRender(
+        warmupConfig,
+        workloadName,
+        warmupRunNumber,
+        null
+      );
+    }
+    if (config.actionsMode === 'expansion') {
+      await profileFileTreeExpansionActions(
+        warmupConfig,
+        workloadName,
+        warmupRunNumber,
+        null
+      );
+    }
   }
 
   for (let runNumber = 1; runNumber <= config.runs; runNumber += 1) {
@@ -3531,16 +4139,34 @@ async function runWorkloadProfile(
       runNumber,
       config.runs
     );
-    const result = await profileFileTreeRender(
-      config,
-      workloadName,
-      runNumber,
-      traceOutputPath
-    );
-    results.push(result);
+    if (config.profileRender) {
+      const result = await profileFileTreeRender(
+        config,
+        workloadName,
+        runNumber,
+        traceOutputPath
+      );
+      results.push(result);
+    }
+    if (config.actionsMode === 'expansion') {
+      actionResults.push(
+        ...(await profileFileTreeExpansionActions(
+          config,
+          workloadName,
+          runNumber,
+          traceOutputPath
+        ))
+      );
+    }
   }
 
-  return createWorkloadOutput(results);
+  const actionProfiles = createActionOutputs(actionResults);
+  const workload = results[0]?.workload ?? actionResults[0]?.workload;
+  if (workload == null) {
+    throw new Error(`No profile results were produced for ${workloadName}.`);
+  }
+
+  return createWorkloadOutput(workload, results, actionProfiles);
 }
 
 async function main(): Promise<void> {
@@ -3548,6 +4174,7 @@ async function main(): Promise<void> {
   let serverProcess: Bun.Subprocess | null = null;
 
   try {
+    await ensureChromeDebugPort(config);
     serverProcess = await startFixtureServerIfNeeded(config);
 
     const workloads: ProfileWorkloadOutput[] = [];
@@ -3578,7 +4205,9 @@ async function main(): Promise<void> {
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(
-      `${message}\n\nRun Chrome with remote debugging first, for example:\n/Applications/Google\\ Chrome\\ Dev.app/Contents/MacOS/Google\\ Chrome\\ Dev --remote-debugging-port=${DEFAULT_BROWSER_DEBUG_PORT} --user-data-dir=/tmp/chrome-devtools-codex`
+      `${message}\n\nThe profiler checks ${createBrowserVersionUrl(
+        config.browserUrl
+      )} before profiling and starts \`bun run chrome\` automatically when a local debug port is closed.`
     );
   } finally {
     serverProcess?.kill();

--- a/packages/trees/test/e2e/fixtures/file-tree-profile-main.ts
+++ b/packages/trees/test/e2e/fixtures/file-tree-profile-main.ts
@@ -3,10 +3,20 @@ import {
   createFileTreeProfileWorkloadSummary,
   DEFAULT_FILE_TREE_PROFILE_WORKLOAD_NAME,
   FILE_TREE_PROFILE_WORKLOAD_NAMES,
+  type FileTreeProfileActionDispatch,
+  type FileTreeProfileActionInitialExpansion,
+  type FileTreeProfileActionOperation,
+  type FileTreeProfileActionSetupOperation,
+  type FileTreeProfileActionSummary,
+  type FileTreeProfileActionTargetVisibility,
   type FileTreeProfilePageSummary,
+  type FileTreeProfileWorkload,
   getFileTreeProfileWorkload,
 } from '../../../scripts/lib/fileTreeProfileShared';
-import type { FileTree as FileTreeClass } from '../../../src/index';
+import type {
+  FileTree as FileTreeClass,
+  FileTreeDirectoryHandle,
+} from '../../../src/index';
 import { createBenchmarkInstrumentation } from './file-tree-profile-benchmarkInstrumentation';
 
 // @ts-expect-error -- the Vite fixture serves the built trees dist from the
@@ -27,14 +37,25 @@ declare global {
   interface Window {
     __treesFileTreeFixtureReady?: boolean;
     __treesFileTreeProfile?: FileTreeProfilePageSummary;
+    __treesFileTreeProfileError?: string;
     treesFileTreeProfile?: {
-      configureFixture: (config: { workloadName?: string }) => {
+      beginPreparedActionClickProfile: () => Promise<PreparedActionClickTarget>;
+      configureFixture: (config: { workloadName?: string }) => Promise<{
         workloadName: string;
-      };
-      getState: () => {
+      }>;
+      getState: () => Promise<{
+        actionScenarioCount: number | null;
         hasRenderedTree: boolean;
+        preparedActionId: string | null;
         workload: ReturnType<typeof createFileTreeProfileWorkloadSummary>;
-      };
+      }>;
+      listExpansionActionScenarios: () => Promise<
+        FileTreeProfileActionSummary[]
+      >;
+      prepareActionProfile: (
+        actionId: string
+      ) => Promise<FileTreeProfileActionSummary>;
+      profilePreparedAction: () => Promise<FileTreeProfilePageSummary>;
       profileRender: () => Promise<FileTreeProfilePageSummary>;
     };
   }
@@ -45,11 +66,45 @@ interface LongTaskEntry {
   startTime: number;
 }
 
+interface DirectoryCandidate {
+  depth: number;
+  hasDescendants: boolean;
+  isMounted: boolean;
+  path: string;
+}
+
+type ActionRowMode = 'flow' | 'sticky';
+type Benchmark = ReturnType<typeof createBenchmarkInstrumentation>;
+type HeapSnapshot = ReturnType<Benchmark['readHeapSnapshot']>;
+
+interface PreparedActionClickTarget {
+  x: number;
+  y: number;
+}
+
+interface PreparedActionContext {
+  item: FileTreeDirectoryHandle;
+  scenario: FileTreeProfileActionSummary;
+  targetWasExpandedBefore: boolean;
+}
+
+interface PreparedActionProfileState extends PreparedActionContext {
+  actionStartedAt: number;
+  benchmark: Benchmark | null;
+  heapBefore: HeapSnapshot;
+  renderedItemCountBefore: number;
+  updatePromise: Promise<void>;
+  workload: FileTreeProfileWorkload;
+}
+
 const START_MARK_NAME = 'trees-file-tree-profile-start';
 const END_MARK_NAME = 'trees-file-tree-profile-end';
 const MEASURE_NAME = 'trees-file-tree-profile-measure';
 const START_TRACE_LABEL = 'trees-file-tree-profile-start';
 const END_TRACE_LABEL = 'trees-file-tree-profile-end';
+const TREE_UPDATE_TIMEOUT_MS = 30_000;
+const AOSP_WORKLOAD_NAME = 'aosp';
+const AOSP_WORKLOAD_URL = '/trees-dev/aosp-files.json.gz';
 
 const searchParams = new URLSearchParams(window.location.search);
 const instrumentationEnabled = searchParams.get('instrumentation') !== '0';
@@ -88,6 +143,14 @@ if (workloadInput.value === '') {
 }
 
 let currentFileTree: FileTreeClass | null = null;
+let cachedExpansionActionScenarios: FileTreeProfileActionSummary[] | null =
+  null;
+let cachedExpansionActionWorkloadName: string | null = null;
+let preparedActionScenario: FileTreeProfileActionSummary | null = null;
+const workloadPromiseCache = new Map<
+  string,
+  Promise<FileTreeProfileWorkload>
+>();
 const longTaskEntries: LongTaskEntry[] = [];
 const longTaskObserver =
   typeof PerformanceObserver !== 'undefined' &&
@@ -104,14 +167,22 @@ const longTaskObserver =
 
 longTaskObserver?.observe({ type: 'longtask', buffered: true });
 
+function clearActionScenarioCache(): void {
+  cachedExpansionActionScenarios = null;
+  cachedExpansionActionWorkloadName = null;
+  preparedActionScenario = null;
+}
+
 function clearRenderedTree(): void {
   currentFileTree?.cleanUp();
   currentFileTree = null;
+  preparedActionScenario = null;
   mount.innerHTML = '';
 }
 
 function clearProfileSummary(): void {
   delete window.__treesFileTreeProfile;
+  delete window.__treesFileTreeProfileError;
   performance.clearMarks(START_MARK_NAME);
   performance.clearMarks(END_MARK_NAME);
   performance.clearMeasures(MEASURE_NAME);
@@ -123,8 +194,260 @@ function getSelectedWorkloadName(): string {
     : workloadInput.value;
 }
 
-function getSelectedWorkload() {
-  return getFileTreeProfileWorkload(getSelectedWorkloadName());
+function assertStringArray(value: unknown, label: string): string[] {
+  if (
+    !Array.isArray(value) ||
+    !value.every((item): item is string => typeof item === 'string')
+  ) {
+    throw new Error(
+      `Invalid AOSP profile workload: expected ${label} strings.`
+    );
+  }
+  return value;
+}
+
+function parseAospPayload(value: unknown): {
+  allExpandedPaths: string[];
+  paths: string[];
+} {
+  if (typeof value !== 'object' || value == null) {
+    throw new Error('Invalid AOSP profile workload: expected a JSON object.');
+  }
+
+  const payload = value as {
+    allExpandedPaths?: unknown;
+    paths?: unknown;
+  };
+  return {
+    allExpandedPaths: assertStringArray(
+      payload.allExpandedPaths,
+      'allExpandedPaths'
+    ),
+    paths: assertStringArray(payload.paths, 'paths'),
+  };
+}
+
+async function parseAospPayloadBytes(bytes: ArrayBuffer): Promise<{
+  allExpandedPaths: string[];
+  paths: string[];
+}> {
+  try {
+    return parseAospPayload(JSON.parse(new TextDecoder().decode(bytes)));
+  } catch (directParseError) {
+    if (typeof DecompressionStream === 'undefined') {
+      throw directParseError;
+    }
+
+    const decompressedBytes = await new Response(
+      new Blob([bytes]).stream().pipeThrough(new DecompressionStream('gzip'))
+    ).arrayBuffer();
+    return parseAospPayload(
+      JSON.parse(new TextDecoder().decode(decompressedBytes))
+    );
+  }
+}
+
+async function loadAospProfileWorkload(): Promise<FileTreeProfileWorkload> {
+  const response = await fetch(AOSP_WORKLOAD_URL);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to load AOSP profile workload from ${AOSP_WORKLOAD_URL}: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const { allExpandedPaths, paths } = await parseAospPayloadBytes(
+    await response.arrayBuffer()
+  );
+  return {
+    expandedFolders: allExpandedPaths,
+    files: paths,
+    label: 'AOSP fixture',
+    name: AOSP_WORKLOAD_NAME,
+  };
+}
+
+async function loadFileTreeProfileWorkload(
+  workloadName: string
+): Promise<FileTreeProfileWorkload> {
+  const cachedWorkload = workloadPromiseCache.get(workloadName);
+  if (cachedWorkload != null) {
+    return cachedWorkload;
+  }
+
+  const workloadPromise =
+    workloadName === AOSP_WORKLOAD_NAME
+      ? loadAospProfileWorkload()
+      : Promise.resolve(getFileTreeProfileWorkload(workloadName));
+  workloadPromiseCache.set(workloadName, workloadPromise);
+  return workloadPromise;
+}
+
+async function getSelectedWorkload(): Promise<FileTreeProfileWorkload> {
+  return await loadFileTreeProfileWorkload(getSelectedWorkloadName());
+}
+
+function getRenderedItemCount(): number {
+  return (
+    mount
+      .querySelector('file-tree-container')
+      ?.shadowRoot?.querySelectorAll('button[data-type="item"]').length ?? 0
+  );
+}
+
+function getProfileShadowRoot(): ShadowRoot {
+  const host = mount.querySelector('file-tree-container');
+  if (!(host instanceof HTMLElement) || host.shadowRoot == null) {
+    throw new Error('Cannot find the rendered file-tree shadow root.');
+  }
+
+  return host.shadowRoot;
+}
+
+function getVirtualizedScrollElement(): HTMLElement {
+  const scrollElement = getProfileShadowRoot().querySelector(
+    '[data-file-tree-virtualized-scroll="true"]'
+  );
+  if (!(scrollElement instanceof HTMLElement)) {
+    throw new Error('Cannot find the rendered file-tree scroll element.');
+  }
+
+  return scrollElement;
+}
+
+function getMountedFolderPaths(): Set<string> {
+  const rows =
+    mount
+      .querySelector('file-tree-container')
+      ?.shadowRoot?.querySelectorAll(
+        'button[data-type="item"][data-item-type="folder"]:not([data-file-tree-sticky-row="true"])'
+      ) ?? [];
+  return new Set(
+    Array.from(rows)
+      .map((row) => row.getAttribute('data-item-path') ?? '')
+      .filter((path) => path !== '')
+  );
+}
+
+function getPathDepth(path: string): number {
+  const segmentCount = path.split('/').filter(Boolean).length;
+  return Math.max(0, segmentCount - 1);
+}
+
+function getButtonPath(button: HTMLButtonElement, mode: ActionRowMode): string {
+  return mode === 'sticky'
+    ? (button.dataset.fileTreeStickyPath ?? button.dataset.itemPath ?? '')
+    : (button.dataset.itemPath ?? '');
+}
+
+function findFolderRowButton(
+  path: string,
+  mode: ActionRowMode
+): HTMLButtonElement | null {
+  const buttons = Array.from(
+    getProfileShadowRoot().querySelectorAll(
+      'button[data-type="item"][data-item-type="folder"]'
+    )
+  );
+  for (const button of buttons) {
+    if (!(button instanceof HTMLButtonElement)) {
+      continue;
+    }
+
+    const isSticky = button.dataset.fileTreeStickyRow === 'true';
+    if (mode === 'sticky' ? !isSticky : isSticky) {
+      continue;
+    }
+
+    if (getButtonPath(button, mode) === path) {
+      return button;
+    }
+  }
+
+  return null;
+}
+
+function getActionRowButton(
+  scenario: FileTreeProfileActionSummary
+): HTMLButtonElement {
+  const mode: ActionRowMode =
+    scenario.targetVisibility === 'sticky' ? 'sticky' : 'flow';
+  const matchingButton = findFolderRowButton(scenario.targetPath, mode);
+
+  if (!(matchingButton instanceof HTMLButtonElement)) {
+    throw new Error(
+      `Cannot click profile action ${scenario.id}; target row is not mounted: ${scenario.targetPath}.`
+    );
+  }
+
+  return matchingButton;
+}
+
+async function waitForFolderRowButton(
+  path: string,
+  mode: ActionRowMode
+): Promise<HTMLButtonElement> {
+  const startedAt = performance.now();
+
+  while (performance.now() - startedAt < TREE_UPDATE_TIMEOUT_MS) {
+    const button = findFolderRowButton(path, mode);
+    if (button != null) {
+      return button;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 16));
+  }
+
+  throw new Error(`Timed out waiting for ${mode} row ${path}.`);
+}
+
+async function prepareStickyActionTarget(path: string): Promise<void> {
+  if (currentFileTree == null) {
+    throw new Error('Cannot prepare a sticky action target before rendering.');
+  }
+
+  const item = getDirectoryHandle(path);
+  let flowButton = findFolderRowButton(path, 'flow');
+  if (flowButton == null && !item.isFocused()) {
+    const updatePromise = waitForNextTreeUpdate(currentFileTree);
+    item.focus();
+    await updatePromise;
+  }
+  await waitForPaint();
+
+  flowButton = await waitForFolderRowButton(path, 'flow');
+  const scrollElement = getVirtualizedScrollElement();
+  const rowRect = flowButton.getBoundingClientRect();
+  const scrollRect = scrollElement.getBoundingClientRect();
+  const rowHeight =
+    rowRect.height > 0 ? rowRect.height : currentFileTree.getItemHeight();
+  scrollElement.scrollTop += Math.max(
+    0,
+    rowRect.top - scrollRect.top + rowHeight
+  );
+  await waitForPaint();
+  await waitForFolderRowButton(path, 'sticky');
+}
+
+function getClickTarget(element: HTMLElement): PreparedActionClickTarget {
+  const rect = element.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0) {
+    throw new Error('Cannot click profile action target with an empty rect.');
+  }
+
+  return {
+    x: rect.left + rect.width / 2,
+    y: rect.top + rect.height / 2,
+  };
+}
+
+function getDirectoryHandle(path: string): FileTreeDirectoryHandle {
+  const item = currentFileTree?.getItem(path);
+  if (item == null || !item.isDirectory()) {
+    throw new Error(
+      `Expected profile action target to be a directory: ${path}`
+    );
+  }
+  return item as FileTreeDirectoryHandle;
 }
 
 async function waitForRenderedTree(): Promise<{
@@ -135,14 +458,12 @@ async function waitForRenderedTree(): Promise<{
 
   while (true) {
     const host = mount.querySelector('file-tree-container');
-    const renderedItemCount =
-      host?.shadowRoot?.querySelectorAll('button[data-type="item"]').length ??
-      0;
+    const renderedItemCount = getRenderedItemCount();
     if (host instanceof HTMLElement && renderedItemCount > 0) {
       return { host, renderedItemCount };
     }
 
-    if (performance.now() - startedAt > 30_000) {
+    if (performance.now() - startedAt > TREE_UPDATE_TIMEOUT_MS) {
       throw new Error('Timed out waiting for the file-tree to render.');
     }
 
@@ -150,9 +471,29 @@ async function waitForRenderedTree(): Promise<{
   }
 }
 
+async function waitForAnimationFrame(): Promise<void> {
+  await new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
 async function waitForPaint(): Promise<void> {
-  await new Promise((resolve) => requestAnimationFrame(resolve));
-  await new Promise((resolve) => requestAnimationFrame(resolve));
+  await waitForAnimationFrame();
+  await waitForAnimationFrame();
+}
+
+function waitForNextTreeUpdate(fileTree: FileTreeClass): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let unsubscribe: (() => void) | null = null;
+    const timeout = window.setTimeout(() => {
+      unsubscribe?.();
+      reject(new Error('Timed out waiting for the file-tree action update.'));
+    }, TREE_UPDATE_TIMEOUT_MS);
+
+    unsubscribe = fileTree.subscribe(() => {
+      window.clearTimeout(timeout);
+      unsubscribe?.();
+      resolve();
+    });
+  });
 }
 
 function formatMs(value: number): string {
@@ -169,71 +510,491 @@ function getTaskOverlapMs(
   return Math.max(0, overlapEnd - overlapStart);
 }
 
-async function profileRender(): Promise<FileTreeProfilePageSummary> {
-  renderButton.disabled = true;
-  renderButton.textContent = 'Rendering…';
+function summarizeLongTasks(
+  startTime: number,
+  endTime: number
+): {
+  longTaskCount: number;
+  longTaskTotalMs: number;
+  longestLongTaskMs: number;
+} {
+  const overlappingTasks = longTaskEntries
+    .map((entry) => ({
+      ...entry,
+      overlapMs: getTaskOverlapMs(entry, startTime, endTime),
+    }))
+    .filter((entry) => entry.overlapMs > 0);
+  return {
+    longTaskCount: overlappingTasks.length,
+    longTaskTotalMs: overlappingTasks.reduce((total, entry) => {
+      return total + entry.overlapMs;
+    }, 0),
+    longestLongTaskMs: overlappingTasks.reduce((longest, entry) => {
+      return Math.max(longest, entry.overlapMs);
+    }, 0),
+  };
+}
+
+function createBenchmark(): Benchmark | null {
+  return instrumentationEnabled ? createBenchmarkInstrumentation() : null;
+}
+
+function createProfileOptions(
+  initialExpansion: FileTreeProfileActionInitialExpansion,
+  benchmark: Benchmark | null,
+  workload: FileTreeProfileWorkload
+) {
+  const createOptions = () =>
+    createFileTreeProfileFixtureOptions(workload, { initialExpansion });
+  return benchmark == null
+    ? createOptions()
+    : benchmark.instrumentation.measurePhase(
+        'page.createOptions',
+        createOptions
+      );
+}
+
+function setWorkloadCounters(
+  benchmark: Benchmark | null,
+  workload: FileTreeProfileWorkload
+): void {
+  if (benchmark == null) {
+    return;
+  }
+
+  benchmark.instrumentation.setCounter(
+    'workload.inputFiles',
+    workload.files.length
+  );
+  benchmark.instrumentation.setCounter(
+    'workload.expandedFolders',
+    workload.expandedFolders.length
+  );
+}
+
+function createProfileFileTree(
+  initialExpansion: FileTreeProfileActionInitialExpansion,
+  benchmark: Benchmark | null,
+  workload: FileTreeProfileWorkload
+): FileTreeClass {
+  const options = createProfileOptions(initialExpansion, benchmark, workload);
+  setWorkloadCounters(benchmark, workload);
+
+  return benchmark == null
+    ? new FileTree({
+        ...options,
+        id: 'file-tree-profile',
+      })
+    : benchmark.instrumentation.measurePhase(
+        'page.createFileTree',
+        () =>
+          new FileTree({
+            ...options,
+            id: 'file-tree-profile',
+          })
+      );
+}
+
+async function renderProfileTree(
+  initialExpansion: FileTreeProfileActionInitialExpansion,
+  benchmark: Benchmark | null,
+  workload: FileTreeProfileWorkload
+): Promise<{
+  fileTree: FileTreeClass;
+  renderedItemCount: number;
+}> {
+  clearRenderedTree();
+  const fileTree = createProfileFileTree(initialExpansion, benchmark, workload);
+  currentFileTree = fileTree;
+
+  if (benchmark == null) {
+    fileTree.render({ containerWrapper: mount });
+  } else {
+    benchmark.instrumentation.measurePhase('page.renderTree', () => {
+      fileTree.render({ containerWrapper: mount });
+    });
+  }
+
+  const { renderedItemCount } =
+    benchmark == null
+      ? await waitForRenderedTree()
+      : await benchmark.instrumentation.measurePhase(
+          'page.waitForRenderReady',
+          () => waitForRenderedTree()
+        );
+  return { fileTree, renderedItemCount };
+}
+
+// Computes which directories have visible descendants without repeatedly
+// scanning the full workload for each action candidate.
+function collectDirectoryPathsWithDescendants(
+  workload: FileTreeProfileWorkload
+): Set<string> {
+  const directoryPaths = new Set(workload.expandedFolders);
+  const pathsWithDescendants = new Set<string>();
+
+  for (const filePath of workload.files) {
+    let slashIndex = filePath.indexOf('/');
+    while (slashIndex > 0) {
+      const directoryPath = filePath.slice(0, slashIndex);
+      if (directoryPaths.has(directoryPath)) {
+        pathsWithDescendants.add(directoryPath);
+      }
+      slashIndex = filePath.indexOf('/', slashIndex + 1);
+    }
+  }
+
+  return pathsWithDescendants;
+}
+
+function collectDirectoryCandidates(
+  fileTree: FileTreeClass,
+  mountedPaths: Set<string>,
+  workload: FileTreeProfileWorkload
+): DirectoryCandidate[] {
+  const seenPaths = new Set<string>();
+  const candidates: DirectoryCandidate[] = [];
+  const pathsWithDescendants = collectDirectoryPathsWithDescendants(workload);
+  for (const path of workload.expandedFolders) {
+    const item = fileTree.getItem(path);
+    if (item == null || !item.isDirectory()) {
+      continue;
+    }
+
+    const canonicalPath = item.getPath();
+    if (seenPaths.has(canonicalPath)) {
+      continue;
+    }
+
+    seenPaths.add(canonicalPath);
+    candidates.push({
+      depth: getPathDepth(canonicalPath),
+      hasDescendants:
+        pathsWithDescendants.has(canonicalPath) ||
+        pathsWithDescendants.has(path),
+      isMounted: mountedPaths.has(canonicalPath),
+      path: canonicalPath,
+    });
+  }
+  return candidates;
+}
+
+function selectCandidate(
+  candidates: readonly DirectoryCandidate[],
+  usedPaths: Set<string>,
+  predicate: (candidate: DirectoryCandidate) => boolean,
+  pick: 'first' | 'last' | 'middle'
+): DirectoryCandidate | null {
+  const matches = candidates.filter((candidate) => {
+    return !usedPaths.has(candidate.path) && predicate(candidate);
+  });
+  if (matches.length === 0) {
+    return null;
+  }
+
+  if (pick === 'last') {
+    return matches[matches.length - 1] ?? null;
+  }
+  if (pick === 'middle') {
+    return matches[Math.floor(matches.length / 2)] ?? null;
+  }
+  return matches[0] ?? null;
+}
+
+function createActionScenario({
+  dispatch,
+  id,
+  initialExpansion,
+  label,
+  operation,
+  setupOperations = [],
+  target,
+  targetVisibility,
+}: {
+  dispatch?: FileTreeProfileActionDispatch;
+  id: string;
+  initialExpansion: FileTreeProfileActionInitialExpansion;
+  label: string;
+  operation: FileTreeProfileActionOperation;
+  setupOperations?: FileTreeProfileActionSetupOperation[];
+  target: DirectoryCandidate;
+  targetVisibility: FileTreeProfileActionTargetVisibility;
+}): FileTreeProfileActionSummary {
+  return {
+    dispatch:
+      dispatch ??
+      (targetVisibility === 'visible' || targetVisibility === 'sticky'
+        ? 'dom-click'
+        : 'api'),
+    id,
+    initialExpansion,
+    label,
+    operation,
+    setupOperations,
+    targetDepth: target.depth,
+    targetPath: target.path,
+    targetVisibility,
+  };
+}
+
+async function buildExpansionActionScenarios(): Promise<
+  FileTreeProfileActionSummary[]
+> {
+  const workload = await getSelectedWorkload();
+  const scenarios: FileTreeProfileActionSummary[] = [];
+  const usedOpenPaths = new Set<string>();
+
+  const { fileTree: openTree } = await renderProfileTree(
+    'open',
+    null,
+    workload
+  );
+  await waitForPaint();
+  const openMountedPaths = getMountedFolderPaths();
+  const openCandidates = collectDirectoryCandidates(
+    openTree,
+    openMountedPaths,
+    workload
+  );
+  const openTargets = [
+    {
+      id: 'open-visible-shallow',
+      label: 'Open visible shallow',
+      pick: 'first' as const,
+      predicate: (candidate: DirectoryCandidate) =>
+        candidate.isMounted && candidate.depth <= 1,
+      visibility: 'visible' as const,
+    },
+    {
+      id: 'open-visible-deep',
+      label: 'Open visible deep',
+      pick: 'last' as const,
+      predicate: (candidate: DirectoryCandidate) =>
+        candidate.isMounted && candidate.depth >= 2,
+      visibility: 'visible' as const,
+    },
+    {
+      id: 'open-sticky-shallow',
+      label: 'Open sticky shallow',
+      pick: 'first' as const,
+      predicate: (candidate: DirectoryCandidate) =>
+        candidate.isMounted && candidate.hasDescendants && candidate.depth <= 1,
+      visibility: 'sticky' as const,
+    },
+    {
+      id: 'open-sticky-deep',
+      label: 'Open sticky deep',
+      pick: 'last' as const,
+      predicate: (candidate: DirectoryCandidate) =>
+        candidate.isMounted && candidate.hasDescendants && candidate.depth >= 2,
+      visibility: 'sticky' as const,
+    },
+    {
+      id: 'open-offscreen-mid',
+      label: 'Open offscreen mid-depth',
+      pick: 'middle' as const,
+      predicate: (candidate: DirectoryCandidate) =>
+        !candidate.isMounted && candidate.depth >= 1 && candidate.depth <= 3,
+      visibility: 'offscreen' as const,
+    },
+    {
+      id: 'open-offscreen-deep',
+      label: 'Open offscreen deep',
+      pick: 'last' as const,
+      predicate: (candidate: DirectoryCandidate) =>
+        !candidate.isMounted && candidate.depth >= 4,
+      visibility: 'offscreen' as const,
+    },
+  ];
+
+  for (const targetConfig of openTargets) {
+    const target = selectCandidate(
+      openCandidates,
+      usedOpenPaths,
+      targetConfig.predicate,
+      targetConfig.pick
+    );
+    if (target == null) {
+      continue;
+    }
+
+    usedOpenPaths.add(target.path);
+    scenarios.push(
+      createActionScenario({
+        id: `${targetConfig.id}-collapse`,
+        initialExpansion: 'open',
+        label: `${targetConfig.label} collapse`,
+        operation: 'collapse',
+        target,
+        targetVisibility: targetConfig.visibility,
+      })
+    );
+    if (targetConfig.visibility !== 'sticky') {
+      scenarios.push(
+        createActionScenario({
+          id: `${targetConfig.id}-expand`,
+          initialExpansion: 'open',
+          label: `${targetConfig.label} expand`,
+          operation: 'expand',
+          setupOperations: [{ operation: 'collapse', path: target.path }],
+          target,
+          targetVisibility: targetConfig.visibility,
+        })
+      );
+    }
+  }
+
+  const { fileTree: closedTree } = await renderProfileTree(
+    'closed',
+    null,
+    workload
+  );
+  await waitForPaint();
+  const closedMountedPaths = getMountedFolderPaths();
+  const closedCandidates = collectDirectoryCandidates(
+    closedTree,
+    closedMountedPaths,
+    workload
+  );
+  const usedClosedPaths = new Set<string>();
+  const closedVisibleTop = selectCandidate(
+    closedCandidates,
+    usedClosedPaths,
+    (candidate) => candidate.isMounted && candidate.depth === 0,
+    'first'
+  );
+  if (closedVisibleTop != null) {
+    usedClosedPaths.add(closedVisibleTop.path);
+    scenarios.push(
+      createActionScenario({
+        id: 'closed-visible-top-expand',
+        initialExpansion: 'closed',
+        label: 'Closed visible top-level expand',
+        operation: 'expand',
+        target: closedVisibleTop,
+        targetVisibility: 'visible',
+      })
+    );
+  }
+
+  const closedHiddenDeep =
+    selectCandidate(
+      closedCandidates,
+      usedClosedPaths,
+      (candidate) => !candidate.isMounted && candidate.depth >= 4,
+      'last'
+    ) ??
+    selectCandidate(
+      closedCandidates,
+      usedClosedPaths,
+      (candidate) => !candidate.isMounted && candidate.depth >= 2,
+      'last'
+    );
+  if (closedHiddenDeep != null) {
+    scenarios.push(
+      createActionScenario({
+        id: 'closed-hidden-deep-expand',
+        initialExpansion: 'closed',
+        label: 'Closed hidden deep expand',
+        operation: 'expand',
+        target: closedHiddenDeep,
+        targetVisibility: 'hidden',
+      })
+    );
+  }
+
+  clearRenderedTree();
+  renderButton.textContent = 'Render';
+  return scenarios;
+}
+
+async function listExpansionActionScenarios(): Promise<
+  FileTreeProfileActionSummary[]
+> {
+  const workloadName = getSelectedWorkloadName();
+  if (
+    cachedExpansionActionScenarios != null &&
+    cachedExpansionActionWorkloadName === workloadName
+  ) {
+    return cachedExpansionActionScenarios;
+  }
 
   clearProfileSummary();
-  clearRenderedTree();
+  cachedExpansionActionScenarios = await buildExpansionActionScenarios();
+  cachedExpansionActionWorkloadName = workloadName;
+  return cachedExpansionActionScenarios;
+}
 
-  const benchmark = instrumentationEnabled
-    ? createBenchmarkInstrumentation()
-    : null;
+async function applySetupOperation(
+  operation: FileTreeProfileActionSetupOperation
+): Promise<void> {
+  if (currentFileTree == null) {
+    throw new Error('Cannot apply an action setup before rendering the tree.');
+  }
+
+  const item = getDirectoryHandle(operation.path);
+  const shouldBeExpanded = operation.operation === 'expand';
+  if (item.isExpanded() === shouldBeExpanded) {
+    return;
+  }
+
+  const updatePromise = waitForNextTreeUpdate(currentFileTree);
+  if (shouldBeExpanded) {
+    item.expand();
+  } else {
+    item.collapse();
+  }
+  await updatePromise;
+  await waitForPaint();
+}
+
+async function prepareActionProfile(
+  actionId: string
+): Promise<FileTreeProfileActionSummary> {
+  const scenarios = await listExpansionActionScenarios();
+  const scenario = scenarios.find((candidate) => candidate.id === actionId);
+  if (scenario == null) {
+    throw new Error(`Unknown file-tree profile action scenario: ${actionId}`);
+  }
+
+  clearProfileSummary();
+  await renderProfileTree(
+    scenario.initialExpansion,
+    null,
+    await getSelectedWorkload()
+  );
+  await waitForPaint();
+  for (const operation of scenario.setupOperations) {
+    await applySetupOperation(operation);
+  }
+  if (scenario.targetVisibility === 'sticky') {
+    await prepareStickyActionTarget(scenario.targetPath);
+  }
+
+  preparedActionScenario = scenario;
+  return scenario;
+}
+
+async function profileRender(): Promise<FileTreeProfilePageSummary> {
+  renderButton.disabled = true;
+  renderButton.textContent = 'Rendering...';
+
+  clearProfileSummary();
+  const benchmark = createBenchmark();
   benchmark?.reset();
+  const workload = await getSelectedWorkload();
 
-  const workload = getSelectedWorkload();
   const renderStartedAt = performance.now();
   const heapBefore = benchmark?.readHeapSnapshot() ?? null;
   performance.mark(START_MARK_NAME);
   console.timeStamp(START_TRACE_LABEL);
 
   try {
-    const options =
-      benchmark == null
-        ? createFileTreeProfileFixtureOptions(workload)
-        : benchmark.instrumentation.measurePhase('page.createOptions', () =>
-            createFileTreeProfileFixtureOptions(workload)
-          );
-    benchmark?.instrumentation.setCounter(
-      'workload.inputFiles',
-      workload.files.length
+    const { renderedItemCount } = await renderProfileTree(
+      'open',
+      benchmark,
+      workload
     );
-    benchmark?.instrumentation.setCounter(
-      'workload.expandedFolders',
-      workload.expandedFolders.length
-    );
-
-    const fileTree =
-      benchmark == null
-        ? new FileTree({
-            ...options,
-            id: 'file-tree-profile',
-          })
-        : benchmark.instrumentation.measurePhase(
-            'page.createFileTree',
-            () =>
-              new FileTree({
-                ...options,
-                id: 'file-tree-profile',
-              })
-          );
-    currentFileTree = fileTree;
-
-    if (benchmark == null) {
-      fileTree.render({ containerWrapper: mount });
-    } else {
-      benchmark.instrumentation.measurePhase('page.renderTree', () => {
-        fileTree.render({ containerWrapper: mount });
-      });
-    }
-
-    const { renderedItemCount } =
-      benchmark == null
-        ? await waitForRenderedTree()
-        : await benchmark.instrumentation.measurePhase(
-            'page.waitForRenderReady',
-            () => waitForRenderedTree()
-          );
     const visibleRowsReadyAt = performance.now();
     await waitForPaint();
     const heapAfter = benchmark?.readHeapSnapshot() ?? null;
@@ -244,19 +1005,8 @@ async function profileRender(): Promise<FileTreeProfilePageSummary> {
 
     const measure = performance.getEntriesByName(MEASURE_NAME).at(-1);
     const renderEndedAt = performance.now();
-    const renderLongTasks = longTaskEntries
-      .map((entry) => ({
-        ...entry,
-        overlapMs: getTaskOverlapMs(entry, renderStartedAt, renderEndedAt),
-      }))
-      .filter((entry) => entry.overlapMs > 0);
-    const longTaskCount = renderLongTasks.length;
-    const longTaskTotalMs = renderLongTasks.reduce((total, entry) => {
-      return total + entry.overlapMs;
-    }, 0);
-    const longestLongTaskMs = renderLongTasks.reduce((longest, entry) => {
-      return Math.max(longest, entry.overlapMs);
-    }, 0);
+    const { longTaskCount, longTaskTotalMs, longestLongTaskMs } =
+      summarizeLongTasks(renderStartedAt, renderEndedAt);
     const instrumentation = benchmark?.summarize(heapBefore, heapAfter) ?? {
       phases: [],
       counters: {},
@@ -269,6 +1019,7 @@ async function profileRender(): Promise<FileTreeProfilePageSummary> {
       longTaskCount,
       longTaskTotalMs,
       longestLongTaskMs,
+      profileKind: 'render',
       renderDurationMs: measure?.duration ?? 0,
       renderedItemCount,
       resultText: `Post-paint ready ${formatMs(
@@ -294,13 +1045,232 @@ async function profileRender(): Promise<FileTreeProfilePageSummary> {
   }
 }
 
-function configureFixture(config: { workloadName?: string }): {
+function getPreparedActionContext(): PreparedActionContext {
+  if (currentFileTree == null || preparedActionScenario == null) {
+    throw new Error(
+      'Call prepareActionProfile(actionId) before profiling a prepared action.'
+    );
+  }
+
+  const scenario = preparedActionScenario;
+  const item = getDirectoryHandle(scenario.targetPath);
+  const targetWasExpandedBefore = item.isExpanded();
+  if (
+    (scenario.operation === 'expand' && targetWasExpandedBefore) ||
+    (scenario.operation === 'collapse' && !targetWasExpandedBefore)
+  ) {
+    throw new Error(
+      `Profile action ${scenario.id} would be a no-op for ${scenario.targetPath}.`
+    );
+  }
+
+  return {
+    item,
+    scenario,
+    targetWasExpandedBefore,
+  };
+}
+
+async function startPreparedActionProfile(
+  context: PreparedActionContext
+): Promise<PreparedActionProfileState> {
+  const fileTree = currentFileTree;
+  if (fileTree == null) {
+    throw new Error('Cannot profile an action before rendering the tree.');
+  }
+
+  clearProfileSummary();
+  const benchmark = createBenchmark();
+  benchmark?.reset();
+  const workload = await getSelectedWorkload();
+  setWorkloadCounters(benchmark, workload);
+
+  const renderedItemCountBefore = getRenderedItemCount();
+  const actionStartedAt = performance.now();
+  const heapBefore = benchmark?.readHeapSnapshot() ?? null;
+  performance.mark(START_MARK_NAME);
+  console.timeStamp(START_TRACE_LABEL);
+
+  const updatePromise = waitForNextTreeUpdate(fileTree);
+
+  return {
+    ...context,
+    actionStartedAt,
+    benchmark,
+    heapBefore,
+    renderedItemCountBefore,
+    updatePromise,
+    workload,
+  };
+}
+
+async function finishPreparedActionProfile(
+  state: PreparedActionProfileState,
+  getActionDurationMs: () => number | null
+): Promise<FileTreeProfilePageSummary> {
+  const {
+    actionStartedAt,
+    benchmark,
+    heapBefore,
+    item,
+    renderedItemCountBefore,
+    scenario,
+    targetWasExpandedBefore,
+    updatePromise,
+    workload,
+  } = state;
+
+  if (benchmark == null) {
+    await updatePromise;
+  } else {
+    await benchmark.instrumentation.measurePhase(
+      'action.waitForTreeUpdate',
+      () => updatePromise
+    );
+  }
+
+  if (benchmark == null) {
+    await waitForAnimationFrame();
+  } else {
+    await benchmark.instrumentation.measurePhase(
+      'action.waitForVisibleRows',
+      () => waitForAnimationFrame()
+    );
+  }
+  const visibleRowsReadyAt = performance.now();
+  const { renderedItemCount } = await waitForRenderedTree();
+
+  if (benchmark == null) {
+    await waitForAnimationFrame();
+  } else {
+    await benchmark.instrumentation.measurePhase('action.waitForPaint', () =>
+      waitForAnimationFrame()
+    );
+  }
+  const heapAfter = benchmark?.readHeapSnapshot() ?? null;
+
+  performance.mark(END_MARK_NAME);
+  console.timeStamp(END_TRACE_LABEL);
+  performance.measure(MEASURE_NAME, START_MARK_NAME, END_MARK_NAME);
+
+  const rawActionDurationMs = getActionDurationMs();
+  const actionDurationMs =
+    rawActionDurationMs == null ? null : Math.max(0, rawActionDurationMs);
+  const targetIsExpandedAfter = item.isExpanded();
+  const measure = performance.getEntriesByName(MEASURE_NAME).at(-1);
+  const actionEndedAt = performance.now();
+  const { longTaskCount, longTaskTotalMs, longestLongTaskMs } =
+    summarizeLongTasks(actionStartedAt, actionEndedAt);
+  const instrumentation = benchmark?.summarize(heapBefore, heapAfter) ?? {
+    phases: [],
+    counters: {},
+    heap: null,
+  };
+  instrumentation.counters['workload.renderedRows'] = renderedItemCount;
+  instrumentation.counters['workload.renderedRowsBefore'] =
+    renderedItemCountBefore;
+  instrumentation.counters['workload.actionTargetDepth'] = scenario.targetDepth;
+  if (actionDurationMs != null) {
+    instrumentation.counters['workload.actionDurationMs'] = actionDurationMs;
+  }
+
+  const action: FileTreeProfileActionSummary = {
+    ...scenario,
+    renderedItemCountAfter: renderedItemCount,
+    renderedItemCountBefore,
+    targetIsExpandedAfter,
+    targetWasExpandedBefore,
+  };
+  const summary: FileTreeProfilePageSummary = {
+    action,
+    instrumentation,
+    longTaskCount,
+    longTaskTotalMs,
+    longestLongTaskMs,
+    profileKind: 'action',
+    renderDurationMs: measure?.duration ?? 0,
+    renderedItemCount,
+    resultText: `${action.label}: ${action.operation} ${action.targetPath}. Input ${action.dispatch}. API action dispatch ${
+      actionDurationMs == null ? 'n/a' : formatMs(actionDurationMs)
+    }. Post-paint ready ${formatMs(
+      measure?.duration ?? 0
+    )}. Visible rows ready ${formatMs(
+      visibleRowsReadyAt - actionStartedAt
+    )}. Rendered rows ${renderedItemCountBefore} -> ${renderedItemCount}. Long tasks ${longTaskCount}; total ${formatMs(
+      longTaskTotalMs
+    )}; longest ${formatMs(longestLongTaskMs)}.`,
+    visibleRowsReadyMs: visibleRowsReadyAt - actionStartedAt,
+    workload: createFileTreeProfileWorkloadSummary(workload),
+    ...(actionDurationMs == null ? {} : { actionDurationMs }),
+  };
+
+  window.__treesFileTreeProfile = summary;
+  console.info('[trees file-tree profile]', summary.resultText);
+  return summary;
+}
+
+async function profilePreparedAction(): Promise<FileTreeProfilePageSummary> {
+  const context = getPreparedActionContext();
+  if (context.scenario.dispatch !== 'api') {
+    throw new Error(
+      `Profile action ${context.scenario.id} is configured for DOM click dispatch.`
+    );
+  }
+
+  const state = await startPreparedActionProfile(context);
+  const { benchmark, item, scenario } = state;
+  const dispatchStartedAt = performance.now();
+  if (benchmark == null) {
+    if (scenario.operation === 'expand') {
+      item.expand();
+    } else {
+      item.collapse();
+    }
+  } else {
+    benchmark.instrumentation.measurePhase('action.dispatch', () => {
+      if (scenario.operation === 'expand') {
+        item.expand();
+      } else {
+        item.collapse();
+      }
+    });
+  }
+  const actionDurationMs = performance.now() - dispatchStartedAt;
+
+  return await finishPreparedActionProfile(state, () => actionDurationMs);
+}
+
+async function beginPreparedActionClickProfile(): Promise<PreparedActionClickTarget> {
+  const context = getPreparedActionContext();
+  if (context.scenario.dispatch !== 'dom-click') {
+    throw new Error(
+      `Profile action ${context.scenario.id} is configured for direct API dispatch.`
+    );
+  }
+
+  const targetButton = getActionRowButton(context.scenario);
+  const target = getClickTarget(targetButton);
+  const state = await startPreparedActionProfile(context);
+
+  void finishPreparedActionProfile(state, () => null).catch(
+    (error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      window.__treesFileTreeProfileError = message;
+      console.error('[trees file-tree profile] action click failed', error);
+    }
+  );
+
+  return target;
+}
+
+async function configureFixture(config: { workloadName?: string }): Promise<{
   workloadName: string;
-} {
+}> {
   const requestedWorkloadName =
     config.workloadName ?? getSelectedWorkloadName();
-  const workload = getFileTreeProfileWorkload(requestedWorkloadName);
+  const workload = await loadFileTreeProfileWorkload(requestedWorkloadName);
   workloadInput.value = workload.name;
+  clearActionScenarioCache();
   clearRenderedTree();
   clearProfileSummary();
   renderButton.textContent = 'Render';
@@ -309,10 +1279,13 @@ function configureFixture(config: { workloadName?: string }): {
   };
 }
 
-function getState() {
+async function getState() {
+  const workload = await getSelectedWorkload();
   return {
+    actionScenarioCount: cachedExpansionActionScenarios?.length ?? null,
     hasRenderedTree: currentFileTree != null,
-    workload: createFileTreeProfileWorkloadSummary(getSelectedWorkload()),
+    preparedActionId: preparedActionScenario?.id ?? null,
+    workload: createFileTreeProfileWorkloadSummary(workload),
   };
 }
 
@@ -321,14 +1294,19 @@ renderButton.addEventListener('click', () => {
 });
 
 workloadInput.addEventListener('input', () => {
+  clearActionScenarioCache();
   clearRenderedTree();
   clearProfileSummary();
   renderButton.textContent = 'Render';
 });
 
 window.treesFileTreeProfile = {
+  beginPreparedActionClickProfile,
   configureFixture,
   getState,
+  listExpansionActionScenarios,
+  prepareActionProfile,
+  profilePreparedAction,
   profileRender,
 };
 window.__treesFileTreeFixtureReady = true;

--- a/packages/trees/test/e2e/vite.config.ts
+++ b/packages/trees/test/e2e/vite.config.ts
@@ -6,6 +6,14 @@ const portFromEnv = Number(process.env.FILE_TREE_E2E_PORT);
 const port = Number.isFinite(portFromEnv) ? portFromEnv : defaultPort;
 
 export default defineConfig({
+  publicDir: resolve(
+    import.meta.dirname,
+    '..',
+    '..',
+    '..',
+    '..',
+    'apps/docs/public'
+  ),
   root: resolve(import.meta.dirname, '..', '..'),
   server: {
     host: '127.0.0.1',

--- a/packages/trees/test/file-tree-profile-cli.test.ts
+++ b/packages/trees/test/file-tree-profile-cli.test.ts
@@ -32,6 +32,9 @@ test('profile:file-tree CLI help advertises the expected workload/render workflo
   expect(stdout).toContain('bun ws trees profile:file-tree');
   expect(stdout).toContain('linux-5x');
   expect(stdout).toContain('file-tree-profile.html');
+  expect(stdout).toContain('starts `bun run chrome` automatically');
+  expect(stdout).toContain('--actions <mode>');
+  expect(stdout).toContain('--actions-only');
 });
 
 test('profile:file-tree CLI help reflects worktree-aware default ports', () => {
@@ -78,4 +81,27 @@ test('profile:file-tree CLI rejects unknown workloads before browser setup', () 
   expect(result.exitCode).not.toBe(0);
   expect(stdout).toBe('');
   expect(stderr).toContain("Invalid --workload value 'not-a-real-workload'");
+});
+
+test('profile:file-tree CLI rejects unknown action modes before browser setup', () => {
+  const result = Bun.spawnSync({
+    cmd: [
+      'bun',
+      'run',
+      './scripts/profileFileTree.ts',
+      '--actions',
+      'not-a-real-mode',
+    ],
+    cwd: packageRoot,
+    env: createCommandEnv(),
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  const stdout = new TextDecoder().decode(result.stdout).trim();
+  const stderr = new TextDecoder().decode(result.stderr);
+
+  expect(result.exitCode).not.toBe(0);
+  expect(stdout).toBe('');
+  expect(stderr).toContain("Invalid --actions value 'not-a-real-mode'");
 });

--- a/packages/trees/test/file-tree-profile-fixture.test.ts
+++ b/packages/trees/test/file-tree-profile-fixture.test.ts
@@ -19,6 +19,7 @@ test('file-tree profile fixture workload defaults mirror the intended tree profi
     'linux-5x',
     'linux-10x',
     'linux',
+    'aosp',
     'demo-small',
   ]);
   expect(DEFAULT_FILE_TREE_PROFILE_WORKLOAD_NAME).toBe('linux-5x');
@@ -35,6 +36,21 @@ test('file-tree profile fixture options mirror the Phase 4 docs tree behavior', 
   expect(options.initialVisibleRowCount).toBe(
     FILE_TREE_PROFILE_VIEWPORT_HEIGHT / 30
   );
+  expect(options.stickyFolders).toBe(true);
+  expect(options.preparedInput).toEqual(
+    preparePresortedFileTreeInput(workload.files)
+  );
+});
+
+test('file-tree profile fixture options can start from a collapsed action state', () => {
+  const workload = getFileTreeProfileWorkload('linux-5x');
+  const options = createFileTreeProfileFixtureOptions(workload, {
+    initialExpansion: 'closed',
+  });
+
+  expect(options.flattenEmptyDirectories).toBe(true);
+  expect(options.initialExpansion).toBe('closed');
+  expect(options.stickyFolders).toBe(true);
   expect(options.preparedInput).toEqual(
     preparePresortedFileTreeInput(workload.files)
   );


### PR DESCRIPTION
Adds the browser profiling preset and AOSP action workload used to measure real DOM-click expand/collapse latency on a large tree. This includes fixture support, CLI JSON/profile output, tests, and demo/docs import updates required by the profiling setup.

Experiments: #2
Metric: open_visible_shallow_collapse_dom_click_paint_ms baseline established at 607 ms.

