### PR TITLE
[trees][wip] Create a new `/scroll` export for a self-virtualizable file tree

### DIFF
--- a/apps/docs/app/(trees)/docs/Guides/HandleLargeTreesEfficiently/constants.ts
+++ b/apps/docs/app/(trees)/docs/Guides/HandleLargeTreesEfficiently/constants.ts
@@ -19,3 +19,21 @@ export const LARGE_TREES_VIRTUALIZATION_KNOBS = docsCodeSnippet(
   overscan: 8,
 });`
 );
+
+export const LARGE_TREES_EXTERNAL_SCROLL = docsCodeSnippet(
+  'external-scroll.ts',
+  `import { FileTree } from '@pierre/trees/scroll';
+
+const tree = new FileTree({
+  preparedInput,
+  stickyFolders: true,
+  externalScroll: {
+    initialSnapshot: {
+      viewportTop: 0,
+      viewportHeight: 480,
+      topInset: 48,
+    },
+    source: externalScrollSource,
+  },
+});`
+);

--- a/apps/docs/app/(trees)/docs/Guides/HandleLargeTreesEfficiently/content.mdx
+++ b/apps/docs/app/(trees)/docs/Guides/HandleLargeTreesEfficiently/content.mdx
@@ -51,6 +51,24 @@ the first render before the browser can measure the actual viewport.
 Keep the language outcome-focused: the tree mounts the visible slice plus a
 small buffer around it.
 
+#### Use external scroll for page-owned scrollers
+
+Use `@pierre/trees/scroll` when a parent scroller contains content above the
+tree, the tree, and content below it. The tree still virtualizes rows, but the
+parent owns the viewport metrics and all scroll movement.
+
+<DocsCodeExample {...LARGE_TREES_EXTERNAL_SCROLL} />
+
+The source reports host-local metrics: `viewportTop`, `viewportHeight`,
+`topInset`, and `bottomInset`. `viewportTop` may be negative or below the tree;
+the tree renders no rows until the viewport intersects the row area, apart from
+normal overscan. In external mode, `initialVisibleRowCount` is only a fallback
+when `externalScroll.initialSnapshot` is missing.
+
+Header and search UI scroll with the tree. Sticky folders pin below `topInset`
+so caller-owned sticky UI stays in charge. Drag edge-autoscroll is not
+implemented in external scroll mode yet.
+
 #### Expansion and search still affect scale
 
 Prepared input lowers the cost of shaping the data, but expansion and search

--- a/apps/docs/app/(trees)/docs/Reference/ReactAPI/constants.ts
+++ b/apps/docs/app/(trees)/docs/Reference/ReactAPI/constants.ts
@@ -19,3 +19,43 @@ const focusedPath = useFileTreeSelector(model, (currentModel) =>
   currentModel.getFocusedPath()
 );`
 );
+
+export const REACT_EXTERNAL_SCROLL_EXAMPLE = docsCodeSnippet(
+  'external-scroll-react.tsx',
+  `import {
+  FileTree as ScrollFileTree,
+  createDomScrollSource,
+} from '@pierre/trees/scroll';
+import { FileTree } from '@pierre/trees/react';
+
+const hostRef = useRef<HTMLElement>(null);
+const source = useMemo(
+  () => createDomScrollSource({ scrollContainer: parentScroller }),
+  [parentScroller]
+);
+const model = useMemo(
+  () =>
+    new ScrollFileTree({
+      paths,
+      stickyFolders: true,
+      externalScroll: { initialSnapshot: source.getSnapshot() },
+    }),
+  [paths, source]
+ );
+
+useEffect(
+  () => () => {
+    model.cleanUp();
+    source.destroy();
+  },
+  [model, source]
+ );
+
+useLayoutEffect(() => {
+  source.setHost(hostRef.current);
+  model.setExternalScrollSource(source);
+  return () => model.setExternalScrollSource(undefined);
+}, [model, source]);
+
+return <FileTree ref={hostRef} model={model} />;`
+);

--- a/apps/docs/app/(trees)/docs/Reference/ReactAPI/content.mdx
+++ b/apps/docs/app/(trees)/docs/Reference/ReactAPI/content.mdx
@@ -36,6 +36,7 @@ Primary props:
 
 - `model`
 - normal host HTML attributes such as `className`, `style`, and `id`
+- `ref`, which receives the FileTree host element
 
 React-only props:
 
@@ -51,6 +52,24 @@ Behavior notes:
 - it uses `id ?? preloadedData?.id` for host identity when hydration is involved
 - `header` and `renderContextMenu` layer React rendering onto the model's
   composition surface
+- it forwards the host ref so external scroll adapters can compute host-local
+  metrics
+
+#### External scroll in React
+
+Create the model from `@pierre/trees/scroll` when a parent scroller owns the
+viewport and the tree is one block inside that scroller. The React component
+still comes from `@pierre/trees/react`. `createDomScrollSource(...)` covers the
+common DOM-scroller case; forward the host ref so the source can compute
+host-local metrics, then attach it with `model.setExternalScrollSource(source)`.
+
+<DocsCodeExample {...REACT_EXTERNAL_SCROLL_EXAMPLE} />
+
+The `source.scrollToViewportTop(...)` method must synchronously update the
+snapshot returned by `source.getSnapshot()`. Header and search content scroll
+with the tree in this mode. Sticky folders pin under `topInset`, not under the
+built-in header or search UI. Drag edge-autoscroll is not implemented in
+external scroll mode yet.
 
 #### Reading tree state from React
 

--- a/apps/docs/app/(trees)/docs/Reference/SSRAPI/constants.ts
+++ b/apps/docs/app/(trees)/docs/Reference/SSRAPI/constants.ts
@@ -11,3 +11,20 @@ const payload = preloadFileTree({
   initialVisibleRowCount: 11,
 });`
 );
+
+export const SSR_EXTERNAL_SCROLL_EXAMPLE = docsCodeSnippet(
+  'external-scroll-ssr.ts',
+  `import { preloadFileTree } from '@pierre/trees/scroll';
+
+const payload = preloadFileTree({
+  preparedInput,
+  externalScroll: {
+    initialSnapshot: {
+      viewportTop: 0,
+      viewportHeight: 480,
+      topInset: 48,
+    },
+  },
+  initialVisibleRowCount: 16,
+});`
+);

--- a/apps/docs/app/(trees)/docs/Reference/SSRAPI/content.mdx
+++ b/apps/docs/app/(trees)/docs/Reference/SSRAPI/content.mdx
@@ -25,6 +25,18 @@ a different public data model.
 The current exported payload type name is `FileTreeSsrPayload`, but the
 docs-facing rule stays the same: pass it through unchanged.
 
+#### External scroll preload
+
+For this mode, import `preloadFileTree` from `@pierre/trees/scroll`. It uses
+`externalScroll.initialSnapshot` for first paint. It does not call
+`externalScroll.source.getSnapshot()` on the server. If no initial snapshot is
+provided, `initialVisibleRowCount` is only a fallback row budget.
+
+<DocsCodeExample {...SSR_EXTERNAL_SCROLL_EXAMPLE} />
+
+Keep the client model's `externalScroll.initialSnapshot` in sync with the server
+payload. Attach the live source on the client after the host exists.
+
 #### `serializeFileTreeSsrPayload(...)`
 
 `serializeFileTreeSsrPayload(payload, mode?)` turns the preloaded payload back
@@ -59,6 +71,7 @@ Match:
   rendered tree
 - the same appearance-affecting options when they change initial markup or icon
   output
+- the same external scroll `initialSnapshot` when `externalScroll` is enabled
 
 Mismatches are not a supported partial merge. They produce hydration mismatch or
 incorrect first state.

--- a/apps/docs/app/(trees)/docs/Reference/SharedConcepts/content.mdx
+++ b/apps/docs/app/(trees)/docs/Reference/SharedConcepts/content.mdx
@@ -37,32 +37,33 @@ tree-input object, not as a hand-rolled shape.
 This table covers the shared meaning of the public options surface across
 runtimes.
 
-| Option                    | Meaning                                                              | Typical use                                                                  |
-| ------------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| `paths`                   | Raw canonical path list.                                             | Small demos, tests, very small static trees.                                 |
-| `preparedInput`           | Pre-shaped tree input created ahead of render.                       | Recommended input for larger trees.                                          |
-| `id`                      | Stable host identity for the tree.                                   | Coordinate server preload and client hydration, or set a predictable DOM id. |
-| `initialExpansion`        | Baseline expansion policy for the first render.                      | Start broadly open, broadly closed, or at a specific depth.                  |
-| `initialExpandedPaths`    | Specific paths that should begin expanded.                           | Keep key folders open on first render.                                       |
-| `initialSelectedPaths`    | Paths selected on first render.                                      | Seed selection for previews or restored state.                               |
-| `flattenEmptyDirectories` | Flattens chains of single-child directories into one visible row.    | Compact repo-style trees.                                                    |
-| `sort`                    | Client-side ordering for non-presorted input.                        | Secondary path when order must be chosen in the client.                      |
-| `search`                  | Enables the built-in search surface and model search methods.        | Searchable trees.                                                            |
-| `initialSearchQuery`      | Starting search value.                                               | Preloaded filtered views or restored search state.                           |
-| `fileTreeSearchMode`      | Controls how matches change the visible tree.                        | Choose between filtering, collapsing, or expanding around matches.           |
-| `onSearchChange`          | Callback for search-value changes.                                   | Sync surrounding controls or analytics.                                      |
-| `onSelectionChange`       | Callback for selection changes.                                      | Update sibling UI that tracks current selection.                             |
-| `dragAndDrop`             | Enables drag and drop plus its policy hooks.                         | Editable trees.                                                              |
-| `renaming`                | Enables inline rename plus policy hooks.                             | Rename-in-place workflows.                                                   |
-| `composition`             | Header and context-menu composition surface.                         | Add a header row or contextual commands.                                     |
-| `gitStatus`               | Built-in Git-style row signals.                                      | Added, modified, deleted, ignored, renamed, and untracked states.            |
-| `icons`                   | Built-in icon set or icon configuration object.                      | Set selection, color mode, remaps, or sprite-sheet extension.                |
-| `renderRowDecoration`     | Custom non-Git row signal renderer.                                  | Generated-file badges, remote markers, validation hints.                     |
-| `density`                 | Density preset or custom spacing factor.                             | Tune row height and spacing in one place.                                    |
-| `itemHeight`              | Explicit row-height override.                                        | Row height that doesn't match a `density` preset.                            |
-| `overscan`                | Extra rows rendered outside the visible window.                      | Smooth scrolling tradeoffs.                                                  |
-| `initialVisibleRowCount`  | Optional first-render row budget before the browser measures height. | Tune SSR and hydration work without pinning steady-state size.               |
-| `unsafeCSS`               | Advanced CSS injection into the tree shadow root.                    | Narrow escape hatch when supported styling surfaces are not enough.          |
+| Option                    | Meaning                                                                        | Typical use                                                                  |
+| ------------------------- | ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| `paths`                   | Raw canonical path list.                                                       | Small demos, tests, very small static trees.                                 |
+| `preparedInput`           | Pre-shaped tree input created ahead of render.                                 | Recommended input for larger trees.                                          |
+| `id`                      | Stable host identity for the tree.                                             | Coordinate server preload and client hydration, or set a predictable DOM id. |
+| `initialExpansion`        | Baseline expansion policy for the first render.                                | Start broadly open, broadly closed, or at a specific depth.                  |
+| `initialExpandedPaths`    | Specific paths that should begin expanded.                                     | Keep key folders open on first render.                                       |
+| `initialSelectedPaths`    | Paths selected on first render.                                                | Seed selection for previews or restored state.                               |
+| `flattenEmptyDirectories` | Flattens chains of single-child directories into one visible row.              | Compact repo-style trees.                                                    |
+| `sort`                    | Client-side ordering for non-presorted input.                                  | Secondary path when order must be chosen in the client.                      |
+| `search`                  | Enables the built-in search surface and model search methods.                  | Searchable trees.                                                            |
+| `initialSearchQuery`      | Starting search value.                                                         | Preloaded filtered views or restored search state.                           |
+| `fileTreeSearchMode`      | Controls how matches change the visible tree.                                  | Choose between filtering, collapsing, or expanding around matches.           |
+| `onSearchChange`          | Callback for search-value changes.                                             | Sync surrounding controls or analytics.                                      |
+| `onSelectionChange`       | Callback for selection changes.                                                | Update sibling UI that tracks current selection.                             |
+| `dragAndDrop`             | Enables drag and drop plus its policy hooks.                                   | Editable trees.                                                              |
+| `renaming`                | Enables inline rename plus policy hooks.                                       | Rename-in-place workflows.                                                   |
+| `composition`             | Header and context-menu composition surface.                                   | Add a header row or contextual commands.                                     |
+| `gitStatus`               | Built-in Git-style row signals.                                                | Added, modified, deleted, ignored, renamed, and untracked states.            |
+| `icons`                   | Built-in icon set or icon configuration object.                                | Set selection, color mode, remaps, or sprite-sheet extension.                |
+| `renderRowDecoration`     | Custom non-Git row signal renderer.                                            | Generated-file badges, remote markers, validation hints.                     |
+| `density`                 | Density preset or custom spacing factor.                                       | Tune row height and spacing in one place.                                    |
+| `itemHeight`              | Explicit row-height override.                                                  | Row height that doesn't match a `density` preset.                            |
+| `overscan`                | Extra rows rendered outside the visible window.                                | Smooth scrolling tradeoffs.                                                  |
+| `initialVisibleRowCount`  | Optional first-render row budget before the browser measures height.           | Tune SSR and hydration work without pinning steady-state size.               |
+| `externalScroll`          | Caller-owned viewport metrics for parent scrollers via `@pierre/trees/scroll`. | Page scrollers that contain content above and below the tree.                |
+| `unsafeCSS`               | Advanced CSS injection into the tree shadow root.                              | Narrow escape hatch when supported styling surfaces are not enough.          |
 
 #### Tree-shape options
 
@@ -134,16 +135,22 @@ For deeper lookup, jump to [Styling and theming](#styling-and-theming) and
 
 #### Scale and rendering settings
 
-`initialVisibleRowCount`, `density`, `itemHeight`, and `overscan` are rendering
-knobs, not onboarding concepts. The rendered container sets steady-state height;
-these options only tune the first-render budget, visual density, and the
-virtualized row window.
+`initialVisibleRowCount`, `density`, `itemHeight`, `overscan`, and
+`externalScroll` are rendering knobs, not onboarding concepts. The rendered
+container sets steady-state height in internal mode. In external mode, the
+caller-owned scroller reports host-local viewport metrics and
+`initialVisibleRowCount` is only a fallback when no `initialSnapshot` exists.
 
 For density, prefer the `density` keyword (`'compact' | 'default' | 'relaxed'`)
 or a numeric factor — it resolves both row height and spacing in one place, and
 the React `<FileTree>` wrapper paints `--trees-item-height` and
 `--trees-density-override` for you. Reach for `itemHeight` only when you need a
 row height that doesn't match a preset.
+
+Use `externalScroll` only when the tree is one block inside a parent scroller
+with caller-owned content above or below it, and construct that model from
+`@pierre/trees/scroll`. The source must update `getSnapshot()` synchronously
+inside `scrollToViewportTop(...)`.
 
 Use [Handle large trees efficiently](#handle-large-trees-efficiently) when scale
 becomes the real problem.

--- a/apps/docs/app/(trees)/docs/Reference/VanillaAPI/constants.ts
+++ b/apps/docs/app/(trees)/docs/Reference/VanillaAPI/constants.ts
@@ -11,3 +11,31 @@ const fileTree = new FileTree({
 
 fileTree.render({ fileTreeContainer: container });`
 );
+
+export const VANILLA_EXTERNAL_SCROLL_EXAMPLE = docsCodeSnippet(
+  'external-scroll-source.ts',
+  `import { FileTree, createDomScrollSource } from '@pierre/trees/scroll';
+
+const source = createDomScrollSource({
+  scrollContainer: scroller,
+  topInset: () => toolbar.getBoundingClientRect().height,
+});
+
+const tree = new FileTree({
+  paths,
+  stickyFolders: true,
+  externalScroll: {
+    initialSnapshot: source.getSnapshot(),
+    source,
+  },
+});
+
+tree.render({ containerWrapper: mount });
+const host = tree.getFileTreeContainer();
+source.setHost(host ?? null);
+
+function disposeTree() {
+  source.destroy();
+  tree.cleanUp();
+}`
+);

--- a/apps/docs/app/(trees)/docs/Reference/VanillaAPI/content.mdx
+++ b/apps/docs/app/(trees)/docs/Reference/VanillaAPI/content.mdx
@@ -46,6 +46,25 @@ For shared option meanings, read
 
 - returns the mounted host element after render or hydrate
 
+#### External scroll source
+
+Use `@pierre/trees/scroll` when the tree sits inside a parent scroller with
+other content above or below it. The parent owns scrolling. The tree receives
+host-local viewport metrics and keeps only its own virtual spacer height.
+`createDomScrollSource(...)` covers the common DOM-scroller case and keeps the
+snapshot in sync once you attach the host after render.
+
+<DocsCodeExample {...VANILLA_EXTERNAL_SCROLL_EXAMPLE} />
+
+Rules:
+
+- `viewportTop` is the parent viewport's top edge in the FileTree host's
+  coordinate system. It may be negative or below the tree.
+- `topInset` and `bottomInset` describe caller-owned sticky or overlay space.
+- `scrollToViewportTop(nextTop, context)` must update `getSnapshot()`
+  synchronously before it returns when you implement a custom source.
+- Drag edge-autoscroll is not implemented in external scroll mode yet.
+
 #### Read APIs
 
 Common read methods are:
@@ -111,6 +130,8 @@ Runtime reconfiguration helpers:
 - `setComposition(composition?)`
 - `setGitStatus(gitStatus?)`
 - `setIcons(icons?)`
+- `setExternalScrollSource(source?)` for attaching or replacing the live
+  external scroll source on a model constructed from `@pierre/trees/scroll`
 
 #### Subscriptions and external systems
 

--- a/apps/docs/app/(trees)/trees-dev/_components/TreesDevSidebar.tsx
+++ b/apps/docs/app/(trees)/trees-dev/_components/TreesDevSidebar.tsx
@@ -12,6 +12,7 @@ const DEMO_PAGES = [
   { slug: '', label: 'Main Demo' },
   { slug: 'react', label: 'React' },
   { slug: 'responsiveness', label: 'Responsiveness' },
+  { slug: 'external-scroll', label: 'External Scroll' },
   { slug: 'density', label: 'Density' },
   { slug: 'search', label: 'Search' },
   { slug: 'git-status', label: 'Git Status' },

--- a/apps/docs/app/(trees)/trees-dev/_demos/ExternalScrollDemoClient.tsx
+++ b/apps/docs/app/(trees)/trees-dev/_demos/ExternalScrollDemoClient.tsx
@@ -1,0 +1,585 @@
+'use client';
+
+import { FileTree } from '@pierre/trees/react';
+import type {
+  FileTreeExternalScrollRequestContext,
+  FileTreeExternalScrollSnapshot,
+  FileTreeExternalScrollSource,
+} from '@pierre/trees/scroll';
+import { FileTree as ScrollFileTree } from '@pierre/trees/scroll';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { ExampleCard } from '../_components/ExampleCard';
+import { useTreesDevSettings } from '../_components/TreesDevSettingsProvider';
+
+const SCROLLER_VIEWPORT_HEIGHT = 360;
+const STICKY_TOOLBAR_HEIGHT = 40;
+const STICKY_SECTION_HEADER_HEIGHT = 32;
+const INITIAL_VIEWPORT_TOP = -1_000;
+const INITIAL_TOP_INSET = STICKY_TOOLBAR_HEIGHT + STICKY_SECTION_HEADER_HEIGHT;
+const DEMO_FOCUS_PATH =
+  'packages/trees/src/render/external/scroll-helper-18.ts';
+const EXTERNAL_SCROLL_DEMO_PATHS = [
+  'README.md',
+  'package.json',
+  'bunfig.toml',
+  'apps/docs/app/(trees)/docs/Overview/content.mdx',
+  ...Array.from(
+    { length: 14 },
+    (_, index) =>
+      `apps/docs/app/(trees)/docs/Guides/Guide-${String(index + 1).padStart(2, '0')}/content.mdx`
+  ),
+  ...Array.from(
+    { length: 14 },
+    (_, index) =>
+      `apps/docs/app/(trees)/docs/Reference/Topic-${String(index + 1).padStart(2, '0')}/content.mdx`
+  ),
+  'packages/trees/src/render/FileTree.ts',
+  'packages/trees/src/render/FileTreeView.tsx',
+  'packages/trees/src/model/layout.ts',
+  ...Array.from(
+    { length: 18 },
+    (_, index) =>
+      `packages/trees/src/render/external/scroll-helper-${String(index + 1).padStart(2, '0')}.ts`
+  ),
+  ...Array.from(
+    { length: 16 },
+    (_, index) =>
+      `packages/trees/test/external-scroll/spec-${String(index + 1).padStart(2, '0')}.test.ts`
+  ),
+  ...Array.from(
+    { length: 12 },
+    (_, index) =>
+      `workspaces/customer-${String(index + 1).padStart(2, '0')}/notes/section-${String(index + 1).padStart(2, '0')}.md`
+  ),
+] as const;
+const EXTERNAL_SCROLL_EXPANDED_PATHS = [
+  'apps/',
+  'apps/docs/',
+  'apps/docs/app/',
+  'apps/docs/app/(trees)/',
+  'apps/docs/app/(trees)/docs/',
+  'apps/docs/app/(trees)/docs/Guides/',
+  'apps/docs/app/(trees)/docs/Reference/',
+  'packages/',
+  'packages/trees/',
+  'packages/trees/src/',
+  'packages/trees/src/render/',
+  'packages/trees/src/render/external/',
+  'packages/trees/test/',
+  'packages/trees/test/external-scroll/',
+] as const;
+const DEMO_INITIAL_SNAPSHOT: FileTreeExternalScrollSnapshot = {
+  topInset: INITIAL_TOP_INSET,
+  viewportHeight: SCROLLER_VIEWPORT_HEIGHT,
+  viewportTop: INITIAL_VIEWPORT_TOP,
+};
+const SECTION_TONES = {
+  below: 'bg-emerald-50/80 border-emerald-200/80',
+  neutral: 'bg-slate-50 border-slate-200',
+  tree: 'bg-white border-slate-300',
+  warning: 'bg-amber-50/80 border-amber-200/80',
+} as const;
+const DEMO_SECTIONS = {
+  above: [
+    {
+      bodyHeight: 220,
+      description:
+        'A sticky section header above the tree proves the parent scroller owns the top inset before the tree ever comes into view.',
+      id: 'overview',
+      sticky: true,
+      title: 'Overview',
+      tone: 'neutral',
+    },
+    {
+      bodyHeight: 180,
+      description:
+        'This section is ordinary flow content. It gives the tree real neighbors without adding another sticky layer.',
+      id: 'release-notes',
+      sticky: false,
+      title: 'Release notes',
+      tone: 'warning',
+    },
+    {
+      bodyHeight: 220,
+      description:
+        'This second sticky section header stays caller-owned. When it pins, the tree should still keep its own sticky folders below it.',
+      id: 'pinned-artifacts',
+      sticky: true,
+      title: 'Pinned artifacts',
+      tone: 'neutral',
+    },
+  ],
+  below: [
+    {
+      bodyHeight: 220,
+      description:
+        'A sticky section below the tree shows that page-owned sticky UI can continue after the tree block without the tree owning the scroll container.',
+      id: 'runbook',
+      sticky: true,
+      title: 'Runbook excerpts',
+      tone: 'below',
+    },
+    {
+      bodyHeight: 180,
+      description:
+        'A normal trailing section keeps plain flow content below the tree as well.',
+      id: 'appendix',
+      sticky: false,
+      title: 'Appendix',
+      tone: 'warning',
+    },
+  ],
+} as const;
+
+type ExternalScrollReadout = {
+  mountedPathCount: number;
+  requestCount: number;
+  stickyPaths: string[];
+  topInset: number;
+  viewportTop: number;
+};
+
+// Measures how much caller-owned sticky UI currently occupies the top edge of
+// the parent scroller. The tree uses that value as `topInset` for sticky rows.
+function measurePinnedStickyInset(scrollContainer: HTMLElement): number {
+  const scrollerTop = scrollContainer.getBoundingClientRect().top;
+  let inset = 0;
+
+  for (const element of scrollContainer.querySelectorAll(
+    '[data-external-scroll-sticky-source="true"]'
+  )) {
+    if (!(element instanceof HTMLElement)) {
+      continue;
+    }
+
+    const rect = element.getBoundingClientRect();
+    const computedTop = window.getComputedStyle(element).top;
+    const stickyTop = Number.parseFloat(computedTop === '' ? '0' : computedTop);
+    const isPinned = Math.abs(rect.top - (scrollerTop + stickyTop)) <= 1.5;
+    if (!isPinned) {
+      continue;
+    }
+
+    inset = Math.max(inset, stickyTop + rect.height);
+  }
+
+  return inset;
+}
+
+// Keeps the live external-scroll snapshot synchronized with the parent scroller
+// and records programmatic reveal requests so the demo can show what happened.
+class DemoExternalScrollSource implements FileTreeExternalScrollSource {
+  readonly requests: {
+    context: FileTreeExternalScrollRequestContext;
+    viewportTop: number;
+  }[] = [];
+  #host: HTMLElement | null = null;
+  #listeners = new Set<() => void>();
+  #scrollContainer: HTMLElement | null = null;
+  #snapshot: FileTreeExternalScrollSnapshot;
+
+  constructor(snapshot: FileTreeExternalScrollSnapshot) {
+    this.#snapshot = snapshot;
+  }
+
+  attach(host: HTMLElement | null, scrollContainer: HTMLElement | null): void {
+    this.#host = host;
+    this.#scrollContainer = scrollContainer;
+    if (host != null && scrollContainer != null) {
+      this.updateFromDom('unknown');
+    }
+  }
+
+  getSnapshot(): FileTreeExternalScrollSnapshot {
+    return this.#snapshot;
+  }
+
+  scrollToViewportTop(
+    viewportTop: number,
+    context: FileTreeExternalScrollRequestContext
+  ): void {
+    if (this.#host == null || this.#scrollContainer == null) {
+      return;
+    }
+
+    this.requests.push({ context, viewportTop });
+    const currentViewportTop = this.#readViewportTop();
+    this.#scrollContainer.scrollTop += viewportTop - currentViewportTop;
+    this.updateFromDom('programmatic');
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.#listeners.add(listener);
+    return () => {
+      this.#listeners.delete(listener);
+    };
+  }
+
+  updateFromDom(
+    scrollOrigin: FileTreeExternalScrollSnapshot['scrollOrigin']
+  ): void {
+    if (this.#host == null || this.#scrollContainer == null) {
+      return;
+    }
+
+    this.#snapshot = {
+      isScrolling: false,
+      scrollOrigin,
+      topInset: measurePinnedStickyInset(this.#scrollContainer),
+      viewportHeight: this.#scrollContainer.clientHeight,
+      viewportTop: this.#readViewportTop(),
+    };
+    this.#notify();
+  }
+
+  #notify(): void {
+    for (const listener of this.#listeners) {
+      listener();
+    }
+  }
+
+  #readViewportTop(): number {
+    if (this.#host == null || this.#scrollContainer == null) {
+      return this.#snapshot.viewportTop;
+    }
+
+    return (
+      this.#scrollContainer.getBoundingClientRect().top -
+      this.#host.getBoundingClientRect().top
+    );
+  }
+}
+
+// Reads the tree's mounted rows and sticky rows so the demo can show how the
+// external viewport changes the rendered slice as the parent scroller moves.
+function readExternalScrollReadout(
+  host: HTMLElement | null,
+  source: DemoExternalScrollSource
+): ExternalScrollReadout {
+  const shadowRoot = host?.shadowRoot;
+  const mountedPathCount = Array.from(
+    shadowRoot?.querySelectorAll(
+      'button[data-type="item"]:not([data-file-tree-sticky-row="true"])'
+    ) ?? []
+  ).filter(
+    (element) =>
+      element instanceof HTMLElement && element.dataset.itemParked !== 'true'
+  ).length;
+  const stickyPaths = Array.from(
+    shadowRoot?.querySelectorAll('button[data-file-tree-sticky-row="true"]') ??
+      []
+  )
+    .map((element) =>
+      element instanceof HTMLElement ? element.dataset.fileTreeStickyPath : null
+    )
+    .filter((path): path is string => path != null);
+  const snapshot = source.getSnapshot();
+
+  return {
+    mountedPathCount,
+    requestCount: source.requests.length,
+    stickyPaths,
+    topInset: snapshot.topInset ?? 0,
+    viewportTop: snapshot.viewportTop,
+  };
+}
+
+function DemoSection({
+  bodyHeight,
+  description,
+  sticky,
+  title,
+  tone,
+}: {
+  bodyHeight: number;
+  description: string;
+  sticky: boolean;
+  title: string;
+  tone: keyof typeof SECTION_TONES;
+}) {
+  return (
+    <section className={`border-b px-4 py-4 ${SECTION_TONES[tone]}`}>
+      <div
+        className={`border-b px-3 text-xs font-semibold tracking-wide uppercase ${SECTION_TONES[tone]} ${
+          sticky ? 'sticky z-10' : ''
+        }`}
+        data-external-scroll-sticky-source={sticky ? 'true' : undefined}
+        style={{
+          height: `${String(STICKY_SECTION_HEADER_HEIGHT)}px`,
+          lineHeight: `${String(STICKY_SECTION_HEADER_HEIGHT)}px`,
+          top: `${String(STICKY_TOOLBAR_HEIGHT)}px`,
+        }}
+      >
+        {title}
+      </div>
+      <div
+        className="pt-3 text-sm leading-6 text-neutral-700"
+        style={{ minHeight: `${String(bodyHeight)}px` }}
+      >
+        <p>{description}</p>
+        <p className="mt-3">
+          Lorem ipsum text stands in for caller-owned content here so the tree
+          has real neighbors inside the parent scroller.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+function ExternalScrollDemoInstance({
+  flattenEmptyDirectories,
+}: {
+  flattenEmptyDirectories: boolean;
+}) {
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const treeHostRef = useRef<HTMLElement | null>(null);
+  const source = useMemo(
+    () => new DemoExternalScrollSource(DEMO_INITIAL_SNAPSHOT),
+    []
+  );
+  const model = useMemo(
+    () =>
+      new ScrollFileTree({
+        externalScroll: { initialSnapshot: source.getSnapshot() },
+        flattenEmptyDirectories,
+        id: 'trees-dev-external-scroll',
+        initialExpandedPaths: EXTERNAL_SCROLL_EXPANDED_PATHS,
+        paths: EXTERNAL_SCROLL_DEMO_PATHS,
+        search: true,
+        stickyFolders: true,
+      }),
+    [flattenEmptyDirectories, source]
+  );
+  useEffect(() => {
+    return () => {
+      model.cleanUp();
+    };
+  }, [model]);
+
+  const [readout, setReadout] = useState<ExternalScrollReadout>(() =>
+    readExternalScrollReadout(treeHostRef.current, source)
+  );
+
+  const syncReadout = useCallback(() => {
+    setReadout(readExternalScrollReadout(treeHostRef.current, source));
+  }, [source]);
+
+  useEffect(() => {
+    const scrollContainer = scrollContainerRef.current;
+    const host = treeHostRef.current;
+    if (scrollContainer == null || host == null) {
+      return;
+    }
+
+    source.attach(host, scrollContainer);
+    model.setExternalScrollSource(source);
+    const unsubscribe = source.subscribe(syncReadout);
+    const resizeObserver = new ResizeObserver(() => {
+      source.updateFromDom('unknown');
+    });
+    resizeObserver.observe(scrollContainer);
+    resizeObserver.observe(host);
+    syncReadout();
+
+    return () => {
+      resizeObserver.disconnect();
+      unsubscribe();
+      model.setExternalScrollSource(undefined);
+    };
+  }, [model, source, syncReadout]);
+
+  useEffect(() => {
+    const scrollContainer = scrollContainerRef.current;
+    if (scrollContainer == null) {
+      return;
+    }
+
+    const handleScroll = (): void => {
+      source.updateFromDom('user');
+    };
+
+    scrollContainer.addEventListener('scroll', handleScroll, { passive: true });
+    return () => {
+      scrollContainer.removeEventListener('scroll', handleScroll);
+    };
+  }, [source]);
+
+  const jumpTo = useCallback((selector: string) => {
+    const scrollContainer = scrollContainerRef.current;
+    const target = scrollContainer?.querySelector(selector);
+    if (scrollContainer == null || !(target instanceof HTMLElement)) {
+      return;
+    }
+
+    scrollContainer.scrollTo({
+      behavior: 'smooth',
+      top: Math.max(0, target.offsetTop - STICKY_TOOLBAR_HEIGHT - 8),
+    });
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-bold">External Scroll</h1>
+        <p className="text-muted-foreground max-w-3xl text-sm leading-6">
+          This proof puts the tree inside a caller-owned scroller with section
+          content above and below it. The parent scroller owns the viewport, the
+          sticky section headers, and the top inset. The tree keeps its own
+          virtualization, search, sticky folders, and focus reveal behavior.
+        </p>
+      </header>
+
+      <ExampleCard
+        title="Caller-owned scroller"
+        description="Scroll the parent container, not the tree. The sticky toolbar and selected section headers stay caller-owned while the tree block sits in ordinary flow between them."
+        controls={
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              className="rounded-sm border px-2 py-1 text-xs"
+              style={{ borderColor: 'var(--color-border)' }}
+              onClick={() => {
+                scrollContainerRef.current?.scrollTo({
+                  behavior: 'smooth',
+                  top: 0,
+                });
+              }}
+            >
+              Scroll to top
+            </button>
+            <button
+              type="button"
+              className="rounded-sm border px-2 py-1 text-xs"
+              style={{ borderColor: 'var(--color-border)' }}
+              onClick={() => {
+                jumpTo('[data-external-scroll-tree-section="true"]');
+              }}
+            >
+              Jump to tree
+            </button>
+            <button
+              type="button"
+              className="rounded-sm border px-2 py-1 text-xs"
+              style={{ borderColor: 'var(--color-border)' }}
+              onClick={() => {
+                jumpTo('[data-external-scroll-below-target="true"]');
+              }}
+            >
+              Jump below tree
+            </button>
+            <button
+              type="button"
+              className="rounded-sm border px-2 py-1 text-xs"
+              style={{ borderColor: 'var(--color-border)' }}
+              onClick={() => {
+                model.focusPath(DEMO_FOCUS_PATH);
+              }}
+            >
+              Focus deep file
+            </button>
+          </div>
+        }
+        footer={
+          <dl className="text-muted-foreground mt-3 grid grid-cols-2 gap-x-3 gap-y-1 text-[11px] leading-5 sm:grid-cols-4">
+            <div>
+              <dt className="font-semibold">viewportTop</dt>
+              <dd>{readout.viewportTop.toFixed(0)}px</dd>
+            </div>
+            <div>
+              <dt className="font-semibold">topInset</dt>
+              <dd>{readout.topInset.toFixed(0)}px</dd>
+            </div>
+            <div>
+              <dt className="font-semibold">mounted rows</dt>
+              <dd>{readout.mountedPathCount}</dd>
+            </div>
+            <div>
+              <dt className="font-semibold">scroll requests</dt>
+              <dd>{readout.requestCount}</dd>
+            </div>
+            <div className="sm:col-span-4">
+              <dt className="font-semibold">sticky folders</dt>
+              <dd>
+                {readout.stickyPaths.length > 0
+                  ? readout.stickyPaths.join(' → ')
+                  : '—'}
+              </dd>
+            </div>
+          </dl>
+        }
+      >
+        <div
+          ref={scrollContainerRef}
+          className="overflow-y-auto rounded-lg border border-[var(--color-border)] bg-neutral-50"
+          style={{ height: `${String(SCROLLER_VIEWPORT_HEIGHT)}px` }}
+        >
+          <div
+            className="sticky top-0 z-20 border-b bg-neutral-950 px-4 text-sm font-semibold text-white"
+            data-external-scroll-sticky-source="true"
+            style={{
+              height: `${String(STICKY_TOOLBAR_HEIGHT)}px`,
+              lineHeight: `${String(STICKY_TOOLBAR_HEIGHT)}px`,
+            }}
+          >
+            Caller sticky toolbar
+          </div>
+
+          {DEMO_SECTIONS.above.map((section) => (
+            <DemoSection key={section.id} {...section} />
+          ))}
+
+          <section
+            className={`border-y px-4 py-4 ${SECTION_TONES.tree}`}
+            data-external-scroll-tree-section="true"
+          >
+            <div className="mb-3 space-y-1">
+              <h2 className="text-sm font-semibold tracking-wide uppercase">
+                Tree section
+              </h2>
+              <p className="text-sm leading-6 text-neutral-700">
+                The tree itself is not wrapped in an internal scroller here. Its
+                header and search UI move with the surrounding document flow.
+              </p>
+            </div>
+            <FileTree
+              ref={treeHostRef}
+              model={model}
+              className="block rounded-md border border-slate-300 bg-white"
+              header={
+                <div className="flex items-center justify-between gap-3 px-3 py-2 text-sm">
+                  <strong>Project files</strong>
+                  <span className="text-xs text-neutral-500">
+                    Parent scroller owns the viewport
+                  </span>
+                </div>
+              }
+            />
+          </section>
+
+          {DEMO_SECTIONS.below.map((section, index) => (
+            <div
+              key={section.id}
+              data-external-scroll-below-target={
+                index === 0 ? 'true' : undefined
+              }
+            >
+              <DemoSection {...section} />
+            </div>
+          ))}
+        </div>
+      </ExampleCard>
+    </div>
+  );
+}
+
+export function ExternalScrollDemoClient() {
+  const { flattenEmptyDirectories } = useTreesDevSettings();
+
+  return (
+    <ExternalScrollDemoInstance
+      key={flattenEmptyDirectories ? 'flattened' : 'hierarchical'}
+      flattenEmptyDirectories={flattenEmptyDirectories}
+    />
+  );
+}

--- a/apps/docs/app/(trees)/trees-dev/external-scroll/page.tsx
+++ b/apps/docs/app/(trees)/trees-dev/external-scroll/page.tsx
@@ -1,0 +1,5 @@
+import { ExternalScrollDemoClient } from '../_demos/ExternalScrollDemoClient';
+
+export default function TreesDevExternalScrollPage() {
+  return <ExternalScrollDemoClient />;
+}

--- a/packages/trees/README.md
+++ b/packages/trees/README.md
@@ -63,6 +63,44 @@ const tree = new FileTree({ preparedInput });
 Use `prepareFileTreeInput(paths)` for raw input. Use
 `preparePresortedFileTreeInput(paths)` when the final order is already known.
 
+## External scroll containers
+
+Import from `@pierre/trees/scroll` when a caller-owned scroller contains content
+above and below the tree. The tree remains a normal block in that scroller and
+owns only its virtual spacer height.
+
+```ts
+import { FileTree, createDomScrollSource } from '@pierre/trees/scroll';
+
+const source = createDomScrollSource({
+  scrollContainer: parentScroller,
+  topInset: () => toolbar.getBoundingClientRect().height,
+});
+
+const tree = new FileTree({
+  paths,
+  stickyFolders: true,
+  externalScroll: {
+    initialSnapshot: source.getSnapshot(),
+    source,
+  },
+});
+
+tree.render({ containerWrapper: mount });
+const host = tree.getFileTreeContainer();
+source.setHost(host ?? null);
+```
+
+`createDomScrollSource()` handles the common DOM-scroller case. If you roll your
+own source, it reports host-local metrics: `viewportTop`, `viewportHeight`,
+`topInset`, `bottomInset`, `isScrolling`, and `scrollOrigin`. Its
+`scrollToViewportTop(nextTop, context)` method must update `getSnapshot()`
+synchronously before returning. `initialVisibleRowCount` is only a fallback in
+external mode when `initialSnapshot` is missing.
+
+Header and search UI scroll with the tree in external mode. Sticky folders pin
+below `topInset`, and drag edge-autoscroll is not implemented in this mode yet.
+
 ## React usage
 
 ```tsx

--- a/packages/trees/package.json
+++ b/packages/trees/package.json
@@ -20,6 +20,9 @@
       "react": [
         "dist/react/index.d.ts"
       ],
+      "scroll": [
+        "dist/scroll/index.d.ts"
+      ],
       "ssr": [
         "dist/ssr/index.d.ts"
       ],
@@ -40,6 +43,10 @@
     "./react": {
       "types": "./dist/react/index.d.ts",
       "import": "./dist/react/index.js"
+    },
+    "./scroll": {
+      "types": "./dist/scroll/index.d.ts",
+      "import": "./dist/scroll/index.js"
     },
     "./ssr": {
       "types": "./dist/ssr/index.d.ts",

--- a/packages/trees/src/components/web-components.ts
+++ b/packages/trees/src/components/web-components.ts
@@ -3,9 +3,14 @@ import rawStyles from '../style.css';
 import { wrapCoreCSS } from '../utils/cssWrappers';
 import { ensureMeasuredScrollbarGutter } from '../utils/scrollbarGutter';
 
-let sheet: CSSStyleSheet | undefined;
+const sheetCache = new Map<string, CSSStyleSheet>();
+
+function getWrappedStyles(styles: string): string {
+  return wrapCoreCSS(styles);
+}
 
 export function ensureFileTreeStyles(shadowRoot: ShadowRoot): void {
+  const wrappedStyles = getWrappedStyles(rawStyles);
   const hasReplaceSync =
     typeof CSSStyleSheet !== 'undefined' &&
     typeof (CSSStyleSheet.prototype as { replaceSync?: unknown })
@@ -14,9 +19,11 @@ export function ensureFileTreeStyles(shadowRoot: ShadowRoot): void {
   const canAdopt = hasReplaceSync && 'adoptedStyleSheets' in shadowRoot;
 
   if (canAdopt) {
+    let sheet = sheetCache.get(wrappedStyles);
     if (sheet == null) {
       sheet = new CSSStyleSheet();
-      sheet.replaceSync(wrapCoreCSS(rawStyles));
+      sheet.replaceSync(wrappedStyles);
+      sheetCache.set(wrappedStyles, sheet);
     }
     let adopted = false;
     try {
@@ -36,12 +43,16 @@ export function ensureFileTreeStyles(shadowRoot: ShadowRoot): void {
   }
 
   // Fallback path for environments without adoptedStyleSheets.
-  // Ensure an inline style exists in the shadow root.
-  if (shadowRoot.querySelector(`style[${FILE_TREE_STYLE_ATTRIBUTE}]`) == null) {
-    const styleEl = document.createElement('style');
+  // Ensure an inline style exists in the shadow root and keep it synced to the
+  // root tree stylesheet.
+  let styleEl = shadowRoot.querySelector(`style[${FILE_TREE_STYLE_ATTRIBUTE}]`);
+  if (!(styleEl instanceof HTMLStyleElement)) {
+    styleEl = document.createElement('style');
     styleEl.setAttribute(FILE_TREE_STYLE_ATTRIBUTE, '');
-    styleEl.textContent = wrapCoreCSS(rawStyles);
     shadowRoot.prepend(styleEl);
+  }
+  if (styleEl.textContent !== wrappedStyles) {
+    styleEl.textContent = wrappedStyles;
   }
 }
 

--- a/packages/trees/src/index.ts
+++ b/packages/trees/src/index.ts
@@ -55,6 +55,7 @@ export type {
   FileTreeInitialExpansion,
   FileTreeItemHandle,
   FileTreeListener,
+  FileTreeModel,
   FileTreeMoveEvent,
   FileTreeMoveOptions,
   FileTreeMutationEvent,

--- a/packages/trees/src/model/externalScroll.ts
+++ b/packages/trees/src/model/externalScroll.ts
@@ -1,0 +1,103 @@
+import type {
+  FileTreeExternalScrollOrigin,
+  FileTreeExternalScrollSnapshot,
+} from '../scroll/publicTypes';
+
+export interface FileTreeNormalizedExternalScrollSnapshot {
+  bottomInset: number;
+  effectiveViewportHeight: number;
+  isScrolling: boolean;
+  scrollOrigin: FileTreeExternalScrollOrigin;
+  topInset: number;
+  viewportHeight: number;
+  viewportTop: number;
+}
+
+export interface FileTreeExternalScrollInitialSnapshotInput {
+  initialSnapshot?: FileTreeExternalScrollSnapshot;
+  initialVisibleRowCount?: number;
+  itemHeight: number;
+}
+
+const VALID_EXTERNAL_SCROLL_ORIGINS = new Set<FileTreeExternalScrollOrigin>([
+  'programmatic',
+  'unknown',
+  'user',
+]);
+
+function finiteOr(value: number | undefined, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function nonNegativeFiniteOr(
+  value: number | undefined,
+  fallback: number
+): number {
+  return Math.max(0, finiteOr(value, fallback));
+}
+
+function normalizeScrollOrigin(
+  origin: FileTreeExternalScrollSnapshot['scrollOrigin']
+): FileTreeExternalScrollOrigin {
+  return origin != null && VALID_EXTERNAL_SCROLL_ORIGINS.has(origin)
+    ? origin
+    : 'unknown';
+}
+
+// Normalizes caller-provided viewport metrics before layout code consumes them.
+// External scroll sources are a system boundary, so bad geometry degrades to a
+// zero-sized viewport instead of leaking NaN through virtualization math.
+export function normalizeFileTreeExternalScrollSnapshot(
+  snapshot: FileTreeExternalScrollSnapshot | undefined,
+  fallbackViewportHeight: number = 0
+): FileTreeNormalizedExternalScrollSnapshot {
+  const viewportTop = finiteOr(snapshot?.viewportTop, 0);
+  const viewportHeight = nonNegativeFiniteOr(
+    snapshot?.viewportHeight,
+    fallbackViewportHeight
+  );
+  const topInset = nonNegativeFiniteOr(snapshot?.topInset, 0);
+  const bottomInset = nonNegativeFiniteOr(snapshot?.bottomInset, 0);
+  const effectiveViewportHeight = Math.max(
+    0,
+    viewportHeight - topInset - bottomInset
+  );
+
+  return {
+    bottomInset,
+    effectiveViewportHeight,
+    isScrolling: snapshot?.isScrolling === true,
+    scrollOrigin: normalizeScrollOrigin(snapshot?.scrollOrigin),
+    topInset,
+    viewportHeight,
+    viewportTop,
+  };
+}
+
+export function getFileTreeExternalScrollFallbackViewportHeight({
+  initialVisibleRowCount,
+  itemHeight,
+}: Pick<
+  FileTreeExternalScrollInitialSnapshotInput,
+  'initialVisibleRowCount' | 'itemHeight'
+>): number {
+  return initialVisibleRowCount == null
+    ? 0
+    : Math.max(0, initialVisibleRowCount) * itemHeight;
+}
+
+export function resolveFileTreeExternalScrollInitialSnapshot({
+  initialSnapshot,
+  initialVisibleRowCount,
+  itemHeight,
+}: FileTreeExternalScrollInitialSnapshotInput): FileTreeNormalizedExternalScrollSnapshot {
+  const fallbackViewportHeight =
+    getFileTreeExternalScrollFallbackViewportHeight({
+      initialVisibleRowCount,
+      itemHeight,
+    });
+  return normalizeFileTreeExternalScrollSnapshot(
+    initialSnapshot,
+    fallbackViewportHeight
+  );
+}

--- a/packages/trees/src/model/layout.ts
+++ b/packages/trees/src/model/layout.ts
@@ -19,6 +19,13 @@ export type FileTreeLayoutMetrics = {
   totalRowCount?: number;
 };
 
+export type FileTreeExternalLayoutMetrics = Omit<
+  FileTreeLayoutMetrics,
+  'scrollTop'
+> & {
+  viewportTop: number;
+};
+
 export type FileTreeLayoutRange = {
   endIndex: number;
   startIndex: number;
@@ -73,6 +80,10 @@ export type FileTreeLayoutSnapshot<
 
 function clamp(value: number, minimum: number, maximum: number): number {
   return Math.min(Math.max(value, minimum), maximum);
+}
+
+function finiteOr(value: number, fallback: number): number {
+  return Number.isFinite(value) ? value : fallback;
 }
 
 function createRange(
@@ -409,6 +420,130 @@ export function computeFileTreeLayout<Row extends FileTreeLayoutRow>(
       maxScrollTop,
       overscan,
       scrollTop,
+      totalHeight,
+      totalRowCount,
+      viewportHeight,
+    },
+    projected: {
+      contentHeight,
+      paneHeight,
+      paneTop,
+    },
+    sticky: {
+      height: stickyHeight,
+      rows: stickyRows,
+    },
+    visible,
+    window: {
+      endIndex: windowRange.endIndex,
+      height: windowHeight,
+      offsetTop: isEmptyRange(windowRange)
+        ? 0
+        : windowRange.startIndex * metrics.itemHeight,
+      startIndex: windowRange.startIndex,
+    },
+  };
+}
+
+export function computeFileTreeExternalLayout<Row extends FileTreeLayoutRow>(
+  rows: readonly Row[],
+  metrics: FileTreeExternalLayoutMetrics
+): FileTreeLayoutSnapshot<Row> {
+  const totalRowCount = metrics.totalRowCount ?? rows.length;
+  const totalHeight = totalRowCount * metrics.itemHeight;
+  const viewportTop = finiteOr(metrics.viewportTop, 0);
+  const viewportHeight = Math.max(0, finiteOr(metrics.viewportHeight, 0));
+  const overscan = Math.max(0, Math.floor(metrics.overscan));
+  const maxScrollTop = Math.max(0, totalHeight - viewportHeight);
+  const viewportBottom = viewportTop + viewportHeight;
+  const intersectsRowArea =
+    totalRowCount > 0 &&
+    viewportHeight > 0 &&
+    viewportBottom > 0 &&
+    viewportTop < totalHeight;
+  const stickyRows =
+    intersectsRowArea && viewportTop > 0
+      ? ((metrics.stickyRows as
+          | readonly FileTreeLayoutStickyRow<Row>[]
+          | undefined) ??
+        computeStickyRows(rows, viewportTop, metrics.itemHeight))
+      : [];
+  const stickyHeight = stickyRows.reduce(
+    (maximumBottom, entry) =>
+      Math.max(maximumBottom, entry.top + metrics.itemHeight),
+    0
+  );
+  const paneTop = viewportTop + stickyHeight;
+  const paneHeight = Math.max(0, viewportHeight - stickyHeight);
+  const contentHeight = Math.max(0, totalHeight - Math.max(0, paneTop));
+
+  const firstVisiblePhysicalIndex = getFirstIntersectingIndex(
+    viewportTop,
+    totalRowCount,
+    metrics.itemHeight
+  );
+  const firstProjectedIndex = getFirstIntersectingIndex(
+    paneTop,
+    totalRowCount,
+    metrics.itemHeight
+  );
+
+  const firstOccludedIndex =
+    stickyHeight <= 0 ||
+    firstVisiblePhysicalIndex < 0 ||
+    firstVisiblePhysicalIndex >= totalRowCount
+      ? -1
+      : firstVisiblePhysicalIndex;
+  const lastOccludedIndex =
+    firstOccludedIndex === -1
+      ? -1
+      : Math.min(totalRowCount - 1, firstProjectedIndex - 1);
+  const occludedCount =
+    firstOccludedIndex === -1 || lastOccludedIndex < firstOccludedIndex
+      ? 0
+      : lastOccludedIndex - firstOccludedIndex + 1;
+
+  const visible =
+    paneHeight <= 0 || firstProjectedIndex >= totalRowCount
+      ? EMPTY_FILE_TREE_LAYOUT_RANGE
+      : createRange(
+          firstProjectedIndex,
+          getLastIntersectingIndex(
+            paneTop + paneHeight,
+            totalRowCount,
+            metrics.itemHeight
+          )
+        );
+
+  const overscanPixels = overscan * metrics.itemHeight;
+  const firstWindowIndex = getFirstIntersectingIndex(
+    paneTop - overscanPixels,
+    totalRowCount,
+    metrics.itemHeight
+  );
+  const lastWindowIndex = getLastIntersectingIndex(
+    paneTop + paneHeight + overscanPixels,
+    totalRowCount,
+    metrics.itemHeight
+  );
+  const minimumWindowStart = lastOccludedIndex + 1;
+  const windowRange = createRange(
+    Math.max(minimumWindowStart, firstWindowIndex),
+    Math.min(totalRowCount - 1, lastWindowIndex)
+  );
+  const windowHeight = getRangeHeight(windowRange, metrics.itemHeight);
+
+  return {
+    occlusion: {
+      firstOccludedIndex,
+      lastOccludedIndex,
+      occludedCount,
+    },
+    physical: {
+      itemHeight: metrics.itemHeight,
+      maxScrollTop,
+      overscan,
+      scrollTop: viewportTop,
       totalHeight,
       totalRowCount,
       viewportHeight,

--- a/packages/trees/src/model/publicTypes.ts
+++ b/packages/trees/src/model/publicTypes.ts
@@ -342,6 +342,35 @@ export interface FileTreeMutationHandle {
 
 export type FileTreeListener = () => void;
 
+export interface FileTreeModel
+  extends FileTreeMutationHandle, FileTreeSearchSessionHandle {
+  cleanUp(): void;
+  focusNearestPath(path: FileTreePublicId | null): FileTreePublicId | null;
+  focusPath(path: FileTreePublicId): void;
+  getComposition(): FileTreeCompositionOptions | undefined;
+  getDensityFactor(): number;
+  getFileTreeContainer(): HTMLElement | undefined;
+  getFocusedItem(): FileTreeItemHandle | null;
+  getFocusedPath(): FileTreePublicId | null;
+  getItem(path: FileTreePublicId): FileTreeItemHandle | null;
+  getItemHeight(): number;
+  getSearchMatchingPaths(): readonly FileTreePublicId[];
+  getSearchValue(): string;
+  getSelectedPaths(): readonly FileTreePublicId[];
+  hydrate(props: FileTreeHydrationProps): void;
+  isSearchOpen(): boolean;
+  render(props: FileTreeRenderProps): void;
+  setComposition(composition?: FileTreeCompositionOptions): void;
+  setGitStatus(gitStatus?: FileTreeOptions['gitStatus']): void;
+  setIcons(icons?: FileTreeOptions['icons']): void;
+  startRenaming(
+    path?: FileTreePublicId,
+    options?: { removeIfCanceled?: boolean }
+  ): boolean;
+  subscribe(listener: FileTreeListener): () => void;
+  unmount(): void;
+}
+
 export type FileTreeSelectionChangeListener = (
   selectedPaths: readonly FileTreePublicId[]
 ) => void;

--- a/packages/trees/src/react/FileTree.tsx
+++ b/packages/trees/src/react/FileTree.tsx
@@ -1,8 +1,9 @@
 /** @jsxImportSource react */
 'use client';
 
-import type { CSSProperties, HTMLAttributes, ReactNode } from 'react';
+import type { CSSProperties, HTMLAttributes, ReactNode, Ref } from 'react';
 import {
+  forwardRef,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -20,9 +21,9 @@ import type {
   FileTreeCompositionOptions,
   FileTreeContextMenuItem,
   FileTreeContextMenuOpenContext,
+  FileTreeModel,
   FileTreeSsrPayload,
 } from '../model/publicTypes';
-import type { FileTree as FileTreeModel } from '../render/FileTree';
 
 const useClientLayoutEffect =
   typeof window === 'undefined' ? useEffect : useLayoutEffect;
@@ -146,6 +147,19 @@ function resolveComposition(
     : undefined;
 }
 
+function assignForwardedRef<T>(ref: Ref<T> | undefined, value: T | null): void {
+  if (ref == null) {
+    return;
+  }
+
+  if (typeof ref === 'function') {
+    ref(value);
+    return;
+  }
+
+  ref.current = value;
+}
+
 export interface FileTreeProps extends Omit<
   HTMLAttributes<HTMLElement>,
   'children'
@@ -159,115 +173,124 @@ export interface FileTreeProps extends Omit<
   ) => ReactNode;
 }
 
-export function FileTree({
-  header,
-  id,
-  model,
-  preloadedData,
-  renderContextMenu,
-  ...hostProps
-}: FileTreeProps): React.JSX.Element {
-  const [activeContextMenu, setActiveContextMenu] =
-    useState<ActiveContextMenuState | null>(null);
-  const [hostElement, setHostElement] = useState<HTMLElement | null>(null);
-  const baselineCompositionRef = useRef<FileTreeCompositionOptions | undefined>(
-    model.getComposition()
-  );
-  const baselineModelRef = useRef(model);
-  if (baselineModelRef.current !== model) {
-    baselineModelRef.current = model;
-    baselineCompositionRef.current = model.getComposition();
-  }
-
-  const hasContextMenu = renderContextMenu != null;
-  const handleContextMenuClose = useCallback(() => {
-    setActiveContextMenu(null);
-  }, []);
-  const handleContextMenuOpen = useCallback(
-    (
-      item: FileTreeContextMenuItem,
-      context: FileTreeContextMenuOpenContext
-    ) => {
-      setActiveContextMenu({ context, item });
-    },
-    []
-  );
-  const baselineComposition = baselineCompositionRef.current;
-  const composition = useMemo<FileTreeCompositionOptions | undefined>(
-    () =>
-      resolveComposition(
-        baselineComposition,
-        header,
-        hasContextMenu,
-        handleContextMenuClose,
-        handleContextMenuOpen
-      ),
-    [
-      baselineComposition,
-      handleContextMenuClose,
-      handleContextMenuOpen,
-      hasContextMenu,
+export const FileTree = forwardRef<HTMLElement, FileTreeProps>(
+  function FileTree(
+    {
       header,
-    ]
-  );
-
-  const handleHostRef = useCallback((node: HTMLElement | null) => {
-    setHostElement(node);
-  }, []);
-
-  useEffect(() => {
-    if (hasContextMenu) {
-      return;
+      id,
+      model,
+      preloadedData,
+      renderContextMenu,
+      ...hostProps
+    }: FileTreeProps,
+    forwardedRef
+  ): React.JSX.Element {
+    const [activeContextMenu, setActiveContextMenu] =
+      useState<ActiveContextMenuState | null>(null);
+    const [hostElement, setHostElement] = useState<HTMLElement | null>(null);
+    const baselineCompositionRef = useRef<
+      FileTreeCompositionOptions | undefined
+    >(model.getComposition());
+    const baselineModelRef = useRef(model);
+    if (baselineModelRef.current !== model) {
+      baselineModelRef.current = model;
+      baselineCompositionRef.current = model.getComposition();
     }
 
-    setActiveContextMenu(null);
-  }, [hasContextMenu]);
+    const hasContextMenu = renderContextMenu != null;
+    const handleContextMenuClose = useCallback(() => {
+      setActiveContextMenu(null);
+    }, []);
+    const handleContextMenuOpen = useCallback(
+      (
+        item: FileTreeContextMenuItem,
+        context: FileTreeContextMenuOpenContext
+      ) => {
+        setActiveContextMenu({ context, item });
+      },
+      []
+    );
+    const baselineComposition = baselineCompositionRef.current;
+    const composition = useMemo<FileTreeCompositionOptions | undefined>(
+      () =>
+        resolveComposition(
+          baselineComposition,
+          header,
+          hasContextMenu,
+          handleContextMenuClose,
+          handleContextMenuOpen
+        ),
+      [
+        baselineComposition,
+        handleContextMenuClose,
+        handleContextMenuOpen,
+        hasContextMenu,
+        header,
+      ]
+    );
 
-  useClientLayoutEffect(() => {
-    model.setComposition(composition);
-  }, [composition, model]);
+    const handleHostRef = useCallback(
+      (node: HTMLElement | null) => {
+        setHostElement(node);
+        assignForwardedRef(forwardedRef, node);
+      },
+      [forwardedRef]
+    );
 
-  useClientLayoutEffect(() => {
-    if (hostElement == null) {
-      return;
-    }
+    useEffect(() => {
+      if (hasContextMenu) {
+        return;
+      }
 
-    if (preloadedData != null && hasExistingPreloadedContent(hostElement)) {
-      model.hydrate({ fileTreeContainer: hostElement });
-    } else {
-      model.render({ fileTreeContainer: hostElement });
-    }
+      setActiveContextMenu(null);
+    }, [hasContextMenu]);
 
-    return () => {
-      model.unmount();
-      model.setComposition(baselineComposition);
+    useClientLayoutEffect(() => {
+      model.setComposition(composition);
+    }, [composition, model]);
+
+    useClientLayoutEffect(() => {
+      if (hostElement == null) {
+        return;
+      }
+
+      if (preloadedData != null && hasExistingPreloadedContent(hostElement)) {
+        model.hydrate({ fileTreeContainer: hostElement });
+      } else {
+        model.render({ fileTreeContainer: hostElement });
+      }
+
+      return () => {
+        model.unmount();
+        model.setComposition(baselineComposition);
+      };
+    }, [baselineComposition, hostElement, model, preloadedData]);
+
+    const children = renderPreloadedShadowDom(
+      renderFileTreeChildren(header, renderContextMenu, activeContextMenu),
+      preloadedData
+    );
+    const resolvedHostId = id ?? preloadedData?.id;
+
+    // Paint the model's resolved density onto the host so callers don't have to
+    // set `--trees-item-height` and `--trees-density-override` themselves.
+    // Caller-provided `style` keys still win via spread order.
+    const mergedStyle: CSSProperties = {
+      ['--trees-item-height' as string]: `${String(model.getItemHeight())}px`,
+      ['--trees-density-override' as string]: model.getDensityFactor(),
+      ...hostProps.style,
     };
-  }, [baselineComposition, hostElement, model, preloadedData]);
 
-  const children = renderPreloadedShadowDom(
-    renderFileTreeChildren(header, renderContextMenu, activeContextMenu),
-    preloadedData
-  );
-  const resolvedHostId = id ?? preloadedData?.id;
-
-  // Paint the model's resolved density onto the host so callers don't have to
-  // set `--trees-item-height` and `--trees-density-override` themselves.
-  // Caller-provided `style` keys still win via spread order.
-  const mergedStyle: CSSProperties = {
-    ['--trees-item-height' as string]: `${String(model.getItemHeight())}px`,
-    ['--trees-density-override' as string]: model.getDensityFactor(),
-    ...hostProps.style,
-  };
-
-  return (
-    <FILE_TREE_TAG_NAME
-      {...hostProps}
-      id={resolvedHostId}
-      ref={handleHostRef}
-      style={mergedStyle}
-      suppressHydrationWarning={preloadedData != null}
-    >
-      {children}
-    </FILE_TREE_TAG_NAME>
-  );
-}
+    return (
+      <FILE_TREE_TAG_NAME
+        {...hostProps}
+        id={resolvedHostId}
+        ref={handleHostRef}
+        style={mergedStyle}
+        suppressHydrationWarning={preloadedData != null}
+      >
+        {children}
+      </FILE_TREE_TAG_NAME>
+    );
+  }
+);

--- a/packages/trees/src/react/useFileTreeSearch.ts
+++ b/packages/trees/src/react/useFileTreeSearch.ts
@@ -2,7 +2,7 @@
 
 import { useMemo } from 'react';
 
-import type { FileTree } from '../render/FileTree';
+import type { FileTreeModel } from '../model/publicTypes';
 import { areArraysEqual, useFileTreeSelector } from './useFileTreeSelector';
 
 interface FileTreeSearchSnapshot {
@@ -30,7 +30,7 @@ function areSearchSnapshotsEqual(
   );
 }
 
-export function useFileTreeSearch(model: FileTree): FileTreeSearchState {
+export function useFileTreeSearch(model: FileTreeModel): FileTreeSearchState {
   const snapshot = useFileTreeSelector(
     model,
     (currentModel): FileTreeSearchSnapshot => ({

--- a/packages/trees/src/react/useFileTreeSelection.ts
+++ b/packages/trees/src/react/useFileTreeSelection.ts
@@ -1,9 +1,9 @@
 'use client';
 
-import type { FileTree } from '../render/FileTree';
+import type { FileTreeModel } from '../model/publicTypes';
 import { areArraysEqual, useFileTreeSelector } from './useFileTreeSelector';
 
-export function useFileTreeSelection(model: FileTree): readonly string[] {
+export function useFileTreeSelection(model: FileTreeModel): readonly string[] {
   return useFileTreeSelector(
     model,
     (currentModel) => currentModel.getSelectedPaths(),

--- a/packages/trees/src/react/useFileTreeSelector.ts
+++ b/packages/trees/src/react/useFileTreeSelector.ts
@@ -2,9 +2,9 @@
 
 import { useCallback, useRef, useSyncExternalStore } from 'react';
 
-import type { FileTree } from '../render/FileTree';
+import type { FileTreeModel } from '../model/publicTypes';
 
-export type FileTreeSelector<TSelected> = (model: FileTree) => TSelected;
+export type FileTreeSelector<TSelected> = (model: FileTreeModel) => TSelected;
 export type FileTreeSelectorEquality<TSelected> = (
   previous: TSelected,
   next: TSelected
@@ -12,7 +12,7 @@ export type FileTreeSelectorEquality<TSelected> = (
 
 interface SelectorCache<TSelected> {
   hasValue: boolean;
-  model: FileTree | null;
+  model: FileTreeModel | null;
   selector: FileTreeSelector<TSelected> | null;
   value: TSelected | undefined;
 }
@@ -51,7 +51,7 @@ function areSelectedValuesEqual<TSelected>(
 // useSyncExternalStore can compare stable values across real store updates.
 
 export function useFileTreeSelector<TSelected>(
-  model: FileTree,
+  model: FileTreeModel,
   selector: FileTreeSelector<TSelected>,
   isEqual?: FileTreeSelectorEquality<TSelected>
 ): TSelected {

--- a/packages/trees/src/render/FileTreeView.tsx
+++ b/packages/trees/src/render/FileTreeView.tsx
@@ -21,7 +21,10 @@ import {
   FILE_TREE_RENAME_VIEW,
   FileTreeController,
 } from '../model/FileTreeController';
-import type { FileTreeViewProps } from '../model/internalTypes';
+import type {
+  FileTreeStickyRowCandidate,
+  FileTreeViewProps,
+} from '../model/internalTypes';
 import {
   computeFileTreeLayout,
   computeStickyRows,
@@ -51,83 +54,24 @@ import {
   GIT_STATUS_LABEL,
   GIT_STATUS_TITLE,
 } from '../utils/gitStatusPresentation';
+import {
+  focusElement,
+  getActiveTreeElement,
+  getCachedViewportHeight,
+  getParkedFocusedRowOffset,
+  getResizeObserverViewportHeight,
+  readMeasuredViewportHeight,
+  scrollFocusedRowIntoView,
+  scrollFocusedRowToViewportOffset,
+} from './focusHelpers';
 import { createFileTreeIconResolver } from './iconResolver';
 import { classifyFileTreeRenameHandoff } from './renameHandoff';
+import { RenameInput } from './RenameInput';
 import { computeFileTreeRowElementAttributes } from './rowAttributes';
 import {
   computeFileTreeRowClickPlan,
   type FileTreeRowClickMode,
 } from './rowClickPlan';
-import {
-  computeFocusedRowScrollIntoView,
-  computeViewportOffsetScrollTop,
-} from './scrollTarget';
-
-function focusElement(element: HTMLElement | null): boolean {
-  if (element == null || !element.isConnected) {
-    return false;
-  }
-  if (element === document.body || element === document.documentElement) {
-    return false;
-  }
-
-  element.focus({ preventScroll: true });
-  const rootNode = element.getRootNode();
-  if (rootNode instanceof ShadowRoot) {
-    return rootNode.activeElement === element;
-  }
-
-  return document.activeElement === element;
-}
-
-// Shadow-root focus lives on shadowRoot.activeElement, so this helper
-// resolves the actual focused tree element regardless of host indirection.
-// Reads the actual focused element from the tree's shadow root so focus
-// sync logic can work even when document.activeElement points at the host.
-function getActiveTreeElement(rootElement: HTMLElement): HTMLElement | null {
-  const rootNode = rootElement.getRootNode();
-  if (rootNode instanceof ShadowRoot) {
-    const activeElement = rootNode.activeElement;
-    return activeElement instanceof HTMLElement ? activeElement : null;
-  }
-
-  const activeElement = document.activeElement;
-  return activeElement instanceof HTMLElement &&
-    rootElement.contains(activeElement)
-    ? activeElement
-    : null;
-}
-
-function RenameInput({
-  ariaLabel,
-  isFlattened = false,
-  ref,
-  value,
-  onBlur,
-  onInput,
-}: {
-  ariaLabel: string;
-  isFlattened?: boolean;
-  onBlur: () => void;
-  onInput: (event: Event) => void;
-  ref: (element: HTMLInputElement | null) => void;
-  value: string;
-}): JSX.Element {
-  return (
-    <input
-      ref={ref}
-      data-item-rename-input
-      {...(isFlattened ? { 'data-item-flattened-rename-input': true } : {})}
-      aria-label={ariaLabel}
-      value={value}
-      onBlur={onBlur}
-      onInput={onInput}
-      onClick={(event) => event.stopPropagation()}
-      onMouseDown={(event) => event.stopPropagation()}
-      onPointerDown={(event) => event.stopPropagation()}
-    />
-  );
-}
 
 function formatFlattenedSegments(
   row: FileTreeVisibleRow,
@@ -199,6 +143,29 @@ type FileTreeViewLayoutState = {
   visibleRows: readonly FileTreeVisibleRow[];
 };
 
+function computeStickyRowsFromCandidates(
+  candidates: readonly FileTreeStickyRowCandidate[],
+  scrollTop: number,
+  itemHeight: number,
+  totalRowCount: number
+): readonly FileTreeLayoutStickyRow<FileTreeVisibleRow>[] {
+  return candidates
+    .map((candidate, slotDepth) => {
+      const defaultTop = slotDepth * itemHeight;
+      const nextBoundaryIndex = candidate.subtreeEndIndex + 1;
+      if (nextBoundaryIndex >= totalRowCount) {
+        return { row: candidate.row, top: defaultTop };
+      }
+
+      const nextBoundaryTop = nextBoundaryIndex * itemHeight - scrollTop;
+      return {
+        row: candidate.row,
+        top: Math.min(defaultTop, nextBoundaryTop - itemHeight),
+      };
+    })
+    .filter((entry) => entry.top + itemHeight > 0);
+}
+
 // Builds one visible-row snapshot so the layout engine and renderer consume the
 // same projection, sticky chain, occlusion window, and mounted list slice.
 //
@@ -222,22 +189,47 @@ function computeFileTreeViewLayoutState({
   viewportHeight: number;
 }): FileTreeViewLayoutState {
   const visibleCount = controller.getVisibleCount();
-  const visibleRows =
+  const stickyCandidates =
     stickyFolders && visibleCount > 0
+      ? controller.getStickyRowCandidates(scrollTop, itemHeight)
+      : [];
+  const visibleRows =
+    stickyCandidates == null && stickyFolders && visibleCount > 0
       ? controller.getVisibleRows(0, visibleCount - 1)
       : [];
+  const stickyRows =
+    stickyCandidates == null
+      ? undefined
+      : computeStickyRowsFromCandidates(
+          stickyCandidates,
+          scrollTop,
+          itemHeight,
+          visibleCount
+        );
   const snapshot = computeFileTreeLayout(visibleRows, {
     itemHeight,
     overscan,
     scrollTop,
+    stickyRows,
     totalRowCount: visibleCount,
     viewportHeight,
   });
 
+  const previewStickyCandidates =
+    stickyFolders && scrollTop <= 0 && visibleCount > 0
+      ? controller.getStickyRowCandidates(1, itemHeight)
+      : [];
   const overlayRows =
-    stickyFolders && scrollTop <= 0 && visibleRows.length > 0
-      ? computeStickyRows(visibleRows, 1, itemHeight)
-      : snapshot.sticky.rows;
+    previewStickyCandidates != null && scrollTop <= 0
+      ? computeStickyRowsFromCandidates(
+          previewStickyCandidates,
+          1,
+          itemHeight,
+          visibleCount
+        )
+      : stickyFolders && scrollTop <= 0 && visibleRows.length > 0
+        ? computeStickyRows(visibleRows, 1, itemHeight)
+        : snapshot.sticky.rows;
   const overlayHeight = overlayRows.reduce(
     (maxBottom, entry) => Math.max(maxBottom, entry.top + itemHeight),
     0
@@ -497,96 +489,10 @@ function isSearchOpenSeedKey(event: KeyboardEvent): boolean {
   );
 }
 
-// Prefers the live scroll element's measured height once layout has run,
-// falling back to the first-render hint while clientHeight is still zero
-// (SSR, initial mount, detached nodes, jsdom).
-function getMeasuredViewportHeight(
-  scrollElement: HTMLElement | null,
-  fallbackViewportHeight: number
-): number {
-  return scrollElement?.clientHeight != null && scrollElement.clientHeight > 0
-    ? scrollElement.clientHeight
-    : fallbackViewportHeight;
-}
-
-// Thin imperative wrapper around `computeFocusedRowScrollIntoView`. The numeric
-// contract lives in the pure helper; this function just applies the returned
-// scrollTop, if any, and reports whether a write happened.
-function scrollFocusedRowIntoView(
-  scrollElement: HTMLElement,
-  focusedIndex: number,
-  itemHeight: number,
-  fallbackViewportHeight: number,
-  topInset: number = 0
-): boolean {
-  const nextScrollTop = computeFocusedRowScrollIntoView({
-    currentScrollTop: scrollElement.scrollTop,
-    focusedIndex,
-    itemHeight,
-    topInset,
-    viewportHeight: getMeasuredViewportHeight(
-      scrollElement,
-      fallbackViewportHeight
-    ),
-  });
-  if (nextScrollTop == null) {
-    return false;
-  }
-
-  scrollElement.scrollTop = nextScrollTop;
-  return true;
-}
-
-// Thin imperative wrapper around `computeViewportOffsetScrollTop`. Used when a
-// logical state change (search closing, sticky-row click) should restore the
-// focused row to a specific vertical offset inside the viewport.
-function scrollFocusedRowToViewportOffset(
-  scrollElement: HTMLElement,
-  focusedIndex: number,
-  itemHeight: number,
-  fallbackViewportHeight: number,
-  totalHeight: number,
-  targetViewportOffset: number
-): boolean {
-  const nextScrollTop = computeViewportOffsetScrollTop({
-    currentScrollTop: scrollElement.scrollTop,
-    focusedIndex,
-    itemHeight,
-    targetViewportOffset,
-    totalHeight,
-    viewportHeight: getMeasuredViewportHeight(
-      scrollElement,
-      fallbackViewportHeight
-    ),
-  });
-  if (nextScrollTop == null) {
-    return false;
-  }
-
-  scrollElement.scrollTop = nextScrollTop;
-  return true;
-}
-
-function getParkedFocusedRowOffset(
-  focusedIndex: number,
-  itemHeight: number,
-  range: { start: number; end: number },
-  windowHeight: number
-): number | null {
-  if (range.end < range.start) {
-    return null;
-  }
-
-  if (focusedIndex < range.start) {
-    return -itemHeight;
-  }
-
-  if (focusedIndex > range.end) {
-    return windowHeight;
-  }
-
-  return null;
-}
+// Reads the live scroll element's border-box height when an exact viewport
+// height is required. `clientHeight` rounds fractional CSS pixels, which
+// misaligns sticky virtualization in layouts where a slotted header leaves a
+// half-pixel scrollport.
 
 function getFileTreeGuideStyleText(focusedParentPath: string | null): string {
   if (focusedParentPath == null) {
@@ -601,6 +507,29 @@ function getFileTreeGuideStyleText(focusedParentPath: string | null): string {
 
 function isContextMenuOpenKey(event: KeyboardEvent): boolean {
   return (event.shiftKey && event.key === 'F10') || event.key === 'ContextMenu';
+}
+
+// Sticky DOM reads are only needed for keys whose behavior depends on the
+// current focused row. This keeps ordinary keydowns out of the query/measure
+// path while preserving stale-DOM-focus repair for sticky keyboard actions.
+function canKeyUseStickyKeyboardState(
+  event: KeyboardEvent,
+  contextMenuEnabled: boolean
+): boolean {
+  if (contextMenuEnabled && isContextMenuOpenKey(event)) {
+    return true;
+  }
+
+  if ((event.ctrlKey || event.metaKey) && isSpaceSelectionKey(event)) {
+    return true;
+  }
+
+  return (
+    event.key === 'ArrowDown' ||
+    event.key === 'ArrowLeft' ||
+    event.key === 'ArrowRight' ||
+    event.key === 'ArrowUp'
+  );
 }
 
 const BLOCKED_CONTEXT_MENU_NAV_KEYS = new Set([
@@ -710,7 +639,98 @@ function getContextMenuAnchorButton(
     return null;
   }
 
-  return stickyButtonRefs.get(path) ?? rowButtonRefs.get(path) ?? null;
+  const stickyButton = stickyButtonRefs.get(path) ?? null;
+  if (stickyButton != null) {
+    return stickyButton;
+  }
+
+  const rowButton = rowButtonRefs.get(path) ?? null;
+  return rowButton?.dataset.itemParked === 'true' ? null : rowButton;
+}
+
+// Sticky keyboard handling runs during the browser event that follows a scroll.
+// Reading the mounted overlay mirrors keeps that event aligned with the row the
+// user can currently focus, even if the React layout snapshot is one frame old.
+function getMountedStickyRowPaths(rootElement: HTMLElement | null): string[] {
+  if (rootElement == null) {
+    return [];
+  }
+
+  const paths: string[] = [];
+  for (const element of rootElement.querySelectorAll(
+    'button[data-file-tree-sticky-row="true"]'
+  )) {
+    if (!(element instanceof HTMLElement)) {
+      continue;
+    }
+
+    const path = element.dataset.fileTreeStickyPath;
+    if (path != null) {
+      paths.push(path);
+    }
+  }
+
+  return paths;
+}
+
+function getFocusedParkedRowElement(
+  rootElement: HTMLElement | null,
+  path: string | null
+): HTMLElement | null {
+  if (rootElement == null || path == null) {
+    return null;
+  }
+
+  for (const element of rootElement.querySelectorAll(
+    'button[data-item-focused="true"][data-item-parked="true"]'
+  )) {
+    if (element instanceof HTMLElement && element.dataset.itemPath === path) {
+      return element;
+    }
+  }
+
+  return null;
+}
+
+// Sticky keyboard exits use the focused sticky mirror as a proxy for where the
+// canonical row should remain after focus moves or the row collapses. Keeping
+// the layout reads here avoids measuring DOM for ordinary key handling.
+function getStickyKeyboardViewportOffset(
+  rootElement: HTMLElement | null,
+  scrollElement: HTMLElement | null,
+  activeTreeElement: HTMLElement | null,
+  path: string | null,
+  itemHeight: number,
+  stickyOverlayHeight: number,
+  viewportHeight: number
+): number {
+  const minimumStickyKeyboardViewportOffset = Math.max(
+    0,
+    stickyOverlayHeight - itemHeight
+  );
+  const scrollElementRect = scrollElement?.getBoundingClientRect() ?? null;
+  const activeElementTopWithinViewport =
+    scrollElementRect == null || activeTreeElement == null
+      ? null
+      : activeTreeElement.getBoundingClientRect().top - scrollElementRect.top;
+  const focusedParkedRowElement = getFocusedParkedRowElement(rootElement, path);
+  const parkedElementTopWithinViewport =
+    scrollElementRect == null || focusedParkedRowElement == null
+      ? null
+      : focusedParkedRowElement.getBoundingClientRect().top -
+        scrollElementRect.top;
+
+  return Math.max(
+    0,
+    Math.min(
+      parkedElementTopWithinViewport ??
+        Math.max(
+          activeElementTopWithinViewport ?? 0,
+          minimumStickyKeyboardViewportOffset
+        ),
+      Math.max(0, viewportHeight - itemHeight)
+    )
+  );
 }
 
 function createContextMenuItem(
@@ -994,10 +1014,8 @@ function renderStyledRow(
     renderDecorationForRow,
     openContextMenuForRow,
     onRowClick,
-    onKeyDown,
   } = frame;
   const targetPath = getFileTreeRowPath(row);
-  const item = controller.getItem(targetPath);
   const { isParked = false, mode = 'flow', style } = options;
   const isSticky = mode === 'sticky';
   const ownGitStatus = gitStatusByPath?.get(targetPath) ?? null;
@@ -1102,7 +1120,7 @@ function renderStyledRow(
             if (!contextMenuRightClickEnabled) {
               return;
             }
-            item?.focus();
+            controller.focusMountedPathFromInput(targetPath);
             openContextMenuForRow(row, targetPath, {
               anchorRect: createAnchorRectFromPoint(
                 event.clientX,
@@ -1114,10 +1132,10 @@ function renderStyledRow(
         : undefined,
     onFocus: !isSticky
       ? () => {
-          item?.focus();
+          controller.focusMountedPathFromInput(targetPath);
         }
       : undefined,
-    onKeyDown: !isSticky ? onKeyDown : undefined,
+    onKeyDown: undefined,
     ref: (element: HTMLElement | null) => {
       registerButton(targetPath, element);
     },
@@ -1215,12 +1233,14 @@ export function FileTreeView({
   const isScrollingRef = useRef(false);
   const listRef = useRef<HTMLDivElement>(null);
   const renameInputRef = useRef<HTMLInputElement>(null);
+  const handleTreeKeyDownRef = useRef<(event: KeyboardEvent) => void>(() => {});
   const rootRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const rowButtonRefs = useRef(new Map<string, HTMLElement>());
   const stickyRowButtonRefs = useRef(new Map<string, HTMLElement>());
   const updateViewportRef = useRef<() => void>(() => {});
+  const measuredViewportHeightRef = useRef<number | null>(null);
   const domFocusOwnerRef = useRef(false);
   const previousFocusedPathRef = useRef<string | null>(null);
   const previousRenamingPathRef = useRef<string | null>(null);
@@ -1268,8 +1288,44 @@ export function FileTreeView({
   contextMenuStateRef.current = contextMenuState;
 
   const pendingStickyFocusPathRef = useRef<string | null>(null);
+  const pendingStickyKeyboardFocusPathRef = useRef<string | null>(null);
+  const pendingStickyKeyboardViewportOffsetRef = useRef<{
+    path: string;
+    viewportOffset: number;
+  } | null>(null);
+  const pendingStickyKeyboardScrollTopRef = useRef<{
+    path: string;
+    scrollTop: number;
+  } | null>(null);
   const debugContextMenuTriggerPathRef = useRef<string | null>(null);
   const debugDisableScrollSuppressionRef = useRef(false);
+
+  // Keep the coupled sticky-keyboard refs moving together so each transition
+  // leaves exactly one preservation mode active.
+  const clearPendingStickyKeyboardState = (): void => {
+    pendingStickyKeyboardFocusPathRef.current = null;
+    pendingStickyKeyboardViewportOffsetRef.current = null;
+    pendingStickyKeyboardScrollTopRef.current = null;
+  };
+
+  const preserveStickyKeyboardFocusAtScrollTop = (
+    path: string,
+    scrollTop: number | null
+  ): void => {
+    pendingStickyKeyboardFocusPathRef.current = path;
+    pendingStickyKeyboardViewportOffsetRef.current = null;
+    pendingStickyKeyboardScrollTopRef.current =
+      scrollTop == null ? null : { path, scrollTop };
+  };
+
+  const restoreStickyKeyboardViewportOffset = (
+    path: string,
+    viewportOffset: number
+  ): void => {
+    pendingStickyKeyboardFocusPathRef.current = null;
+    pendingStickyKeyboardViewportOffsetRef.current = { path, viewportOffset };
+    pendingStickyKeyboardScrollTopRef.current = null;
+  };
 
   // Trees that mount with an already-open search session (because a caller
   // passed `initialSearchQuery`) should not steal focus from sibling trees
@@ -1467,14 +1523,6 @@ export function FileTreeView({
     focusedIndex >= 0 &&
     focusedIndex >= range.start &&
     focusedIndex <= range.end;
-  const focusedRowIsVisible =
-    focusedIndex >= 0 &&
-    focusedIndex >= layoutSnapshot.visible.startIndex &&
-    focusedIndex <= layoutSnapshot.visible.endIndex;
-  const focusedRowIsSticky =
-    focusedPath != null &&
-    stickyRows.some((entry) => getFileTreeRowPath(entry.row) === focusedPath);
-  const focusedRowHasVisibleAnchor = focusedRowIsVisible || focusedRowIsSticky;
   const renderDecorationForRow = useCallback(
     (
       row: FileTreeVisibleRow,
@@ -1557,8 +1605,23 @@ export function FileTreeView({
         return;
       }
 
+      const anchorButton = getTriggerAnchorButton(targetPath);
+      if (anchorButton?.dataset.fileTreeStickyRow === 'true') {
+        const scrollElement = scrollRef.current;
+        preserveStickyKeyboardFocusAtScrollTop(
+          targetPath,
+          scrollElement?.scrollTop ?? null
+        );
+        domFocusOwnerRef.current = true;
+        setActiveItemPath((previousPath) =>
+          previousPath === targetPath ? previousPath : targetPath
+        );
+      }
+      // FileTree item focus is controller focus, not DOM focus. Sticky anchor
+      // preservation relies on this remaining scroll-neutral so the canonical
+      // offscreen row is not revealed before the layout effect restores focus.
       item.focus();
-      updateTriggerPosition(getTriggerAnchorButton(targetPath));
+      updateTriggerPosition(anchorButton);
       shouldRestoreContextMenuFocusRef.current = true;
       setContextMenuState({
         anchorRect: options?.anchorRect ?? null,
@@ -1577,7 +1640,7 @@ export function FileTreeView({
 
       if (controller.isSearchOpen()) {
         const scrollElement = scrollRef.current;
-        const viewportHeight = getMeasuredViewportHeight(
+        const viewportHeight = readMeasuredViewportHeight(
           scrollElement,
           resolvedViewportHeight
         );
@@ -1640,7 +1703,7 @@ export function FileTreeView({
         return false;
       }
 
-      const liveViewportHeight = getMeasuredViewportHeight(
+      const liveViewportHeight = readMeasuredViewportHeight(
         scrollElement,
         resolvedViewportHeight
       );
@@ -1678,6 +1741,7 @@ export function FileTreeView({
 
   const shouldSuppressContextMenu = (): boolean => {
     return (
+      isScrollingRef.current === true ||
       touchLongPressTimerRef.current != null ||
       touchDragActiveRef.current === true
     );
@@ -1931,9 +1995,11 @@ export function FileTreeView({
     touchSourceElementRef.current = dragSource;
     dragSource.setAttribute('draggable', 'false');
 
-    const clearPendingTouchStart = ({
-      restoreNativeDraggable = true,
-    }: { restoreNativeDraggable?: boolean } = {}): void => {
+    const clearPendingTouchStart = (
+      options: { restoreNativeDraggable?: boolean } = {}
+    ): void => {
+      const restoreNativeDraggable =
+        options.restoreNativeDraggable ?? !touchDragActiveRef.current;
       if (touchLongPressTimerRef.current != null) {
         clearTimeout(touchLongPressTimerRef.current);
         touchLongPressTimerRef.current = null;
@@ -2116,7 +2182,7 @@ export function FileTreeView({
           controller.selectOnlyPath(currentFocusedPath);
         }
         const scrollElement = scrollRef.current;
-        const viewportHeight = getMeasuredViewportHeight(
+        const viewportHeight = readMeasuredViewportHeight(
           scrollElement,
           resolvedViewportHeight
         );
@@ -2155,6 +2221,43 @@ export function FileTreeView({
       return;
     }
 
+    const isKeyboardContextMenuRequest =
+      contextMenuEnabled && isContextMenuOpenKey(event);
+    const shouldInspectStickyKeyboardState = canKeyUseStickyKeyboardState(
+      event,
+      contextMenuEnabled
+    );
+    const activeTreeElement =
+      shouldInspectStickyKeyboardState && rootRef.current != null
+        ? getActiveTreeElement(rootRef.current)
+        : null;
+    const mountedStickyRowPathSet = shouldInspectStickyKeyboardState
+      ? new Set(getMountedStickyRowPaths(rootRef.current))
+      : new Set<string>();
+    const activeStickyFocusPath =
+      activeTreeElement?.dataset.fileTreeStickyPath ?? null;
+    const activeStickyRowOwnsFocus =
+      activeTreeElement?.dataset.fileTreeStickyRow === 'true' &&
+      activeStickyFocusPath != null;
+    if (
+      activeStickyRowOwnsFocus &&
+      activeStickyFocusPath !== focusedPath &&
+      mountedStickyRowPathSet.has(activeStickyFocusPath)
+    ) {
+      // Syncing controller focus to a sticky DOM mirror can otherwise reveal
+      // the offscreen canonical row before the key action decides what to do.
+      // Shift+F10 may also be followed by a native contextmenu event, so this
+      // preservation has to be in place before the controller emits.
+      const scrollElement = scrollRef.current;
+      preserveStickyKeyboardFocusAtScrollTop(
+        activeStickyFocusPath,
+        scrollElement?.scrollTop ?? null
+      );
+      controller.focusPath(activeStickyFocusPath);
+    }
+
+    const effectiveFocusedPath = controller.getFocusedPath();
+    const effectiveFocusedIndex = controller.getFocusedIndex();
     const focusedItem = controller.getFocusedItem();
     if (focusedItem == null) {
       return;
@@ -2163,24 +2266,48 @@ export function FileTreeView({
     const focusedDirectoryItem = isFileTreeDirectoryHandle(focusedItem)
       ? focusedItem
       : null;
+    const startedFromStickyRow =
+      effectiveFocusedPath != null &&
+      (stickyRowPathSet.has(effectiveFocusedPath) ||
+        (activeStickyRowOwnsFocus &&
+          activeStickyFocusPath === effectiveFocusedPath &&
+          mountedStickyRowPathSet.has(effectiveFocusedPath)));
+    const shouldPreserveLocalStickyFocusMove =
+      event.key === 'ArrowDown' ||
+      event.key === 'ArrowUp' ||
+      (event.key === 'ArrowRight' &&
+        focusedDirectoryItem != null &&
+        focusedDirectoryItem.isExpanded());
+    const shouldRestoreCollapsedStickyFocusViewport =
+      event.key === 'ArrowLeft' &&
+      startedFromStickyRow &&
+      focusedDirectoryItem != null &&
+      focusedDirectoryItem.isExpanded();
+    const scrollElement = scrollRef.current;
     let handled = true;
     if (event.shiftKey && event.key === 'ArrowDown') {
       controller.extendSelectionFromFocused(1);
     } else if (event.shiftKey && event.key === 'ArrowUp') {
       controller.extendSelectionFromFocused(-1);
     } else if (
-      contextMenuEnabled &&
-      isContextMenuOpenKey(event) &&
-      focusedPath != null &&
-      focusedIndex >= 0
+      isKeyboardContextMenuRequest &&
+      effectiveFocusedPath != null &&
+      effectiveFocusedIndex >= 0
     ) {
       const focusedRow =
-        controller.getVisibleRows(focusedIndex, focusedIndex)[0] ?? null;
-      const focusedButton = rowButtonRefs.current.get(focusedPath) ?? null;
+        controller.getVisibleRows(
+          effectiveFocusedIndex,
+          effectiveFocusedIndex
+        )[0] ?? null;
+      const focusedButton = getContextMenuAnchorButton(
+        effectiveFocusedPath,
+        stickyRowButtonRefs.current,
+        rowButtonRefs.current
+      );
       if (focusedRow == null || focusedButton == null) {
         handled = false;
       } else {
-        openContextMenuForRow(focusedRow, focusedPath);
+        openContextMenuForRow(focusedRow, effectiveFocusedPath);
       }
     } else if ((event.ctrlKey || event.metaKey) && isSpaceSelectionKey(event)) {
       controller.toggleFocusedSelection();
@@ -2233,6 +2360,69 @@ export function FileTreeView({
     }
 
     setLastContextMenuInteraction('focus');
+    const nextFocusedPath = controller.getFocusedPath();
+    const nextFocusedPathIsMountedSticky =
+      nextFocusedPath != null &&
+      (stickyRowPathSet.has(nextFocusedPath) ||
+        mountedStickyRowPathSet.has(nextFocusedPath));
+    const stickyKeyboardMoveLandsOnDifferentStickyRow =
+      shouldPreserveLocalStickyFocusMove &&
+      nextFocusedPath !== effectiveFocusedPath;
+    const stickyKeyboardMenuStaysOnStickyRow =
+      isKeyboardContextMenuRequest &&
+      activeStickyRowOwnsFocus &&
+      activeStickyFocusPath === effectiveFocusedPath &&
+      nextFocusedPath === effectiveFocusedPath;
+    const shouldPreserveStickyKeyboardFocusPath =
+      (stickyKeyboardMoveLandsOnDifferentStickyRow &&
+        nextFocusedPathIsMountedSticky) ||
+      stickyKeyboardMenuStaysOnStickyRow;
+
+    if (
+      (startedFromStickyRow || stickyKeyboardMenuStaysOnStickyRow) &&
+      nextFocusedPath != null &&
+      shouldPreserveStickyKeyboardFocusPath
+    ) {
+      preserveStickyKeyboardFocusAtScrollTop(
+        nextFocusedPath,
+        scrollElement?.scrollTop ?? null
+      );
+      domFocusOwnerRef.current = true;
+      setActiveItemPath((previousPath) =>
+        previousPath === nextFocusedPath ? previousPath : nextFocusedPath
+      );
+    } else {
+      const stickyArrowUpExitsStack =
+        event.key === 'ArrowUp' &&
+        startedFromStickyRow &&
+        nextFocusedPath !== effectiveFocusedPath;
+      const stickyCollapseStaysOnRow =
+        shouldRestoreCollapsedStickyFocusViewport &&
+        nextFocusedPath === effectiveFocusedPath;
+      if (
+        nextFocusedPath != null &&
+        (stickyArrowUpExitsStack || stickyCollapseStaysOnRow)
+      ) {
+        restoreStickyKeyboardViewportOffset(
+          nextFocusedPath,
+          getStickyKeyboardViewportOffset(
+            rootRef.current,
+            scrollElement,
+            activeTreeElement,
+            effectiveFocusedPath,
+            itemHeight,
+            stickyOverlayHeight,
+            resolvedViewportHeight
+          )
+        );
+        domFocusOwnerRef.current = true;
+        setActiveItemPath((previousPath) =>
+          previousPath === nextFocusedPath ? previousPath : nextFocusedPath
+        );
+      } else {
+        clearPendingStickyKeyboardState();
+      }
+    }
 
     // Focus-only and selection-only controller updates do not change
     // range/itemCount, so force a render tick before the DOM-focus sync effect
@@ -2260,6 +2450,8 @@ export function FileTreeView({
   // rendered input and grabs focus. The classifier here turns the ref state +
   // rendered-input presence into a single action so the transitions are
   // explicit instead of buried in early-return logic.
+  handleTreeKeyDownRef.current = handleTreeKeyDown;
+
   useLayoutEffect(() => {
     const input = renameInputRef.current;
     const action = classifyFileTreeRenameHandoff({
@@ -2304,7 +2496,6 @@ export function FileTreeView({
     if (rootElement == null) {
       return;
     }
-
     let nullFocusOutTimer: ReturnType<typeof setTimeout> | null = null;
 
     const clearNullFocusOutTimer = (): void => {
@@ -2375,6 +2566,34 @@ export function FileTreeView({
     };
   }, []);
 
+  useLayoutEffect(() => {
+    const onDocumentKeyDown = (event: KeyboardEvent): void => {
+      const rootElement = rootRef.current;
+      const rootNode = rootElement?.getRootNode();
+      const hostElement =
+        rootNode instanceof ShadowRoot && rootNode.host instanceof HTMLElement
+          ? rootNode.host
+          : rootElement;
+      if (hostElement == null || event.target !== hostElement) {
+        return;
+      }
+      handleTreeKeyDownRef.current(event);
+    };
+
+    document.addEventListener(
+      'keydown',
+      onDocumentKeyDown as EventListener,
+      true
+    );
+    return () => {
+      document.removeEventListener(
+        'keydown',
+        onDocumentKeyDown as EventListener,
+        true
+      );
+    };
+  });
+
   // Mirror `scrollTop <= 0` onto the root element as a data attribute so CSS
   // can hide the pre-populated sticky overlay when the list is at rest at the
   // top. We drive this from the layout snapshot (synced on every scroll +
@@ -2402,10 +2621,15 @@ export function FileTreeView({
       return;
     }
 
+    measuredViewportHeightRef.current = readMeasuredViewportHeight(
+      scrollElement,
+      initialViewportHeight
+    );
+
     const update = (): void => {
       const nextItemCount = controller.getVisibleCount();
-      const nextViewportHeight = getMeasuredViewportHeight(
-        scrollElement,
+      const nextViewportHeight = getCachedViewportHeight(
+        measuredViewportHeightRef.current,
         initialViewportHeight
       );
       const maxScrollTop = Math.max(
@@ -2431,8 +2655,13 @@ export function FileTreeView({
     };
 
     updateViewportRef.current = update;
+    let hasSeenInitialControllerSnapshot = false;
     const unsubscribe = controller.subscribe(() => {
-      setControllerRevision((revision) => revision + 1);
+      if (hasSeenInitialControllerSnapshot) {
+        setControllerRevision((revision) => revision + 1);
+      } else {
+        hasSeenInitialControllerSnapshot = true;
+      }
       update();
     });
     // Flip a plain DOM attribute on the root (not React state) so the anchor
@@ -2572,12 +2801,18 @@ export function FileTreeView({
     scrollElement.addEventListener('keydown', onKeyDownPreScroll);
     const resizeObserver =
       typeof ResizeObserver !== 'undefined'
-        ? new ResizeObserver(() => {
+        ? new ResizeObserver((entries) => {
+            const observedViewportHeight =
+              entries[0] == null
+                ? null
+                : getResizeObserverViewportHeight(entries[0]);
+            measuredViewportHeightRef.current =
+              observedViewportHeight ??
+              readMeasuredViewportHeight(scrollElement, initialViewportHeight);
             update();
           })
         : null;
     resizeObserver?.observe(scrollElement);
-    update();
 
     return () => {
       updateViewportRef.current = () => {};
@@ -2604,6 +2839,7 @@ export function FileTreeView({
       // rebinds (e.g. viewportHeight changes) while scrollTop is still 0,
       // because the sync effect only fires when scrollTop itself changes.
       isScrollingRef.current = false;
+      measuredViewportHeightRef.current = null;
       resizeObserver?.disconnect();
     };
   }, [controller, initialViewportHeight, itemHeight, overscan, stickyFolders]);
@@ -2765,9 +3001,19 @@ export function FileTreeView({
     const preservedViewportOffset =
       restoreTreeFocusViewportOffsetRef.current ?? 0;
     const pendingStickyFocusPath = pendingStickyFocusPathRef.current;
+    const pendingStickyKeyboardFocusPath =
+      pendingStickyKeyboardFocusPathRef.current;
+    const pendingStickyKeyboardViewportOffset =
+      pendingStickyKeyboardViewportOffsetRef.current;
+    const pendingStickyKeyboardScrollTop =
+      pendingStickyKeyboardScrollTopRef.current;
     const focusWithinTree = activeTreeElement != null;
     const shouldOwnDomFocus = domFocusOwnerRef.current || focusWithinTree;
     const focusedPathChanged = previousFocusedPathRef.current !== focusedPath;
+    const shouldPreserveStickyKeyboardFocusViewport =
+      pendingStickyKeyboardFocusPath != null &&
+      pendingStickyKeyboardFocusPath === focusedPath &&
+      focusedPath != null;
 
     const shouldRestoreFocusedRowViewportOffset =
       shouldRestoreTreeFocusAfterSearchClose &&
@@ -2790,13 +3036,34 @@ export function FileTreeView({
         totalScrollableHeight,
         stickyOverlayHeight
       );
+    const shouldRestoreStickyKeyboardViewportOffset =
+      pendingStickyKeyboardViewportOffset != null &&
+      pendingStickyKeyboardViewportOffset.path === focusedPath &&
+      scrollFocusedRowToViewportOffset(
+        scrollElement,
+        focusedIndex,
+        itemHeight,
+        resolvedViewportHeight,
+        totalScrollableHeight,
+        pendingStickyKeyboardViewportOffset.viewportOffset
+      );
+    const shouldRestoreStickyKeyboardScrollTop =
+      pendingStickyKeyboardScrollTop != null &&
+      pendingStickyKeyboardScrollTop.path === focusedPath &&
+      scrollElement.scrollTop !== pendingStickyKeyboardScrollTop.scrollTop;
+    if (shouldRestoreStickyKeyboardScrollTop) {
+      scrollElement.scrollTop = pendingStickyKeyboardScrollTop.scrollTop;
+    }
 
     if (
+      shouldRestoreStickyKeyboardScrollTop ||
       shouldRestoreStickyFocusedRowViewportOffset ||
+      shouldRestoreStickyKeyboardViewportOffset ||
       shouldRestoreFocusedRowViewportOffset ||
       (shouldOwnDomFocus &&
         focusedPathChanged &&
         pendingStickyFocusPath !== focusedPath &&
+        !shouldPreserveStickyKeyboardFocusViewport &&
         scrollFocusedRowIntoView(
           scrollElement,
           focusedIndex,
@@ -2843,12 +3110,24 @@ export function FileTreeView({
       focusedPathChanged ||
       shouldRestoreTreeFocusAfterSearchClose ||
       pendingStickyFocusPath === focusedPath ||
+      pendingStickyKeyboardFocusPath === focusedPath ||
+      pendingStickyKeyboardViewportOffset?.path === focusedPath ||
+      pendingStickyKeyboardScrollTop?.path === focusedPath ||
       activeTreeElementPath == null ||
       activeTreeElementPath !== focusedPath
     ) {
       focusElement(focusedButton);
       if (pendingStickyFocusPath === focusedPath) {
         pendingStickyFocusPathRef.current = null;
+      }
+      if (pendingStickyKeyboardFocusPath === focusedPath) {
+        pendingStickyKeyboardFocusPathRef.current = null;
+      }
+      if (pendingStickyKeyboardViewportOffset?.path === focusedPath) {
+        pendingStickyKeyboardViewportOffsetRef.current = null;
+      }
+      if (pendingStickyKeyboardScrollTop?.path === focusedPath) {
+        pendingStickyKeyboardScrollTopRef.current = null;
       }
       restoreTreeFocusAfterSearchCloseRef.current = false;
       restoreTreeFocusViewportOffsetRef.current = null;
@@ -2870,6 +3149,14 @@ export function FileTreeView({
     visibleRows,
   ]);
 
+  const focusedRowIsVisible =
+    focusedIndex >= 0 &&
+    focusedIndex >= layoutSnapshot.visible.startIndex &&
+    focusedIndex <= layoutSnapshot.visible.endIndex;
+  const focusedRowIsSticky =
+    focusedPath != null &&
+    stickyRows.some((entry) => getFileTreeRowPath(entry.row) === focusedPath);
+  const focusedRowHasVisibleAnchor = focusedRowIsVisible || focusedRowIsSticky;
   const focusTriggerPath =
     contextMenuButtonTriggerEnabled &&
     domFocusOwnerRef.current === true &&
@@ -3157,7 +3444,6 @@ export function FileTreeView({
       targetPath: string,
       mode: FileTreeRenderedRowMode
     ): void => {
-      const item = controller.getItem(targetPath);
       const plan = computeFileTreeRowClickPlan({
         event: {
           ctrlKey: event.ctrlKey,
@@ -3165,19 +3451,29 @@ export function FileTreeView({
           shiftKey: event.shiftKey,
         },
         isDirectory: row.kind === 'directory',
-        isSearchOpen: controller.isSearchOpen(),
+        isSearchOpen,
         mode,
       });
 
+      const shouldToggleDirectory =
+        plan.toggleDirectory && row.kind === 'directory';
+      const mountedDirectoryPath = shouldToggleDirectory
+        ? controller.resolveMountedDirectoryPathFromInput(targetPath)
+        : null;
+      if (shouldToggleDirectory && mountedDirectoryPath == null) {
+        return;
+      }
+      const actionTargetPath = mountedDirectoryPath ?? targetPath;
+
       switch (plan.selection.kind) {
         case 'range':
-          controller.selectPathRange(targetPath, plan.selection.additive);
+          controller.selectPathRange(actionTargetPath, plan.selection.additive);
           break;
         case 'toggle':
-          controller.togglePathSelectionFromInput(targetPath);
+          controller.togglePathSelectionFromInput(actionTargetPath);
           break;
         case 'single':
-          controller.selectOnlyPath(targetPath);
+          controller.selectOnlyMountedPathFromInput(actionTargetPath);
           break;
       }
 
@@ -3192,28 +3488,29 @@ export function FileTreeView({
         clickedElement != null &&
         clickedElement.dataset.itemParked !== 'true';
 
-      item?.focus();
+      controller.focusMountedPathFromInput(actionTargetPath);
       if (shouldExposeFocusedTrigger) {
         domFocusOwnerRef.current = true;
         setActiveItemPath((previousPath) =>
-          previousPath === targetPath ? previousPath : targetPath
+          previousPath === actionTargetPath ? previousPath : actionTargetPath
         );
         setLastContextMenuInteraction('focus');
       }
-      if (plan.toggleDirectory && isFileTreeDirectoryHandle(item)) {
-        item.toggle();
+      if (shouldToggleDirectory) {
+        controller.toggleMountedDirectoryFromInput(actionTargetPath);
       }
       if (plan.closeSearch) {
         controller.closeSearch();
       }
       if (plan.revealCanonical) {
-        revealCanonicalRowAtStickyOffset(targetPath, {
+        revealCanonicalRowAtStickyOffset(actionTargetPath, {
           targetOffset: 'sticky-parents',
         });
       }
     },
     [
       controller,
+      isSearchOpen,
       layoutSnapshot.visible.endIndex,
       layoutSnapshot.visible.startIndex,
       revealCanonicalRowAtStickyOffset,
@@ -3221,11 +3518,11 @@ export function FileTreeView({
   );
 
   const openMenuFromTrigger = (): void => {
-    if (!contextMenuButtonTriggerEnabled) {
+    if (isScrollingRef.current) {
       return;
     }
 
-    if (isScrollingRef.current && contextMenuState == null) {
+    if (!contextMenuButtonTriggerEnabled) {
       return;
     }
 
@@ -3237,6 +3534,7 @@ export function FileTreeView({
     if (triggerItem == null) {
       return;
     }
+
     updateTriggerPosition(triggerButton);
     shouldRestoreContextMenuFocusRef.current = true;
     setContextMenuState({
@@ -3314,7 +3612,6 @@ export function FileTreeView({
       onDragLeave={dragAndDropEnabled ? handleTreeDragLeave : undefined}
       onDragOver={dragAndDropEnabled ? handleTreeDragOver : undefined}
       onDrop={dragAndDropEnabled ? handleTreeDrop : undefined}
-      onKeyDown={handleTreeKeyDown}
       onPointerLeave={contextMenuEnabled ? handleTreePointerLeave : undefined}
       onPointerOver={contextMenuEnabled ? handleTreePointerOver : undefined}
       role="tree"

--- a/packages/trees/src/render/FileTreeView.tsx
+++ b/packages/trees/src/render/FileTreeView.tsx
@@ -270,7 +270,40 @@ function getPointElement(
     pointRoot.elementFromPoint?.(clientX, clientY) ??
     documentElementFromPoint?.(clientX, clientY) ??
     null;
+  if (
+    rootNode instanceof ShadowRoot &&
+    (element == null || !rootNode.contains(element))
+  ) {
+    return getShadowPointElementByGeometry(rootNode, clientX, clientY);
+  }
+
   return element instanceof HTMLElement ? element : null;
+}
+
+function getShadowPointElementByGeometry(
+  rootNode: ShadowRoot,
+  clientX: number,
+  clientY: number
+): HTMLElement | null {
+  const candidates = Array.from(
+    rootNode.querySelectorAll<HTMLElement>(
+      '[data-type="item"], [data-item-flattened-subitem]'
+    )
+  );
+  for (let index = candidates.length - 1; index >= 0; index--) {
+    const candidate = candidates[index];
+    const rect = candidate.getBoundingClientRect();
+    if (
+      clientX >= rect.left &&
+      clientX <= rect.right &&
+      clientY >= rect.top &&
+      clientY <= rect.bottom
+    ) {
+      return candidate;
+    }
+  }
+
+  return null;
 }
 
 function resolveDropTargetFromElement(
@@ -1224,6 +1257,7 @@ export function FileTreeView({
   const [lastContextMenuInteraction, setLastContextMenuInteraction] = useState<
     'focus' | 'pointer' | null
   >(null);
+  const [scrollSettledRevision, setScrollSettledRevision] = useState(0);
   const [contextMenuState, setContextMenuState] = useState<{
     anchorRect: FileTreeContextMenuOpenContext['anchorRect'] | null;
     item: FileTreeContextMenuItem;
@@ -1433,6 +1467,14 @@ export function FileTreeView({
     focusedIndex >= 0 &&
     focusedIndex >= range.start &&
     focusedIndex <= range.end;
+  const focusedRowIsVisible =
+    focusedIndex >= 0 &&
+    focusedIndex >= layoutSnapshot.visible.startIndex &&
+    focusedIndex <= layoutSnapshot.visible.endIndex;
+  const focusedRowIsSticky =
+    focusedPath != null &&
+    stickyRows.some((entry) => getFileTreeRowPath(entry.row) === focusedPath);
+  const focusedRowHasVisibleAnchor = focusedRowIsVisible || focusedRowIsSticky;
   const renderDecorationForRow = useCallback(
     (
       row: FileTreeVisibleRow,
@@ -1889,7 +1931,9 @@ export function FileTreeView({
     touchSourceElementRef.current = dragSource;
     dragSource.setAttribute('draggable', 'false');
 
-    const clearPendingTouchStart = (): void => {
+    const clearPendingTouchStart = ({
+      restoreNativeDraggable = true,
+    }: { restoreNativeDraggable?: boolean } = {}): void => {
       if (touchLongPressTimerRef.current != null) {
         clearTimeout(touchLongPressTimerRef.current);
         touchLongPressTimerRef.current = null;
@@ -1900,7 +1944,7 @@ export function FileTreeView({
       if (touchCleanupRef.current === clearPendingTouchStart) {
         touchCleanupRef.current = null;
       }
-      if (!touchDragActiveRef.current) {
+      if (restoreNativeDraggable) {
         dragSource.setAttribute('draggable', 'true');
         if (touchSourceElementRef.current === dragSource) {
           touchSourceElementRef.current = null;
@@ -1939,7 +1983,10 @@ export function FileTreeView({
     document.addEventListener('touchcancel', handlePendingTouchEnd);
     touchCleanupRef.current = clearPendingTouchStart;
     touchLongPressTimerRef.current = setTimeout(() => {
-      clearPendingTouchStart();
+      // Keep native draggable disabled while the custom touch drag activates.
+      // iOS Safari can otherwise promote the same long press into its native
+      // HTML drag flow before the touch-specific listeners take over.
+      clearPendingTouchStart({ restoreNativeDraggable: false });
       if (controller.startDrag(targetPath) === false) {
         dragSource.setAttribute('draggable', 'true');
         if (touchSourceElementRef.current === dragSource) {
@@ -2258,6 +2305,17 @@ export function FileTreeView({
       return;
     }
 
+    let nullFocusOutTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const clearNullFocusOutTimer = (): void => {
+      if (nullFocusOutTimer == null) {
+        return;
+      }
+
+      clearTimeout(nullFocusOutTimer);
+      nullFocusOutTimer = null;
+    };
+
     const updateActiveItemPath = (): void => {
       const activeTreeElement = getActiveTreeElement(rootElement);
       const nextActiveItemPath = activeTreeElement?.dataset.itemPath ?? null;
@@ -2267,6 +2325,7 @@ export function FileTreeView({
     };
 
     const onFocusIn = (): void => {
+      clearNullFocusOutTimer();
       domFocusOwnerRef.current = true;
       updateActiveItemPath();
     };
@@ -2274,22 +2333,43 @@ export function FileTreeView({
       const nextTarget = event.relatedTarget;
       if (nextTarget == null) {
         // Virtualization can swap the focused row between rendered and parked
-        // states before the replacement element receives focus.
+        // states before the replacement element receives focus. Defer the
+        // ownership check so a true blur to the page can still clear visual
+        // focus once the browser has finished moving focus.
+        clearNullFocusOutTimer();
+        nullFocusOutTimer = setTimeout(() => {
+          nullFocusOutTimer = null;
+          if (getActiveTreeElement(rootElement) != null) {
+            updateActiveItemPath();
+            return;
+          }
+
+          domFocusOwnerRef.current = false;
+          setActiveItemPath(null);
+        }, 0);
         return;
       }
 
       if (!(nextTarget instanceof Node) || !rootElement.contains(nextTarget)) {
+        clearNullFocusOutTimer();
         domFocusOwnerRef.current = false;
         setActiveItemPath(null);
         return;
       }
 
-      updateActiveItemPath();
+      const nextActiveItemPath =
+        nextTarget instanceof HTMLElement
+          ? (nextTarget.dataset.itemPath ?? null)
+          : null;
+      setActiveItemPath((previousPath) =>
+        previousPath === nextActiveItemPath ? previousPath : nextActiveItemPath
+      );
     };
 
     rootElement.addEventListener('focusin', onFocusIn);
     rootElement.addEventListener('focusout', onFocusOut);
     return () => {
+      clearNullFocusOutTimer();
       rootElement.removeEventListener('focusin', onFocusIn);
       rootElement.removeEventListener('focusout', onFocusOut);
     };
@@ -2382,6 +2462,7 @@ export function FileTreeView({
           delete rootElement.dataset.isScrolling;
         }
         isScrollingRef.current = false;
+        setScrollSettledRevision((revision) => revision + 1);
         scrollTimer = null;
       }, 50);
     };
@@ -2790,7 +2871,9 @@ export function FileTreeView({
   ]);
 
   const focusTriggerPath =
-    contextMenuButtonTriggerEnabled && domFocusOwnerRef.current === true
+    contextMenuButtonTriggerEnabled &&
+    domFocusOwnerRef.current === true &&
+    focusedRowHasVisibleAnchor
       ? focusedPath
       : null;
   const pointerTriggerPath =
@@ -2804,11 +2887,17 @@ export function FileTreeView({
   const isPointerContextMenuOpen = contextMenuState?.source === 'right-click';
 
   useLayoutEffect(() => {
+    if (isScrollingRef.current && contextMenuState == null) {
+      return;
+    }
+
     updateTriggerPosition(getTriggerAnchorButton(triggerPath));
   }, [
+    contextMenuState,
     getTriggerAnchorButton,
     range,
     resolvedViewportHeight,
+    scrollSettledRevision,
     stickyRows,
     triggerPath,
     updateTriggerPosition,
@@ -3136,6 +3225,10 @@ export function FileTreeView({
       return;
     }
 
+    if (isScrollingRef.current && contextMenuState == null) {
+      return;
+    }
+
     if (triggerPath == null || triggerButton == null) {
       return;
     }
@@ -3144,7 +3237,6 @@ export function FileTreeView({
     if (triggerItem == null) {
       return;
     }
-
     updateTriggerPosition(triggerButton);
     shouldRestoreContextMenuFocusRef.current = true;
     setContextMenuState({

--- a/packages/trees/src/render/FileTreeView.tsx
+++ b/packages/trees/src/render/FileTreeView.tsx
@@ -1014,6 +1014,7 @@ function renderStyledRow(
     renderDecorationForRow,
     openContextMenuForRow,
     onRowClick,
+    onKeyDown,
   } = frame;
   const targetPath = getFileTreeRowPath(row);
   const { isParked = false, mode = 'flow', style } = options;
@@ -1135,7 +1136,7 @@ function renderStyledRow(
           controller.focusMountedPathFromInput(targetPath);
         }
       : undefined,
-    onKeyDown: undefined,
+    onKeyDown,
     ref: (element: HTMLElement | null) => {
       registerButton(targetPath, element);
     },
@@ -3612,6 +3613,7 @@ export function FileTreeView({
       onDragLeave={dragAndDropEnabled ? handleTreeDragLeave : undefined}
       onDragOver={dragAndDropEnabled ? handleTreeDragOver : undefined}
       onDrop={dragAndDropEnabled ? handleTreeDrop : undefined}
+      onKeyDown={handleTreeKeyDown}
       onPointerLeave={contextMenuEnabled ? handleTreePointerLeave : undefined}
       onPointerOver={contextMenuEnabled ? handleTreePointerOver : undefined}
       role="tree"

--- a/packages/trees/src/render/scrollTarget.ts
+++ b/packages/trees/src/render/scrollTarget.ts
@@ -17,6 +17,18 @@ export type FileTreeMinimalScrollIntoViewInput = FileTreeScrollTargetInput & {
   topInset?: number;
 };
 
+export type FileTreeExternalScrollTargetInput = FileTreeScrollTargetInput & {
+  bottomInset?: number;
+  currentViewportTop: number;
+  topInset?: number;
+};
+
+function getExternalScrollTargetViewportHeight(
+  viewportHeight: number,
+  bottomInset: number | undefined
+): number {
+  return Math.max(0, viewportHeight - Math.max(0, bottomInset ?? 0));
+}
 // Minimal adjustment to bring the focused row fully inside the viewport while
 // respecting a `topInset` (the sticky overlay height). Returns `null` when the
 // row is already visible.
@@ -53,11 +65,32 @@ export function computeFocusedRowScrollIntoView(
   return null;
 }
 
+export function computeExternalFocusedRowViewportTop(
+  input: FileTreeExternalScrollTargetInput
+): number | null {
+  return computeFocusedRowScrollIntoView({
+    currentScrollTop: input.currentViewportTop,
+    focusedIndex: input.focusedIndex,
+    itemHeight: input.itemHeight,
+    topInset: input.topInset,
+    viewportHeight: getExternalScrollTargetViewportHeight(
+      input.viewportHeight,
+      input.bottomInset
+    ),
+  });
+}
+
 export type FileTreeViewportOffsetScrollInput = FileTreeScrollTargetInput & {
   currentScrollTop: number;
   totalHeight: number;
   targetViewportOffset: number;
 };
+
+export type FileTreeExternalViewportOffsetScrollInput =
+  FileTreeExternalScrollTargetInput & {
+    targetViewportOffset: number;
+    totalHeight: number;
+  };
 
 // Places the focused row at a specific viewport offset (used when restoring
 // state after search closes or after a sticky-row click collapses ancestors).
@@ -95,4 +128,20 @@ export function computeViewportOffsetScrollTop(
     Math.min(itemTop - effectiveOffset, maxScrollTop)
   );
   return preservedScrollTop === currentScrollTop ? null : preservedScrollTop;
+}
+
+export function computeExternalViewportOffsetTop(
+  input: FileTreeExternalViewportOffsetScrollInput
+): number | null {
+  return computeViewportOffsetScrollTop({
+    currentScrollTop: input.currentViewportTop,
+    focusedIndex: input.focusedIndex,
+    itemHeight: input.itemHeight,
+    targetViewportOffset: input.targetViewportOffset,
+    totalHeight: input.totalHeight,
+    viewportHeight: getExternalScrollTargetViewportHeight(
+      input.viewportHeight,
+      input.bottomInset
+    ),
+  });
 }

--- a/packages/trees/src/scroll/FileTree.ts
+++ b/packages/trees/src/scroll/FileTree.ts
@@ -5,10 +5,7 @@ import {
   getBuiltInSpriteSheet,
   isColoredBuiltInIconSet,
 } from '../builtInIcons';
-import {
-  FileTreeContainerLoaded,
-  prepareFileTreeShadowRoot,
-} from '../components/web-components';
+import { FileTreeContainerLoaded } from '../components/web-components';
 import {
   FILE_TREE_STYLE_ATTRIBUTE,
   FILE_TREE_TAG_NAME,
@@ -20,23 +17,24 @@ import {
   type FileTreeDensityPreset,
   resolveFileTreeDensity,
 } from '../model/density';
+import {
+  type FileTreeNormalizedExternalScrollSnapshot,
+  resolveFileTreeExternalScrollInitialSnapshot,
+} from '../model/externalScroll';
 import { FileTreeController } from '../model/FileTreeController';
 import {
   type FileTreeGitStatusState,
   resolveFileTreeGitStatusState,
 } from '../model/gitStatus';
-import type { FileTreeViewProps } from '../model/internalTypes';
 import type {
   FileTreeBatchOperation,
   FileTreeCompositionOptions,
   FileTreeHydrationProps,
   FileTreeItemHandle,
   FileTreeListener,
-  FileTreeModel,
   FileTreeMoveOptions,
   FileTreeMutationEventForType,
   FileTreeMutationEventType,
-  FileTreeOptions,
   FileTreeRemoveOptions,
   FileTreeRenderProps,
   FileTreeResetOptions,
@@ -48,19 +46,26 @@ import {
   FILE_TREE_DEFAULT_ITEM_HEIGHT,
   FILE_TREE_DEFAULT_VIEWPORT_HEIGHT,
 } from '../model/virtualization';
-import fileTreeStyles from '../style.css';
+import { FileTreeManagedSlotHost } from '../render/slotHost';
 import {
   escapeStyleTextForHtml,
   wrapCoreCSS,
   wrapUnsafeCSS,
 } from '../utils/cssWrappers';
 import { FileTreeView } from './FileTreeView';
+import type { FileTreeScrollMode, FileTreeViewProps } from './internalTypes';
+import type {
+  FileTreeExternalScrollModel,
+  FileTreeExternalScrollSource,
+  FileTreeOptions,
+} from './publicTypes';
 import {
   hydrateFileTreeRoot,
   renderFileTreeRoot,
   unmountFileTreeRoot,
 } from './runtime';
-import { FileTreeManagedSlotHost } from './slotHost';
+import { prepareScrollFileTreeShadowRoot } from './shadowRoot';
+import fileTreeStyles from './style.css';
 
 let serverInstanceId = 0;
 let clientInstanceId = 0;
@@ -83,9 +88,8 @@ function createServerId(explicitId?: string): string {
   return `pst_srv_${serverInstanceId}`;
 }
 
-// Translates the public row-budget hint into the provisional pixel height shared
-// by SSR and the first client render before the DOM can report a measured
-// scroll viewport.
+// Translates the public row-budget hint into the pixel height shared by SSR and
+// the first client render before the DOM can report a measured scroll viewport.
 function resolveInitialViewportHeight({
   initialVisibleRowCount,
   itemHeight,
@@ -125,14 +129,15 @@ function getHeaderSlotHtml(
 function getFileTreeOuterStart(
   id: string,
   mode: 'declarative' | 'dom',
-  hostStyle: string
+  hostStyle: string,
+  scrollMode: FileTreeScrollMode
 ): string {
   const templateAttr =
     mode === 'declarative'
       ? 'shadowrootmode="open"'
       : 'data-file-tree-shadowrootmode="open"';
   const styleAttr = hostStyle.length === 0 ? '' : ` style="${hostStyle}"`;
-  return `<file-tree-container id="${id}" data-file-tree-virtualized="true"${styleAttr}><template ${templateAttr}>`;
+  return `<file-tree-container id="${id}" data-file-tree-virtualized="true" data-file-tree-scroll-mode="${scrollMode}"${styleAttr}><template ${templateAttr}>`;
 }
 
 function getFileTreeOuterEnd(headerSlotHtml: string): string {
@@ -166,7 +171,7 @@ function getTopLevelSpriteSheets(shadowRoot: ShadowRoot): SVGElement[] {
   );
 }
 
-export class FileTree implements FileTreeModel {
+export class FileTree implements FileTreeExternalScrollModel {
   static LoadedCustomComponent: boolean = FileTreeContainerLoaded;
 
   #composition: FileTreeCompositionOptions | undefined;
@@ -184,6 +189,11 @@ export class FileTree implements FileTreeModel {
     FileTreeOptions,
     'initialVisibleRowCount' | 'itemHeight' | 'overscan' | 'stickyFolders'
   >;
+  readonly #scrollMode: FileTreeScrollMode;
+  #externalScrollSource: FileTreeExternalScrollSource | undefined;
+  readonly #externalScrollInitialSnapshot:
+    | FileTreeNormalizedExternalScrollSnapshot
+    | undefined;
   #fileTreeContainer: HTMLElement | undefined;
   #gitStatusState: FileTreeGitStatusState | null;
   #icons: FileTreeOptions['icons'];
@@ -206,6 +216,7 @@ export class FileTree implements FileTreeModel {
       composition,
       density,
       fileTreeSearchMode,
+      externalScroll,
       gitStatus,
       id,
       initialSearchQuery,
@@ -242,6 +253,16 @@ export class FileTree implements FileTreeModel {
       stickyFolders,
       initialVisibleRowCount,
     };
+    this.#scrollMode = externalScroll == null ? 'internal' : 'external';
+    this.#externalScrollSource = externalScroll?.source;
+    this.#externalScrollInitialSnapshot =
+      externalScroll == null
+        ? undefined
+        : resolveFileTreeExternalScrollInitialSnapshot({
+            initialSnapshot: externalScroll.initialSnapshot,
+            initialVisibleRowCount,
+            itemHeight: this.#density.itemHeight,
+          });
     this.#controller = new FileTreeController({
       ...controllerOptions,
       fileTreeSearchMode,
@@ -262,6 +283,7 @@ export class FileTree implements FileTreeModel {
     if (this.#wrapper != null) {
       unmountFileTreeRoot(this.#wrapper);
       delete this.#wrapper.dataset.fileTreeVirtualizedWrapper;
+      delete this.#wrapper.dataset.fileTreeScrollMode;
       this.#wrapper = undefined;
     }
 
@@ -269,6 +291,7 @@ export class FileTree implements FileTreeModel {
     this.#slotHost.setHost(null);
     if (this.#fileTreeContainer != null) {
       delete this.#fileTreeContainer.dataset.fileTreeVirtualized;
+      delete this.#fileTreeContainer.dataset.fileTreeScrollMode;
       this.#removeOwnedDensityHostStyle(this.#fileTreeContainer);
       this.#fileTreeContainer = undefined;
     }
@@ -410,6 +433,22 @@ export class FileTree implements FileTreeModel {
     this.#controller.resetPaths(paths, options);
   }
 
+  public setExternalScrollSource(source?: FileTreeExternalScrollSource): void {
+    if (this.#scrollMode !== 'external') {
+      throw new Error(
+        'FileTree.setExternalScrollSource() can only be used when the model was constructed with externalScroll.'
+      );
+    }
+
+    this.#externalScrollSource = source;
+    const mountedTree = this.#getMountedTreeElements();
+    if (mountedTree == null) {
+      return;
+    }
+
+    renderFileTreeRoot(mountedTree.wrapper, this.#getViewProps());
+  }
+
   // Deliberately rerenders even when the same object reference is passed again.
   // Callers can reuse one composition object while changing what its render
   // callbacks return, so identity alone is not a reliable no-op signal.
@@ -504,6 +543,9 @@ export class FileTree implements FileTreeModel {
       searchFakeFocus: this.#searchFakeFocus,
       slotHost: this.#slotHost,
       ...this.#getInitialViewOptions(),
+      externalScrollInitialSnapshot: this.#externalScrollInitialSnapshot,
+      externalScrollSource: this.#externalScrollSource,
+      scrollMode: this.#scrollMode,
     };
   }
 
@@ -696,6 +738,7 @@ export class FileTree implements FileTreeModel {
     this.#wrapper = existingWrapper ?? document.createElement('div');
     this.#wrapper.dataset.fileTreeId = this.#id;
     this.#wrapper.dataset.fileTreeVirtualizedWrapper = 'true';
+    this.#wrapper.dataset.fileTreeScrollMode = this.#scrollMode;
     this.#syncIconSurface(host, this.#wrapper);
 
     if (this.#wrapper.parentNode !== shadowRoot) {
@@ -718,9 +761,10 @@ export class FileTree implements FileTreeModel {
     }
 
     const shadowRoot = host.shadowRoot ?? host.attachShadow({ mode: 'open' });
-    prepareFileTreeShadowRoot(host, shadowRoot);
+    prepareScrollFileTreeShadowRoot(host, shadowRoot);
     this.#syncUnsafeCSS(shadowRoot);
     host.dataset.fileTreeVirtualized = 'true';
+    host.dataset.fileTreeScrollMode = this.#scrollMode;
     host.style.display = 'flex';
     this.#applyDensityHostStyle(host);
     this.#slotHost.setHost(host);
@@ -777,6 +821,7 @@ export function preloadFileTree(options: FileTreeOptions): FileTreeSsrPayload {
     composition,
     density,
     fileTreeSearchMode,
+    externalScroll,
     gitStatus,
     id,
     initialSearchQuery,
@@ -809,6 +854,16 @@ export function preloadFileTree(options: FileTreeOptions): FileTreeSsrPayload {
     initialVisibleRowCount,
     itemHeight: resolvedItemHeight,
   });
+  const scrollMode: FileTreeScrollMode =
+    externalScroll == null ? 'internal' : 'external';
+  const externalScrollInitialSnapshot =
+    externalScroll == null
+      ? undefined
+      : resolveFileTreeExternalScrollInitialSnapshot({
+          initialSnapshot: externalScroll.initialSnapshot,
+          initialVisibleRowCount,
+          itemHeight: resolvedItemHeight,
+        });
   const normalizedIcons = normalizeFileTreeIcons(icons);
   const customSpriteSheet = normalizedIcons.spriteSheet?.trim() ?? '';
   const coloredIconsAttr =
@@ -841,11 +896,13 @@ export function preloadFileTree(options: FileTreeOptions): FileTreeSsrPayload {
       searchFakeFocus: searchFakeFocus === true,
       stickyFolders,
       initialViewportHeight,
+      externalScrollInitialSnapshot,
+      scrollMode,
     })
   );
   controller.destroy();
 
-  const shadowHtml = `${getBuiltInSpriteSheet(normalizedIcons.set)}${customSpriteSheet}<style ${FILE_TREE_STYLE_ATTRIBUTE}>${wrappedCoreCss}</style>${unsafeCssStyle}<div data-file-tree-id="${resolvedId}" data-file-tree-virtualized-wrapper="true"${coloredIconsAttr}>${bodyHtml}</div>`;
+  const shadowHtml = `${getBuiltInSpriteSheet(normalizedIcons.set)}${customSpriteSheet}<style ${FILE_TREE_STYLE_ATTRIBUTE}>${wrappedCoreCss}</style>${unsafeCssStyle}<div data-file-tree-id="${resolvedId}" data-file-tree-virtualized-wrapper="true" data-file-tree-scroll-mode="${scrollMode}"${coloredIconsAttr}>${bodyHtml}</div>`;
   const headerSlotHtml = getHeaderSlotHtml(composition);
   // Inline the resolved density on the host so vanilla SSR consumers get the
   // same first paint as the React wrapper, where the model paints these vars
@@ -855,9 +912,15 @@ export function preloadFileTree(options: FileTreeOptions): FileTreeSsrPayload {
   const outerStart = getFileTreeOuterStart(
     resolvedId,
     'declarative',
-    hostStyle
+    hostStyle,
+    scrollMode
   );
-  const domOuterStart = getFileTreeOuterStart(resolvedId, 'dom', hostStyle);
+  const domOuterStart = getFileTreeOuterStart(
+    resolvedId,
+    'dom',
+    hostStyle,
+    scrollMode
+  );
   const outerEnd = getFileTreeOuterEnd(headerSlotHtml);
   return {
     domOuterStart,

--- a/packages/trees/src/scroll/FileTreeView.tsx
+++ b/packages/trees/src/scroll/FileTreeView.tsx
@@ -17,12 +17,13 @@ import {
   CONTEXT_MENU_TRIGGER_TYPE,
   HEADER_SLOT_NAME,
 } from '../constants';
+import { normalizeFileTreeExternalScrollSnapshot } from '../model/externalScroll';
 import {
   FILE_TREE_RENAME_VIEW,
   FileTreeController,
 } from '../model/FileTreeController';
-import type { FileTreeViewProps } from '../model/internalTypes';
 import {
+  computeFileTreeExternalLayout,
   computeFileTreeLayout,
   computeStickyRows,
   type FileTreeLayoutSnapshot,
@@ -45,89 +46,39 @@ import {
   FILE_TREE_DEFAULT_VIEWPORT_HEIGHT,
 } from '../model/virtualization';
 import type { GitStatus } from '../publicTypes';
+import {
+  focusElement,
+  getActiveTreeElement,
+  getCachedViewportHeight,
+  getParkedFocusedRowOffset,
+  getResizeObserverViewportHeight,
+  readMeasuredViewportHeight,
+  scrollFocusedRowIntoView,
+  scrollFocusedRowToViewportOffset,
+} from '../render/focusHelpers';
+import { createFileTreeIconResolver } from '../render/iconResolver';
+import { classifyFileTreeRenameHandoff } from '../render/renameHandoff';
+import { RenameInput } from '../render/RenameInput';
+import { computeFileTreeRowElementAttributes } from '../render/rowAttributes';
+import {
+  computeFileTreeRowClickPlan,
+  type FileTreeRowClickMode,
+} from '../render/rowClickPlan';
+import {
+  computeExternalFocusedRowViewportTop,
+  computeExternalViewportOffsetTop,
+} from '../render/scrollTarget';
 import type { SVGSpriteNames } from '../sprite';
 import {
   GIT_STATUS_DESCENDANT_TITLE,
   GIT_STATUS_LABEL,
   GIT_STATUS_TITLE,
 } from '../utils/gitStatusPresentation';
-import { createFileTreeIconResolver } from './iconResolver';
-import { classifyFileTreeRenameHandoff } from './renameHandoff';
-import { computeFileTreeRowElementAttributes } from './rowAttributes';
-import {
-  computeFileTreeRowClickPlan,
-  type FileTreeRowClickMode,
-} from './rowClickPlan';
-import {
-  computeFocusedRowScrollIntoView,
-  computeViewportOffsetScrollTop,
-} from './scrollTarget';
-
-function focusElement(element: HTMLElement | null): boolean {
-  if (element == null || !element.isConnected) {
-    return false;
-  }
-  if (element === document.body || element === document.documentElement) {
-    return false;
-  }
-
-  element.focus({ preventScroll: true });
-  const rootNode = element.getRootNode();
-  if (rootNode instanceof ShadowRoot) {
-    return rootNode.activeElement === element;
-  }
-
-  return document.activeElement === element;
-}
-
-// Shadow-root focus lives on shadowRoot.activeElement, so this helper
-// resolves the actual focused tree element regardless of host indirection.
-// Reads the actual focused element from the tree's shadow root so focus
-// sync logic can work even when document.activeElement points at the host.
-function getActiveTreeElement(rootElement: HTMLElement): HTMLElement | null {
-  const rootNode = rootElement.getRootNode();
-  if (rootNode instanceof ShadowRoot) {
-    const activeElement = rootNode.activeElement;
-    return activeElement instanceof HTMLElement ? activeElement : null;
-  }
-
-  const activeElement = document.activeElement;
-  return activeElement instanceof HTMLElement &&
-    rootElement.contains(activeElement)
-    ? activeElement
-    : null;
-}
-
-function RenameInput({
-  ariaLabel,
-  isFlattened = false,
-  ref,
-  value,
-  onBlur,
-  onInput,
-}: {
-  ariaLabel: string;
-  isFlattened?: boolean;
-  onBlur: () => void;
-  onInput: (event: Event) => void;
-  ref: (element: HTMLInputElement | null) => void;
-  value: string;
-}): JSX.Element {
-  return (
-    <input
-      ref={ref}
-      data-item-rename-input
-      {...(isFlattened ? { 'data-item-flattened-rename-input': true } : {})}
-      aria-label={ariaLabel}
-      value={value}
-      onBlur={onBlur}
-      onInput={onInput}
-      onClick={(event) => event.stopPropagation()}
-      onMouseDown={(event) => event.stopPropagation()}
-      onPointerDown={(event) => event.stopPropagation()}
-    />
-  );
-}
+import type {
+  FileTreeStickyRowCandidate,
+  FileTreeViewProps,
+} from './internalTypes';
+import type { FileTreeExternalScrollRequestContext } from './publicTypes';
 
 function formatFlattenedSegments(
   row: FileTreeVisibleRow,
@@ -199,6 +150,29 @@ type FileTreeViewLayoutState = {
   visibleRows: readonly FileTreeVisibleRow[];
 };
 
+function computeStickyRowsFromCandidates(
+  candidates: readonly FileTreeStickyRowCandidate[],
+  scrollTop: number,
+  itemHeight: number,
+  totalRowCount: number
+): readonly FileTreeLayoutStickyRow<FileTreeVisibleRow>[] {
+  return candidates
+    .map((candidate, slotDepth) => {
+      const defaultTop = slotDepth * itemHeight;
+      const nextBoundaryIndex = candidate.subtreeEndIndex + 1;
+      if (nextBoundaryIndex >= totalRowCount) {
+        return { row: candidate.row, top: defaultTop };
+      }
+
+      const nextBoundaryTop = nextBoundaryIndex * itemHeight - scrollTop;
+      return {
+        row: candidate.row,
+        top: Math.min(defaultTop, nextBoundaryTop - itemHeight),
+      };
+    })
+    .filter((entry) => entry.top + itemHeight > 0);
+}
+
 // Builds one visible-row snapshot so the layout engine and renderer consume the
 // same projection, sticky chain, occlusion window, and mounted list slice.
 //
@@ -222,22 +196,117 @@ function computeFileTreeViewLayoutState({
   viewportHeight: number;
 }): FileTreeViewLayoutState {
   const visibleCount = controller.getVisibleCount();
-  const visibleRows =
+  const stickyCandidates =
     stickyFolders && visibleCount > 0
+      ? controller.getStickyRowCandidates(scrollTop, itemHeight)
+      : [];
+  const visibleRows =
+    stickyCandidates == null && stickyFolders && visibleCount > 0
       ? controller.getVisibleRows(0, visibleCount - 1)
       : [];
+  const stickyRows =
+    stickyCandidates == null
+      ? undefined
+      : computeStickyRowsFromCandidates(
+          stickyCandidates,
+          scrollTop,
+          itemHeight,
+          visibleCount
+        );
   const snapshot = computeFileTreeLayout(visibleRows, {
     itemHeight,
     overscan,
     scrollTop,
+    stickyRows,
     totalRowCount: visibleCount,
     viewportHeight,
   });
 
+  const previewStickyCandidates =
+    stickyFolders && scrollTop <= 0 && visibleCount > 0
+      ? controller.getStickyRowCandidates(1, itemHeight)
+      : [];
   const overlayRows =
-    stickyFolders && scrollTop <= 0 && visibleRows.length > 0
-      ? computeStickyRows(visibleRows, 1, itemHeight)
-      : snapshot.sticky.rows;
+    previewStickyCandidates != null && scrollTop <= 0
+      ? computeStickyRowsFromCandidates(
+          previewStickyCandidates,
+          1,
+          itemHeight,
+          visibleCount
+        )
+      : stickyFolders && scrollTop <= 0 && visibleRows.length > 0
+        ? computeStickyRows(visibleRows, 1, itemHeight)
+        : snapshot.sticky.rows;
+  const overlayHeight = overlayRows.reduce(
+    (maxBottom, entry) => Math.max(maxBottom, entry.top + itemHeight),
+    0
+  );
+
+  return {
+    overlayHeight,
+    overlayRows,
+    snapshot,
+    visibleRows,
+  };
+}
+
+function computeFileTreeExternalViewLayoutState({
+  controller,
+  itemHeight,
+  overscan,
+  stickyFolders,
+  viewportHeight,
+  viewportTop,
+}: {
+  controller: FileTreeController;
+  itemHeight: number;
+  overscan: number;
+  stickyFolders: boolean;
+  viewportHeight: number;
+  viewportTop: number;
+}): FileTreeViewLayoutState {
+  const visibleCount = controller.getVisibleCount();
+  const stickyCandidates =
+    stickyFolders && visibleCount > 0 && viewportHeight > 0
+      ? controller.getStickyRowCandidates(viewportTop, itemHeight)
+      : [];
+  const visibleRows =
+    stickyCandidates == null && stickyFolders && visibleCount > 0
+      ? controller.getVisibleRows(0, visibleCount - 1)
+      : [];
+  const stickyRows =
+    stickyCandidates == null
+      ? undefined
+      : computeStickyRowsFromCandidates(
+          stickyCandidates,
+          viewportTop,
+          itemHeight,
+          visibleCount
+        );
+  const snapshot = computeFileTreeExternalLayout(visibleRows, {
+    itemHeight,
+    overscan,
+    stickyRows,
+    totalRowCount: visibleCount,
+    viewportHeight,
+    viewportTop,
+  });
+
+  const previewStickyCandidates =
+    stickyFolders && viewportTop <= 0 && visibleCount > 0
+      ? controller.getStickyRowCandidates(1, itemHeight)
+      : [];
+  const overlayRows =
+    previewStickyCandidates != null && viewportTop <= 0
+      ? computeStickyRowsFromCandidates(
+          previewStickyCandidates,
+          1,
+          itemHeight,
+          visibleCount
+        )
+      : stickyFolders && viewportTop <= 0 && visibleRows.length > 0
+        ? computeStickyRows(visibleRows, 1, itemHeight)
+        : snapshot.sticky.rows;
   const overlayHeight = overlayRows.reduce(
     (maxBottom, entry) => Math.max(maxBottom, entry.top + itemHeight),
     0
@@ -270,7 +339,40 @@ function getPointElement(
     pointRoot.elementFromPoint?.(clientX, clientY) ??
     documentElementFromPoint?.(clientX, clientY) ??
     null;
+  if (
+    rootNode instanceof ShadowRoot &&
+    (element == null || !rootNode.contains(element))
+  ) {
+    return getShadowPointElementByGeometry(rootNode, clientX, clientY);
+  }
+
   return element instanceof HTMLElement ? element : null;
+}
+
+function getShadowPointElementByGeometry(
+  rootNode: ShadowRoot,
+  clientX: number,
+  clientY: number
+): HTMLElement | null {
+  const candidates = Array.from(
+    rootNode.querySelectorAll<HTMLElement>(
+      '[data-type="item"], [data-item-flattened-subitem]'
+    )
+  );
+  for (let index = candidates.length - 1; index >= 0; index--) {
+    const candidate = candidates[index];
+    const rect = candidate.getBoundingClientRect();
+    if (
+      clientX >= rect.left &&
+      clientX <= rect.right &&
+      clientY >= rect.top &&
+      clientY <= rect.bottom
+    ) {
+      return candidate;
+    }
+  }
+
+  return null;
 }
 
 function resolveDropTargetFromElement(
@@ -464,96 +566,10 @@ function isSearchOpenSeedKey(event: KeyboardEvent): boolean {
   );
 }
 
-// Prefers the live scroll element's measured height once layout has run,
-// falling back to the first-render hint while clientHeight is still zero
-// (SSR, initial mount, detached nodes, jsdom).
-function getMeasuredViewportHeight(
-  scrollElement: HTMLElement | null,
-  fallbackViewportHeight: number
-): number {
-  return scrollElement?.clientHeight != null && scrollElement.clientHeight > 0
-    ? scrollElement.clientHeight
-    : fallbackViewportHeight;
-}
-
-// Thin imperative wrapper around `computeFocusedRowScrollIntoView`. The numeric
-// contract lives in the pure helper; this function just applies the returned
-// scrollTop, if any, and reports whether a write happened.
-function scrollFocusedRowIntoView(
-  scrollElement: HTMLElement,
-  focusedIndex: number,
-  itemHeight: number,
-  fallbackViewportHeight: number,
-  topInset: number = 0
-): boolean {
-  const nextScrollTop = computeFocusedRowScrollIntoView({
-    currentScrollTop: scrollElement.scrollTop,
-    focusedIndex,
-    itemHeight,
-    topInset,
-    viewportHeight: getMeasuredViewportHeight(
-      scrollElement,
-      fallbackViewportHeight
-    ),
-  });
-  if (nextScrollTop == null) {
-    return false;
-  }
-
-  scrollElement.scrollTop = nextScrollTop;
-  return true;
-}
-
-// Thin imperative wrapper around `computeViewportOffsetScrollTop`. Used when a
-// logical state change (search closing, sticky-row click) should restore the
-// focused row to a specific vertical offset inside the viewport.
-function scrollFocusedRowToViewportOffset(
-  scrollElement: HTMLElement,
-  focusedIndex: number,
-  itemHeight: number,
-  fallbackViewportHeight: number,
-  totalHeight: number,
-  targetViewportOffset: number
-): boolean {
-  const nextScrollTop = computeViewportOffsetScrollTop({
-    currentScrollTop: scrollElement.scrollTop,
-    focusedIndex,
-    itemHeight,
-    targetViewportOffset,
-    totalHeight,
-    viewportHeight: getMeasuredViewportHeight(
-      scrollElement,
-      fallbackViewportHeight
-    ),
-  });
-  if (nextScrollTop == null) {
-    return false;
-  }
-
-  scrollElement.scrollTop = nextScrollTop;
-  return true;
-}
-
-function getParkedFocusedRowOffset(
-  focusedIndex: number,
-  itemHeight: number,
-  range: { start: number; end: number },
-  windowHeight: number
-): number | null {
-  if (range.end < range.start) {
-    return null;
-  }
-
-  if (focusedIndex < range.start) {
-    return -itemHeight;
-  }
-
-  if (focusedIndex > range.end) {
-    return windowHeight;
-  }
-
-  return null;
-}
+// Reads the live scroll element's border-box height when an exact viewport
+// height is required. `clientHeight` rounds fractional CSS pixels, which
+// misaligns sticky virtualization in layouts where a slotted header leaves a
+// half-pixel scrollport.
 
 function getFileTreeGuideStyleText(focusedParentPath: string | null): string {
   if (focusedParentPath == null) {
@@ -568,6 +584,29 @@ function getFileTreeGuideStyleText(focusedParentPath: string | null): string {
 
 function isContextMenuOpenKey(event: KeyboardEvent): boolean {
   return (event.shiftKey && event.key === 'F10') || event.key === 'ContextMenu';
+}
+
+// Sticky DOM reads are only needed for keys whose behavior depends on the
+// current focused row. This keeps ordinary keydowns out of the query/measure
+// path while preserving stale-DOM-focus repair for sticky keyboard actions.
+function canKeyUseStickyKeyboardState(
+  event: KeyboardEvent,
+  contextMenuEnabled: boolean
+): boolean {
+  if (contextMenuEnabled && isContextMenuOpenKey(event)) {
+    return true;
+  }
+
+  if ((event.ctrlKey || event.metaKey) && isSpaceSelectionKey(event)) {
+    return true;
+  }
+
+  return (
+    event.key === 'ArrowDown' ||
+    event.key === 'ArrowLeft' ||
+    event.key === 'ArrowRight' ||
+    event.key === 'ArrowUp'
+  );
 }
 
 const BLOCKED_CONTEXT_MENU_NAV_KEYS = new Set([
@@ -677,7 +716,98 @@ function getContextMenuAnchorButton(
     return null;
   }
 
-  return stickyButtonRefs.get(path) ?? rowButtonRefs.get(path) ?? null;
+  const stickyButton = stickyButtonRefs.get(path) ?? null;
+  if (stickyButton != null) {
+    return stickyButton;
+  }
+
+  const rowButton = rowButtonRefs.get(path) ?? null;
+  return rowButton?.dataset.itemParked === 'true' ? null : rowButton;
+}
+
+// Sticky keyboard handling runs during the browser event that follows a scroll.
+// Reading the mounted overlay mirrors keeps that event aligned with the row the
+// user can currently focus, even if the React layout snapshot is one frame old.
+function getMountedStickyRowPaths(rootElement: HTMLElement | null): string[] {
+  if (rootElement == null) {
+    return [];
+  }
+
+  const paths: string[] = [];
+  for (const element of rootElement.querySelectorAll(
+    'button[data-file-tree-sticky-row="true"]'
+  )) {
+    if (!(element instanceof HTMLElement)) {
+      continue;
+    }
+
+    const path = element.dataset.fileTreeStickyPath;
+    if (path != null) {
+      paths.push(path);
+    }
+  }
+
+  return paths;
+}
+
+function getFocusedParkedRowElement(
+  rootElement: HTMLElement | null,
+  path: string | null
+): HTMLElement | null {
+  if (rootElement == null || path == null) {
+    return null;
+  }
+
+  for (const element of rootElement.querySelectorAll(
+    'button[data-item-focused="true"][data-item-parked="true"]'
+  )) {
+    if (element instanceof HTMLElement && element.dataset.itemPath === path) {
+      return element;
+    }
+  }
+
+  return null;
+}
+
+// Sticky keyboard exits use the focused sticky mirror as a proxy for where the
+// canonical row should remain after focus moves or the row collapses. Keeping
+// the layout reads here avoids measuring DOM for ordinary key handling.
+function getStickyKeyboardViewportOffset(
+  rootElement: HTMLElement | null,
+  scrollElement: HTMLElement | null,
+  activeTreeElement: HTMLElement | null,
+  path: string | null,
+  itemHeight: number,
+  stickyOverlayHeight: number,
+  viewportHeight: number
+): number {
+  const minimumStickyKeyboardViewportOffset = Math.max(
+    0,
+    stickyOverlayHeight - itemHeight
+  );
+  const scrollElementRect = scrollElement?.getBoundingClientRect() ?? null;
+  const activeElementTopWithinViewport =
+    scrollElementRect == null || activeTreeElement == null
+      ? null
+      : activeTreeElement.getBoundingClientRect().top - scrollElementRect.top;
+  const focusedParkedRowElement = getFocusedParkedRowElement(rootElement, path);
+  const parkedElementTopWithinViewport =
+    scrollElementRect == null || focusedParkedRowElement == null
+      ? null
+      : focusedParkedRowElement.getBoundingClientRect().top -
+        scrollElementRect.top;
+
+  return Math.max(
+    0,
+    Math.min(
+      parkedElementTopWithinViewport ??
+        Math.max(
+          activeElementTopWithinViewport ?? 0,
+          minimumStickyKeyboardViewportOffset
+        ),
+      Math.max(0, viewportHeight - itemHeight)
+    )
+  );
 }
 
 function createContextMenuItem(
@@ -695,6 +825,25 @@ function getFileTreeRootDomId(
   instanceId: string | undefined
 ): string | undefined {
   return instanceId == null ? undefined : `${instanceId}__tree`;
+}
+
+function readRowAreaTopWithinHost(
+  rootElement: HTMLElement | null,
+  rowAreaElement: HTMLElement | null
+): number {
+  if (rootElement == null || rowAreaElement == null) {
+    return 0;
+  }
+
+  const rootNode = rootElement.getRootNode();
+  const hostElement =
+    rootNode instanceof ShadowRoot && rootNode.host instanceof HTMLElement
+      ? rootNode.host
+      : rootElement;
+  const hostRect = hostElement.getBoundingClientRect();
+  const rowAreaRect = rowAreaElement.getBoundingClientRect();
+  const nextTop = rowAreaRect.top - hostRect.top;
+  return Number.isFinite(nextTop) ? nextTop : 0;
 }
 
 // Search keeps DOM focus on the built-in input, so the focused row still needs
@@ -964,7 +1113,6 @@ function renderStyledRow(
     onKeyDown,
   } = frame;
   const targetPath = getFileTreeRowPath(row);
-  const item = controller.getItem(targetPath);
   const { isParked = false, mode = 'flow', style } = options;
   const isSticky = mode === 'sticky';
   const ownGitStatus = gitStatusByPath?.get(targetPath) ?? null;
@@ -1069,7 +1217,7 @@ function renderStyledRow(
             if (!contextMenuRightClickEnabled) {
               return;
             }
-            item?.focus();
+            controller.focusMountedPathFromInput(targetPath);
             openContextMenuForRow(row, targetPath, {
               anchorRect: createAnchorRectFromPoint(
                 event.clientX,
@@ -1081,7 +1229,7 @@ function renderStyledRow(
         : undefined,
     onFocus: !isSticky
       ? () => {
-          item?.focus();
+          controller.focusMountedPathFromInput(targetPath);
         }
       : undefined,
     onKeyDown: !isSticky ? onKeyDown : undefined,
@@ -1160,6 +1308,8 @@ function renderRangeChildren(
 export function FileTreeView({
   composition,
   controller,
+  externalScrollInitialSnapshot,
+  externalScrollSource,
   gitStatusByPath,
   ignoredGitDirectories,
   directoriesWithGitChanges,
@@ -1174,6 +1324,7 @@ export function FileTreeView({
   searchFakeFocus = false,
   slotHost,
   stickyFolders = false,
+  scrollMode,
   initialViewportHeight = FILE_TREE_DEFAULT_VIEWPORT_HEIGHT,
 }: FileTreeViewProps): JSX.Element {
   'use no memo';
@@ -1188,6 +1339,7 @@ export function FileTreeView({
   const rowButtonRefs = useRef(new Map<string, HTMLElement>());
   const stickyRowButtonRefs = useRef(new Map<string, HTMLElement>());
   const updateViewportRef = useRef<() => void>(() => {});
+  const measuredViewportHeightRef = useRef<number | null>(null);
   const domFocusOwnerRef = useRef(false);
   const previousFocusedPathRef = useRef<string | null>(null);
   const previousRenamingPathRef = useRef<string | null>(null);
@@ -1224,6 +1376,7 @@ export function FileTreeView({
   const [lastContextMenuInteraction, setLastContextMenuInteraction] = useState<
     'focus' | 'pointer' | null
   >(null);
+  const [scrollSettledRevision, setScrollSettledRevision] = useState(0);
   const [contextMenuState, setContextMenuState] = useState<{
     anchorRect: FileTreeContextMenuOpenContext['anchorRect'] | null;
     item: FileTreeContextMenuItem;
@@ -1234,8 +1387,51 @@ export function FileTreeView({
   contextMenuStateRef.current = contextMenuState;
 
   const pendingStickyFocusPathRef = useRef<string | null>(null);
+  const pendingStickyKeyboardFocusPathRef = useRef<string | null>(null);
+  const pendingStickyKeyboardViewportOffsetRef = useRef<{
+    path: string;
+    viewportOffset: number;
+  } | null>(null);
+  const pendingStickyKeyboardScrollTopRef = useRef<{
+    path: string;
+    scrollTop: number;
+  } | null>(null);
   const debugContextMenuTriggerPathRef = useRef<string | null>(null);
   const debugDisableScrollSuppressionRef = useRef(false);
+  const externalScrollSourceRef = useRef(externalScrollSource);
+  externalScrollSourceRef.current = externalScrollSource;
+  const initialExternalScrollSnapshot =
+    externalScrollInitialSnapshot ??
+    normalizeFileTreeExternalScrollSnapshot(undefined, initialViewportHeight);
+  const externalScrollSnapshotRef = useRef(initialExternalScrollSnapshot);
+  const rowAreaTopWithinHostRef = useRef(0);
+
+  // Keep the coupled sticky-keyboard refs moving together so each transition
+  // leaves exactly one preservation mode active.
+  const clearPendingStickyKeyboardState = (): void => {
+    pendingStickyKeyboardFocusPathRef.current = null;
+    pendingStickyKeyboardViewportOffsetRef.current = null;
+    pendingStickyKeyboardScrollTopRef.current = null;
+  };
+
+  const preserveStickyKeyboardFocusAtScrollTop = (
+    path: string,
+    scrollTop: number | null
+  ): void => {
+    pendingStickyKeyboardFocusPathRef.current = path;
+    pendingStickyKeyboardViewportOffsetRef.current = null;
+    pendingStickyKeyboardScrollTopRef.current =
+      scrollTop == null ? null : { path, scrollTop };
+  };
+
+  const restoreStickyKeyboardViewportOffset = (
+    path: string,
+    viewportOffset: number
+  ): void => {
+    pendingStickyKeyboardFocusPathRef.current = null;
+    pendingStickyKeyboardViewportOffsetRef.current = { path, viewportOffset };
+    pendingStickyKeyboardScrollTopRef.current = null;
+  };
 
   // Trees that mount with an already-open search session (because a caller
   // passed `initialSearchQuery`) should not steal focus from sibling trees
@@ -1265,6 +1461,14 @@ export function FileTreeView({
   // should resume so they can dismiss the filter with a blur like any other
   // tree.
   const searchInputUserInteractedRef = useRef(false);
+  const isExternalScrollMode = scrollMode === 'external';
+  const initialLayoutViewportHeight = isExternalScrollMode
+    ? initialExternalScrollSnapshot.effectiveViewportHeight
+    : initialViewportHeight;
+  const initialLayoutScrollTop = isExternalScrollMode
+    ? initialExternalScrollSnapshot.viewportTop +
+      initialExternalScrollSnapshot.topInset
+    : 0;
 
   const markSearchInputInteracted = useCallback(() => {
     searchInputUserInteractedRef.current = true;
@@ -1272,14 +1476,23 @@ export function FileTreeView({
   }, []);
 
   const [layoutState, setLayoutState] = useState<FileTreeViewLayoutState>(() =>
-    computeFileTreeViewLayoutState({
-      controller,
-      itemHeight,
-      overscan,
-      scrollTop: 0,
-      stickyFolders,
-      viewportHeight: initialViewportHeight,
-    })
+    isExternalScrollMode
+      ? computeFileTreeExternalViewLayoutState({
+          controller,
+          itemHeight,
+          overscan,
+          stickyFolders,
+          viewportHeight: initialLayoutViewportHeight,
+          viewportTop: initialLayoutScrollTop,
+        })
+      : computeFileTreeViewLayoutState({
+          controller,
+          itemHeight,
+          overscan,
+          scrollTop: initialLayoutScrollTop,
+          stickyFolders,
+          viewportHeight: initialLayoutViewportHeight,
+        })
   );
   const [hasStickyUiMount, setHasStickyUiMount] = useState(false);
   useEffect(() => {
@@ -1423,6 +1636,140 @@ export function FileTreeView({
   const occludedStickyRows = layoutSnapshot.sticky.rows;
   const totalScrollableHeight = layoutSnapshot.physical.totalHeight;
   const stickyOverlayHeight = layoutSnapshot.sticky.height;
+  const externalTopInset = isExternalScrollMode
+    ? externalScrollSnapshotRef.current.topInset
+    : 0;
+  const getExternalRowViewportTop = useCallback(
+    (): number =>
+      externalScrollSnapshotRef.current.viewportTop -
+      rowAreaTopWithinHostRef.current,
+    []
+  );
+  const requestExternalRowViewportTop = useCallback(
+    (
+      nextRowViewportTop: number,
+      context: FileTreeExternalScrollRequestContext
+    ): boolean => {
+      const source = externalScrollSourceRef.current;
+      if (!isExternalScrollMode || source == null) {
+        return false;
+      }
+
+      source.scrollToViewportTop(
+        nextRowViewportTop + rowAreaTopWithinHostRef.current,
+        context
+      );
+      externalScrollSnapshotRef.current =
+        normalizeFileTreeExternalScrollSnapshot(
+          source.getSnapshot(),
+          externalScrollSnapshotRef.current.viewportHeight
+        );
+      updateViewportRef.current();
+      return true;
+    },
+    [isExternalScrollMode]
+  );
+  const getRuntimeViewportHeight = useCallback(
+    (scrollElement: HTMLElement | null): number => {
+      if (isExternalScrollMode) {
+        const snapshot = externalScrollSnapshotRef.current;
+        return Math.max(0, snapshot.viewportHeight - snapshot.bottomInset);
+      }
+
+      return readMeasuredViewportHeight(scrollElement, resolvedViewportHeight);
+    },
+    [isExternalScrollMode, resolvedViewportHeight]
+  );
+  const getRuntimeScrollTop = useCallback(
+    (scrollElement: HTMLElement | null): number | null =>
+      isExternalScrollMode
+        ? getExternalRowViewportTop()
+        : (scrollElement?.scrollTop ?? null),
+    [getExternalRowViewportTop, isExternalScrollMode]
+  );
+  const scrollFocusedRowIntoViewForMode = useCallback(
+    (
+      scrollElement: HTMLElement,
+      context: FileTreeExternalScrollRequestContext
+    ): boolean => {
+      if (!isExternalScrollMode) {
+        return scrollFocusedRowIntoView(
+          scrollElement,
+          focusedIndex,
+          itemHeight,
+          resolvedViewportHeight,
+          stickyOverlayHeight
+        );
+      }
+
+      const snapshot = externalScrollSnapshotRef.current;
+      const nextViewportTop = computeExternalFocusedRowViewportTop({
+        bottomInset: snapshot.bottomInset,
+        currentViewportTop: getExternalRowViewportTop(),
+        focusedIndex,
+        itemHeight,
+        topInset: snapshot.topInset + stickyOverlayHeight,
+        viewportHeight: snapshot.viewportHeight,
+      });
+      return nextViewportTop == null
+        ? false
+        : requestExternalRowViewportTop(nextViewportTop, context);
+    },
+    [
+      focusedIndex,
+      getExternalRowViewportTop,
+      isExternalScrollMode,
+      itemHeight,
+      requestExternalRowViewportTop,
+      resolvedViewportHeight,
+      stickyOverlayHeight,
+    ]
+  );
+  const scrollFocusedRowToViewportOffsetForMode = useCallback(
+    (
+      scrollElement: HTMLElement,
+      targetViewportOffset: number,
+      context: FileTreeExternalScrollRequestContext,
+      focusedRowIndex: number = focusedIndex,
+      totalHeight: number = totalScrollableHeight,
+      viewportHeight: number = resolvedViewportHeight
+    ): boolean => {
+      if (!isExternalScrollMode) {
+        return scrollFocusedRowToViewportOffset(
+          scrollElement,
+          focusedRowIndex,
+          itemHeight,
+          viewportHeight,
+          totalHeight,
+          targetViewportOffset
+        );
+      }
+
+      const snapshot = externalScrollSnapshotRef.current;
+      const nextViewportTop = computeExternalViewportOffsetTop({
+        bottomInset: snapshot.bottomInset,
+        currentViewportTop: getExternalRowViewportTop(),
+        focusedIndex: focusedRowIndex,
+        itemHeight,
+        targetViewportOffset,
+        topInset: snapshot.topInset,
+        totalHeight,
+        viewportHeight: snapshot.viewportHeight,
+      });
+      return nextViewportTop == null
+        ? false
+        : requestExternalRowViewportTop(nextViewportTop, context);
+    },
+    [
+      focusedIndex,
+      getExternalRowViewportTop,
+      isExternalScrollMode,
+      itemHeight,
+      requestExternalRowViewportTop,
+      resolvedViewportHeight,
+      totalScrollableHeight,
+    ]
+  );
   const stickyRowPathSet = useMemo(
     () =>
       new Set(occludedStickyRows.map((entry) => getFileTreeRowPath(entry.row))),
@@ -1515,8 +1862,23 @@ export function FileTreeView({
         return;
       }
 
+      const anchorButton = getTriggerAnchorButton(targetPath);
+      if (anchorButton?.dataset.fileTreeStickyRow === 'true') {
+        const scrollElement = scrollRef.current;
+        preserveStickyKeyboardFocusAtScrollTop(
+          targetPath,
+          getRuntimeScrollTop(scrollElement)
+        );
+        domFocusOwnerRef.current = true;
+        setActiveItemPath((previousPath) =>
+          previousPath === targetPath ? previousPath : targetPath
+        );
+      }
+      // FileTree item focus is controller focus, not DOM focus. Sticky anchor
+      // preservation relies on this remaining scroll-neutral so the canonical
+      // offscreen row is not revealed before the layout effect restores focus.
       item.focus();
-      updateTriggerPosition(getTriggerAnchorButton(targetPath));
+      updateTriggerPosition(anchorButton);
       shouldRestoreContextMenuFocusRef.current = true;
       setContextMenuState({
         anchorRect: options?.anchorRect ?? null,
@@ -1525,7 +1887,12 @@ export function FileTreeView({
         source: options?.source ?? 'keyboard',
       });
     },
-    [controller, getTriggerAnchorButton, updateTriggerPosition]
+    [
+      controller,
+      getRuntimeScrollTop,
+      getTriggerAnchorButton,
+      updateTriggerPosition,
+    ]
   );
   const startRenameFromPath = useCallback(
     (path?: string): void => {
@@ -1535,17 +1902,15 @@ export function FileTreeView({
 
       if (controller.isSearchOpen()) {
         const scrollElement = scrollRef.current;
-        const viewportHeight = getMeasuredViewportHeight(
-          scrollElement,
-          resolvedViewportHeight
-        );
+        const viewportHeight = getRuntimeViewportHeight(scrollElement);
+        const scrollTop = getRuntimeScrollTop(scrollElement);
         restoreTreeFocusViewportOffsetRef.current =
-          focusedIndex < 0 || scrollElement == null
+          focusedIndex < 0 || scrollTop == null
             ? null
             : Math.max(
                 0,
                 Math.min(
-                  focusedIndex * itemHeight - scrollElement.scrollTop,
+                  focusedIndex * itemHeight - scrollTop,
                   Math.max(0, viewportHeight - itemHeight)
                 )
               );
@@ -1562,9 +1927,10 @@ export function FileTreeView({
     [
       controller,
       focusedIndex,
+      getRuntimeScrollTop,
+      getRuntimeViewportHeight,
       itemHeight,
       renamingEnabled,
-      resolvedViewportHeight,
     ]
   );
 
@@ -1598,44 +1964,70 @@ export function FileTreeView({
         return false;
       }
 
-      const liveViewportHeight = getMeasuredViewportHeight(
-        scrollElement,
-        resolvedViewportHeight
-      );
+      const liveViewportHeight = getRuntimeViewportHeight(scrollElement);
       const liveTotalHeight = controller.getVisibleCount() * itemHeight;
+      const currentRuntimeScrollTop = getRuntimeScrollTop(scrollElement) ?? 0;
       const targetViewportOffset =
         targetOffset === 'sticky-parents'
           ? focusedRow.ancestorPaths.length * itemHeight
-          : computeFileTreeViewLayoutState({
-              controller,
-              itemHeight,
-              overscan,
-              scrollTop: scrollElement.scrollTop,
-              stickyFolders,
-              viewportHeight: liveViewportHeight,
-            }).snapshot.sticky.height;
+          : isExternalScrollMode
+            ? computeFileTreeExternalViewLayoutState({
+                controller,
+                itemHeight,
+                overscan,
+                stickyFolders,
+                viewportHeight:
+                  externalScrollSnapshotRef.current.effectiveViewportHeight,
+                viewportTop:
+                  currentRuntimeScrollTop +
+                  externalScrollSnapshotRef.current.topInset,
+              }).snapshot.sticky.height
+            : computeFileTreeViewLayoutState({
+                controller,
+                itemHeight,
+                overscan,
+                scrollTop: currentRuntimeScrollTop,
+                stickyFolders,
+                viewportHeight: liveViewportHeight,
+              }).snapshot.sticky.height;
 
       // A sticky interaction can mutate the tree before we reveal the canonical
       // row. Collapsing the interacted sticky row should leave only its parents
       // pinned, while rename handoff keeps using the live overlay geometry.
       domFocusOwnerRef.current = true;
-      scrollFocusedRowToViewportOffset(
+      scrollFocusedRowToViewportOffsetForMode(
         scrollElement,
+        isExternalScrollMode
+          ? externalScrollSnapshotRef.current.topInset + targetViewportOffset
+          : targetViewportOffset,
+        {
+          origin: 'programmatic',
+          path,
+          reason: 'sticky-row-restore',
+        },
         visibleIndex,
-        itemHeight,
-        liveViewportHeight,
         liveTotalHeight,
-        targetViewportOffset
+        liveViewportHeight
       );
       updateViewportRef.current();
       pendingStickyFocusPathRef.current = restoreTreeFocus ? path : null;
       return true;
     },
-    [controller, itemHeight, overscan, resolvedViewportHeight, stickyFolders]
+    [
+      controller,
+      getRuntimeScrollTop,
+      getRuntimeViewportHeight,
+      isExternalScrollMode,
+      itemHeight,
+      overscan,
+      scrollFocusedRowToViewportOffsetForMode,
+      stickyFolders,
+    ]
   );
 
   const shouldSuppressContextMenu = (): boolean => {
     return (
+      isScrollingRef.current === true ||
       touchLongPressTimerRef.current != null ||
       touchDragActiveRef.current === true
     );
@@ -1770,6 +2162,9 @@ export function FileTreeView({
 
   const runDragAutoScroll = (): void => {
     dragAutoScrollFrameRef.current = null;
+    if (isExternalScrollMode) {
+      return;
+    }
     const dragPoint = dragPointRef.current;
     const scrollElement = scrollRef.current;
     if (
@@ -1809,6 +2204,9 @@ export function FileTreeView({
   };
 
   const updateDragPoint = (clientX: number, clientY: number): void => {
+    if (isExternalScrollMode) {
+      return;
+    }
     dragPointRef.current = { clientX, clientY };
     dragAutoScrollFrameRef.current ??=
       requestDragAnimationFrame(runDragAutoScroll);
@@ -1889,7 +2287,11 @@ export function FileTreeView({
     touchSourceElementRef.current = dragSource;
     dragSource.setAttribute('draggable', 'false');
 
-    const clearPendingTouchStart = (): void => {
+    const clearPendingTouchStart = (
+      options: { restoreNativeDraggable?: boolean } = {}
+    ): void => {
+      const restoreNativeDraggable =
+        options.restoreNativeDraggable ?? !touchDragActiveRef.current;
       if (touchLongPressTimerRef.current != null) {
         clearTimeout(touchLongPressTimerRef.current);
         touchLongPressTimerRef.current = null;
@@ -1900,7 +2302,7 @@ export function FileTreeView({
       if (touchCleanupRef.current === clearPendingTouchStart) {
         touchCleanupRef.current = null;
       }
-      if (!touchDragActiveRef.current) {
+      if (restoreNativeDraggable) {
         dragSource.setAttribute('draggable', 'true');
         if (touchSourceElementRef.current === dragSource) {
           touchSourceElementRef.current = null;
@@ -1939,7 +2341,10 @@ export function FileTreeView({
     document.addEventListener('touchcancel', handlePendingTouchEnd);
     touchCleanupRef.current = clearPendingTouchStart;
     touchLongPressTimerRef.current = setTimeout(() => {
-      clearPendingTouchStart();
+      // Keep native draggable disabled while the custom touch drag activates.
+      // iOS Safari can otherwise promote the same long press into its native
+      // HTML drag flow before the touch-specific listeners take over.
+      clearPendingTouchStart({ restoreNativeDraggable: false });
       if (controller.startDrag(targetPath) === false) {
         dragSource.setAttribute('draggable', 'true');
         if (touchSourceElementRef.current === dragSource) {
@@ -2069,17 +2474,15 @@ export function FileTreeView({
           controller.selectOnlyPath(currentFocusedPath);
         }
         const scrollElement = scrollRef.current;
-        const viewportHeight = getMeasuredViewportHeight(
-          scrollElement,
-          resolvedViewportHeight
-        );
+        const viewportHeight = getRuntimeViewportHeight(scrollElement);
+        const scrollTop = getRuntimeScrollTop(scrollElement);
         restoreTreeFocusViewportOffsetRef.current =
-          focusedIndex < 0 || scrollElement == null
+          focusedIndex < 0 || scrollTop == null
             ? null
             : Math.max(
                 0,
                 Math.min(
-                  focusedIndex * itemHeight - scrollElement.scrollTop,
+                  focusedIndex * itemHeight - scrollTop,
                   Math.max(0, viewportHeight - itemHeight)
                 )
               );
@@ -2108,6 +2511,43 @@ export function FileTreeView({
       return;
     }
 
+    const isKeyboardContextMenuRequest =
+      contextMenuEnabled && isContextMenuOpenKey(event);
+    const shouldInspectStickyKeyboardState = canKeyUseStickyKeyboardState(
+      event,
+      contextMenuEnabled
+    );
+    const activeTreeElement =
+      shouldInspectStickyKeyboardState && rootRef.current != null
+        ? getActiveTreeElement(rootRef.current)
+        : null;
+    const mountedStickyRowPathSet = shouldInspectStickyKeyboardState
+      ? new Set(getMountedStickyRowPaths(rootRef.current))
+      : new Set<string>();
+    const activeStickyFocusPath =
+      activeTreeElement?.dataset.fileTreeStickyPath ?? null;
+    const activeStickyRowOwnsFocus =
+      activeTreeElement?.dataset.fileTreeStickyRow === 'true' &&
+      activeStickyFocusPath != null;
+    if (
+      activeStickyRowOwnsFocus &&
+      activeStickyFocusPath !== focusedPath &&
+      mountedStickyRowPathSet.has(activeStickyFocusPath)
+    ) {
+      // Syncing controller focus to a sticky DOM mirror can otherwise reveal
+      // the offscreen canonical row before the key action decides what to do.
+      // Shift+F10 may also be followed by a native contextmenu event, so this
+      // preservation has to be in place before the controller emits.
+      const scrollElement = scrollRef.current;
+      preserveStickyKeyboardFocusAtScrollTop(
+        activeStickyFocusPath,
+        getRuntimeScrollTop(scrollElement)
+      );
+      controller.focusPath(activeStickyFocusPath);
+    }
+
+    const effectiveFocusedPath = controller.getFocusedPath();
+    const effectiveFocusedIndex = controller.getFocusedIndex();
     const focusedItem = controller.getFocusedItem();
     if (focusedItem == null) {
       return;
@@ -2116,24 +2556,48 @@ export function FileTreeView({
     const focusedDirectoryItem = isFileTreeDirectoryHandle(focusedItem)
       ? focusedItem
       : null;
+    const startedFromStickyRow =
+      effectiveFocusedPath != null &&
+      (stickyRowPathSet.has(effectiveFocusedPath) ||
+        (activeStickyRowOwnsFocus &&
+          activeStickyFocusPath === effectiveFocusedPath &&
+          mountedStickyRowPathSet.has(effectiveFocusedPath)));
+    const shouldPreserveLocalStickyFocusMove =
+      event.key === 'ArrowDown' ||
+      event.key === 'ArrowUp' ||
+      (event.key === 'ArrowRight' &&
+        focusedDirectoryItem != null &&
+        focusedDirectoryItem.isExpanded());
+    const shouldRestoreCollapsedStickyFocusViewport =
+      event.key === 'ArrowLeft' &&
+      startedFromStickyRow &&
+      focusedDirectoryItem != null &&
+      focusedDirectoryItem.isExpanded();
+    const scrollElement = scrollRef.current;
     let handled = true;
     if (event.shiftKey && event.key === 'ArrowDown') {
       controller.extendSelectionFromFocused(1);
     } else if (event.shiftKey && event.key === 'ArrowUp') {
       controller.extendSelectionFromFocused(-1);
     } else if (
-      contextMenuEnabled &&
-      isContextMenuOpenKey(event) &&
-      focusedPath != null &&
-      focusedIndex >= 0
+      isKeyboardContextMenuRequest &&
+      effectiveFocusedPath != null &&
+      effectiveFocusedIndex >= 0
     ) {
       const focusedRow =
-        controller.getVisibleRows(focusedIndex, focusedIndex)[0] ?? null;
-      const focusedButton = rowButtonRefs.current.get(focusedPath) ?? null;
+        controller.getVisibleRows(
+          effectiveFocusedIndex,
+          effectiveFocusedIndex
+        )[0] ?? null;
+      const focusedButton = getContextMenuAnchorButton(
+        effectiveFocusedPath,
+        stickyRowButtonRefs.current,
+        rowButtonRefs.current
+      );
       if (focusedRow == null || focusedButton == null) {
         handled = false;
       } else {
-        openContextMenuForRow(focusedRow, focusedPath);
+        openContextMenuForRow(focusedRow, effectiveFocusedPath);
       }
     } else if ((event.ctrlKey || event.metaKey) && isSpaceSelectionKey(event)) {
       controller.toggleFocusedSelection();
@@ -2186,6 +2650,68 @@ export function FileTreeView({
     }
 
     setLastContextMenuInteraction('focus');
+    const nextFocusedPath = controller.getFocusedPath();
+    const nextFocusedPathIsMountedSticky =
+      nextFocusedPath != null &&
+      (stickyRowPathSet.has(nextFocusedPath) ||
+        mountedStickyRowPathSet.has(nextFocusedPath));
+    const stickyKeyboardMoveLandsOnDifferentStickyRow =
+      shouldPreserveLocalStickyFocusMove &&
+      nextFocusedPath !== effectiveFocusedPath;
+    const stickyKeyboardMenuStaysOnStickyRow =
+      isKeyboardContextMenuRequest &&
+      activeStickyRowOwnsFocus &&
+      activeStickyFocusPath === effectiveFocusedPath &&
+      nextFocusedPath === effectiveFocusedPath;
+    const shouldPreserveStickyKeyboardFocusPath =
+      (stickyKeyboardMoveLandsOnDifferentStickyRow &&
+        nextFocusedPathIsMountedSticky) ||
+      stickyKeyboardMenuStaysOnStickyRow;
+    if (
+      (startedFromStickyRow || stickyKeyboardMenuStaysOnStickyRow) &&
+      nextFocusedPath != null &&
+      shouldPreserveStickyKeyboardFocusPath
+    ) {
+      preserveStickyKeyboardFocusAtScrollTop(
+        nextFocusedPath,
+        getRuntimeScrollTop(scrollElement)
+      );
+      domFocusOwnerRef.current = true;
+      setActiveItemPath((previousPath) =>
+        previousPath === nextFocusedPath ? previousPath : nextFocusedPath
+      );
+    } else {
+      const stickyArrowUpExitsStack =
+        event.key === 'ArrowUp' &&
+        startedFromStickyRow &&
+        nextFocusedPath !== effectiveFocusedPath;
+      const stickyCollapseStaysOnRow =
+        shouldRestoreCollapsedStickyFocusViewport &&
+        nextFocusedPath === effectiveFocusedPath;
+      if (
+        nextFocusedPath != null &&
+        (stickyArrowUpExitsStack || stickyCollapseStaysOnRow)
+      ) {
+        restoreStickyKeyboardViewportOffset(
+          nextFocusedPath,
+          getStickyKeyboardViewportOffset(
+            rootRef.current,
+            scrollElement,
+            activeTreeElement,
+            effectiveFocusedPath,
+            itemHeight,
+            stickyOverlayHeight,
+            getRuntimeViewportHeight(scrollElement)
+          )
+        );
+        domFocusOwnerRef.current = true;
+        setActiveItemPath((previousPath) =>
+          previousPath === nextFocusedPath ? previousPath : nextFocusedPath
+        );
+      } else {
+        clearPendingStickyKeyboardState();
+      }
+    }
 
     // Focus-only and selection-only controller updates do not change
     // range/itemCount, so force a render tick before the DOM-focus sync effect
@@ -2257,6 +2783,16 @@ export function FileTreeView({
     if (rootElement == null) {
       return;
     }
+    let nullFocusOutTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const clearNullFocusOutTimer = (): void => {
+      if (nullFocusOutTimer == null) {
+        return;
+      }
+
+      clearTimeout(nullFocusOutTimer);
+      nullFocusOutTimer = null;
+    };
 
     const updateActiveItemPath = (): void => {
       const activeTreeElement = getActiveTreeElement(rootElement);
@@ -2267,6 +2803,7 @@ export function FileTreeView({
     };
 
     const onFocusIn = (): void => {
+      clearNullFocusOutTimer();
       domFocusOwnerRef.current = true;
       updateActiveItemPath();
     };
@@ -2274,22 +2811,43 @@ export function FileTreeView({
       const nextTarget = event.relatedTarget;
       if (nextTarget == null) {
         // Virtualization can swap the focused row between rendered and parked
-        // states before the replacement element receives focus.
+        // states before the replacement element receives focus. Defer the
+        // ownership check so a true blur to the page can still clear visual
+        // focus once the browser has finished moving focus.
+        clearNullFocusOutTimer();
+        nullFocusOutTimer = setTimeout(() => {
+          nullFocusOutTimer = null;
+          if (getActiveTreeElement(rootElement) != null) {
+            updateActiveItemPath();
+            return;
+          }
+
+          domFocusOwnerRef.current = false;
+          setActiveItemPath(null);
+        }, 0);
         return;
       }
 
       if (!(nextTarget instanceof Node) || !rootElement.contains(nextTarget)) {
+        clearNullFocusOutTimer();
         domFocusOwnerRef.current = false;
         setActiveItemPath(null);
         return;
       }
 
-      updateActiveItemPath();
+      const nextActiveItemPath =
+        nextTarget instanceof HTMLElement
+          ? (nextTarget.dataset.itemPath ?? null)
+          : null;
+      setActiveItemPath((previousPath) =>
+        previousPath === nextActiveItemPath ? previousPath : nextActiveItemPath
+      );
     };
 
     rootElement.addEventListener('focusin', onFocusIn);
     rootElement.addEventListener('focusout', onFocusOut);
     return () => {
+      clearNullFocusOutTimer();
       rootElement.removeEventListener('focusin', onFocusIn);
       rootElement.removeEventListener('focusout', onFocusOut);
     };
@@ -2322,10 +2880,153 @@ export function FileTreeView({
       return;
     }
 
+    if (isExternalScrollMode) {
+      if (rootElement == null) {
+        return;
+      }
+
+      const normalizeExternalSnapshot = (
+        snapshot: Parameters<
+          typeof normalizeFileTreeExternalScrollSnapshot
+        >[0] = externalScrollSnapshotRef.current
+      ): ReturnType<typeof normalizeFileTreeExternalScrollSnapshot> =>
+        normalizeFileTreeExternalScrollSnapshot(
+          snapshot,
+          externalScrollSnapshotRef.current.viewportHeight
+        );
+      const applyScrollingState = (
+        snapshot: ReturnType<typeof normalizeFileTreeExternalScrollSnapshot>,
+        viewportTop: number
+      ): void => {
+        const isUserScroll =
+          snapshot.isScrolling &&
+          (snapshot.scrollOrigin === 'user' ||
+            snapshot.scrollOrigin === 'unknown');
+        if (
+          snapshot.isScrolling &&
+          debugDisableScrollSuppressionRef.current !== true
+        ) {
+          if (listElement != null) {
+            listElement.dataset.isScrolling ??= '';
+          }
+          rootElement.dataset.isScrolling ??= '';
+          isScrollingRef.current = true;
+        } else {
+          if (listElement != null) {
+            delete listElement.dataset.isScrolling;
+          }
+          delete rootElement.dataset.isScrolling;
+          if (isScrollingRef.current) {
+            setScrollSettledRevision((revision) => revision + 1);
+          }
+          isScrollingRef.current = false;
+        }
+
+        if (snapshot.isScrolling && viewportTop <= 0) {
+          rootElement.dataset.overlayReveal = 'true';
+        } else if (!snapshot.isScrolling || viewportTop > 0) {
+          delete rootElement.dataset.overlayReveal;
+        }
+
+        if (!isUserScroll) {
+          return;
+        }
+
+        setContextHoverPath((previousPath) =>
+          previousPath == null ? previousPath : null
+        );
+        if (contextMenuStateRef.current != null) {
+          closeContextMenuRef.current();
+        }
+      };
+      const updateExternalLayout = (
+        snapshot: Parameters<
+          typeof normalizeFileTreeExternalScrollSnapshot
+        >[0] = externalScrollSnapshotRef.current
+      ): void => {
+        const normalizedSnapshot = normalizeExternalSnapshot(snapshot);
+        externalScrollSnapshotRef.current = normalizedSnapshot;
+        rowAreaTopWithinHostRef.current = readRowAreaTopWithinHost(
+          rootElement,
+          scrollElement
+        );
+        const viewportTop =
+          normalizedSnapshot.viewportTop -
+          rowAreaTopWithinHostRef.current +
+          normalizedSnapshot.topInset;
+        setLayoutState(
+          computeFileTreeExternalViewLayoutState({
+            controller,
+            itemHeight,
+            overscan,
+            stickyFolders,
+            viewportHeight: normalizedSnapshot.effectiveViewportHeight,
+            viewportTop,
+          })
+        );
+        applyScrollingState(normalizedSnapshot, viewportTop);
+      };
+
+      updateViewportRef.current = () => {
+        const source = externalScrollSourceRef.current;
+        updateExternalLayout(
+          source == null
+            ? externalScrollSnapshotRef.current
+            : normalizeExternalSnapshot(source.getSnapshot())
+        );
+      };
+
+      let hasSeenInitialControllerSnapshot = false;
+      const unsubscribeController = controller.subscribe(() => {
+        if (hasSeenInitialControllerSnapshot) {
+          setControllerRevision((revision) => revision + 1);
+        } else {
+          hasSeenInitialControllerSnapshot = true;
+        }
+        updateViewportRef.current();
+      });
+      const source = externalScrollSourceRef.current;
+      const unsubscribeSource =
+        source == null
+          ? null
+          : source.subscribe(() => {
+              updateExternalLayout(
+                normalizeExternalSnapshot(source.getSnapshot())
+              );
+            });
+      updateViewportRef.current();
+
+      const resizeObserver =
+        typeof ResizeObserver !== 'undefined'
+          ? new ResizeObserver(() => {
+              updateViewportRef.current();
+            })
+          : null;
+      resizeObserver?.observe(rootElement);
+
+      return () => {
+        updateViewportRef.current = () => {};
+        unsubscribeController();
+        unsubscribeSource?.();
+        resizeObserver?.disconnect();
+        if (listElement != null) {
+          delete listElement.dataset.isScrolling;
+        }
+        delete rootElement.dataset.isScrolling;
+        delete rootElement.dataset.overlayReveal;
+        isScrollingRef.current = false;
+      };
+    }
+
+    measuredViewportHeightRef.current = readMeasuredViewportHeight(
+      scrollElement,
+      initialViewportHeight
+    );
+
     const update = (): void => {
       const nextItemCount = controller.getVisibleCount();
-      const nextViewportHeight = getMeasuredViewportHeight(
-        scrollElement,
+      const nextViewportHeight = getCachedViewportHeight(
+        measuredViewportHeightRef.current,
         initialViewportHeight
       );
       const maxScrollTop = Math.max(
@@ -2351,8 +3052,13 @@ export function FileTreeView({
     };
 
     updateViewportRef.current = update;
+    let hasSeenInitialControllerSnapshot = false;
     const unsubscribe = controller.subscribe(() => {
-      setControllerRevision((revision) => revision + 1);
+      if (hasSeenInitialControllerSnapshot) {
+        setControllerRevision((revision) => revision + 1);
+      } else {
+        hasSeenInitialControllerSnapshot = true;
+      }
       update();
     });
     // Flip a plain DOM attribute on the root (not React state) so the anchor
@@ -2382,6 +3088,7 @@ export function FileTreeView({
           delete rootElement.dataset.isScrolling;
         }
         isScrollingRef.current = false;
+        setScrollSettledRevision((revision) => revision + 1);
         scrollTimer = null;
       }, 50);
     };
@@ -2491,12 +3198,18 @@ export function FileTreeView({
     scrollElement.addEventListener('keydown', onKeyDownPreScroll);
     const resizeObserver =
       typeof ResizeObserver !== 'undefined'
-        ? new ResizeObserver(() => {
+        ? new ResizeObserver((entries) => {
+            const observedViewportHeight =
+              entries[0] == null
+                ? null
+                : getResizeObserverViewportHeight(entries[0]);
+            measuredViewportHeightRef.current =
+              observedViewportHeight ??
+              readMeasuredViewportHeight(scrollElement, initialViewportHeight);
             update();
           })
         : null;
     resizeObserver?.observe(scrollElement);
-    update();
 
     return () => {
       updateViewportRef.current = () => {};
@@ -2523,9 +3236,18 @@ export function FileTreeView({
       // rebinds (e.g. viewportHeight changes) while scrollTop is still 0,
       // because the sync effect only fires when scrollTop itself changes.
       isScrollingRef.current = false;
+      measuredViewportHeightRef.current = null;
       resizeObserver?.disconnect();
     };
-  }, [controller, initialViewportHeight, itemHeight, overscan, stickyFolders]);
+  }, [
+    controller,
+    externalScrollSource,
+    initialViewportHeight,
+    isExternalScrollMode,
+    itemHeight,
+    overscan,
+    stickyFolders,
+  ]);
 
   useLayoutEffect(() => {
     if (contextMenuEnabled || contextMenuState == null) {
@@ -2684,45 +3406,91 @@ export function FileTreeView({
     const preservedViewportOffset =
       restoreTreeFocusViewportOffsetRef.current ?? 0;
     const pendingStickyFocusPath = pendingStickyFocusPathRef.current;
+    const pendingStickyKeyboardFocusPath =
+      pendingStickyKeyboardFocusPathRef.current;
+    const pendingStickyKeyboardViewportOffset =
+      pendingStickyKeyboardViewportOffsetRef.current;
+    const pendingStickyKeyboardScrollTop =
+      pendingStickyKeyboardScrollTopRef.current;
     const focusWithinTree = activeTreeElement != null;
     const shouldOwnDomFocus = domFocusOwnerRef.current || focusWithinTree;
     const focusedPathChanged = previousFocusedPathRef.current !== focusedPath;
+    const shouldPreserveStickyKeyboardFocusViewport =
+      pendingStickyKeyboardFocusPath != null &&
+      pendingStickyKeyboardFocusPath === focusedPath &&
+      focusedPath != null;
 
     const shouldRestoreFocusedRowViewportOffset =
       shouldRestoreTreeFocusAfterSearchClose &&
-      scrollFocusedRowToViewportOffset(
+      scrollFocusedRowToViewportOffsetForMode(
         scrollElement,
-        focusedIndex,
-        itemHeight,
-        resolvedViewportHeight,
-        totalScrollableHeight,
-        preservedViewportOffset
+        preservedViewportOffset,
+        {
+          origin: 'programmatic',
+          path: focusedPath,
+          reason: 'search-restore',
+        }
       );
     const shouldRestoreStickyFocusedRowViewportOffset =
       pendingStickyFocusPath != null &&
       pendingStickyFocusPath === focusedPath &&
-      scrollFocusedRowToViewportOffset(
+      scrollFocusedRowToViewportOffsetForMode(
         scrollElement,
-        focusedIndex,
-        itemHeight,
-        resolvedViewportHeight,
-        totalScrollableHeight,
-        stickyOverlayHeight
+        isExternalScrollMode
+          ? externalScrollSnapshotRef.current.topInset + stickyOverlayHeight
+          : stickyOverlayHeight,
+        {
+          origin: 'programmatic',
+          path: focusedPath,
+          reason: 'sticky-row-restore',
+        }
       );
+    const shouldRestoreStickyKeyboardViewportOffset =
+      pendingStickyKeyboardViewportOffset != null &&
+      pendingStickyKeyboardViewportOffset.path === focusedPath &&
+      scrollFocusedRowToViewportOffsetForMode(
+        scrollElement,
+        pendingStickyKeyboardViewportOffset.viewportOffset,
+        {
+          origin: 'programmatic',
+          path: focusedPath,
+          reason: 'sticky-keyboard-restore',
+        }
+      );
+    const currentRuntimeScrollTop = getRuntimeScrollTop(scrollElement);
+    const shouldRestoreStickyKeyboardScrollTop =
+      pendingStickyKeyboardScrollTop != null &&
+      pendingStickyKeyboardScrollTop.path === focusedPath &&
+      currentRuntimeScrollTop !== pendingStickyKeyboardScrollTop.scrollTop;
+    if (shouldRestoreStickyKeyboardScrollTop) {
+      if (isExternalScrollMode) {
+        requestExternalRowViewportTop(
+          pendingStickyKeyboardScrollTop.scrollTop,
+          {
+            origin: 'programmatic',
+            path: focusedPath,
+            reason: 'sticky-keyboard-restore',
+          }
+        );
+      } else {
+        scrollElement.scrollTop = pendingStickyKeyboardScrollTop.scrollTop;
+      }
+    }
 
     if (
+      shouldRestoreStickyKeyboardScrollTop ||
       shouldRestoreStickyFocusedRowViewportOffset ||
+      shouldRestoreStickyKeyboardViewportOffset ||
       shouldRestoreFocusedRowViewportOffset ||
       (shouldOwnDomFocus &&
         focusedPathChanged &&
         pendingStickyFocusPath !== focusedPath &&
-        scrollFocusedRowIntoView(
-          scrollElement,
-          focusedIndex,
-          itemHeight,
-          resolvedViewportHeight,
-          stickyOverlayHeight
-        ))
+        !shouldPreserveStickyKeyboardFocusViewport &&
+        scrollFocusedRowIntoViewForMode(scrollElement, {
+          origin: 'programmatic',
+          path: focusedPath,
+          reason: 'focus-reveal',
+        }))
     ) {
       updateViewportRef.current();
     }
@@ -2744,13 +3512,14 @@ export function FileTreeView({
 
     if (focusedButton == null) {
       if (shouldRestoreTreeFocusAfterSearchClose && focusedIndex >= 0) {
-        scrollFocusedRowToViewportOffset(
+        scrollFocusedRowToViewportOffsetForMode(
           scrollElement,
-          focusedIndex,
-          itemHeight,
-          resolvedViewportHeight,
-          totalScrollableHeight,
-          preservedViewportOffset
+          preservedViewportOffset,
+          {
+            origin: 'programmatic',
+            path: focusedPath,
+            reason: 'search-restore',
+          }
         );
         updateViewportRef.current();
       }
@@ -2762,6 +3531,9 @@ export function FileTreeView({
       focusedPathChanged ||
       shouldRestoreTreeFocusAfterSearchClose ||
       pendingStickyFocusPath === focusedPath ||
+      pendingStickyKeyboardFocusPath === focusedPath ||
+      pendingStickyKeyboardViewportOffset?.path === focusedPath ||
+      pendingStickyKeyboardScrollTop?.path === focusedPath ||
       activeTreeElementPath == null ||
       activeTreeElementPath !== focusedPath
     ) {
@@ -2769,28 +3541,45 @@ export function FileTreeView({
       if (pendingStickyFocusPath === focusedPath) {
         pendingStickyFocusPathRef.current = null;
       }
+      if (pendingStickyKeyboardFocusPath === focusedPath) {
+        pendingStickyKeyboardFocusPathRef.current = null;
+      }
+      if (pendingStickyKeyboardViewportOffset?.path === focusedPath) {
+        pendingStickyKeyboardViewportOffsetRef.current = null;
+      }
+      if (pendingStickyKeyboardScrollTop?.path === focusedPath) {
+        pendingStickyKeyboardScrollTopRef.current = null;
+      }
       restoreTreeFocusAfterSearchCloseRef.current = false;
       restoreTreeFocusViewportOffsetRef.current = null;
     }
     previousFocusedPathRef.current = focusedPath;
   }, [
-    controller,
     focusedIndex,
     focusedPath,
-    focusedRowIsMounted,
-    itemHeight,
+    getRuntimeScrollTop,
+    isExternalScrollMode,
     isRenaming,
     isSearchOpen,
-    range,
-    resolvedViewportHeight,
+    requestExternalRowViewportTop,
+    scrollFocusedRowIntoViewForMode,
+    scrollFocusedRowToViewportOffsetForMode,
     searchEnabled,
     stickyOverlayHeight,
-    totalScrollableHeight,
-    visibleRows,
   ]);
 
+  const focusedRowIsVisible =
+    focusedIndex >= 0 &&
+    focusedIndex >= layoutSnapshot.visible.startIndex &&
+    focusedIndex <= layoutSnapshot.visible.endIndex;
+  const focusedRowIsSticky =
+    focusedPath != null &&
+    stickyRows.some((entry) => getFileTreeRowPath(entry.row) === focusedPath);
+  const focusedRowHasVisibleAnchor = focusedRowIsVisible || focusedRowIsSticky;
   const focusTriggerPath =
-    contextMenuButtonTriggerEnabled && domFocusOwnerRef.current === true
+    contextMenuButtonTriggerEnabled &&
+    domFocusOwnerRef.current === true &&
+    focusedRowHasVisibleAnchor
       ? focusedPath
       : null;
   const pointerTriggerPath =
@@ -2804,11 +3593,17 @@ export function FileTreeView({
   const isPointerContextMenuOpen = contextMenuState?.source === 'right-click';
 
   useLayoutEffect(() => {
+    if (isScrollingRef.current && contextMenuState == null) {
+      return;
+    }
+
     updateTriggerPosition(getTriggerAnchorButton(triggerPath));
   }, [
+    contextMenuState,
     getTriggerAnchorButton,
     range,
     resolvedViewportHeight,
+    scrollSettledRevision,
     stickyRows,
     triggerPath,
     updateTriggerPosition,
@@ -3068,7 +3863,6 @@ export function FileTreeView({
       targetPath: string,
       mode: FileTreeRenderedRowMode
     ): void => {
-      const item = controller.getItem(targetPath);
       const plan = computeFileTreeRowClickPlan({
         event: {
           ctrlKey: event.ctrlKey,
@@ -3076,19 +3870,29 @@ export function FileTreeView({
           shiftKey: event.shiftKey,
         },
         isDirectory: row.kind === 'directory',
-        isSearchOpen: controller.isSearchOpen(),
+        isSearchOpen,
         mode,
       });
 
+      const shouldToggleDirectory =
+        plan.toggleDirectory && row.kind === 'directory';
+      const mountedDirectoryPath = shouldToggleDirectory
+        ? controller.resolveMountedDirectoryPathFromInput(targetPath)
+        : null;
+      if (shouldToggleDirectory && mountedDirectoryPath == null) {
+        return;
+      }
+      const actionTargetPath = mountedDirectoryPath ?? targetPath;
+
       switch (plan.selection.kind) {
         case 'range':
-          controller.selectPathRange(targetPath, plan.selection.additive);
+          controller.selectPathRange(actionTargetPath, plan.selection.additive);
           break;
         case 'toggle':
-          controller.togglePathSelectionFromInput(targetPath);
+          controller.togglePathSelectionFromInput(actionTargetPath);
           break;
         case 'single':
-          controller.selectOnlyPath(targetPath);
+          controller.selectOnlyMountedPathFromInput(actionTargetPath);
           break;
       }
 
@@ -3103,28 +3907,29 @@ export function FileTreeView({
         clickedElement != null &&
         clickedElement.dataset.itemParked !== 'true';
 
-      item?.focus();
+      controller.focusMountedPathFromInput(actionTargetPath);
       if (shouldExposeFocusedTrigger) {
         domFocusOwnerRef.current = true;
         setActiveItemPath((previousPath) =>
-          previousPath === targetPath ? previousPath : targetPath
+          previousPath === actionTargetPath ? previousPath : actionTargetPath
         );
         setLastContextMenuInteraction('focus');
       }
-      if (plan.toggleDirectory && isFileTreeDirectoryHandle(item)) {
-        item.toggle();
+      if (shouldToggleDirectory) {
+        controller.toggleMountedDirectoryFromInput(actionTargetPath);
       }
       if (plan.closeSearch) {
         controller.closeSearch();
       }
       if (plan.revealCanonical) {
-        revealCanonicalRowAtStickyOffset(targetPath, {
+        revealCanonicalRowAtStickyOffset(actionTargetPath, {
           targetOffset: 'sticky-parents',
         });
       }
     },
     [
       controller,
+      isSearchOpen,
       layoutSnapshot.visible.endIndex,
       layoutSnapshot.visible.startIndex,
       revealCanonicalRowAtStickyOffset,
@@ -3132,6 +3937,10 @@ export function FileTreeView({
   );
 
   const openMenuFromTrigger = (): void => {
+    if (isScrollingRef.current) {
+      return;
+    }
+
     if (!contextMenuButtonTriggerEnabled) {
       return;
     }
@@ -3219,6 +4028,7 @@ export function FileTreeView({
       }
       data-file-tree-has-git-lane={gitLaneActive ? 'true' : undefined}
       data-file-tree-virtualized-root="true"
+      data-file-tree-scroll-mode={scrollMode}
       onDragLeave={dragAndDropEnabled ? handleTreeDragLeave : undefined}
       onDragOver={dragAndDropEnabled ? handleTreeDragOver : undefined}
       onDrop={dragAndDropEnabled ? handleTreeDrop : undefined}
@@ -3276,9 +4086,21 @@ export function FileTreeView({
           />
         </div>
       ) : null}
-      <div ref={scrollRef} data-file-tree-virtualized-scroll="true">
+      <div
+        ref={scrollRef}
+        data-file-tree-scroll-mode={scrollMode}
+        data-file-tree-virtualized-scroll="true"
+      >
         {stickyFolders && hasStickyUiMount && stickyRows.length > 0 ? (
-          <div aria-hidden="true" data-file-tree-sticky-overlay="true">
+          <div
+            aria-hidden="true"
+            data-file-tree-sticky-overlay="true"
+            style={
+              isExternalScrollMode
+                ? { top: `${externalTopInset}px` }
+                : undefined
+            }
+          >
             <div
               data-file-tree-sticky-overlay-content="true"
               style={{ height: `${overlayRowsHeight}px` }}

--- a/packages/trees/src/scroll/createDomScrollSource.ts
+++ b/packages/trees/src/scroll/createDomScrollSource.ts
@@ -1,0 +1,138 @@
+import type {
+  FileTreeExternalScrollOrigin,
+  FileTreeExternalScrollRequestContext,
+  FileTreeExternalScrollSnapshot,
+  FileTreeExternalScrollSource,
+} from './publicTypes';
+
+export interface CreateDomScrollSourceOptions {
+  bottomInset?: number | (() => number);
+  host?: HTMLElement | null;
+  scrollContainer: HTMLElement;
+  topInset?: number | (() => number);
+}
+
+export interface FileTreeDomScrollSource extends FileTreeExternalScrollSource {
+  destroy(): void;
+  setHost(host: HTMLElement | null): void;
+  updateSnapshot(scrollOrigin?: FileTreeExternalScrollOrigin): void;
+}
+
+function resolveInset(value: number | (() => number) | undefined): number {
+  const nextValue = typeof value === 'function' ? value() : value;
+  return typeof nextValue === 'number' && Number.isFinite(nextValue)
+    ? Math.max(0, nextValue)
+    : 0;
+}
+
+export function createDomScrollSource({
+  bottomInset,
+  host: initialHost,
+  scrollContainer,
+  topInset,
+}: CreateDomScrollSourceOptions): FileTreeDomScrollSource {
+  const listeners = new Set<() => void>();
+  let host = initialHost ?? null;
+  let snapshot: FileTreeExternalScrollSnapshot = {
+    bottomInset: resolveInset(bottomInset),
+    topInset: resolveInset(topInset),
+    viewportHeight: Math.max(0, scrollContainer.clientHeight),
+    viewportTop: 0,
+  };
+
+  const resizeObserver =
+    typeof ResizeObserver === 'undefined'
+      ? null
+      : new ResizeObserver(() => {
+          syncSnapshot('unknown');
+        });
+
+  function readViewportTop(): number {
+    if (host == null) {
+      return snapshot.viewportTop;
+    }
+
+    return (
+      scrollContainer.getBoundingClientRect().top -
+      host.getBoundingClientRect().top
+    );
+  }
+
+  function syncSnapshot(
+    scrollOrigin: FileTreeExternalScrollOrigin = 'unknown',
+    notify: boolean = true
+  ): void {
+    snapshot = {
+      bottomInset: resolveInset(bottomInset),
+      isScrolling: false,
+      scrollOrigin,
+      topInset: resolveInset(topInset),
+      viewportHeight: Math.max(0, scrollContainer.clientHeight),
+      viewportTop: readViewportTop(),
+    };
+    if (!notify) {
+      return;
+    }
+    for (const listener of listeners) {
+      listener();
+    }
+  }
+
+  function observeHost(nextHost: HTMLElement | null): void {
+    if (resizeObserver != null && host != null) {
+      resizeObserver.unobserve(host);
+    }
+    host = nextHost;
+    if (resizeObserver != null && host != null) {
+      resizeObserver.observe(host);
+    }
+  }
+
+  const handleScroll = (): void => {
+    syncSnapshot('user');
+  };
+
+  scrollContainer.addEventListener('scroll', handleScroll, { passive: true });
+  resizeObserver?.observe(scrollContainer);
+  observeHost(host);
+  syncSnapshot('unknown', false);
+
+  return {
+    destroy(): void {
+      scrollContainer.removeEventListener('scroll', handleScroll);
+      if (resizeObserver != null) {
+        if (host != null) {
+          resizeObserver.unobserve(host);
+        }
+        resizeObserver.disconnect();
+      }
+      listeners.clear();
+    },
+    getSnapshot(): FileTreeExternalScrollSnapshot {
+      return snapshot;
+    },
+    scrollToViewportTop(
+      viewportTop: number,
+      _context: FileTreeExternalScrollRequestContext
+    ): void {
+      const currentViewportTop = readViewportTop();
+      scrollContainer.scrollTop += viewportTop - currentViewportTop;
+      syncSnapshot('programmatic', false);
+    },
+    setHost(nextHost: HTMLElement | null): void {
+      observeHost(nextHost);
+      syncSnapshot('unknown');
+    },
+    subscribe(listener: () => void): () => void {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    updateSnapshot(
+      scrollOrigin: FileTreeExternalScrollOrigin = 'unknown'
+    ): void {
+      syncSnapshot(scrollOrigin);
+    },
+  };
+}

--- a/packages/trees/src/scroll/createDomScrollSource.ts
+++ b/packages/trees/src/scroll/createDomScrollSource.ts
@@ -47,13 +47,16 @@ export function createDomScrollSource({
           syncSnapshot('unknown');
         });
 
+  // Measure from the scrollport edge rather than the border box so bordered
+  // scrollers report the same viewport origin the user actually sees.
   function readViewportTop(): number {
     if (host == null) {
       return snapshot.viewportTop;
     }
 
     return (
-      scrollContainer.getBoundingClientRect().top -
+      scrollContainer.getBoundingClientRect().top +
+      scrollContainer.clientTop -
       host.getBoundingClientRect().top
     );
   }

--- a/packages/trees/src/scroll/index.ts
+++ b/packages/trees/src/scroll/index.ts
@@ -1,0 +1,24 @@
+export {
+  FileTree,
+  preloadFileTree,
+  serializeFileTreeSsrPayload,
+} from './FileTree';
+export { createDomScrollSource } from './createDomScrollSource';
+export type {
+  CreateDomScrollSourceOptions,
+  FileTreeDomScrollSource,
+} from './createDomScrollSource';
+
+export type {
+  FileTreeExternalScrollModel,
+  FileTreeExternalScrollOptions,
+  FileTreeExternalScrollOrigin,
+  FileTreeExternalScrollRequestContext,
+  FileTreeExternalScrollRequestReason,
+  FileTreeExternalScrollSnapshot,
+  FileTreeExternalScrollSource,
+  FileTreeModel,
+  FileTreeOptions,
+  FileTreeRenderOptions,
+  FileTreeSsrPayload,
+} from './publicTypes';

--- a/packages/trees/src/scroll/internalTypes.ts
+++ b/packages/trees/src/scroll/internalTypes.ts
@@ -1,0 +1,75 @@
+import type { FileTreeIcons } from '../iconConfig';
+import type { FileTreeNormalizedExternalScrollSnapshot } from '../model/externalScroll';
+import type {
+  FileTreeCompositionOptions,
+  FileTreePublicId,
+  FileTreeRowDecorationRenderer,
+  FileTreeSearchBlurBehavior,
+  FileTreeVisibleRow,
+} from '../model/publicTypes';
+import type { GitStatus } from '../publicTypes';
+import type {
+  FileTreeExternalScrollSource,
+  FileTreeRenderOptions,
+} from './publicTypes';
+
+export type FileTreeControllerListener = () => void;
+
+export interface FileTreeStickyRowCandidate {
+  row: FileTreeVisibleRow;
+  subtreeEndIndex: number;
+}
+
+export interface FileTreeViewportMetrics {
+  itemCount: number;
+  itemHeight: number;
+  overscan?: number;
+  scrollTop: number;
+  viewportHeight: number;
+}
+
+export interface FileTreeRange {
+  end: number;
+  start: number;
+}
+
+export interface FileTreeStickyWindowLayout {
+  offsetHeight: number;
+  stickyInset: number;
+  totalHeight: number;
+  windowHeight: number;
+}
+
+export interface FileTreeSlotHost {
+  clearSlotContent(slotName: string): void;
+  setSlotContent(slotName: string, content: HTMLElement | null): void;
+}
+
+export type FileTreeScrollMode = 'external' | 'internal';
+
+export interface FileTreeViewProps extends Omit<
+  FileTreeRenderOptions,
+  'externalScroll' | 'initialVisibleRowCount'
+> {
+  composition?: FileTreeCompositionOptions;
+  controller: import('../model/FileTreeController').FileTreeController;
+  directoriesWithGitChanges?: ReadonlySet<FileTreePublicId>;
+  gitStatusByPath?: ReadonlyMap<FileTreePublicId, GitStatus>;
+  ignoredGitDirectories?: ReadonlySet<FileTreePublicId>;
+  icons?: FileTreeIcons;
+  externalScrollInitialSnapshot?: FileTreeNormalizedExternalScrollSnapshot;
+  externalScrollSource?: FileTreeExternalScrollSource;
+  // First-render viewport height in CSS pixels, used as the fallback when the
+  // scroll element's clientHeight is still zero. The public option is
+  // `initialVisibleRowCount` (rows); the resolver multiplies it by itemHeight
+  // before passing the pixel value down here.
+  initialViewportHeight?: number;
+  instanceId?: string;
+  renamingEnabled?: boolean;
+  renderRowDecoration?: FileTreeRowDecorationRenderer;
+  searchBlurBehavior?: FileTreeSearchBlurBehavior;
+  searchEnabled?: boolean;
+  searchFakeFocus?: boolean;
+  slotHost?: FileTreeSlotHost;
+  scrollMode: FileTreeScrollMode;
+}

--- a/packages/trees/src/scroll/publicTypes.ts
+++ b/packages/trees/src/scroll/publicTypes.ts
@@ -1,0 +1,79 @@
+import type {
+  FileTreeHydrationProps,
+  FileTreeListener,
+  FileTreeModel,
+  FileTreeRenderProps,
+  FileTreeSsrPayload,
+  FileTreeOptions as InternalFileTreeOptions,
+  FileTreeRenderOptions as InternalFileTreeRenderOptions,
+} from '../model/publicTypes';
+
+// Callers should usually report `'user'` or `'programmatic'`. The runtime uses
+// `'unknown'` when a source omits the field or cannot classify the change yet.
+export type FileTreeExternalScrollOrigin = 'programmatic' | 'unknown' | 'user';
+
+// Host-local viewport metrics from a caller-owned scroller. `viewportTop` is the
+// scroller viewport's top edge in the file-tree host coordinate system, so it may
+// be negative or below the tree when the tree is partially or fully offscreen.
+export interface FileTreeExternalScrollSnapshot {
+  viewportTop: number;
+  viewportHeight: number;
+  topInset?: number;
+  bottomInset?: number;
+  isScrolling?: boolean;
+  scrollOrigin?: FileTreeExternalScrollOrigin;
+}
+
+export type FileTreeExternalScrollRequestReason =
+  | 'focus-reveal'
+  | 'search-restore'
+  | 'sticky-row-restore'
+  | 'sticky-keyboard-restore';
+
+export interface FileTreeExternalScrollRequestContext {
+  origin: 'programmatic';
+  path?: string | null;
+  reason: FileTreeExternalScrollRequestReason;
+}
+
+// External scroll sources bridge the tree's virtualization math to a
+// caller-owned scroller.
+//
+// `scrollToViewportTop(...)` must update `getSnapshot()` synchronously before it
+// returns so the tree can recompute layout against the new position in the same
+// turn.
+export interface FileTreeExternalScrollSource {
+  getSnapshot(): FileTreeExternalScrollSnapshot;
+  scrollToViewportTop(
+    viewportTop: number,
+    context: FileTreeExternalScrollRequestContext
+  ): void;
+  subscribe(listener: () => void): () => void;
+}
+
+export interface FileTreeExternalScrollOptions {
+  initialSnapshot?: FileTreeExternalScrollSnapshot;
+  source?: FileTreeExternalScrollSource;
+}
+
+export type FileTreeRenderOptions = InternalFileTreeRenderOptions & {
+  externalScroll?: FileTreeExternalScrollOptions;
+};
+
+export type FileTreeOptions = InternalFileTreeOptions & {
+  externalScroll?: FileTreeExternalScrollOptions;
+};
+
+export interface FileTreeExternalScrollModel extends FileTreeModel {
+  // Swap the live source without rebuilding the tree model. Pass `undefined` to
+  // detach a source while keeping the model in external-scroll mode.
+  setExternalScrollSource(source?: FileTreeExternalScrollSource): void;
+}
+
+export type {
+  FileTreeHydrationProps,
+  FileTreeListener,
+  FileTreeModel,
+  FileTreeRenderProps,
+  FileTreeSsrPayload,
+};

--- a/packages/trees/src/scroll/runtime.ts
+++ b/packages/trees/src/scroll/runtime.ts
@@ -1,0 +1,38 @@
+import { h, hydrate, render } from 'preact';
+
+import { FileTreeView } from './FileTreeView';
+import type { FileTreeViewProps } from './internalTypes';
+
+export const fileTreeRenderer: {
+  hydrateRoot: (element: HTMLElement, props: FileTreeViewProps) => void;
+  renderRoot: (element: HTMLElement, props: FileTreeViewProps) => void;
+  unmountRoot: (element: HTMLElement) => void;
+} = {
+  hydrateRoot: (element, props) => {
+    hydrate(h(FileTreeView, props), element);
+  },
+  renderRoot: (element, props) => {
+    render(h(FileTreeView, props), element);
+  },
+  unmountRoot: (element) => {
+    render(null, element);
+  },
+};
+
+export function renderFileTreeRoot(
+  element: HTMLElement,
+  props: FileTreeViewProps
+): void {
+  fileTreeRenderer.renderRoot(element, props);
+}
+
+export function hydrateFileTreeRoot(
+  element: HTMLElement,
+  props: FileTreeViewProps
+): void {
+  fileTreeRenderer.hydrateRoot(element, props);
+}
+
+export function unmountFileTreeRoot(element: HTMLElement): void {
+  fileTreeRenderer.unmountRoot(element);
+}

--- a/packages/trees/src/scroll/shadowRoot.ts
+++ b/packages/trees/src/scroll/shadowRoot.ts
@@ -1,0 +1,55 @@
+import { adoptDeclarativeShadowDom } from '../components/web-components';
+import { FILE_TREE_STYLE_ATTRIBUTE } from '../constants';
+import { wrapCoreCSS } from '../utils/cssWrappers';
+import { ensureMeasuredScrollbarGutter } from '../utils/scrollbarGutter';
+import scrollStyles from './style.css';
+
+let sheet: CSSStyleSheet | undefined;
+const wrappedScrollStyles = wrapCoreCSS(scrollStyles);
+
+function ensureScrollFileTreeStyles(shadowRoot: ShadowRoot): void {
+  const hasReplaceSync =
+    typeof CSSStyleSheet !== 'undefined' &&
+    typeof (CSSStyleSheet.prototype as { replaceSync?: unknown })
+      .replaceSync === 'function';
+
+  const canAdopt = hasReplaceSync && 'adoptedStyleSheets' in shadowRoot;
+
+  if (canAdopt) {
+    if (sheet == null) {
+      sheet = new CSSStyleSheet();
+      sheet.replaceSync(wrappedScrollStyles);
+    }
+    let adopted = false;
+    try {
+      shadowRoot.adoptedStyleSheets = [sheet];
+      adopted = true;
+    } catch {
+      // Some environments expose adoptedStyleSheets but disallow assignment.
+    }
+
+    if (adopted) {
+      shadowRoot.querySelector(`style[${FILE_TREE_STYLE_ATTRIBUTE}]`)?.remove();
+      return;
+    }
+  }
+
+  let styleEl = shadowRoot.querySelector(`style[${FILE_TREE_STYLE_ATTRIBUTE}]`);
+  if (!(styleEl instanceof HTMLStyleElement)) {
+    styleEl = document.createElement('style');
+    styleEl.setAttribute(FILE_TREE_STYLE_ATTRIBUTE, '');
+    shadowRoot.prepend(styleEl);
+  }
+  if (styleEl.textContent !== wrappedScrollStyles) {
+    styleEl.textContent = wrappedScrollStyles;
+  }
+}
+
+export function prepareScrollFileTreeShadowRoot(
+  host: HTMLElement,
+  shadowRoot: ShadowRoot
+): void {
+  adoptDeclarativeShadowDom(host, shadowRoot);
+  ensureScrollFileTreeStyles(shadowRoot);
+  ensureMeasuredScrollbarGutter(host, shadowRoot);
+}

--- a/packages/trees/src/scroll/style.css
+++ b/packages/trees/src/scroll/style.css
@@ -128,6 +128,7 @@
       --trees-padding-inline-override
     */
 
+    --trees-accent: var(--trees-accent-override, #009fff);
     --trees-fg: var(
       --trees-fg-override,
       var(--trees-theme-sidebar-fg, light-dark(#6c6c71, #adadb1))
@@ -159,7 +160,6 @@
         )
       )
     );
-    --trees-accent: var(--trees-accent-override, #009fff);
     --trees-input-bg: var(
       --trees-input-bg-override,
       light-dark(#f8f8f8, #070707)
@@ -573,26 +573,57 @@
     font-weight: var(--trees-font-weight-regular);
   }
 
-  :host([data-file-tree-virtualized='true']) {
+  :host(
+    [data-file-tree-virtualized='true']:not(
+      [data-file-tree-scroll-mode='external']
+    )
+  ) {
     height: 100%;
     overflow: hidden;
+  }
+
+  :host([data-file-tree-scroll-mode='external']) {
+    height: auto;
+    overflow: visible;
   }
 
   [data-file-tree-virtualized-wrapper='true'] {
-    height: 100%;
-    overflow: hidden;
     display: flex;
     flex-direction: column;
+  }
+
+  [data-file-tree-virtualized-wrapper='true']:not(
+    [data-file-tree-scroll-mode='external']
+  ) {
+    height: 100%;
+    overflow: hidden;
+  }
+
+  [data-file-tree-virtualized-wrapper='true'][data-file-tree-scroll-mode='external'] {
+    height: auto;
+    overflow: visible;
   }
 
   [data-file-tree-virtualized-root='true'] {
-    height: 100%;
     display: flex;
     flex-direction: column;
+  }
+
+  [data-file-tree-virtualized-root='true']:not(
+    [data-file-tree-scroll-mode='external']
+  ) {
+    height: 100%;
     overflow: hidden;
   }
 
-  [data-file-tree-virtualized-scroll='true'],
+  [data-file-tree-virtualized-root='true'][data-file-tree-scroll-mode='external'] {
+    height: auto;
+    overflow: visible;
+  }
+
+  [data-file-tree-virtualized-scroll='true']:not(
+    [data-file-tree-scroll-mode='external']
+  ),
   [data-file-tree-scrollbar-measure='true'] {
     overflow-y: auto;
     scrollbar-gutter: stable;
@@ -633,7 +664,9 @@
   }
 
   @supports (-moz-appearance: none) {
-    [data-file-tree-virtualized-scroll='true'],
+    [data-file-tree-virtualized-scroll='true']:not(
+      [data-file-tree-scroll-mode='external']
+    ),
     [data-file-tree-scrollbar-measure='true'] {
       scrollbar-width: thin;
       scrollbar-color: var(--trees-scrollbar-thumb) transparent;
@@ -665,6 +698,12 @@
         ),
         0px
       );
+  }
+
+  [data-file-tree-virtualized-scroll='true'][data-file-tree-scroll-mode='external'] {
+    overflow: visible;
+    flex: 0 0 auto;
+    min-height: 0;
   }
 
   @supports (-moz-appearance: none) {
@@ -829,6 +868,7 @@
     --truncate-marker-background-color: var(--trees-bg);
     --truncate-marker-background-overlay-color: transparent;
     --truncate-marker-block-inset: 0px;
+
     &:hover,
     &[data-item-context-hover='true'] {
       background-color: var(--trees-bg-muted);

--- a/packages/trees/test/e2e/file-tree-external-scroll.pw.ts
+++ b/packages/trees/test/e2e/file-tree-external-scroll.pw.ts
@@ -1,0 +1,130 @@
+import { expect, type Page, test } from '@playwright/test';
+
+type ExternalScrollSample = {
+  belowTopWithinScroller: number;
+  mountedPaths: string[];
+  parentScrollTop: number;
+  requestCount: number;
+  requests: {
+    context: {
+      origin: 'programmatic';
+      path?: string | null;
+      reason: string;
+    };
+    viewportTop: number;
+  }[];
+  stickyPaths: string[];
+  stickyTopWithinScroller: number | null;
+  topInset: number;
+};
+
+declare global {
+  interface Window {
+    __externalScrollFixtureReady?: boolean;
+    __externalScrollProbe?: {
+      focusFirstRow: () => Promise<void>;
+      nextFrames: (count?: number) => Promise<void>;
+      pressFocusedRowKey: (key: string) => Promise<void>;
+      sample: () => ExternalScrollSample;
+      setScrollTop: (scrollTop: number) => Promise<void>;
+    };
+  }
+}
+
+const fixturePath = '/test/e2e/fixtures/file-tree-external-scroll.html';
+
+async function gotoFixture(page: Page): Promise<void> {
+  const browserErrors: string[] = [];
+  page.on('pageerror', (error) => {
+    browserErrors.push(error.message);
+  });
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      browserErrors.push(message.text());
+    }
+  });
+
+  await page.goto(fixturePath);
+  try {
+    await page.waitForFunction(
+      () => window.__externalScrollFixtureReady === true,
+      undefined,
+      { timeout: 5_000 }
+    );
+  } catch (error) {
+    throw new Error(
+      `External scroll fixture did not become ready. Browser errors: ${browserErrors.join(
+        '\n'
+      )}`,
+      { cause: error }
+    );
+  }
+}
+
+async function setScrollTop(page: Page, scrollTop: number): Promise<void> {
+  await page.evaluate((nextScrollTop) => {
+    return window.__externalScrollProbe?.setScrollTop(nextScrollTop);
+  }, scrollTop);
+}
+
+async function sample(page: Page): Promise<ExternalScrollSample> {
+  const result = await page.evaluate(() => {
+    return window.__externalScrollProbe?.sample() ?? null;
+  });
+  expect(result).not.toBeNull();
+  if (result == null) {
+    throw new Error('Missing external scroll sample.');
+  }
+  return result;
+}
+
+test.describe('external scroll fixture', () => {
+  test('uses caller-owned scrolling with sticky folders and offscreen virtualization', async ({
+    page,
+  }) => {
+    await gotoFixture(page);
+
+    const aboveTree = await sample(page);
+    expect(aboveTree.mountedPaths).toEqual([]);
+
+    await setScrollTop(page, 520);
+    const intersectingTree = await sample(page);
+    expect(intersectingTree.mountedPaths.length).toBeGreaterThan(0);
+    expect(intersectingTree.mountedPaths[0]).toMatch(/^src\//);
+
+    await setScrollTop(page, 700);
+    const stickyTree = await sample(page);
+    expect(stickyTree.stickyPaths).toContain('src/');
+    expect(stickyTree.stickyTopWithinScroller).not.toBeNull();
+    expect(stickyTree.stickyTopWithinScroller ?? 0).toBeGreaterThanOrEqual(
+      stickyTree.topInset - 1
+    );
+
+    await setScrollTop(page, 3_600);
+    const belowTree = await sample(page);
+    expect(belowTree.belowTopWithinScroller).toBeLessThan(360);
+  });
+
+  test('keyboard focus reveal requests parent scroll movement', async ({
+    page,
+  }) => {
+    await gotoFixture(page);
+    await setScrollTop(page, 520);
+    const before = await sample(page);
+
+    await page.evaluate(() => window.__externalScrollProbe?.focusFirstRow());
+    await page.evaluate(() =>
+      window.__externalScrollProbe?.pressFocusedRowKey('End')
+    );
+
+    const after = await sample(page);
+    expect(after.requestCount).toBeGreaterThan(before.requestCount);
+    const lastRequest = after.requests.at(-1);
+    expect(lastRequest?.context).toEqual({
+      origin: 'programmatic',
+      path: 'z/file_023.ts',
+      reason: 'focus-reveal',
+    });
+    expect(after.parentScrollTop).toBeGreaterThan(before.parentScrollTop);
+  });
+});

--- a/packages/trees/test/e2e/fixtures/file-tree-external-scroll.html
+++ b/packages/trees/test/e2e/fixtures/file-tree-external-scroll.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>file-tree external scroll fixture</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 16px;
+        font-family: system-ui, sans-serif;
+        background: #f7f7f8;
+      }
+
+      [data-external-scroll-shell] {
+        width: 440px;
+        height: 360px;
+        overflow-y: auto;
+        border: 1px solid #d4d4d8;
+        border-radius: 12px;
+        background: white;
+      }
+
+      [data-external-scroll-sticky] {
+        position: sticky;
+        top: 0;
+        z-index: 10;
+        height: 40px;
+        display: flex;
+        align-items: center;
+        padding-inline: 12px;
+        background: #111827;
+        color: #f9fafb;
+        font-weight: 600;
+      }
+
+      [data-external-scroll-above],
+      [data-external-scroll-below] {
+        min-height: 500px;
+        padding: 16px;
+        background: #eef2ff;
+      }
+
+      [data-external-scroll-below] {
+        background: #ecfdf5;
+      }
+
+      [data-external-scroll-mount] {
+        border-block: 1px solid #d4d4d8;
+      }
+    </style>
+  </head>
+  <body>
+    <div data-external-scroll-shell>
+      <div data-external-scroll-sticky>Caller sticky toolbar</div>
+      <div data-external-scroll-above>Content above the tree</div>
+      <div data-external-scroll-mount></div>
+      <div data-external-scroll-below>Content below the tree</div>
+    </div>
+    <script type="module" src="./file-tree-external-scroll.ts"></script>
+  </body>
+</html>

--- a/packages/trees/test/e2e/fixtures/file-tree-external-scroll.ts
+++ b/packages/trees/test/e2e/fixtures/file-tree-external-scroll.ts
@@ -1,0 +1,278 @@
+import type {
+  FileTreeExternalScrollRequestContext,
+  FileTreeExternalScrollSnapshot,
+  FileTreeExternalScrollSource,
+} from '../../../src/scroll';
+
+const fileTreeRuntimePath: string = '/dist/scroll/index.js';
+const { FileTree } = (await import(
+  /* @vite-ignore */ fileTreeRuntimePath
+)) as typeof import('../../../src/scroll');
+
+type ExternalScrollRequest = {
+  context: FileTreeExternalScrollRequestContext;
+  viewportTop: number;
+};
+
+type ExternalScrollSample = {
+  belowTopWithinScroller: number;
+  mountedPaths: string[];
+  parentScrollTop: number;
+  requestCount: number;
+  requests: ExternalScrollRequest[];
+  stickyPaths: string[];
+  stickyTopWithinScroller: number | null;
+  topInset: number;
+};
+
+type ExternalScrollProbe = {
+  focusFirstRow: () => Promise<void>;
+  nextFrames: (count?: number) => Promise<void>;
+  pressFocusedRowKey: (key: string) => Promise<void>;
+  sample: () => ExternalScrollSample;
+  setScrollTop: (scrollTop: number) => Promise<void>;
+};
+
+type ExternalScrollWindow = Window & {
+  __externalScrollFixtureReady?: boolean;
+  __externalScrollProbe?: ExternalScrollProbe;
+};
+
+class FixtureExternalScrollSource implements FileTreeExternalScrollSource {
+  readonly requests: ExternalScrollRequest[] = [];
+  #host: HTMLElement | null = null;
+  #listeners = new Set<() => void>();
+  #snapshot: FileTreeExternalScrollSnapshot = {
+    topInset: 40,
+    viewportHeight: 360,
+    viewportTop: -1_000,
+  };
+
+  constructor(private readonly scrollContainer: HTMLElement) {}
+
+  attachHost(host: HTMLElement): void {
+    this.#host = host;
+    this.updateFromDom('unknown');
+  }
+
+  getSnapshot(): FileTreeExternalScrollSnapshot {
+    return this.#snapshot;
+  }
+
+  scrollToViewportTop(
+    viewportTop: number,
+    context: FileTreeExternalScrollRequestContext
+  ): void {
+    this.requests.push({ context, viewportTop });
+    const currentViewportTop = this.#readViewportTop();
+    this.scrollContainer.scrollTop += viewportTop - currentViewportTop;
+    this.updateFromDom('programmatic', false);
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.#listeners.add(listener);
+    return () => {
+      this.#listeners.delete(listener);
+    };
+  }
+
+  updateFromDom(
+    scrollOrigin: FileTreeExternalScrollSnapshot['scrollOrigin'] = 'user',
+    notify: boolean = true
+  ): void {
+    this.#snapshot = {
+      isScrolling: false,
+      scrollOrigin,
+      topInset: this.#readTopInset(),
+      viewportHeight: this.scrollContainer.clientHeight,
+      viewportTop: this.#readViewportTop(),
+    };
+    if (!notify) {
+      return;
+    }
+    for (const listener of this.#listeners) {
+      listener();
+    }
+  }
+
+  #readTopInset(): number {
+    const toolbar = this.scrollContainer.querySelector(
+      '[data-external-scroll-sticky]'
+    );
+    return toolbar instanceof HTMLElement
+      ? toolbar.getBoundingClientRect().height
+      : 0;
+  }
+
+  #readViewportTop(): number {
+    if (this.#host == null) {
+      return this.#snapshot.viewportTop;
+    }
+
+    return (
+      this.scrollContainer.getBoundingClientRect().top -
+      this.#host.getBoundingClientRect().top
+    );
+  }
+}
+
+const scrollContainer = document.querySelector('[data-external-scroll-shell]');
+const mount = document.querySelector('[data-external-scroll-mount]');
+const below = document.querySelector('[data-external-scroll-below]');
+if (
+  !(scrollContainer instanceof HTMLElement) ||
+  !(mount instanceof HTMLDivElement) ||
+  !(below instanceof HTMLElement)
+) {
+  throw new Error('Missing external scroll fixture shell.');
+}
+
+const paths = [
+  ...Array.from(
+    { length: 40 },
+    (_, index) => `src/file_${String(index).padStart(3, '0')}.ts`
+  ),
+  ...Array.from(
+    { length: 16 },
+    (_, index) => `src/nested/file_${String(index).padStart(3, '0')}.ts`
+  ),
+  ...Array.from(
+    { length: 24 },
+    (_, index) => `test/spec_${String(index).padStart(3, '0')}.ts`
+  ),
+  ...Array.from(
+    { length: 24 },
+    (_, index) => `z/file_${String(index).padStart(3, '0')}.ts`
+  ),
+];
+
+const source = new FixtureExternalScrollSource(scrollContainer);
+const fileTree = new FileTree({
+  externalScroll: {
+    initialSnapshot: source.getSnapshot(),
+    source,
+  },
+  flattenEmptyDirectories: false,
+  initialExpansion: 'open',
+  overscan: 1,
+  paths,
+  stickyFolders: true,
+});
+fileTree.render({ containerWrapper: mount });
+
+const nextFrames = async (count: number = 2): Promise<void> => {
+  for (let index = 0; index < count; index += 1) {
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+};
+
+const waitForTree = async (): Promise<HTMLElement> => {
+  const started = performance.now();
+  while (true) {
+    const host = mount.querySelector('file-tree-container');
+    if (host instanceof HTMLElement && host.shadowRoot != null) {
+      return host;
+    }
+
+    if (performance.now() - started > 5_000) {
+      throw new Error('Timed out waiting for external scroll fixture tree.');
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 16));
+  }
+};
+
+const host = await waitForTree();
+source.attachHost(host);
+await nextFrames(2);
+
+scrollContainer.addEventListener('scroll', () => {
+  source.updateFromDom('user');
+});
+
+const getShadow = (): ShadowRoot => {
+  if (!(host.shadowRoot instanceof ShadowRoot)) {
+    throw new Error(
+      'Expected open shadow root on external scroll fixture host.'
+    );
+  }
+  return host.shadowRoot;
+};
+
+const getMountedPaths = (): string[] =>
+  Array.from(
+    getShadow().querySelectorAll(
+      'button[data-type="item"]:not([data-file-tree-sticky-row="true"])'
+    )
+  )
+    .filter((element): element is HTMLElement => element instanceof HTMLElement)
+    .filter((element) => element.dataset.itemParked !== 'true')
+    .map((element) => element.dataset.itemPath)
+    .filter((path): path is string => path != null);
+
+const getStickyRows = (): HTMLElement[] =>
+  Array.from(
+    getShadow().querySelectorAll('button[data-file-tree-sticky-row="true"]')
+  ).filter((element): element is HTMLElement => element instanceof HTMLElement);
+
+const sample = (): ExternalScrollSample => {
+  const scrollRect = scrollContainer.getBoundingClientRect();
+  const stickyRows = getStickyRows();
+  const firstStickyRow = stickyRows[0] ?? null;
+  return {
+    belowTopWithinScroller: below.getBoundingClientRect().top - scrollRect.top,
+    mountedPaths: getMountedPaths(),
+    parentScrollTop: scrollContainer.scrollTop,
+    requestCount: source.requests.length,
+    requests: [...source.requests],
+    stickyPaths: stickyRows
+      .map((element) => element.dataset.fileTreeStickyPath)
+      .filter((path): path is string => path != null),
+    stickyTopWithinScroller:
+      firstStickyRow == null
+        ? null
+        : firstStickyRow.getBoundingClientRect().top - scrollRect.top,
+    topInset: source.getSnapshot().topInset ?? 0,
+  };
+};
+
+const setScrollTop: ExternalScrollProbe['setScrollTop'] = async (scrollTop) => {
+  scrollContainer.scrollTop = scrollTop;
+  source.updateFromDom('user');
+  await nextFrames(2);
+};
+
+const focusFirstRow: ExternalScrollProbe['focusFirstRow'] = async () => {
+  const firstRow = getShadow().querySelector(
+    'button[data-type="item"]:not([data-file-tree-sticky-row="true"])'
+  );
+  if (!(firstRow instanceof HTMLButtonElement)) {
+    throw new Error('Missing first mounted external scroll row.');
+  }
+  firstRow.focus({ preventScroll: true });
+  await nextFrames(1);
+};
+
+const pressFocusedRowKey: ExternalScrollProbe['pressFocusedRowKey'] = async (
+  key
+) => {
+  const focused = getShadow().activeElement;
+  if (!(focused instanceof HTMLButtonElement)) {
+    throw new Error(`Expected focused row before pressing ${key}.`);
+  }
+  focused.dispatchEvent(
+    new KeyboardEvent('keydown', { bubbles: true, cancelable: true, key })
+  );
+  await nextFrames(2);
+};
+
+(window as ExternalScrollWindow).__externalScrollProbe = {
+  focusFirstRow,
+  nextFrames,
+  pressFocusedRowKey,
+  sample,
+  setScrollTop,
+};
+(window as ExternalScrollWindow).__externalScrollFixtureReady = true;

--- a/packages/trees/test/file-tree-external-scroll.test.ts
+++ b/packages/trees/test/file-tree-external-scroll.test.ts
@@ -1,0 +1,742 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  getFileTreeExternalScrollFallbackViewportHeight,
+  normalizeFileTreeExternalScrollSnapshot,
+  resolveFileTreeExternalScrollInitialSnapshot,
+} from '../src/model/externalScroll';
+import {
+  computeFileTreeExternalLayout,
+  type FileTreeLayoutRow,
+} from '../src/model/layout';
+import {
+  createDomScrollSource,
+  type FileTreeExternalScrollRequestContext,
+  type FileTreeExternalScrollSnapshot,
+} from '../src/scroll';
+import { flushDom, installDom } from './helpers/dom';
+import { loadScrollFileTree } from './helpers/loadFileTree';
+import {
+  getItemButton,
+  getMountedItemPaths,
+  getStickyRowPaths,
+  pressKey,
+} from './helpers/renderHarness';
+
+describe('external scroll snapshot normalization', () => {
+  test('preserves valid metrics and derives the effective viewport height', () => {
+    expect(
+      normalizeFileTreeExternalScrollSnapshot({
+        bottomInset: 12,
+        isScrolling: true,
+        scrollOrigin: 'user',
+        topInset: 18,
+        viewportHeight: 120,
+        viewportTop: -30,
+      })
+    ).toEqual({
+      bottomInset: 12,
+      effectiveViewportHeight: 90,
+      isScrolling: true,
+      scrollOrigin: 'user',
+      topInset: 18,
+      viewportHeight: 120,
+      viewportTop: -30,
+    });
+  });
+
+  test('clamps heights and insets while keeping raw finite viewportTop', () => {
+    expect(
+      normalizeFileTreeExternalScrollSnapshot({
+        bottomInset: -4,
+        topInset: -10,
+        viewportHeight: -120,
+        viewportTop: -45,
+      })
+    ).toEqual({
+      bottomInset: 0,
+      effectiveViewportHeight: 0,
+      isScrolling: false,
+      scrollOrigin: 'unknown',
+      topInset: 0,
+      viewportHeight: 0,
+      viewportTop: -45,
+    });
+  });
+
+  test('falls back for non-finite numbers and invalid origins', () => {
+    const snapshot = {
+      bottomInset: Number.POSITIVE_INFINITY,
+      isScrolling: false,
+      scrollOrigin: 'gesture',
+      topInset: Number.NaN,
+      viewportHeight: Number.NaN,
+      viewportTop: Number.NEGATIVE_INFINITY,
+    } as unknown as FileTreeExternalScrollSnapshot;
+
+    expect(normalizeFileTreeExternalScrollSnapshot(snapshot, 150)).toEqual({
+      bottomInset: 0,
+      effectiveViewportHeight: 150,
+      isScrolling: false,
+      scrollOrigin: 'unknown',
+      topInset: 0,
+      viewportHeight: 150,
+      viewportTop: 0,
+    });
+  });
+
+  test('derives the initial fallback viewport height from visible row count', () => {
+    expect(
+      getFileTreeExternalScrollFallbackViewportHeight({
+        initialVisibleRowCount: 4.5,
+        itemHeight: 24,
+      })
+    ).toBe(108);
+    expect(
+      getFileTreeExternalScrollFallbackViewportHeight({
+        initialVisibleRowCount: -2,
+        itemHeight: 24,
+      })
+    ).toBe(0);
+  });
+
+  test('uses initialSnapshot before the initialVisibleRowCount fallback', () => {
+    expect(
+      resolveFileTreeExternalScrollInitialSnapshot({
+        initialSnapshot: { viewportHeight: 60, viewportTop: 15 },
+        initialVisibleRowCount: 10,
+        itemHeight: 30,
+      }).viewportHeight
+    ).toBe(60);
+  });
+
+  test('uses initialVisibleRowCount when no initialSnapshot exists', () => {
+    expect(
+      resolveFileTreeExternalScrollInitialSnapshot({
+        initialVisibleRowCount: 5,
+        itemHeight: 30,
+      })
+    ).toEqual({
+      bottomInset: 0,
+      effectiveViewportHeight: 150,
+      isScrolling: false,
+      scrollOrigin: 'unknown',
+      topInset: 0,
+      viewportHeight: 150,
+      viewportTop: 0,
+    });
+  });
+});
+
+function createLayoutRows(count: number): FileTreeLayoutRow[] {
+  return Array.from({ length: count }, (_, index) => ({
+    ancestorPaths: [],
+    isExpanded: false,
+    kind: 'file',
+    path: `file-${String(index).padStart(2, '0')}.ts`,
+  }));
+}
+
+describe('computeFileTreeExternalLayout', () => {
+  const itemHeight = 10;
+  const rows = createLayoutRows(10);
+
+  test('returns an empty mounted window when the viewport is fully above overscan', () => {
+    const layout = computeFileTreeExternalLayout(rows, {
+      itemHeight,
+      overscan: 1,
+      viewportHeight: 10,
+      viewportTop: -40,
+    });
+
+    expect(layout.visible).toEqual({ endIndex: -1, startIndex: -1 });
+    expect(layout.window).toMatchObject({ endIndex: -1, startIndex: -1 });
+  });
+
+  test('mounts rows when an above-tree viewport is within overscan', () => {
+    const layout = computeFileTreeExternalLayout(rows, {
+      itemHeight,
+      overscan: 1,
+      viewportHeight: 10,
+      viewportTop: -15,
+    });
+
+    expect(layout.visible).toEqual({ endIndex: -1, startIndex: -1 });
+    expect(layout.window).toMatchObject({ endIndex: 0, startIndex: 0 });
+  });
+
+  test('renders top rows when the viewport partially overlaps the row area', () => {
+    const layout = computeFileTreeExternalLayout(rows, {
+      itemHeight,
+      overscan: 1,
+      viewportHeight: 20,
+      viewportTop: -5,
+    });
+
+    expect(layout.visible).toEqual({ endIndex: 1, startIndex: 0 });
+    expect(layout.window).toMatchObject({ endIndex: 2, startIndex: 0 });
+  });
+
+  test('renders the expected row window for an in-tree viewport', () => {
+    const layout = computeFileTreeExternalLayout(rows, {
+      itemHeight,
+      overscan: 1,
+      viewportHeight: 20,
+      viewportTop: 25,
+    });
+
+    expect(layout.visible).toEqual({ endIndex: 4, startIndex: 2 });
+    expect(layout.window).toMatchObject({
+      endIndex: 5,
+      offsetTop: 10,
+      startIndex: 1,
+    });
+  });
+
+  test('returns an empty mounted window when the viewport is fully below overscan', () => {
+    const layout = computeFileTreeExternalLayout(rows, {
+      itemHeight,
+      overscan: 1,
+      viewportHeight: 10,
+      viewportTop: 120,
+    });
+
+    expect(layout.visible).toEqual({ endIndex: -1, startIndex: -1 });
+    expect(layout.window).toMatchObject({ endIndex: -1, startIndex: -1 });
+  });
+
+  test('uses normalized insets to reduce the external viewport height', () => {
+    const snapshot = normalizeFileTreeExternalScrollSnapshot({
+      bottomInset: 10,
+      topInset: 10,
+      viewportHeight: 40,
+      viewportTop: 20,
+    });
+    const layout = computeFileTreeExternalLayout(rows, {
+      itemHeight,
+      overscan: 0,
+      viewportHeight: snapshot.effectiveViewportHeight,
+      viewportTop: snapshot.viewportTop + snapshot.topInset,
+    });
+
+    expect(layout.visible).toEqual({ endIndex: 4, startIndex: 3 });
+  });
+
+  test('does not compute sticky rows when the viewport is outside the tree', () => {
+    const directoryRows: FileTreeLayoutRow[] = [
+      {
+        ancestorPaths: [],
+        isExpanded: true,
+        kind: 'directory',
+        path: 'src/',
+      },
+      ...createLayoutRows(4).map((row) => ({
+        ...row,
+        ancestorPaths: ['src/'],
+        path: `src/${row.path}`,
+      })),
+    ];
+
+    const layout = computeFileTreeExternalLayout(directoryRows, {
+      itemHeight,
+      overscan: 1,
+      viewportHeight: 20,
+      viewportTop: 100,
+    });
+
+    expect(layout.sticky.rows).toEqual([]);
+  });
+});
+
+class TestExternalScrollSource {
+  requests: {
+    context: FileTreeExternalScrollRequestContext;
+    viewportTop: number;
+  }[] = [];
+  unsubscribeCount = 0;
+  #listeners = new Set<() => void>();
+  #snapshot: FileTreeExternalScrollSnapshot;
+
+  constructor(snapshot: FileTreeExternalScrollSnapshot) {
+    this.#snapshot = snapshot;
+  }
+
+  getSnapshot(): FileTreeExternalScrollSnapshot {
+    return this.#snapshot;
+  }
+
+  scrollToViewportTop(
+    viewportTop: number,
+    context: FileTreeExternalScrollRequestContext
+  ): void {
+    this.requests.push({ context, viewportTop });
+    this.#snapshot = {
+      ...this.#snapshot,
+      isScrolling: false,
+      scrollOrigin: 'programmatic',
+      viewportTop,
+    };
+  }
+
+  setSnapshot(snapshot: FileTreeExternalScrollSnapshot): void {
+    this.#snapshot = snapshot;
+    for (const listener of this.#listeners) {
+      listener();
+    }
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.#listeners.add(listener);
+    return () => {
+      this.unsubscribeCount += 1;
+      this.#listeners.delete(listener);
+    };
+  }
+}
+
+function createFlatPaths(count: number): string[] {
+  return Array.from(
+    { length: count },
+    (_, index) => `item${String(index).padStart(3, '0')}.ts`
+  );
+}
+
+describe('createDomScrollSource', () => {
+  const createRect = (top: number, height: number): DOMRect =>
+    ({
+      bottom: top + height,
+      height,
+      left: 0,
+      right: 0,
+      toJSON: () => null,
+      top,
+      width: 0,
+      x: 0,
+      y: top,
+    }) as DOMRect;
+
+  test('tracks host-local metrics and updates synchronously', () => {
+    const { cleanup, dom } = installDom();
+    try {
+      const scrollContainer = dom.window.document.createElement('div');
+      const host = dom.window.document.createElement('div');
+      const scrollContainerTop = 80;
+      const hostBaseTop = 200;
+
+      Object.defineProperty(scrollContainer, 'clientHeight', {
+        configurable: true,
+        get: () => 120,
+      });
+      scrollContainer.getBoundingClientRect = () =>
+        createRect(scrollContainerTop, 120);
+      host.getBoundingClientRect = () =>
+        createRect(hostBaseTop - scrollContainer.scrollTop, 24);
+
+      const source = createDomScrollSource({
+        bottomInset: () => 6,
+        scrollContainer,
+        topInset: () => 12,
+      });
+      source.setHost(host);
+
+      expect(source.getSnapshot()).toEqual({
+        bottomInset: 6,
+        isScrolling: false,
+        scrollOrigin: 'unknown',
+        topInset: 12,
+        viewportHeight: 120,
+        viewportTop: -120,
+      });
+
+      let notificationCount = 0;
+      const unsubscribe = source.subscribe(() => {
+        notificationCount += 1;
+      });
+
+      scrollContainer.scrollTop = 30;
+      scrollContainer.dispatchEvent(new dom.window.Event('scroll'));
+      expect(notificationCount).toBe(1);
+      expect(source.getSnapshot()).toMatchObject({
+        scrollOrigin: 'user',
+        viewportTop: -90,
+      });
+
+      source.scrollToViewportTop(40, {
+        origin: 'programmatic',
+        reason: 'focus-reveal',
+      });
+      expect(scrollContainer.scrollTop).toBe(160);
+      expect(source.getSnapshot()).toMatchObject({
+        scrollOrigin: 'programmatic',
+        viewportTop: 40,
+      });
+
+      unsubscribe();
+      source.destroy();
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('FileTree external scroll runtime', () => {
+  test('initial snapshot drives the first rendered window', async () => {
+    const { cleanup, dom } = installDom();
+    try {
+      const FileTree = await loadScrollFileTree();
+      const wrapper = dom.window.document.createElement('div');
+      dom.window.document.body.appendChild(wrapper);
+      const fileTree = new FileTree({
+        externalScroll: {
+          initialSnapshot: { viewportHeight: 60, viewportTop: 90 },
+        },
+        flattenEmptyDirectories: false,
+        overscan: 0,
+        paths: createFlatPaths(20),
+      });
+
+      fileTree.render({ containerWrapper: wrapper });
+      await flushDom();
+
+      expect(
+        getMountedItemPaths(fileTree.getFileTreeContainer()?.shadowRoot, dom)
+      ).toEqual(['item003.ts', 'item004.ts']);
+      expect(fileTree.getFileTreeContainer()?.dataset.fileTreeScrollMode).toBe(
+        'external'
+      );
+
+      fileTree.cleanUp();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('source subscription updates rendered rows', async () => {
+    const { cleanup, dom } = installDom();
+    try {
+      const FileTree = await loadScrollFileTree();
+      const source = new TestExternalScrollSource({
+        viewportHeight: 60,
+        viewportTop: 0,
+      });
+      const wrapper = dom.window.document.createElement('div');
+      dom.window.document.body.appendChild(wrapper);
+      const fileTree = new FileTree({
+        externalScroll: { source },
+        flattenEmptyDirectories: false,
+        overscan: 0,
+        paths: createFlatPaths(20),
+      });
+
+      fileTree.render({ containerWrapper: wrapper });
+      await flushDom();
+      expect(
+        getMountedItemPaths(fileTree.getFileTreeContainer()?.shadowRoot, dom)
+      ).toEqual(['item000.ts', 'item001.ts']);
+
+      source.setSnapshot({ viewportHeight: 60, viewportTop: 180 });
+      await flushDom();
+      expect(
+        getMountedItemPaths(fileTree.getFileTreeContainer()?.shadowRoot, dom)
+      ).toEqual(['item006.ts', 'item007.ts']);
+
+      fileTree.cleanUp();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('outside external viewports render no rows until they intersect', async () => {
+    const { cleanup, dom } = installDom();
+    try {
+      const FileTree = await loadScrollFileTree();
+      const source = new TestExternalScrollSource({
+        viewportHeight: 30,
+        viewportTop: -90,
+      });
+      const wrapper = dom.window.document.createElement('div');
+      dom.window.document.body.appendChild(wrapper);
+      const fileTree = new FileTree({
+        externalScroll: { source },
+        flattenEmptyDirectories: false,
+        overscan: 0,
+        paths: createFlatPaths(20),
+      });
+
+      fileTree.render({ containerWrapper: wrapper });
+      await flushDom();
+      expect(
+        getMountedItemPaths(fileTree.getFileTreeContainer()?.shadowRoot, dom)
+      ).toEqual([]);
+
+      source.setSnapshot({ viewportHeight: 30, viewportTop: -10 });
+      await flushDom();
+      expect(
+        getMountedItemPaths(fileTree.getFileTreeContainer()?.shadowRoot, dom)
+      ).toEqual(['item000.ts']);
+
+      source.setSnapshot({ viewportHeight: 30, viewportTop: 900 });
+      await flushDom();
+      expect(
+        getMountedItemPaths(fileTree.getFileTreeContainer()?.shadowRoot, dom)
+      ).toEqual([]);
+
+      fileTree.cleanUp();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('topInset and bottomInset shrink the rendered external window', async () => {
+    const { cleanup, dom } = installDom();
+    try {
+      const FileTree = await loadScrollFileTree();
+      const wrapper = dom.window.document.createElement('div');
+      dom.window.document.body.appendChild(wrapper);
+      const fileTree = new FileTree({
+        externalScroll: {
+          initialSnapshot: {
+            bottomInset: 30,
+            topInset: 30,
+            viewportHeight: 90,
+            viewportTop: 0,
+          },
+        },
+        flattenEmptyDirectories: false,
+        overscan: 0,
+        paths: createFlatPaths(20),
+      });
+
+      fileTree.render({ containerWrapper: wrapper });
+      await flushDom();
+
+      expect(
+        getMountedItemPaths(fileTree.getFileTreeContainer()?.shadowRoot, dom)
+      ).toEqual(['item001.ts']);
+
+      fileTree.cleanUp();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('focus reveal calls the external source with structured context', async () => {
+    const { cleanup, dom } = installDom();
+    try {
+      const FileTree = await loadScrollFileTree();
+      const source = new TestExternalScrollSource({
+        bottomInset: 30,
+        topInset: 0,
+        viewportHeight: 90,
+        viewportTop: 0,
+      });
+      const wrapper = dom.window.document.createElement('div');
+      dom.window.document.body.appendChild(wrapper);
+      const fileTree = new FileTree({
+        externalScroll: { source },
+        flattenEmptyDirectories: false,
+        overscan: 0,
+        paths: createFlatPaths(50),
+      });
+
+      fileTree.render({ containerWrapper: wrapper });
+      await flushDom();
+      const shadowRoot = fileTree.getFileTreeContainer()?.shadowRoot;
+      getItemButton(shadowRoot, dom, 'item000.ts').focus();
+      pressKey(getItemButton(shadowRoot, dom, 'item000.ts'), dom, 'End');
+      await flushDom(2);
+
+      expect(source.requests).toEqual([
+        {
+          context: {
+            origin: 'programmatic',
+            path: 'item049.ts',
+            reason: 'focus-reveal',
+          },
+          viewportTop: 1440,
+        },
+      ]);
+
+      fileTree.cleanUp();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('missing live source leaves scroll requests as no-ops', async () => {
+    const { cleanup, dom } = installDom();
+    try {
+      const FileTree = await loadScrollFileTree();
+      const wrapper = dom.window.document.createElement('div');
+      dom.window.document.body.appendChild(wrapper);
+      const fileTree = new FileTree({
+        externalScroll: {
+          initialSnapshot: { viewportHeight: 60, viewportTop: 0 },
+        },
+        flattenEmptyDirectories: false,
+        overscan: 0,
+        paths: createFlatPaths(20),
+      });
+
+      fileTree.render({ containerWrapper: wrapper });
+      await flushDom();
+      const shadowRoot = fileTree.getFileTreeContainer()?.shadowRoot;
+      getItemButton(shadowRoot, dom, 'item000.ts').focus();
+      expect(() => {
+        pressKey(getItemButton(shadowRoot, dom, 'item000.ts'), dom, 'End');
+      }).not.toThrow();
+      await flushDom(2);
+
+      fileTree.cleanUp();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('detaching the live source leaves reveal requests as no-ops', async () => {
+    const { cleanup, dom } = installDom();
+    try {
+      const FileTree = await loadScrollFileTree();
+      const source = new TestExternalScrollSource({
+        viewportHeight: 60,
+        viewportTop: 0,
+      });
+      const wrapper = dom.window.document.createElement('div');
+      dom.window.document.body.appendChild(wrapper);
+      const fileTree = new FileTree({
+        externalScroll: {
+          initialSnapshot: { viewportHeight: 60, viewportTop: 0 },
+        },
+        flattenEmptyDirectories: false,
+        overscan: 0,
+        paths: createFlatPaths(20),
+      });
+
+      fileTree.render({ containerWrapper: wrapper });
+      await flushDom();
+      fileTree.setExternalScrollSource(source);
+      fileTree.setExternalScrollSource(undefined);
+      expect(source.unsubscribeCount).toBe(1);
+
+      const shadowRoot = fileTree.getFileTreeContainer()?.shadowRoot;
+      getItemButton(shadowRoot, dom, 'item000.ts').focus();
+      expect(() => {
+        pressKey(getItemButton(shadowRoot, dom, 'item000.ts'), dom, 'End');
+      }).not.toThrow();
+      await flushDom(2);
+      expect(source.requests).toEqual([]);
+
+      fileTree.cleanUp();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('setExternalScrollSource replaces the source subscription', async () => {
+    const { cleanup, dom } = installDom();
+    try {
+      const FileTree = await loadScrollFileTree();
+      const wrapper = dom.window.document.createElement('div');
+      dom.window.document.body.appendChild(wrapper);
+      const firstSource = new TestExternalScrollSource({
+        viewportHeight: 60,
+        viewportTop: 0,
+      });
+      const secondSource = new TestExternalScrollSource({
+        viewportHeight: 60,
+        viewportTop: 180,
+      });
+      const fileTree = new FileTree({
+        externalScroll: {
+          initialSnapshot: { viewportHeight: 60, viewportTop: 0 },
+        },
+        flattenEmptyDirectories: false,
+        overscan: 0,
+        paths: createFlatPaths(20),
+      });
+
+      fileTree.render({ containerWrapper: wrapper });
+      await flushDom();
+      fileTree.setExternalScrollSource(firstSource);
+      firstSource.setSnapshot({ viewportHeight: 60, viewportTop: 90 });
+      await flushDom();
+      expect(
+        getMountedItemPaths(fileTree.getFileTreeContainer()?.shadowRoot, dom)
+      ).toEqual(['item003.ts', 'item004.ts']);
+
+      fileTree.setExternalScrollSource(secondSource);
+      expect(firstSource.unsubscribeCount).toBe(1);
+      secondSource.setSnapshot({ viewportHeight: 60, viewportTop: 180 });
+      firstSource.setSnapshot({ viewportHeight: 60, viewportTop: 0 });
+      await flushDom();
+      expect(
+        getMountedItemPaths(fileTree.getFileTreeContainer()?.shadowRoot, dom)
+      ).toEqual(['item006.ts', 'item007.ts']);
+
+      fileTree.cleanUp();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('internal-scroll models reject external source attachment', async () => {
+    const { cleanup } = installDom();
+    try {
+      const FileTree = await loadScrollFileTree();
+      const fileTree = new FileTree({
+        flattenEmptyDirectories: false,
+        paths: createFlatPaths(2),
+      });
+
+      expect(() => {
+        fileTree.setExternalScrollSource(
+          new TestExternalScrollSource({ viewportHeight: 60, viewportTop: 0 })
+        );
+      }).toThrow(/constructed with externalScroll/);
+
+      fileTree.cleanUp();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('sticky folders use the external top inset', async () => {
+    const { cleanup, dom } = installDom();
+    try {
+      const FileTree = await loadScrollFileTree();
+      const wrapper = dom.window.document.createElement('div');
+      dom.window.document.body.appendChild(wrapper);
+      const fileTree = new FileTree({
+        externalScroll: {
+          initialSnapshot: {
+            topInset: 12,
+            viewportHeight: 90,
+            viewportTop: 45,
+          },
+        },
+        flattenEmptyDirectories: false,
+        initialExpansion: 'open',
+        overscan: 0,
+        paths: ['src/a.ts', 'src/b.ts', 'src/nested/c.ts', 'test/a.ts'],
+        stickyFolders: true,
+      });
+
+      fileTree.render({ containerWrapper: wrapper });
+      await flushDom();
+      const shadowRoot = fileTree.getFileTreeContainer()?.shadowRoot;
+      expect(getStickyRowPaths(shadowRoot, dom)).toContain('src/');
+      const overlay = shadowRoot?.querySelector(
+        '[data-file-tree-sticky-overlay="true"]'
+      );
+      expect(
+        overlay instanceof dom.window.HTMLElement
+          ? overlay.style.getPropertyValue('top')
+          : null
+      ).toBe('12px');
+
+      fileTree.cleanUp();
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/packages/trees/test/file-tree-external-scroll.test.ts
+++ b/packages/trees/test/file-tree-external-scroll.test.ts
@@ -327,6 +327,10 @@ describe('createDomScrollSource', () => {
         configurable: true,
         get: () => 120,
       });
+      Object.defineProperty(scrollContainer, 'clientTop', {
+        configurable: true,
+        get: () => 8,
+      });
       scrollContainer.getBoundingClientRect = () =>
         createRect(scrollContainerTop, 120);
       host.getBoundingClientRect = () =>
@@ -345,7 +349,7 @@ describe('createDomScrollSource', () => {
         scrollOrigin: 'unknown',
         topInset: 12,
         viewportHeight: 120,
-        viewportTop: -120,
+        viewportTop: -112,
       });
 
       let notificationCount = 0;
@@ -358,14 +362,14 @@ describe('createDomScrollSource', () => {
       expect(notificationCount).toBe(1);
       expect(source.getSnapshot()).toMatchObject({
         scrollOrigin: 'user',
-        viewportTop: -90,
+        viewportTop: -82,
       });
 
       source.scrollToViewportTop(40, {
         origin: 'programmatic',
         reason: 'focus-reveal',
       });
-      expect(scrollContainer.scrollTop).toBe(160);
+      expect(scrollContainer.scrollTop).toBe(152);
       expect(source.getSnapshot()).toMatchObject({
         scrollOrigin: 'programmatic',
         viewportTop: 40,

--- a/packages/trees/test/file-tree-scroll-target.test.ts
+++ b/packages/trees/test/file-tree-scroll-target.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'bun:test';
 
 import {
+  computeExternalFocusedRowViewportTop,
+  computeExternalViewportOffsetTop,
   computeFocusedRowScrollIntoView,
   computeViewportOffsetScrollTop,
 } from '../src/render/scrollTarget';
@@ -184,5 +186,49 @@ describe('computeViewportOffsetScrollTop', () => {
         viewportHeight,
       })
     ).toBe(300);
+  });
+});
+
+describe('external scroll target helpers', () => {
+  const itemHeight = 30;
+
+  test('reveals a row beneath the external top inset', () => {
+    expect(
+      computeExternalFocusedRowViewportTop({
+        bottomInset: 0,
+        currentViewportTop: 300,
+        focusedIndex: 10,
+        itemHeight,
+        topInset: 60,
+        viewportHeight: 180,
+      })
+    ).toBe(240);
+  });
+
+  test('uses bottomInset to reduce the effective viewport bottom', () => {
+    expect(
+      computeExternalFocusedRowViewportTop({
+        bottomInset: 30,
+        currentViewportTop: 0,
+        focusedIndex: 5,
+        itemHeight,
+        topInset: 0,
+        viewportHeight: 180,
+      })
+    ).toBe(30);
+  });
+
+  test('requests an offset-preserving external viewport top', () => {
+    expect(
+      computeExternalViewportOffsetTop({
+        bottomInset: 0,
+        currentViewportTop: 0,
+        focusedIndex: 10,
+        itemHeight,
+        targetViewportOffset: 90,
+        totalHeight: 1200,
+        viewportHeight: 180,
+      })
+    ).toBe(210);
   });
 });

--- a/packages/trees/test/helpers/dom.ts
+++ b/packages/trees/test/helpers/dom.ts
@@ -39,6 +39,7 @@ class MockStyleSheet {
 
 class MockResizeObserver {
   observe(_target: Element): void {}
+  unobserve(_target: Element): void {}
   disconnect(): void {}
 }
 

--- a/packages/trees/test/helpers/loadFileTree.ts
+++ b/packages/trees/test/helpers/loadFileTree.ts
@@ -7,6 +7,13 @@ export async function loadFileTree(): Promise<
   return FileTree;
 }
 
+export async function loadScrollFileTree(): Promise<
+  typeof import('../../src/scroll').FileTree
+> {
+  const { FileTree } = await import('../../src/scroll/FileTree');
+  return FileTree;
+}
+
 export async function loadFileTreeController(): Promise<
   typeof import('../../src/model/FileTreeController').FileTreeController
 > {


### PR DESCRIPTION
Summary

 This PR introduces a dedicated @pierre/trees/scroll entry point for the
 external-scroll integration.

 The goal is to keep the normal @pierre/trees path focused on the built-in internal
 scroller, while moving caller-owned scroll-container support behind an explicit
 advanced import.

 With this change:

 - regular tree users stay on @pierre/trees
 - external-scroll users opt into @pierre/trees/scroll
 - React rendering stays reusable through @pierre/trees/react
 - SSR preload for external-scroll trees also moves behind the scroll entry point
 - the common DOM-scroller case now has a built-in helper: createDomScrollSource(...)

 What this adds

 ### New public entry point

 @pierre/trees/scroll

 It exports:
 - FileTree
 - preloadFileTree
 - serializeFileTreeSsrPayload
 - createDomScrollSource
 - external-scroll types such as:
     - FileTreeExternalScrollSource
     - FileTreeExternalScrollSnapshot
     - FileTreeExternalScrollRequestContext
     - FileTreeExternalScrollModel

 ### New external-scroll helper

 createDomScrollSource(...)

 This covers the common “tree inside a normal page scroller” case:
 - tracks viewportTop relative to the tree host
 - reports viewportHeight, topInset, and bottomInset
 - subscribes to scroll/resize changes
 - updates synchronously for programmatic reveal requests

 ### React reuse without a separate /scroll/react

 External-scroll models created from @pierre/trees/scroll can still render through:
 - @pierre/trees/react
 - existing selector/search/selection hooks

 That means the advanced model is new, but the React view layer stays shared.

 Behavioral change

 External-scroll setup is no longer part of the root @pierre/trees surface.

 If you were previously doing this through the root package:
 - new FileTree({ externalScroll: ... })
 - root SSR preload with externalScroll
 - root exports of external-scroll types

 you now need to move those integrations to @pierre/trees/scroll.

 Normal internal-scroll trees are unchanged in how they are created and rendered.

 How to use it

 ### Vanilla / imperative usage

 ```ts
   import { FileTree, createDomScrollSource } from '@pierre/trees/scroll';

   const source = createDomScrollSource({
     scrollContainer: parentScroller,
     topInset: () => toolbar.getBoundingClientRect().height,
   });

   const tree = new FileTree({
     paths,
     stickyFolders: true,
     externalScroll: {
       initialSnapshot: source.getSnapshot(),
       source,
     },
   });

   tree.render({ containerWrapper: mount });

   const host = tree.getFileTreeContainer();
   source.setHost(host ?? null);
 ```

 Cleanup:

 ```ts
   source.destroy();
   tree.cleanUp();
 ```

 ### React usage

 Create the model from @pierre/trees/scroll, but keep using the shared React component
 from @pierre/trees/react.

 ```tsx
   import {
     FileTree as ScrollFileTree,
     createDomScrollSource,
   } from '@pierre/trees/scroll';
   import { FileTree } from '@pierre/trees/react';

   const hostRef = useRef<HTMLElement>(null);

   const source = useMemo(
     () => createDomScrollSource({ scrollContainer: parentScroller }),
     [parentScroller]
   );

   const model = useMemo(
     () =>
       new ScrollFileTree({
         paths,
         stickyFolders: true,
         externalScroll: {
           initialSnapshot: source.getSnapshot(),
         },
       }),
     [paths, source]
   );

   useEffect(() => {
     return () => {
       model.cleanUp();
       source.destroy();
     };
   }, [model, source]);

   useLayoutEffect(() => {
     source.setHost(hostRef.current);
     model.setExternalScrollSource(source);
     return () => model.setExternalScrollSource(undefined);
   }, [model, source]);

   return <FileTree ref={hostRef} model={model} />;
 ```

 ### SSR usage

 Use the scroll entry point for preloading too:

 ```ts
   import { preloadFileTree } from '@pierre/trees/scroll';

   const payload = preloadFileTree({
     preparedInput,
     externalScroll: {
       initialSnapshot: {
         viewportTop: 0,
         viewportHeight: 480,
         topInset: 48,
       },
     },
     initialVisibleRowCount: 16,
   });
 ```

 Contract for custom sources

 If you implement your own FileTreeExternalScrollSource, the important contract is:

 - viewportTop must be host-local
 - scrollToViewportTop(nextTop, context) must update getSnapshot() synchronously before
 returning

 That synchronous update matters because the tree recalculates layout immediately after
 requesting scroll movement.

 Why this split exists

 This keeps the advanced external-scroll feature explicit and opt-in:
 - normal users keep the simpler root API
 - external-scroll users get a focused entry point and helper
 - docs/tests/examples now show one consistent integration path