### PR TITLE
fix(diffs): empty files marked as deleted

### DIFF
--- a/packages/diffs/src/utils/parsePatchFiles.ts
+++ b/packages/diffs/src/utils/parsePatchFiles.ts
@@ -456,10 +456,18 @@ export function processFile(
       }
     }
     // Sort of a hack for detecting deleted/added files...
-    else if (newFile != null && newFile.contents === '') {
-      currentFile.type = 'deleted';
-    } else if (oldFile != null && oldFile.contents === '') {
+    else if (
+      (oldFile == null || oldFile.contents === '') &&
+      newFile != null &&
+      newFile.contents !== ''
+    ) {
       currentFile.type = 'new';
+    } else if (
+      oldFile != null &&
+      oldFile.contents !== '' &&
+      (newFile == null || newFile.contents === '')
+    ) {
+      currentFile.type = 'deleted';
     }
   }
   if (

--- a/packages/diffs/test/parseDiffFromFile.test.ts
+++ b/packages/diffs/test/parseDiffFromFile.test.ts
@@ -54,4 +54,32 @@ describe('parseDiffFromFile', () => {
     });
     expect(withoutWhitespace.hunks).toHaveLength(0);
   });
+
+  test('should have type "change" (default) when files did not change', () => {
+    const oldFile = {
+      name: 'test.txt',
+      contents: 'abc',
+    };
+    const newFile = {
+      name: 'test.txt',
+      contents: 'abc',
+    };
+
+    const result = parseDiffFromFile(oldFile, newFile);
+    expect(result.type).toBe('change');
+  });
+
+  test('should have type "change" (default) when empty files did not change', () => {
+    const oldFile = {
+      name: 'test.txt',
+      contents: '',
+    };
+    const newFile = {
+      name: 'test.txt',
+      contents: '',
+    };
+
+    const result = parseDiffFromFile(oldFile, newFile);
+    expect(result.type).toBe('change');
+  });
 });


### PR DESCRIPTION
### Description

Hello :wave: 

I noticed a minor inconsistency while using newFile/oldFile between 1) rendering a diff of a file with content that didn't change, and 2) rendering a diff of an empty file that didn't change.

### Motivation & Context

#### Current behavior:

<details>
<summary>File with content and no change</summary>

```ts
const fileDiffInstance = new FileDiff({ theme: "pierre-dark" });

fileDiffInstance.render({
  oldFile: { name: "my-file", contents: "abc" },
  newFile: { name: "my-file", contents: "abc" }, // content didn't change
  containerWrapper: document.body,
});
```

<img width="1059" height="199" alt="image" src="https://github.com/user-attachments/assets/e2d6cb92-ac58-4168-abae-b4c81741d93c"></img>

</details>

<details>
<summary>Empty file with no change</summary>

```ts
const fileDiffInstance = new FileDiff({ theme: "pierre-dark" });

fileDiffInstance.render({
  oldFile: { name: "my-file", contents: "" },
  newFile: { name: "my-file", contents: "" }, // stays empty
  containerWrapper: document.body,
});
```

<img width="1055" height="169" alt="image" src="https://github.com/user-attachments/assets/4ccc4566-2d6e-45e0-9a7c-d165222887e1" />

</details>

We should expect both diff to be of type `change`, but the second one is rendered as `deleted` (even though the file has not been deleted, it's just empty).

#### New behavior:

<details>
<summary>File with content and no change</summary>

```ts
// same code as before and same result
const fileDiffInstance = new FileDiff({ theme: "pierre-dark" });

fileDiffInstance.render({
  oldFile: { name: "my-file", contents: "abc" },
  newFile: { name: "my-file", contents: "abc" },
  containerWrapper: document.body,
});
```

<img width="1059" height="199" alt="image" src="https://github.com/user-attachments/assets/e2d6cb92-ac58-4168-abae-b4c81741d93c"></img>

</details>

<details>
<summary>Empty file with no change</summary>

```ts
// same code as before, but now the rendered diff is "change", not "deleted"
const fileDiffInstance = new FileDiff({ theme: "pierre-dark" });

fileDiffInstance.render({
  oldFile: { name: "my-file", contents: "" },
  newFile: { name: "my-file", contents: "" },
  containerWrapper: document.body,
});
```

<img width="1060" height="159" alt="image" src="https://github.com/user-attachments/assets/d23b3b2b-c4dc-48cc-a2a1-9040cf0e00aa" />

</details>

Now the empty file is correctly rendered as `change` and not `deleted`.


### Type of changes

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [X] I have read the
      [contributing guidelines](https://github.com/pierrecomputer/pierre/blob/main/.github/CONTRIBUTING.md)
- [X] My code follows the code style of the project (`bun run lint`)
- [X] My code is formatted properly (`bun run format`)
- [X] I have updated the documentation accordingly (if applicable)
- [X] I have added tests to cover my changes (if applicable)
- [X] All new and existing tests pass (`bun run diffs:test`)

### How was AI used in generating this PR

No AI used at all. I just crawled trough the codebase like a caveman.

### Related issues

#399-ish