### PR TITLE
Fix a scroll fix if container grows

### DIFF
--- a/apps/docs/app/(diffshub)/(view)/_components/CodeViewHeader.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/CodeViewHeader.tsx
@@ -178,7 +178,7 @@ export const CodeViewHeader = memo(function CodeViewHeader({
           patchIndex
         );
         for (const fileDiff of patch.files) {
-          const id = `${fileIndex++}`;
+          const id = `${fileIndex++}:${fileDiff.name}`;
           const fileOrder = items.length;
 
           items.push({

--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -629,6 +629,7 @@ export class CodeView<LAnnotation = undefined> {
     this.root?.removeEventListener('touchstart', this.clearPendingScroll);
     this.root?.removeEventListener('pointerdown', this.clearPendingScroll);
     this.root?.removeEventListener('keydown', this.clearPendingScroll);
+    this.root?.style.removeProperty('overflow-anchor');
     this.container?.remove();
     this.stickyOffset.remove();
     this.stickyContainer.remove();

--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -415,7 +415,7 @@ export class CodeView<LAnnotation = undefined> {
   private slotSnapshot: CodeViewRenderedItem<LAnnotation>[] | undefined;
   private scrollListeners: Set<CodeViewScrollListener<LAnnotation>> = new Set();
   private scrollHeight = 0;
-  private lastContainerHeight = -1;
+  private containerHeight = -1;
   private scrollTop: number = 0;
   private scrollDirty = true;
   private pointerEventsRestoreTimer: ReturnType<typeof setTimeout> | undefined;
@@ -542,6 +542,7 @@ export class CodeView<LAnnotation = undefined> {
       throw new Error('CodeView.setup: already setup');
     }
     this.root = root;
+    this.root.style.overflowAnchor = 'none';
     this.container ??= document.createElement('div');
     this.container.style.contain = 'layout size style';
     this.syncViewerMetrics();
@@ -1721,6 +1722,7 @@ export class CodeView<LAnnotation = undefined> {
     // collapse, so clamp before deriving the render window for this frame.
     if (recomputeScrollTop) {
       currentScrollTop = this.clampScrollTop(currentScrollTop);
+      this.syncContainerHeight();
     }
 
     // From our currentScrollTop, we should compute where we might be headed
@@ -1828,6 +1830,7 @@ export class CodeView<LAnnotation = undefined> {
 
     this.flushSlotCoordinator();
     this.reconcileRenderedItems(updatedItems);
+    this.syncContainerHeight();
     this.updateStickyPositioning();
 
     // Now that the dom has been flushed and we've computed our updated
@@ -1883,11 +1886,6 @@ export class CodeView<LAnnotation = undefined> {
     }
     this.renderState.scrollTop = roundToDevicePixel(renderedScrollTop);
 
-    const totalScrollHeight = this.getScrollHeight();
-    if (this.lastContainerHeight !== totalScrollHeight) {
-      this.container.style.height = `${totalScrollHeight}px`;
-      this.lastContainerHeight = totalScrollHeight;
-    }
     this.flushManagers(updatedItems);
 
     // If we are hitting a fitPerfectly heuristic, we should queue up another
@@ -1904,6 +1902,16 @@ export class CodeView<LAnnotation = undefined> {
     for (const item of updatedItems) {
       item.instance.flushManagers();
     }
+  }
+
+  private syncContainerHeight(): void {
+    const totalScrollHeight = this.getScrollHeight();
+    if (this.container == null || this.containerHeight === totalScrollHeight) {
+      return;
+    }
+
+    this.container.style.height = `${totalScrollHeight}px`;
+    this.containerHeight = totalScrollHeight;
   }
 
   private reconcileRenderedItems(

--- a/packages/diffs/test/CodeView.pointerEvents.test.ts
+++ b/packages/diffs/test/CodeView.pointerEvents.test.ts
@@ -158,6 +158,26 @@ describe('CodeView pointer events while scrolling', () => {
     }
   });
 
+  test('cleanUp unsets the root overflow anchor style', async () => {
+    const { cleanup } = installDom();
+    const viewer = new CodeView();
+    try {
+      const root = document.createElement('div');
+      root.style.overflowAnchor = 'auto';
+
+      viewer.setup(root);
+      expect(root.style.overflowAnchor).toBe('none');
+
+      viewer.cleanUp();
+
+      expect(root.style.overflowAnchor).toBe('');
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+
   test('setOptions preserves the pending pointer events restore timer', async () => {
     const { cleanup } = installDom();
     const viewer = new CodeView();

--- a/packages/diffs/test/CodeView.scrollAnchoring.test.ts
+++ b/packages/diffs/test/CodeView.scrollAnchoring.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, test } from 'bun:test';
+import { JSDOM } from 'jsdom';
+
+import { CodeView } from '../src/components/CodeView';
+import { DEFAULT_CODE_VIEW_METRICS } from '../src/constants';
+import type { CodeViewItem, FileContents } from '../src/types';
+import { parseDiffFromFile } from '../src/utils/parseDiffFromFile';
+
+const ROOT_HEIGHT = 800;
+
+function installDom() {
+  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+    url: 'http://localhost',
+  });
+  const originalValues = {
+    cancelAnimationFrame: Reflect.get(globalThis, 'cancelAnimationFrame'),
+    document: Reflect.get(globalThis, 'document'),
+    DocumentFragment: Reflect.get(globalThis, 'DocumentFragment'),
+    Element: Reflect.get(globalThis, 'Element'),
+    HTMLDivElement: Reflect.get(globalThis, 'HTMLDivElement'),
+    HTMLElement: Reflect.get(globalThis, 'HTMLElement'),
+    HTMLPreElement: Reflect.get(globalThis, 'HTMLPreElement'),
+    Node: Reflect.get(globalThis, 'Node'),
+    requestAnimationFrame: Reflect.get(globalThis, 'requestAnimationFrame'),
+    ResizeObserver: Reflect.get(globalThis, 'ResizeObserver'),
+    SVGElement: Reflect.get(globalThis, 'SVGElement'),
+    window: Reflect.get(globalThis, 'window'),
+  };
+
+  class MockResizeObserver {
+    observe(_target: Element): void {}
+    unobserve(_target: Element): void {}
+    disconnect(): void {}
+  }
+
+  let nextFrameId = 0;
+  const frames = new Map<number, ReturnType<typeof setTimeout>>();
+
+  Object.assign(globalThis, {
+    cancelAnimationFrame: ((id: number) => {
+      const timeout = frames.get(id);
+      if (timeout != null) {
+        clearTimeout(timeout);
+        frames.delete(id);
+      }
+    }) as typeof cancelAnimationFrame,
+    document: dom.window.document,
+    DocumentFragment: dom.window.DocumentFragment,
+    Element: dom.window.Element,
+    HTMLDivElement: dom.window.HTMLDivElement,
+    HTMLElement: dom.window.HTMLElement,
+    HTMLPreElement: dom.window.HTMLPreElement,
+    Node: dom.window.Node,
+    requestAnimationFrame: ((callback: FrameRequestCallback) => {
+      const id = ++nextFrameId;
+      const timeout = setTimeout(() => {
+        frames.delete(id);
+        callback(performance.now());
+      }, 0);
+      frames.set(id, timeout);
+      return id;
+    }) as typeof requestAnimationFrame,
+    ResizeObserver: MockResizeObserver,
+    SVGElement: dom.window.SVGElement,
+    window: dom.window,
+  });
+
+  return {
+    cleanup() {
+      for (const timeout of frames.values()) {
+        clearTimeout(timeout);
+      }
+      frames.clear();
+
+      for (const [key, value] of Object.entries(originalValues)) {
+        if (value === undefined) {
+          Reflect.deleteProperty(globalThis, key);
+        } else {
+          Object.assign(globalThis, { [key]: value });
+        }
+      }
+      dom.window.close();
+    },
+  };
+}
+
+function createClampingRoot(): HTMLDivElement {
+  const root = document.createElement('div');
+  root.scrollTo = (options?: ScrollToOptions | number, y?: number) => {
+    const top =
+      typeof options === 'number' ? (y ?? 0) : (options?.top ?? root.scrollTop);
+    root.scrollTop = Math.min(Math.max(top, 0), getRootMaxScrollTop(root));
+  };
+  Object.defineProperty(root, 'getBoundingClientRect', {
+    value: () => ({
+      bottom: ROOT_HEIGHT,
+      height: ROOT_HEIGHT,
+      left: 0,
+      right: 1000,
+      top: 0,
+      width: 1000,
+      x: 0,
+      y: 0,
+      toJSON() {
+        return {};
+      },
+    }),
+  });
+  document.body.appendChild(root);
+  return root;
+}
+
+function getRootMaxScrollTop(root: HTMLElement): number {
+  const container = root.firstElementChild;
+  if (!(container instanceof HTMLElement)) {
+    return 0;
+  }
+
+  const contentHeight = Number.parseFloat(
+    container.style.height !== '' ? container.style.height : '0'
+  );
+  const marginTop = Number.parseFloat(
+    container.style.marginTop !== '' ? container.style.marginTop : '0'
+  );
+  const marginBottom = Number.parseFloat(
+    container.style.marginBottom !== '' ? container.style.marginBottom : '0'
+  );
+  return Math.max(contentHeight + marginTop + marginBottom - ROOT_HEIGHT, 0);
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function dispatchScroll(root: HTMLElement): void {
+  root.dispatchEvent(new window.Event('scroll'));
+}
+
+function makeFile(name: string, lineCount: number): FileContents {
+  return {
+    name,
+    contents: Array.from(
+      { length: lineCount },
+      (_, index) => `line ${index + 1}`
+    ).join('\n'),
+  };
+}
+
+function makeReplacementDiffItem(
+  id: string,
+  lineCount: number
+): CodeViewItem<undefined> {
+  const oldFile = makeFile('src/replaced.ts', lineCount);
+  const newFile: FileContents = {
+    name: oldFile.name,
+    contents: Array.from(
+      { length: lineCount },
+      (_, index) => `replacement ${index + 1}`
+    ).join('\n'),
+  };
+
+  return {
+    id,
+    type: 'diff',
+    fileDiff: parseDiffFromFile(oldFile, newFile),
+  };
+}
+
+async function renderItems(
+  viewer: CodeView,
+  items: readonly CodeViewItem[]
+): Promise<void> {
+  viewer.setItems(items);
+  viewer.render(true);
+  await wait(0);
+}
+
+describe('CodeView scroll anchoring', () => {
+  test('keeps an item anchor fixed when split to unified grows past the old scroll range', async () => {
+    const { cleanup } = installDom();
+    const viewer = new CodeView({ diffStyle: 'split' });
+    const root = createClampingRoot();
+    const anchorItem: CodeViewItem = {
+      id: 'file:anchor',
+      type: 'file',
+      file: makeFile('anchor.ts', 90),
+    };
+    const items = [makeReplacementDiffItem('diff:growing', 100), anchorItem];
+
+    try {
+      viewer.setup(root);
+      await renderItems(viewer, items);
+
+      const splitAnchorTop =
+        DEFAULT_CODE_VIEW_METRICS.paddingTop +
+        (viewer.getTopForItem(anchorItem.id) ?? 0);
+      const splitMaxScrollTop = getRootMaxScrollTop(root);
+      expect(splitMaxScrollTop).toBeGreaterThan(splitAnchorTop);
+
+      root.scrollTop = splitAnchorTop;
+      dispatchScroll(root);
+      viewer.render(true);
+
+      viewer.setOptions({ diffStyle: 'unified' });
+      viewer.render(true);
+
+      const unifiedAnchorTop =
+        DEFAULT_CODE_VIEW_METRICS.paddingTop +
+        (viewer.getTopForItem(anchorItem.id) ?? 0);
+      expect(unifiedAnchorTop).toBeGreaterThan(splitMaxScrollTop);
+      expect(root.scrollTop).toBe(unifiedAnchorTop);
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
When scroll fixing due to option changes (like when changing diffStyle for example), the height of the scroll region could dramatically change. We had an optimization where we do the scroll fix prior to applying the new dom structure to help coalesce mutations together and not trigger unnecessary reflows. However, if the new adjusted scroll position was outside the bounds of the current window, then the scroll fix would ultimately get clamped and we wouldn't be in the right spot for the new dom that would then adjust the height of the scroll view.

Essentially the fix here is to first sync the new container height, then apply the early scroll fix so it doesn't get clamped.

I also realized we don't disable browser scroll anchoring on our root by default, and that's something that's very important and we should apply it and not depend on the user space applying this.