### PR TITLE
[trees] add demo for drag outside integration

### DIFF
--- a/apps/docs/app/(trees)/trees-dev/_demos/DragAndDropDemoClient.tsx
+++ b/apps/docs/app/(trees)/trees-dev/_demos/DragAndDropDemoClient.tsx
@@ -6,10 +6,17 @@ import {
   type FileTreeMutationEvent,
 } from '@pierre/trees';
 import type { FileTreePathOptions } from '@trees/_lib/fileTreePathOptions';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  type DragEvent as ReactDragEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { ExampleCard } from '../_components/ExampleCard';
 import { StateLog, useStateLog } from '../_components/StateLog';
+import { createPresortedPreparedInput } from '../_lib/createPresortedPreparedInput';
 
 function formatMutationEvent(event: FileTreeMutationEvent): string {
   switch (event.operation) {
@@ -38,9 +45,32 @@ function formatDropResult(event: FileTreeDropResult): string {
   return `drop:${event.operation} [${event.draggedPaths.join(', ')}] -> ${targetLabel}${flattenedSegmentLabel}`;
 }
 
+// Reads the tree path from a DOM drop payload and ignores empty or root-only values.
+function getDroppedPath(dataTransfer: DataTransfer): string | null {
+  const rawPath = dataTransfer.getData('text/plain').trim();
+  if (rawPath === '') {
+    return null;
+  }
+
+  const pathWithoutTrailingSlash = rawPath.endsWith('/')
+    ? rawPath.slice(0, -1)
+    : rawPath;
+  return pathWithoutTrailingSlash === '' ? null : pathWithoutTrailingSlash;
+}
+
+// Derives the display name from a canonical tree path while leaving logs path-first.
+function getFileNameFromPath(path: string): string {
+  const lastSlashIndex = path.lastIndexOf('/');
+  const fileName = path.slice(lastSlashIndex + 1);
+  return fileName === '' ? path : fileName;
+}
+
 interface DragAndDropDemoClientProps {
   containerHtml: string;
-  sharedOptions: Omit<FileTreePathOptions, 'dragAndDrop' | 'id'>;
+  sharedOptions: Omit<
+    FileTreePathOptions,
+    'dragAndDrop' | 'id' | 'preparedInput'
+  >;
 }
 
 export function DragAndDropDemoClient({
@@ -51,10 +81,38 @@ export function DragAndDropDemoClient({
   const mountRef = useRef<HTMLDivElement | null>(null);
   const [blockReadmeDrag, setBlockReadmeDrag] = useState(false);
   const [blockSrcLibDrop, setBlockSrcLibDrop] = useState(false);
+  const preparedInput = useMemo(
+    () => createPresortedPreparedInput(sharedOptions.paths),
+    [sharedOptions.paths]
+  );
+  const [lastHostDroppedFileName, setLastHostDroppedFileName] = useState<
+    string | null
+  >(null);
+
+  const handleHostDropzoneDragOver = (
+    event: ReactDragEvent<HTMLDivElement>
+  ): void => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+  };
+
+  const handleHostDropzoneDrop = (
+    event: ReactDragEvent<HTMLDivElement>
+  ): void => {
+    event.preventDefault();
+    const droppedPath = getDroppedPath(event.dataTransfer);
+    if (droppedPath == null) {
+      return;
+    }
+
+    setLastHostDroppedFileName(getFileNameFromPath(droppedPath));
+    addLog(`external-drop:${droppedPath}`);
+  };
 
   const options = useMemo<FileTreePathOptions>(
     () => ({
       ...sharedOptions,
+      preparedInput,
       dragAndDrop: {
         canDrag: (paths) => !blockReadmeDrag || !paths.includes('README.md'),
         canDrop: (event) => {
@@ -81,7 +139,7 @@ export function DragAndDropDemoClient({
         addLog(`search:${value ?? '<closed>'}`);
       },
     }),
-    [addLog, blockReadmeDrag, blockSrcLibDrop, sharedOptions]
+    [addLog, blockReadmeDrag, blockSrcLibDrop, preparedInput, sharedOptions]
   );
 
   useEffect(() => {
@@ -113,15 +171,16 @@ export function DragAndDropDemoClient({
       <header className="space-y-2">
         <h1 className="text-2xl font-bold">Drag and Drop</h1>
         <p className="text-muted-foreground max-w-3xl text-sm leading-6">
-          Pointer and touch drag and drop now runs on the same mutation-first
-          tree as search, rename, and runtime resets. Drops resolve to canonical
-          folder paths and commit through the built-in move or batch APIs.
+          Drag tree rows inside the tree or out to a host-page dropzone.
+          Internal drops commit through the built-in move APIs. External drops
+          expose the dragged path through the browser&apos;s text/plain
+          DataTransfer payload.
         </p>
       </header>
 
       <ExampleCard
         title="Hydrated drag-and-drop tree"
-        description="Drag with a mouse or long-press touch. Active filtered search blocks drag starts, hovering a collapsed folder auto-opens it, and flattened path segments target their exact canonical folder path."
+        description="Drag with a mouse or long-press touch. Active search blocks drag starts, collapsed folders auto-open, and flattened path segments target their canonical folder. Drop inside the tree to move paths, or on the host box below to read the full path without changing the tree."
         controls={
           <div className="flex flex-col gap-2 text-xs leading-5">
             <label className="flex items-center gap-2">
@@ -157,12 +216,36 @@ export function DragAndDropDemoClient({
           />
         }
       >
-        <div
-          ref={mountRef}
-          style={{ height: '460px' }}
-          dangerouslySetInnerHTML={{ __html: containerHtml }}
-          suppressHydrationWarning
-        />
+        <div className="space-y-4">
+          <div
+            data-test-host-dropzone="true"
+            onDragOver={handleHostDropzoneDragOver}
+            onDrop={handleHostDropzoneDrop}
+            className="bg-muted/30 space-y-2 rounded-md border border-dashed border-[var(--color-border)] p-4 text-sm leading-6"
+          >
+            <p className="font-medium">Host page dropzone</p>
+            <p className="text-muted-foreground">
+              Drop a tree row here to read the tree path with a normal DOM drop
+              handler.
+            </p>
+            <p className="text-xs">
+              <strong>Last dropped file:</strong>{' '}
+              <span
+                data-test-host-dropzone-last-file="true"
+                className="font-mono"
+              >
+                {lastHostDroppedFileName ?? 'None'}
+              </span>
+            </p>
+          </div>
+
+          <div
+            ref={mountRef}
+            style={{ height: '460px' }}
+            dangerouslySetInnerHTML={{ __html: containerHtml }}
+            suppressHydrationWarning
+          />
+        </div>
       </ExampleCard>
     </div>
   );

--- a/apps/docs/app/(trees)/trees-dev/_demos/GitStatusDemoClient.tsx
+++ b/apps/docs/app/(trees)/trees-dev/_demos/GitStatusDemoClient.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useRef } from 'react';
 
 import { ExampleCard } from '../_components/ExampleCard';
 import { useGitStatusControls } from '../_components/useGitStatusControls';
+import { createPresortedPreparedInput } from '../_lib/createPresortedPreparedInput';
 import {
   ITEM_CUSTOMIZATION_DEMO_DEFAULTS,
   TREES_DEV_GIT_STATUS_PRESETS,
@@ -14,12 +15,17 @@ import {
 interface GitStatusDemoClientProps {
   containerHtml: string;
   fileCountLabel: string;
-  sharedOptions: Omit<FileTreePathOptions, 'gitStatus' | 'id'>;
+  pathsArePresorted: boolean;
+  sharedOptions: Omit<
+    FileTreePathOptions,
+    'gitStatus' | 'id' | 'preparedInput'
+  >;
 }
 
 export function GitStatusDemoClient({
   containerHtml,
   fileCountLabel,
+  pathsArePresorted,
   sharedOptions,
 }: GitStatusDemoClientProps) {
   const mountRef = useRef<HTMLDivElement | null>(null);
@@ -30,12 +36,20 @@ export function GitStatusDemoClient({
     presets: TREES_DEV_GIT_STATUS_PRESETS,
   });
   const initialGitStatusRef = useRef(gitStatus);
+  const preparedInput = useMemo(
+    () =>
+      pathsArePresorted
+        ? createPresortedPreparedInput(sharedOptions.paths)
+        : undefined,
+    [pathsArePresorted, sharedOptions.paths]
+  );
   const options = useMemo<FileTreePathOptions>(
     () => ({
       ...sharedOptions,
+      preparedInput,
       id: 'trees-git-status',
     }),
-    [sharedOptions]
+    [preparedInput, sharedOptions]
   );
 
   useEffect(() => {

--- a/apps/docs/app/(trees)/trees-dev/_demos/ItemCustomizationDemoClient.tsx
+++ b/apps/docs/app/(trees)/trees-dev/_demos/ItemCustomizationDemoClient.tsx
@@ -17,6 +17,7 @@ import {
 import { createRoot, type Root as ReactDomRoot } from 'react-dom/client';
 
 import { ExampleCard } from '../_components/ExampleCard';
+import { createPresortedPreparedInput } from '../_lib/createPresortedPreparedInput';
 import {
   getContextMenuSideOffset,
   getFloatingContextMenuTriggerStyle,
@@ -42,6 +43,7 @@ import {
 interface ItemCustomizationDemoClientProps {
   containerHtml: string;
   fileCountLabel: string;
+  pathsArePresorted: boolean;
   sharedOptions: Omit<
     FileTreePathOptions,
     | 'composition'
@@ -49,6 +51,7 @@ interface ItemCustomizationDemoClientProps {
     | 'id'
     | 'onSelectionChange'
     | 'renderRowDecoration'
+    | 'preparedInput'
   >;
 }
 
@@ -301,6 +304,7 @@ function HydratedItemCustomizationTree({
 export function ItemCustomizationDemoClient({
   containerHtml,
   fileCountLabel,
+  pathsArePresorted,
   sharedOptions,
 }: ItemCustomizationDemoClientProps) {
   const desiredSelectedPathsRef = useRef<readonly string[]>([]);
@@ -331,6 +335,13 @@ export function ItemCustomizationDemoClient({
   const [selectedPaths, setSelectedPaths] = useState<readonly string[]>([]);
   const [lastMenuInteraction, setLastMenuInteraction] = useState(
     'Open the context menu to inspect a row.'
+  );
+  const preparedInput = useMemo(
+    () =>
+      pathsArePresorted
+        ? createPresortedPreparedInput(sharedOptions.paths)
+        : undefined,
+    [pathsArePresorted, sharedOptions.paths]
   );
 
   const activeGitStatusPreset = useMemo(
@@ -410,6 +421,7 @@ export function ItemCustomizationDemoClient({
       },
       id: 'trees-dev-item-customization',
       onSelectionChange: handleSelectionChange,
+      preparedInput,
       renderRowDecoration: activeDecorationRenderer,
     };
   }, [
@@ -418,6 +430,7 @@ export function ItemCustomizationDemoClient({
     contextMenuEnabled,
     handleMenuAction,
     handleSelectionChange,
+    preparedInput,
     sharedOptions,
     triggerMode,
   ]);

--- a/apps/docs/app/(trees)/trees-dev/drag-and-drop/page.tsx
+++ b/apps/docs/app/(trees)/trees-dev/drag-and-drop/page.tsx
@@ -33,7 +33,10 @@ const TREE_HEADER_HTML =
 
 export default async function TreesDevDragAndDropPage() {
   const { flattenEmptyDirectories } = await readSettingsCookies();
-  const sharedOptions: Omit<FileTreePathOptions, 'dragAndDrop' | 'id'> = {
+  const sharedOptions: Omit<
+    FileTreePathOptions,
+    'dragAndDrop' | 'id' | 'preparedInput'
+  > = {
     composition: {
       header: {
         html: TREE_HEADER_HTML,
@@ -49,7 +52,6 @@ export default async function TreesDevDragAndDropPage() {
       'workspace/',
     ],
     paths: DRAG_AND_DROP_PREPARED_INPUT.paths,
-    preparedInput: DRAG_AND_DROP_PREPARED_INPUT,
     search: true,
     initialVisibleRowCount: 460 / 30,
   };
@@ -58,6 +60,7 @@ export default async function TreesDevDragAndDropPage() {
     ...sharedOptions,
     dragAndDrop: true,
     id: 'trees-drag-and-drop',
+    preparedInput: DRAG_AND_DROP_PREPARED_INPUT,
   });
 
   return (

--- a/apps/docs/app/(trees)/trees-dev/git-status/page.tsx
+++ b/apps/docs/app/(trees)/trees-dev/git-status/page.tsx
@@ -25,13 +25,16 @@ export default async function TreesDevGitStatusPage() {
   const defaultGitStatusPreset = getTreesDevGitStatusPreset(
     ITEM_CUSTOMIZATION_DEMO_DEFAULTS.gitStatusPresetId
   );
-  const sharedOptions: Omit<FileTreePathOptions, 'gitStatus' | 'id'> = {
+  const preparedInput = workloadData.pathsArePresorted
+    ? createPresortedPreparedInput(workloadData.paths)
+    : undefined;
+  const sharedOptions: Omit<
+    FileTreePathOptions,
+    'gitStatus' | 'id' | 'preparedInput'
+  > = {
     flattenEmptyDirectories,
     initialExpandedPaths: workloadData.initialExpandedPaths,
     paths: workloadData.paths,
-    preparedInput: workloadData.pathsArePresorted
-      ? createPresortedPreparedInput(workloadData.paths)
-      : undefined,
     initialVisibleRowCount: GIT_STATUS_VIEWPORT_HEIGHT / 30,
   };
 
@@ -39,12 +42,14 @@ export default async function TreesDevGitStatusPage() {
     ...sharedOptions,
     gitStatus: defaultGitStatusPreset.entries,
     id: 'trees-git-status',
+    preparedInput,
   });
 
   return (
     <GitStatusDemoClient
       containerHtml={serializeFileTreeSsrPayload(payload, 'dom')}
       fileCountLabel={workloadData.selectedWorkload.fileCountLabel}
+      pathsArePresorted={workloadData.pathsArePresorted}
       sharedOptions={sharedOptions}
     />
   );

--- a/apps/docs/app/(trees)/trees-dev/item-customization/page.tsx
+++ b/apps/docs/app/(trees)/trees-dev/item-customization/page.tsx
@@ -30,6 +30,9 @@ export default async function TreesDevItemCustomizationPage() {
   const defaultDecorationPreset = getItemCustomizationDecorationPreset(
     ITEM_CUSTOMIZATION_DEMO_DEFAULTS.decorationPresetId
   );
+  const preparedInput = workloadData.pathsArePresorted
+    ? createPresortedPreparedInput(workloadData.paths)
+    : undefined;
   const sharedOptions: Omit<
     FileTreePathOptions,
     | 'composition'
@@ -37,14 +40,12 @@ export default async function TreesDevItemCustomizationPage() {
     | 'id'
     | 'onSelectionChange'
     | 'renderRowDecoration'
+    | 'preparedInput'
   > = {
     flattenEmptyDirectories,
     icons: ITEM_CUSTOMIZATION_DECORATION_ICONS,
     initialExpandedPaths: workloadData.initialExpandedPaths,
     paths: workloadData.paths,
-    preparedInput: workloadData.pathsArePresorted
-      ? createPresortedPreparedInput(workloadData.paths)
-      : undefined,
     initialVisibleRowCount: ITEM_CUSTOMIZATION_VIEWPORT_HEIGHT / 30,
   };
 
@@ -59,6 +60,7 @@ export default async function TreesDevItemCustomizationPage() {
     },
     gitStatus: defaultGitStatusPreset.entries,
     id: 'trees-dev-item-customization',
+    preparedInput,
     renderRowDecoration: defaultDecorationPreset.renderer ?? undefined,
   });
 
@@ -66,6 +68,7 @@ export default async function TreesDevItemCustomizationPage() {
     <ItemCustomizationDemoClient
       containerHtml={serializeFileTreeSsrPayload(payload, 'dom')}
       fileCountLabel={workloadData.selectedWorkload.fileCountLabel}
+      pathsArePresorted={workloadData.pathsArePresorted}
       sharedOptions={sharedOptions}
     />
   );

--- a/apps/docs/test/e2e/trees-dev-drag-and-drop.pw.ts
+++ b/apps/docs/test/e2e/trees-dev-drag-and-drop.pw.ts
@@ -1,0 +1,56 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('trees-dev drag-and-drop route', () => {
+  test('host dropzone reads the file name without moving the tree row', async ({
+    page,
+  }) => {
+    await page.goto('/trees-dev/drag-and-drop');
+    await expect(
+      page.getByRole('heading', { level: 1, name: 'Drag and Drop' })
+    ).toBeVisible();
+
+    const sourcePath = 'assets/images/social/logo.png';
+    const source = page.locator(
+      `file-tree-container button[data-type="item"][data-item-path="${sourcePath}"]`
+    );
+    const dropzone = page.locator('[data-test-host-dropzone="true"]');
+
+    await expect(source).toBeVisible();
+    await expect(dropzone).toBeVisible();
+
+    await source.dragTo(dropzone);
+
+    await expect(
+      page.locator('[data-test-host-dropzone-last-file="true"]')
+    ).toContainText('logo.png');
+    await expect(
+      page.getByText(`external-drop:${sourcePath}`, { exact: true })
+    ).toBeVisible();
+    await expect(source).toHaveCount(1);
+    await expect(source).toBeVisible();
+  });
+
+  test('internal drag still moves a row inside the tree', async ({ page }) => {
+    await page.goto('/trees-dev/drag-and-drop');
+
+    const sourcePath = 'assets/images/social/logo.png';
+    const movedPath = 'docs/guides/logo.png';
+    const source = page.locator(
+      `file-tree-container button[data-type="item"][data-item-path="${sourcePath}"]`
+    );
+    const target = page.locator(
+      'file-tree-container button[data-type="item"][data-item-path="docs/guides/"]'
+    );
+    const moved = page.locator(
+      `file-tree-container button[data-type="item"][data-item-path="${movedPath}"]`
+    );
+
+    await expect(source).toBeVisible();
+    await expect(target).toBeVisible();
+
+    await source.dragTo(target);
+
+    await expect(moved).toBeVisible();
+    await expect(source).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
No changes were needed in the published @pierre/trees library for this host-page dropzone behavior.

 Observed existing support:
 - Tree rows are already draggable when dragAndDrop is enabled.
 - On drag start, packages/trees/src/render/FileTreeView.tsx already writes the dragged path to the browser DataTransfer payload:

 ```ts
   event.dataTransfer.setData('text/plain', targetPath);
 ```

 - A dropzone outside the tree can use ordinary DOM/React drag handlers:
     - onDragOver: event.preventDefault()
     - onDrop: event.dataTransfer.getData('text/plain')

 So users on the latest code can already do this:

 ```tsx
   function HostDropzone() {
     const [lastDroppedPath, setLastDroppedPath] = useState<string | null>(null);

     return (
       <div
         onDragOver={(event) => {
           event.preventDefault();
           event.dataTransfer.dropEffect = 'move';
         }}
         onDrop={(event) => {
           event.preventDefault();
           const path = event.dataTransfer.getData('text/plain').trim();
           if (path !== '') {
             setLastDroppedPath(path);
           }
         }}
       >
         Last dropped path: {lastDroppedPath ?? 'None'}
       </div>
     );
   }
 ```

 The branch only adds a docs demo and E2E coverage proving that integration path.