### PR TITLE
[trees] Strict Mode Fix

### DIFF
--- a/packages/trees/src/react/useFileTree.ts
+++ b/packages/trees/src/react/useFileTree.ts
@@ -1,9 +1,14 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import type { FileTreeOptions } from '../model/publicTypes';
 import { FileTree } from '../render/FileTree';
+
+interface CleanUpRef {
+  timeout: ReturnType<typeof setTimeout> | null;
+  model: FileTree;
+}
 
 export interface UseFileTreeResult {
   model: FileTree;
@@ -13,17 +18,19 @@ export interface UseFileTreeResult {
 // runtime. Later option changes are intentionally ignored; callers must use
 // explicit model methods like resetPaths and setComposition.
 export function useFileTree(options: FileTreeOptions): UseFileTreeResult {
-  const modelRef = useRef<FileTree | null>(null);
-
-  modelRef.current ??= new FileTree(options);
-
+  const [model] = useState(() => new FileTree(options));
+  const cleanUpRef = useRef<CleanUpRef>({ timeout: null, model });
   useEffect(() => {
-    const model = modelRef.current;
+    const { current } = cleanUpRef;
+    // NOTE(amadeus): This is designed to ensure strict mode doesn't blow away
+    // our instance -- we wait a cycle to clean up
+    if (current.timeout != null) {
+      clearTimeout(current.timeout);
+      current.timeout = null;
+    }
     return () => {
-      model?.cleanUp();
-      modelRef.current = null;
+      current.timeout = setTimeout(() => current.model.cleanUp(), 1);
     };
   }, []);
-
-  return { model: modelRef.current };
+  return { model };
 }

--- a/packages/trees/test/file-tree-react.test.tsx
+++ b/packages/trees/test/file-tree-react.test.tsx
@@ -11,7 +11,7 @@ import {
   test,
 } from 'bun:test';
 import { JSDOM } from 'jsdom';
-import { act, useState } from 'react';
+import { act, StrictMode, useState } from 'react';
 import { createRoot, hydrateRoot, type Root } from 'react-dom/client';
 import { renderToString } from 'react-dom/server';
 
@@ -258,11 +258,72 @@ describe('file-tree React lane', () => {
       act(() => {
         localRoot.unmount();
       });
+      expect(cleanUpSpy).toHaveBeenCalledTimes(0);
+      await flushDom();
       expect(cleanUpSpy).toHaveBeenCalledTimes(1);
       cleanUpSpy.mockRestore();
     } finally {
       localContainer.remove();
     }
+  });
+
+  test('keeps the model subscribed through StrictMode effect replay', async () => {
+    let capturedModel: InstanceType<
+      typeof import('../src/render/FileTree').FileTree
+    > | null = null;
+    const options = {
+      flattenEmptyDirectories: false,
+      initialExpandedPaths: ['src/'],
+      paths: ['README.md', 'src/index.ts', 'src/lib.ts'],
+      initialVisibleRowCount: 120 / 30,
+    } as const;
+
+    function Harness() {
+      const { model } = useFileTree(options);
+      capturedModel = model;
+      return <FileTreeReact model={model} />;
+    }
+
+    await actAndFlush(() => {
+      root.render(
+        <StrictMode>
+          <Harness />
+        </StrictMode>
+      );
+    });
+
+    const host = getHost(container);
+    expect(getItemButton(host, 'src/').getAttribute('aria-expanded')).toBe(
+      'true'
+    );
+    expect(getItemButton(host, 'src/index.ts')).not.toBeNull();
+
+    const model = capturedModel as {
+      getItem(path: string): import('../src').FileTreeItemHandle | null;
+    } | null;
+    if (model == null) {
+      throw new Error('expected model from useFileTree');
+    }
+
+    const sourceDirectory = model.getItem('src/');
+    if (
+      sourceDirectory == null ||
+      sourceDirectory.isDirectory() !== true ||
+      !('collapse' in sourceDirectory)
+    ) {
+      throw new Error('expected src directory item');
+    }
+
+    await actAndFlush(() => {
+      sourceDirectory.collapse();
+    });
+
+    expect(getItemButton(host, 'src/').getAttribute('aria-expanded')).toBe(
+      'false'
+    );
+    expect(
+      host.shadowRoot?.querySelector('[data-item-path="src/index.ts"]')
+    ).toBeNull();
   });
 
   test('can remount the same model instance after unmount', async () => {


### PR DESCRIPTION
When a dev environment has react strict mode enabled, the lifecycle for the FileTree component gets messed up. This new variant ensures a stable instance, and a cleanup that's always deferred by a tick.

Also addes a regression test