### PR TITLE
[trees] Optimize mounted file-tree row click actions

### DIFF
--- a/packages/trees/src/model/FileTreeController.ts
+++ b/packages/trees/src/model/FileTreeController.ts
@@ -648,6 +648,20 @@ export class FileTreeController
     }
   }
 
+  // DOM row clicks already know the target row is mounted, so they can focus it
+  // by path without materializing every visible row in large open trees.
+  public focusMountedPathFromInput(path: string): void {
+    const resolvedPath = this.#store.getPathInfo(path)?.path ?? null;
+    if (resolvedPath == null) {
+      return;
+    }
+
+    const nextFocusedIndex = this.#resolveFocusedIndex(resolvedPath);
+    if (nextFocusedIndex >= 0) {
+      this.#setFocusedIndex(nextFocusedIndex);
+    }
+  }
+
   public focusNearestPath(path: string | null): string | null {
     const nextPath = this.resolveNearestVisiblePath(path);
     if (nextPath == null) {
@@ -886,6 +900,21 @@ export class FileTreeController
       : this.#getOrCreateItemHandle(itemInfo.path, itemInfo);
   }
 
+  // Mounted directory rows already carry their expanded state, so click
+  // handling can skip the extra isExpanded() lookup that the public handle
+  // toggle performs before applying the same store mutation.
+  public toggleMountedDirectoryFromInput(
+    path: string,
+    isExpanded: boolean
+  ): void {
+    if (isExpanded) {
+      this.#collapseDirectory(path);
+      return;
+    }
+
+    this.#store.expand(path);
+  }
+
   public selectAllVisiblePaths(): void {
     this.#ensureFullProjection();
     const nextSelectedPaths = [...this.#getCurrentVisiblePaths()];
@@ -902,6 +931,12 @@ export class FileTreeController
     }
 
     this.#applySelection([resolvedPath], resolvedPath);
+  }
+
+  // Mounted rows already provide canonical public paths, so regular row clicks
+  // can update selection without re-normalizing the same path through the store.
+  public selectOnlyMountedPathFromInput(path: string): void {
+    this.#applySelection([path], path);
   }
 
   public selectPath(path: string): void {
@@ -1897,14 +1932,21 @@ export class FileTreeController
   }
 
   #syncSearchVisibilityState(): void {
+    if (this.#searchValue == null || this.#searchValue.length === 0) {
+      this.#searchMatchingPaths = [];
+      this.#searchVisibleIndices = null;
+      this.#searchVisiblePaths = null;
+      this.#searchVisibleIndexByPath = null;
+      this.#visibleCount = this.#storeVisibleCount;
+      return;
+    }
+
     const currentVisiblePaths = this.#projectionPaths;
     this.#searchMatchingPaths = currentVisiblePaths.filter((path) =>
       this.#searchMatchPathSet.has(path)
     );
 
     if (
-      this.#searchValue == null ||
-      this.#searchValue.length === 0 ||
       this.#searchMode !== 'hide-non-matches' ||
       this.#searchMatchPathSet.size === 0
     ) {

--- a/packages/trees/src/model/FileTreeController.ts
+++ b/packages/trees/src/model/FileTreeController.ts
@@ -902,9 +902,22 @@ export class FileTreeController
 
   // Only use this for paths sourced from currently mounted directory rows. The
   // mounted-row invariant lets click handling skip public handle creation while
-  // preserving normal toggle semantics against the store's live expansion state.
+  // still revalidating stale DOM events against the live store.
+  public resolveMountedDirectoryPathFromInput(path: string): string | null {
+    const pathInfo = this.#store.getPathInfo(path);
+    return pathInfo?.kind === 'directory' ? pathInfo.path : null;
+  }
+
+  // Only use this for paths sourced from currently mounted directory rows. The
+  // live-path check prevents stale DOM events from throwing if the row was
+  // removed or became a file before the click handler ran.
   public toggleMountedDirectoryFromInput(path: string): void {
-    this.#toggleDirectory(path);
+    const directoryPath = this.resolveMountedDirectoryPathFromInput(path);
+    if (directoryPath == null) {
+      return;
+    }
+
+    this.#toggleDirectory(directoryPath);
   }
 
   public selectAllVisiblePaths(): void {

--- a/packages/trees/src/model/FileTreeController.ts
+++ b/packages/trees/src/model/FileTreeController.ts
@@ -648,7 +648,7 @@ export class FileTreeController
     }
   }
 
-  // DOM row clicks already know the target row is mounted, so they can focus it
+  // DOM row events already know the target row is mounted, so they can focus it
   // by path without materializing every visible row in large open trees.
   public focusMountedPathFromInput(path: string): void {
     const resolvedPath = this.#store.getPathInfo(path)?.path ?? null;
@@ -900,19 +900,11 @@ export class FileTreeController
       : this.#getOrCreateItemHandle(itemInfo.path, itemInfo);
   }
 
-  // Mounted directory rows already carry their expanded state, so click
-  // handling can skip the extra isExpanded() lookup that the public handle
-  // toggle performs before applying the same store mutation.
-  public toggleMountedDirectoryFromInput(
-    path: string,
-    isExpanded: boolean
-  ): void {
-    if (isExpanded) {
-      this.#collapseDirectory(path);
-      return;
-    }
-
-    this.#store.expand(path);
+  // Only use this for paths sourced from currently mounted directory rows. The
+  // mounted-row invariant lets click handling skip public handle creation while
+  // preserving normal toggle semantics against the store's live expansion state.
+  public toggleMountedDirectoryFromInput(path: string): void {
+    this.#toggleDirectory(path);
   }
 
   public selectAllVisiblePaths(): void {
@@ -933,8 +925,9 @@ export class FileTreeController
     this.#applySelection([resolvedPath], resolvedPath);
   }
 
-  // Mounted rows already provide canonical public paths, so regular row clicks
-  // can update selection without re-normalizing the same path through the store.
+  // Only use this for paths sourced from currently mounted rows. Visible rows
+  // already provide canonical public paths, so regular row clicks can update
+  // selection without re-normalizing the same path through the store.
   public selectOnlyMountedPathFromInput(path: string): void {
     this.#applySelection([path], path);
   }

--- a/packages/trees/src/render/FileTreeView.tsx
+++ b/packages/trees/src/render/FileTreeView.tsx
@@ -3602,15 +3602,25 @@ export function FileTreeView({
         mode,
       });
 
+      const shouldToggleDirectory =
+        plan.toggleDirectory && row.kind === 'directory';
+      const mountedDirectoryPath = shouldToggleDirectory
+        ? controller.resolveMountedDirectoryPathFromInput(targetPath)
+        : null;
+      if (shouldToggleDirectory && mountedDirectoryPath == null) {
+        return;
+      }
+      const actionTargetPath = mountedDirectoryPath ?? targetPath;
+
       switch (plan.selection.kind) {
         case 'range':
-          controller.selectPathRange(targetPath, plan.selection.additive);
+          controller.selectPathRange(actionTargetPath, plan.selection.additive);
           break;
         case 'toggle':
-          controller.togglePathSelectionFromInput(targetPath);
+          controller.togglePathSelectionFromInput(actionTargetPath);
           break;
         case 'single':
-          controller.selectOnlyMountedPathFromInput(targetPath);
+          controller.selectOnlyMountedPathFromInput(actionTargetPath);
           break;
       }
 
@@ -3625,22 +3635,22 @@ export function FileTreeView({
         clickedElement != null &&
         clickedElement.dataset.itemParked !== 'true';
 
-      controller.focusMountedPathFromInput(targetPath);
+      controller.focusMountedPathFromInput(actionTargetPath);
       if (shouldExposeFocusedTrigger) {
         domFocusOwnerRef.current = true;
         setActiveItemPath((previousPath) =>
-          previousPath === targetPath ? previousPath : targetPath
+          previousPath === actionTargetPath ? previousPath : actionTargetPath
         );
         setLastContextMenuInteraction('focus');
       }
-      if (plan.toggleDirectory && row.kind === 'directory') {
-        controller.toggleMountedDirectoryFromInput(targetPath);
+      if (shouldToggleDirectory) {
+        controller.toggleMountedDirectoryFromInput(actionTargetPath);
       }
       if (plan.closeSearch) {
         controller.closeSearch();
       }
       if (plan.revealCanonical) {
-        revealCanonicalRowAtStickyOffset(targetPath, {
+        revealCanonicalRowAtStickyOffset(actionTargetPath, {
           targetOffset: 'sticky-parents',
         });
       }

--- a/packages/trees/src/render/FileTreeView.tsx
+++ b/packages/trees/src/render/FileTreeView.tsx
@@ -1299,7 +1299,7 @@ function renderStyledRow(
             if (!contextMenuRightClickEnabled) {
               return;
             }
-            controller.focusPath(targetPath);
+            controller.focusMountedPathFromInput(targetPath);
             openContextMenuForRow(row, targetPath, {
               anchorRect: createAnchorRectFromPoint(
                 event.clientX,
@@ -1311,7 +1311,7 @@ function renderStyledRow(
         : undefined,
     onFocus: !isSticky
       ? () => {
-          controller.focusPath(targetPath);
+          controller.focusMountedPathFromInput(targetPath);
         }
       : undefined,
     onKeyDown: !isSticky ? onKeyDown : undefined,
@@ -3591,7 +3591,6 @@ export function FileTreeView({
       targetPath: string,
       mode: FileTreeRenderedRowMode
     ): void => {
-      const item = controller.getItem(targetPath);
       const plan = computeFileTreeRowClickPlan({
         event: {
           ctrlKey: event.ctrlKey,
@@ -3599,7 +3598,7 @@ export function FileTreeView({
           shiftKey: event.shiftKey,
         },
         isDirectory: row.kind === 'directory',
-        isSearchOpen: controller.isSearchOpen(),
+        isSearchOpen,
         mode,
       });
 
@@ -3611,7 +3610,7 @@ export function FileTreeView({
           controller.togglePathSelectionFromInput(targetPath);
           break;
         case 'single':
-          controller.selectOnlyPath(targetPath);
+          controller.selectOnlyMountedPathFromInput(targetPath);
           break;
       }
 
@@ -3626,7 +3625,7 @@ export function FileTreeView({
         clickedElement != null &&
         clickedElement.dataset.itemParked !== 'true';
 
-      item?.focus();
+      controller.focusMountedPathFromInput(targetPath);
       if (shouldExposeFocusedTrigger) {
         domFocusOwnerRef.current = true;
         setActiveItemPath((previousPath) =>
@@ -3634,8 +3633,8 @@ export function FileTreeView({
         );
         setLastContextMenuInteraction('focus');
       }
-      if (plan.toggleDirectory && isFileTreeDirectoryHandle(item)) {
-        item.toggle();
+      if (plan.toggleDirectory && row.kind === 'directory') {
+        controller.toggleMountedDirectoryFromInput(targetPath, row.isExpanded);
       }
       if (plan.closeSearch) {
         controller.closeSearch();
@@ -3648,6 +3647,7 @@ export function FileTreeView({
     },
     [
       controller,
+      isSearchOpen,
       layoutSnapshot.visible.endIndex,
       layoutSnapshot.visible.startIndex,
       revealCanonicalRowAtStickyOffset,

--- a/packages/trees/src/render/FileTreeView.tsx
+++ b/packages/trees/src/render/FileTreeView.tsx
@@ -3634,7 +3634,7 @@ export function FileTreeView({
         setLastContextMenuInteraction('focus');
       }
       if (plan.toggleDirectory && row.kind === 'directory') {
-        controller.toggleMountedDirectoryFromInput(targetPath, row.isExpanded);
+        controller.toggleMountedDirectoryFromInput(targetPath);
       }
       if (plan.closeSearch) {
         controller.closeSearch();

--- a/packages/trees/test/file-tree-render-scroll.test.ts
+++ b/packages/trees/test/file-tree-render-scroll.test.ts
@@ -819,6 +819,90 @@ describe('file-tree render + scroll', () => {
     }
   });
 
+  test('rapid double-click toggles against live directory state', async () => {
+    const { cleanup, dom } = installDom();
+    try {
+      const FileTree = await loadFileTree();
+      const containerWrapper = dom.window.document.createElement('div');
+      dom.window.document.body.appendChild(containerWrapper);
+
+      const fileTree = new FileTree({
+        flattenEmptyDirectories: false,
+        initialExpandedPaths: ['src'],
+        paths: ['README.md', 'src/index.ts', 'src/lib/util.ts'],
+        initialVisibleRowCount: 120 / 30,
+      });
+
+      fileTree.render({ containerWrapper });
+      const shadowRoot = fileTree.getFileTreeContainer()?.shadowRoot;
+      const srcDirectory = fileTree.getItem('src/');
+      if (
+        srcDirectory == null ||
+        srcDirectory.isDirectory() !== true ||
+        !('isExpanded' in srcDirectory)
+      ) {
+        throw new Error('expected src directory item');
+      }
+
+      clickItem(shadowRoot, dom, 'src/');
+      clickItem(shadowRoot, dom, 'src/');
+      await flushDom();
+
+      expect(srcDirectory.isExpanded()).toBe(true);
+      expect(shadowRoot?.innerHTML).toContain('src/index.ts');
+
+      fileTree.cleanUp();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('flattened directory row clicks select and toggle the terminal path', async () => {
+    const { cleanup, dom } = installDom();
+    try {
+      const FileTree = await loadFileTree();
+      const containerWrapper = dom.window.document.createElement('div');
+      dom.window.document.body.appendChild(containerWrapper);
+
+      const fileTree = new FileTree({
+        flattenEmptyDirectories: true,
+        initialExpandedPaths: ['root/', 'root/branch/leaf/'],
+        paths: [
+          'root/branch/leaf/file.ts',
+          'root/branch/leaf/other.ts',
+          'root/sibling.ts',
+        ],
+        initialVisibleRowCount: 180 / 30,
+      });
+
+      fileTree.render({ containerWrapper });
+      const shadowRoot = fileTree.getFileTreeContainer()?.shadowRoot;
+      const leafDirectory = fileTree.getItem('root/branch/leaf/');
+      if (
+        leafDirectory == null ||
+        leafDirectory.isDirectory() !== true ||
+        !('isExpanded' in leafDirectory)
+      ) {
+        throw new Error('expected flattened leaf directory item');
+      }
+
+      expect(getItemButton(shadowRoot, dom, 'root/branch/leaf/')).toBeTruthy();
+      expect(shadowRoot?.innerHTML).toContain('file.ts');
+
+      clickItem(shadowRoot, dom, 'root/branch/leaf/');
+      await flushDom();
+
+      expect(leafDirectory.isExpanded()).toBe(false);
+      expect(fileTree.getSelectedPaths()).toEqual(['root/branch/leaf/']);
+      expect(fileTree.getFocusedPath()).toBe('root/branch/leaf/');
+      expect(shadowRoot?.innerHTML).not.toContain('file.ts');
+
+      fileTree.cleanUp();
+    } finally {
+      cleanup();
+    }
+  });
+
   test('modified clicks recreate the baseline selection semantics in spirit', async () => {
     const { cleanup, dom } = installDom();
     try {

--- a/packages/trees/test/file-tree-render-scroll.test.ts
+++ b/packages/trees/test/file-tree-render-scroll.test.ts
@@ -819,6 +819,41 @@ describe('file-tree render + scroll', () => {
     }
   });
 
+  test('stale directory row clicks after path reset are ignored', async () => {
+    const { cleanup, dom } = installDom();
+    try {
+      const FileTree = await loadFileTree();
+      const containerWrapper = dom.window.document.createElement('div');
+      dom.window.document.body.appendChild(containerWrapper);
+
+      const fileTree = new FileTree({
+        flattenEmptyDirectories: false,
+        initialExpandedPaths: ['src'],
+        paths: ['README.md', 'src/index.ts'],
+        initialVisibleRowCount: 120 / 30,
+      });
+
+      fileTree.render({ containerWrapper });
+      const shadowRoot = fileTree.getFileTreeContainer()?.shadowRoot;
+      const staleSrcButton = getItemButton(shadowRoot, dom, 'src/');
+
+      fileTree.resetPaths(['README.md']);
+      expect(fileTree.getItem('src/')).toBeNull();
+
+      staleSrcButton.dispatchEvent(
+        new dom.window.MouseEvent('click', { bubbles: true })
+      );
+      await flushDom();
+
+      expect(fileTree.getSelectedPaths()).toEqual([]);
+      expect(fileTree.getItem('src/')).toBeNull();
+
+      fileTree.cleanUp();
+    } finally {
+      cleanup();
+    }
+  });
+
   test('rapid double-click toggles against live directory state', async () => {
     const { cleanup, dom } = installDom();
     try {


### PR DESCRIPTION
Removes worst-case controller work from mounted row expand/collapse clicks. Inactive search state no longer scans the visible projection, DOM row focus uses a mounted-row path instead of public focusPath's full-projection rebuild, mounted directory toggles reuse row expansion state, ordinary mounted single-click selection trusts the canonical row path, and click planning reuses the rendered search-open state.

Experiments: #7, #8, #9, #11, #14, #15, #21, #26
Metric: open_visible_shallow_collapse_dom_click_paint_ms 607 ms → 32.5 ms (-94.6%).

