### PR TITLE
[diffs] Fix for patch trailer metadata

### DIFF
--- a/packages/diffs/src/utils/parsePatchFiles.ts
+++ b/packages/diffs/src/utils/parsePatchFiles.ts
@@ -295,7 +295,21 @@ export function processFile(
     }
 
     // Now we process each line of the hunk
+    let parsedAdditionLines = 0;
+    let parsedDeletionLines = 0;
     for (const rawLine of lines) {
+      if (
+        isHunkBodyComplete({
+          additionCount: hunkData.additionCount,
+          parsedAdditionLines,
+          deletionCount: hunkData.deletionCount,
+          parsedDeletionLines,
+        }) &&
+        !rawLine.startsWith('\\')
+      ) {
+        break;
+      }
+
       const parsedLine = parseLineType(rawLine);
       // If we can't properly process the line, well, lets just try to salvage
       // things and continue... It's possible an AI generated diff might have
@@ -316,6 +330,7 @@ export function processFile(
           hunkData.hunkContent.push(currentContent);
         }
         additionLineIndex++;
+        parsedAdditionLines++;
         if (isPartial) {
           currentFile.additionLines.push(line);
         }
@@ -332,6 +347,7 @@ export function processFile(
           hunkData.hunkContent.push(currentContent);
         }
         deletionLineIndex++;
+        parsedDeletionLines++;
         if (isPartial) {
           currentFile.deletionLines.push(line);
         }
@@ -349,6 +365,8 @@ export function processFile(
         }
         additionLineIndex++;
         deletionLineIndex++;
+        parsedAdditionLines++;
+        parsedDeletionLines++;
         if (isPartial) {
           currentFile.deletionLines.push(line);
           currentFile.additionLines.push(line);
@@ -477,6 +495,27 @@ export function processFile(
     currentFile.prevName = undefined;
   }
   return currentFile;
+}
+
+interface isHunkBodyCompleteProps {
+  additionCount: number;
+  parsedAdditionLines: number;
+  deletionCount: number;
+  parsedDeletionLines: number;
+}
+
+// Git format-patch trailers follow the final hunk without a new diff marker.
+// Once both header-declared line counts are satisfied, the next non-metadata
+// line belongs to the surrounding patch file rather than the hunk body.
+function isHunkBodyComplete({
+  additionCount,
+  parsedAdditionLines,
+  deletionCount,
+  parsedDeletionLines,
+}: isHunkBodyCompleteProps): boolean {
+  return (
+    parsedAdditionLines >= additionCount && parsedDeletionLines >= deletionCount
+  );
 }
 
 /**

--- a/packages/diffs/test/mocks.ts
+++ b/packages/diffs/test/mocks.ts
@@ -18,6 +18,28 @@ export const diffPatch: string = readFileSync(
   'utf-8'
 );
 
+export const formatPatchWithVersionTrailer = `From 02a2e4e6806f7e8f3adf685fde57cc773196f206 Mon Sep 17 00:00:00 2001
+From: "Patch Fixture" <patch.fixture@example.invalid>
+Date: Tue, 5 May 2026 15:45:50 -0600
+Subject: [PATCH] example patch with version trailer
+
+---
+ file.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/file.txt b/file.txt
+index 626799f..8c1202a 100644
+--- a/file.txt
++++ b/file.txt
+@@ -1,2 +1,3 @@
+ line one
++line two
+ line three
+-- 
+2.52.0
+
+`;
+
 export const mockFiles: Record<string, FileContents> = {
   file1: {
     name: 'file1.ts',

--- a/packages/diffs/test/parsePatchFiles.test.ts
+++ b/packages/diffs/test/parsePatchFiles.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, spyOn, test } from 'bun:test';
 
 import { DiffHunksRenderer } from '../src/renderers/DiffHunksRenderer';
 import { parsePatchFiles } from '../src/utils/parsePatchFiles';
-import { diffPatch, finalBlankLinePatch, malformedPatch } from './mocks';
+import {
+  diffPatch,
+  finalBlankLinePatch,
+  formatPatchWithVersionTrailer,
+  malformedPatch,
+} from './mocks';
 import {
   assertDefined,
   countRenderedLines,
@@ -35,18 +40,40 @@ describe('parsePatchFiles', () => {
         console.log('  * test expected console.error:', args);
       }
     );
-    const result = parsePatchFiles(malformedPatch);
+    try {
+      const result = parsePatchFiles(malformedPatch);
 
-    // Should have logged an error for the invalid line, but should still try
-    // to do its best to parse things out
-    expect(consoleError).toHaveBeenCalled();
-    expect(consoleError.mock.calls[0][0]).toContain('Invalid firstChar');
+      // Should have logged an error for the invalid line, but should still try
+      // to do its best to parse things out
+      expect(consoleError).toHaveBeenCalled();
+      expect(consoleError.mock.calls[0][0]).toContain('Invalid firstChar');
 
-    // The hunk counts should be off by 1 due to the missing line
-    const hunk = result[0].files[0].hunks[0];
-    expect(hunk.deletionCount).toBe(87);
-    expect(hunk.deletionLines).toBe(86);
-    expect(result).toMatchSnapshot('malformed patch');
+      // The hunk counts should be off by 1 due to the missing line
+      const hunk = result[0].files[0].hunks[0];
+      expect(hunk.deletionCount).toBe(87);
+      expect(hunk.deletionLines).toBe(86);
+      expect(result).toMatchSnapshot('malformed patch');
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  test('ignores format-patch version trailers after the final hunk', () => {
+    const consoleError = spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const result = parsePatchFiles(formatPatchWithVersionTrailer);
+      const { valid, errors } = verifyPatchHunkValues(result);
+      if (!valid) {
+        console.error('Hunk line value errors:', errors);
+      }
+
+      expect(consoleError).not.toHaveBeenCalled();
+      expect(valid).toBe(true);
+      expect(result[0].files[0].hunks[0].additionLines).toBe(1);
+      expect(result[0].files[0].hunks[0].deletionLines).toBe(0);
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   test(


### PR DESCRIPTION
Found a bug when supporting tangled.org patch files (they included patch file trailer data that github usually strips out. Anyways we should be able to support it, surprised nobody has run into this bug yet.