### PR TITLE
[trees] Fix scrollbar show on hover

### DIFF
--- a/packages/trees/src/style.css
+++ b/packages/trees/src/style.css
@@ -594,8 +594,13 @@
 
   [data-file-tree-virtualized-scroll='true'],
   [data-file-tree-scrollbar-measure='true'] {
+    --trees-scrollbar-thumb-current: transparent;
     overflow-y: auto;
     scrollbar-gutter: stable;
+
+    &:hover {
+      --trees-scrollbar-thumb-current: var(--trees-scrollbar-thumb);
+    }
 
     &::-webkit-scrollbar {
       width: var(--trees-scrollbar-gutter);
@@ -607,7 +612,7 @@
     }
 
     &::-webkit-scrollbar-thumb {
-      background-color: var(--trees-scrollbar-thumb);
+      background-color: var(--trees-scrollbar-thumb-current);
       border: 1px solid transparent;
       background-clip: content-box;
       border-radius: calc(var(--trees-scrollbar-gutter) / 2);
@@ -636,7 +641,7 @@
     [data-file-tree-virtualized-scroll='true'],
     [data-file-tree-scrollbar-measure='true'] {
       scrollbar-width: thin;
-      scrollbar-color: var(--trees-scrollbar-thumb) transparent;
+      scrollbar-color: var(--trees-scrollbar-thumb-current) transparent;
     }
   }
 


### PR DESCRIPTION
We had undone this logic for release because the initial version had bugs. But in messing around with the DiffsHub page, I found a workaround for this issue and implemented it here:

https://github.com/user-attachments/assets/1b81757b-b664-40c5-b73b-24500f0cfbd8