### PR TITLE
fix(@pierre/trees): mark `preact` and `preact-render-to-string` as optional peer dependencies

### DIFF
--- a/packages/trees/package.json
+++ b/packages/trees/package.json
@@ -71,8 +71,6 @@
   },
   "dependencies": {
     "@pierre/path-store": "workspace:*",
-    "preact": "catalog:",
-    "preact-render-to-string": "catalog:"
   },
   "devDependencies": {
     "@arethetypeswrong/core": "catalog:",
@@ -92,7 +90,17 @@
     "typescript": "catalog:",
     "vite": "catalog:"
   },
+  "peerDependenciesMeta": {
+    "preact": {
+      "optional": true
+    },
+    "preact-render-to-string": {
+      "optional": true
+    }
+  },
   "peerDependencies": {
+    "preact": "catalog:",
+    "preact-render-to-string": "catalog:",
     "react": "^18.3.1 || ^19.0.0",
     "react-dom": "^18.3.1 || ^19.0.0"
   }


### PR DESCRIPTION
### Description

I don’t see the point of installing these dependencies for React-only projects

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality). You must have
      first discussed with the dev team and they should be aware that this PR is
      being opened
- [ ] Breaking change (fix or feature that would change existing functionality).
      You must have first discussed with the dev team and they should be aware
      that this PR is being opened
- [ ] Documentation update

### Checklist

- [ ] I have read the
      [contributing guidelines](https://github.com/pierrecomputer/pierre/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project (`bun run lint`)
- [ ] My code is formatted properly (`bun run format`)
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have added tests to cover my changes (if applicable)
- [ ] All new and existing tests pass (`bun run diffs:test`)

### How was AI used in generating this PR

<!-- You must disclosed any and all use of AI in PRs to help us asses how to
review it -->

### Related issues

<!-- Please link any related issues here. -->
