### PR TITLE
[diffs] CodeView item metrics validation

### DIFF
--- a/apps/demo/src/codeViewDemo.ts
+++ b/apps/demo/src/codeViewDemo.ts
@@ -101,7 +101,7 @@ export function renderDemoCodeView(
     enableLineSelection: true,
     enableGutterUtility: true,
     stickyHeaders: true,
-    viewerMetrics: { paddingTop: 10, paddingBottom: 24, gap: 12 },
+    layout: { paddingTop: 10, paddingBottom: 24, gap: 12 },
     onGutterUtilityClick(range, context) {
       if (context.item.type !== 'diff') {
         return;

--- a/apps/docs/app/(diffs)/docs/CodeView/constants.ts
+++ b/apps/docs/app/(diffs)/docs/CodeView/constants.ts
@@ -127,7 +127,7 @@ export function ReviewSurface() {
           stickyHeaders: true,
           enableLineSelection: true,
           enableGutterUtility: true,
-          viewerMetrics: { paddingTop: 16, paddingBottom: 24, gap: 12 },
+          layout: { paddingTop: 16, paddingBottom: 16, gap: 12 },
         }}
         selectedLines={selectedLines}
         onSelectedLinesChange={setSelectedLines}
@@ -180,7 +180,7 @@ const viewer = new CodeView({
   stickyHeaders: true,
   enableLineSelection: true,
   enableGutterUtility: true,
-  viewerMetrics: { paddingTop: 16, paddingBottom: 24, gap: 12 },
+  layout: { paddingTop: 16, paddingBottom: 16, gap: 12 },
   onSelectedLinesChange(selection) {
     console.log('selected lines', selection);
   },

--- a/apps/docs/app/(diffs)/docs/CodeView/content.mdx
+++ b/apps/docs/app/(diffs)/docs/CodeView/content.mdx
@@ -37,10 +37,62 @@ yourself.
 - Set `collapsed: true` on an item to mount that file or diff as header-only.
   Collapse state is part of the item snapshot, so publish a new `version` when
   changing it for an existing item id.
-- Viewer-level options such as `viewerMetrics`, `itemMetrics`, `stickyHeaders`,
+- CodeView-level options such as `layout`, `itemMetrics`, `stickyHeaders`,
   `pointerEventsOnScroll`, and `smoothScrollSettings` tune the outer
   orchestrator. Most of the regular `File` / `FileDiff` options are still
   forwarded to each item, but `collapsed` is item-owned in `CodeView`.
+
+### Layout And Item Metrics
+
+`CodeView` has two layout-related option groups. `layout` controls the spacing
+owned by the outer scroll surface:
+
+```ts
+options: {
+  layout: {
+    paddingTop: 16,
+    paddingBottom: 24,
+    gap: 12,
+  }
+}
+```
+
+`itemMetrics` does not change the rendered layout. It only tells `CodeView` what
+heights to expect for each rendered file or diff. Those estimates need to match
+the actual DOM layout or the viewer can scroll to the wrong position, produce
+sticky-header gaps, or render the wrong window of lines.
+
+Only customize `itemMetrics` when you use `unsafeCSS` to change layout-affecting
+styles. Enable the internal development validator while tuning those values:
+
+```ts
+options: {
+  __devOnlyValidateItemHeights: true,
+  itemMetrics: {
+    lineHeight: 22,
+    diffHeaderHeight: 48,
+    hunkSeparatorHeight: 32,
+    hunkLineCount: 1,
+    spacing: 8,
+  },
+}
+```
+
+Any `unsafeCSS` that changes file header height, line height, hunk separator
+height, padding, or vertical spacing must be reflected in `itemMetrics`, and
+`__devOnlyValidateItemHeights` is the fastest way to catch mismatches while
+developing.
+
+`__devOnlyValidateItemHeights` compares each rendered item host's DOM height
+with the item height that `CodeView` reconciled for its active sticky window.
+When the values differ, `CodeView` logs a console error with the item id, item
+type, expected height, actual height, delta, scroll position, and related
+DOM/instance references.
+
+The validator option lives on the top-level `CodeView` options object because it
+is a diagnostic switch for the whole viewer, not one of the layout metrics. It
+only runs when the package is used in development, and is disabled intentionally
+in production builds because it can cause a significant performance hit.
 
 ### Examples
 

--- a/apps/docs/app/(diffs)/docs/ReactAPI/constants.ts
+++ b/apps/docs/app/(diffs)/docs/ReactAPI/constants.ts
@@ -670,7 +670,7 @@ export function ReviewSurface() {
       options={{
         theme: { dark: 'pierre-dark', light: 'pierre-light' },
         stickyHeaders: true,
-        viewerMetrics: { paddingTop: 16, paddingBottom: 24, gap: 12 },
+        layout: { paddingTop: 16, paddingBottom: 16, gap: 12 },
       }}
     />
   );

--- a/apps/docs/app/(diffs)/docs/VanillaAPI/constants.ts
+++ b/apps/docs/app/(diffs)/docs/VanillaAPI/constants.ts
@@ -154,7 +154,7 @@ root.style.overflow = 'auto';
 const viewer = new CodeView({
   theme: { dark: 'pierre-dark', light: 'pierre-light' },
   stickyHeaders: true,
-  viewerMetrics: { paddingTop: 16, paddingBottom: 24, gap: 12 },
+  layout: { paddingTop: 16, paddingBottom: 16, gap: 12 },
 });
 
 viewer.setup(root);

--- a/apps/docs/app/(diffs)/docs/VanillaAPI/content.mdx
+++ b/apps/docs/app/(diffs)/docs/VanillaAPI/content.mdx
@@ -39,10 +39,10 @@ Both `FileDiff` and `File` accept an options object in their constructor. The
 uses `LineAnnotation` instead of `DiffLineAnnotation` (no `side` property).
 
 `CodeView` forwards many of those same options to each rendered item, while
-adding viewer-specific controls like `viewerMetrics`, `itemMetrics`,
-`stickyHeaders`, `pointerEventsOnScroll`, and `smoothScrollSettings`. Its class
-instance also exposes item-level methods such as `addItems`, `getItem`, and
-`updateItem`. See [CodeView](#code-view) for the dedicated guide.
+adding CodeView-specific controls like `layout`, `itemMetrics`, `stickyHeaders`,
+`pointerEventsOnScroll`, and `smoothScrollSettings`. Its class instance also
+exposes item-level methods such as `addItems`, `getItem`, and `updateItem`. See
+[CodeView](#code-view) for the dedicated guide.
 
 Header customization and collapsing behavior:
 

--- a/apps/docs/app/(diffshub)/(view)/_components/CodeViewWrapper.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/CodeViewWrapper.tsx
@@ -20,8 +20,8 @@ import { memo, type RefObject, useMemo, useRef, useState } from 'react';
 
 import type { AvatarName } from './annotation-shared';
 import {
+  BASE_CODE_VIEW_LAYOUT,
   CODE_VIEW_CUSTOM_CSS,
-  CODE_VIEW_PADDING_BLOCK,
   getCodeViewMarginOffset,
   getCodeViewPaddingTop,
 } from './constants';
@@ -39,11 +39,6 @@ import {
   isSavedAnnotation,
 } from './utils';
 import { cn } from '@/lib/utils';
-
-const BASE_VIEWER_METRICS = {
-  gap: 8,
-  paddingBottom: CODE_VIEW_PADDING_BLOCK,
-};
 
 function getNextItemVersion(item: CodeViewItem<CommentMetadata>): number {
   return typeof item.version === 'number' ? item.version + 1 : 1;
@@ -362,9 +357,9 @@ export const CodeViewWrapper = memo(function CodeViewWrapper({
     }
   });
 
-  const viewerMetrics = useMemo(
+  const layout = useMemo(
     () => ({
-      ...BASE_VIEWER_METRICS,
+      ...BASE_CODE_VIEW_LAYOUT,
       paddingTop: getCodeViewPaddingTop(isMobile),
     }),
     [isMobile]
@@ -431,7 +426,9 @@ export const CodeViewWrapper = memo(function CodeViewWrapper({
   const options: CodeViewOptions<CommentMetadata> = useMemo(
     () =>
       ({
-        viewerMetrics,
+        // Use this to validate itemMetrics when changing layout with unsafeCSS.
+        // __devOnlyValidateItemHeights: true,
+        layout,
         theme: DEFAULT_THEMES,
         diffStyle,
         diffIndicators,
@@ -463,7 +460,7 @@ export const CodeViewWrapper = memo(function CodeViewWrapper({
       lineNumbers,
       overflow,
       showBackgrounds,
-      viewerMetrics,
+      layout,
     ]
   );
   return (

--- a/apps/docs/app/(diffshub)/(view)/_components/constants.ts
+++ b/apps/docs/app/(diffshub)/(view)/_components/constants.ts
@@ -1,3 +1,4 @@
+import type { CodeViewLayout } from '@pierre/diffs';
 import type { FileTreeOptions } from '@pierre/trees';
 
 export type ViewerLoadState =
@@ -10,6 +11,11 @@ export type ViewerLoadState =
 export const CODE_VIEW_MARGIN_OFFSET = 12;
 
 export const CODE_VIEW_PADDING_BLOCK = 13;
+
+export const BASE_CODE_VIEW_LAYOUT: Omit<CodeViewLayout, 'paddingTop'> = {
+  gap: 8,
+  paddingBottom: CODE_VIEW_PADDING_BLOCK,
+};
 
 export function getCodeViewMarginOffset(isMobile: boolean): number {
   return isMobile ? 0 : CODE_VIEW_MARGIN_OFFSET;

--- a/apps/docs/app/gh/CodeViewWrapper.tsx
+++ b/apps/docs/app/gh/CodeViewWrapper.tsx
@@ -58,7 +58,7 @@ const unsafeCSS = `[data-diffs-header] {
   }
 }`;
 
-const VIEWER_METRICS = { gap: 12, paddingBottom: 20, paddingTop: 20 };
+const CODE_VIEW_LAYOUT = { gap: 12, paddingBottom: 20, paddingTop: 20 };
 
 interface CodeViewWrapperProps {
   className?: string;
@@ -368,7 +368,7 @@ export const CodeViewWrapper = memo(function CodeViewWrapper({
   const options: CodeViewOptions<CommentMetadata> = useMemo(
     () =>
       ({
-        viewerMetrics: VIEWER_METRICS,
+        layout: CODE_VIEW_LAYOUT,
         theme: DEFAULT_THEMES,
         diffStyle,
         overflow,

--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -1,8 +1,9 @@
 import {
   DEFAULT_CODE_VIEW_FILE_METRICS,
-  DEFAULT_CODE_VIEW_METRICS,
+  DEFAULT_CODE_VIEW_LAYOUT,
   DEFAULT_SMOOTH_SCROLL_SETTINGS,
   DEFAULT_THEMES,
+  DIFFS_DEVELOPMENT_BUILD,
   DIFFS_TAG_NAME,
 } from '../constants';
 import type { SelectionWriteOptions } from '../managers/InteractionManager';
@@ -16,8 +17,8 @@ import type {
   CodeViewItem,
   CodeViewItemScrollTarget,
   CodeViewItemVersion,
+  CodeViewLayout,
   CodeViewLineScrollTarget,
-  CodeViewMetrics,
   CodeViewPositionScrollTarget,
   CodeViewRangeScrollTarget,
   CodeViewScrollBehavior,
@@ -369,7 +370,12 @@ export interface CodeViewOptions<LAnnotation>
   stickyHeaders?: boolean;
   controlledSelection?: boolean;
   onSelectedLinesChange?(selection: CodeViewLineSelection | null): void;
-  viewerMetrics?: CodeViewMetrics;
+  layout?: CodeViewLayout;
+
+  /** Internal dev-only check to ensure your `itemMetrics` are correct.  Its
+   * automatically disabled in a production build because it will hurt
+   * performance fairly significantly */
+  __devOnlyValidateItemHeights?: boolean;
 }
 
 const DEFAULT_POINTER_EVENTS_RESTORE_DELAY_MS = 120;
@@ -504,8 +510,8 @@ export class CodeView<LAnnotation = undefined> {
     this.stickyContainer.style.flexDirection = 'column';
   }
 
-  private getViewerMetrics(): CodeViewMetrics {
-    return this.options.viewerMetrics ?? DEFAULT_CODE_VIEW_METRICS;
+  private getLayout(): CodeViewLayout {
+    return this.options.layout ?? DEFAULT_CODE_VIEW_LAYOUT;
   }
 
   private getItemMetrics(): VirtualFileMetrics {
@@ -518,6 +524,53 @@ export class CodeView<LAnnotation = undefined> {
 
   private shouldDisablePointerEvents(): boolean {
     return this.options.pointerEventsOnScroll !== true;
+  }
+
+  private shouldValidateItemHeights(): boolean {
+    return (
+      DIFFS_DEVELOPMENT_BUILD &&
+      this.options.__devOnlyValidateItemHeights === true
+    );
+  }
+
+  private validateRenderedItemHeight(
+    item: CodeViewContextItem<LAnnotation>
+  ): void {
+    if (!this.shouldValidateItemHeights() || item.element == null) {
+      return;
+    }
+
+    const stickySpecs = item.instance.getAdvancedStickySpecs();
+    if (stickySpecs == null) {
+      return;
+    }
+
+    const expectedHeight = stickySpecs.height;
+    const actualHeight = item.element.getBoundingClientRect().height;
+
+    if (expectedHeight === actualHeight) {
+      return;
+    }
+
+    console.error(
+      'CodeView: reconciled item height does not match DOM height',
+      {
+        id: item.item.id,
+        type: item.type,
+        index: item.index,
+        version: item.version,
+        expectedHeight,
+        actualHeight,
+        delta: actualHeight - expectedHeight,
+        stickyTopOffset: stickySpecs.topOffset,
+        virtualizedHeight: item.instance.getVirtualizedHeight(),
+        top: item.top,
+        scrollTop: this.getScrollTop(),
+        windowSpecs: { ...this.windowSpecs },
+        element: item.element,
+        instance: item.instance,
+      }
+    );
   }
 
   private clearPointerEventsTimer(): void {
@@ -552,8 +605,8 @@ export class CodeView<LAnnotation = undefined> {
     this.pointerEventsDisabled = false;
   };
 
-  private syncViewerMetrics(): void {
-    const { gap, paddingBottom, paddingTop } = this.getViewerMetrics();
+  private syncLayout(): void {
+    const { gap, paddingBottom, paddingTop } = this.getLayout();
     this.stickyContainer.style.gap = `${gap}px`;
     this.container?.style.setProperty('margin-top', `${paddingTop}px`);
     this.container?.style.setProperty('margin-bottom', `${paddingBottom}px`);
@@ -569,7 +622,7 @@ export class CodeView<LAnnotation = undefined> {
     // NOTE(amadeus): We can't put `size` in here or it breaks
     // Firefox's sticky headers
     this.container.style.contain = 'layout style';
-    this.syncViewerMetrics();
+    this.syncLayout();
     this.container.appendChild(this.stickyOffset);
     this.container.appendChild(this.stickyContainer);
     this.root.appendChild(this.container);
@@ -820,9 +873,8 @@ export class CodeView<LAnnotation = undefined> {
       return;
     }
 
-    const viewerMetrics = this.getViewerMetrics();
-    let nextTop =
-      this.items.length === 0 ? 0 : this.scrollHeight + viewerMetrics.gap;
+    const layout = this.getLayout();
+    let nextTop = this.items.length === 0 ? 0 : this.scrollHeight + layout.gap;
     const appendedTop = nextTop;
     for (let index = 0; index < inputs.length; index++) {
       const input = inputs[index];
@@ -838,10 +890,10 @@ export class CodeView<LAnnotation = undefined> {
       this.idToItem.set(item.item.id, item);
       this.instanceToItem.set(item.instance, item);
       item.height = prepareItemInstance(item);
-      nextTop += item.height + viewerMetrics.gap;
+      nextTop += item.height + layout.gap;
     }
 
-    this.scrollHeight = nextTop - viewerMetrics.gap;
+    this.scrollHeight = nextTop - layout.gap;
     this.scrollDirty = true;
     if (render) {
       if (this.canSkipRenderForAppend(appendedTop)) {
@@ -869,7 +921,7 @@ export class CodeView<LAnnotation = undefined> {
     }
 
     this.capturePendingLayoutAnchor();
-    const previousViewerMetrics = this.getViewerMetrics();
+    const previousLayout = this.getLayout();
     const previousItemMetrics = this.getItemMetrics();
 
     // NOTE(amadeus): This is also something that's probably ridiculously
@@ -881,8 +933,8 @@ export class CodeView<LAnnotation = undefined> {
       previousItemMetrics,
       nextItemMetrics
     );
-    if (!areObjectsEqual(previousViewerMetrics, this.getViewerMetrics())) {
-      this.syncViewerMetrics();
+    if (!areObjectsEqual(previousLayout, this.getLayout())) {
+      this.syncLayout();
     }
     for (let index = 0; index < this.items.length; index++) {
       const item = this.items[index];
@@ -1040,7 +1092,7 @@ export class CodeView<LAnnotation = undefined> {
     if (item == null) {
       return undefined;
     }
-    return item.top + this.getViewerMetrics().paddingTop;
+    return item.top + this.getLayout().paddingTop;
   }
 
   private createItem(
@@ -1470,7 +1522,7 @@ export class CodeView<LAnnotation = undefined> {
   }
 
   private getMaxScrollTopForHeight(scrollHeight: number): number {
-    const { paddingBottom, paddingTop } = this.getViewerMetrics();
+    const { paddingBottom, paddingTop } = this.getLayout();
     return Math.max(
       paddingTop + scrollHeight + paddingBottom - this.getHeight(),
       0
@@ -1667,7 +1719,7 @@ export class CodeView<LAnnotation = undefined> {
     // Determine a stable scrollTo target for `nearest` alignment. This is to
     // ensure that we don't experience any scroll bouncing
     const offset = target.offset ?? 0;
-    const targetTop = this.getViewerMetrics().paddingTop + rect.top;
+    const targetTop = this.getLayout().paddingTop + rect.top;
     const targetBottom = targetTop + rect.height;
     const currentTop = this.getScrollTop();
     const visibleTop =
@@ -1786,7 +1838,7 @@ export class CodeView<LAnnotation = undefined> {
     offset = 0,
     stickyOffset = 0
   ): number {
-    targetTop += this.getViewerMetrics().paddingTop;
+    targetTop += this.getLayout().paddingTop;
     const viewportHeight = this.getHeight();
     // If the item + offset is bigger than the viewport, we'll fall back to
     // 'start'
@@ -2309,10 +2361,11 @@ export class CodeView<LAnnotation = undefined> {
           heightChanged = true;
           item.height = item.instance.getVirtualizedHeight();
         }
+        this.validateRenderedItemHeight(item);
       }
       currentTop += item.instance.getVirtualizedHeight();
       if (index < this.items.length - 1) {
-        currentTop += this.getViewerMetrics().gap;
+        currentTop += this.getLayout().gap;
       }
     }
 
@@ -2455,7 +2508,7 @@ export class CodeView<LAnnotation = undefined> {
         continue;
       }
 
-      const absoluteItemTop = this.getViewerMetrics().paddingTop + item.top;
+      const absoluteItemTop = this.getLayout().paddingTop + item.top;
       const absoluteItemBottom = absoluteItemTop + item.height;
       // Skip items entirely above the viewport since we can't see it
       if (absoluteItemBottom <= scrollTop) {
@@ -2510,7 +2563,7 @@ export class CodeView<LAnnotation = undefined> {
       return undefined;
     }
 
-    const { paddingTop } = this.getViewerMetrics();
+    const { paddingTop } = this.getLayout();
     if (anchor.type === 'item') {
       const absoluteItemTop = paddingTop + item.top;
       return this.clampScrollTop(absoluteItemTop - anchor.viewportOffset);
@@ -2709,14 +2762,14 @@ export class CodeView<LAnnotation = undefined> {
       return;
     }
 
-    const viewerMetrics = this.getViewerMetrics();
+    const layout = this.getLayout();
     let runningTop = 0;
     if (startIndex > 0) {
       const previousItem = this.items[startIndex - 1];
       if (previousItem == null) {
         throw new Error('CodeView.recomputeLayout: invalid dirty index');
       }
-      runningTop = previousItem.top + previousItem.height + viewerMetrics.gap;
+      runningTop = previousItem.top + previousItem.height + layout.gap;
     }
 
     for (let index = startIndex; index < this.items.length; index++) {
@@ -2732,7 +2785,7 @@ export class CodeView<LAnnotation = undefined> {
       }
       runningTop += item.height;
       if (index < this.items.length - 1) {
-        runningTop += viewerMetrics.gap;
+        runningTop += layout.gap;
       }
     }
 
@@ -2757,7 +2810,7 @@ export class CodeView<LAnnotation = undefined> {
   // between.  We do this by adding the the gap and header height above and
   // below the viewport
   private getFitPerfectlyOverscroll() {
-    return this.getViewerMetrics().gap + this.getItemMetrics().diffHeaderHeight;
+    return this.getLayout().gap + this.getItemMetrics().diffHeaderHeight;
   }
 }
 

--- a/packages/diffs/src/constants.ts
+++ b/packages/diffs/src/constants.ts
@@ -1,5 +1,5 @@
 import type {
-  CodeViewMetrics,
+  CodeViewLayout,
   HunkExpansionRegion,
   RenderRange,
   SmoothScrollSettings,
@@ -8,6 +8,16 @@ import type {
 } from './types';
 
 export const DIFFS_TAG_NAME = 'diffs-container' as const;
+
+// Keep this as a NODE_ENV read so app builds can hard-disable development-only
+// checks unless they are explicitly built for development.
+export const DIFFS_DEVELOPMENT_BUILD: boolean = (() => {
+  try {
+    return process.env.NODE_ENV === 'development';
+  } catch {
+    return false;
+  }
+})();
 
 // Misc patch/content parsing regexes
 export const COMMIT_METADATA_SPLIT: RegExp = /(?=^From [a-f0-9]+ .+$)/m;
@@ -61,7 +71,7 @@ export const DEFAULT_CODE_VIEW_FILE_METRICS: VirtualFileMetrics = {
   hunkLineCount: 1,
 };
 
-export const DEFAULT_CODE_VIEW_METRICS: CodeViewMetrics = {
+export const DEFAULT_CODE_VIEW_LAYOUT: CodeViewLayout = {
   paddingTop: 8,
   paddingBottom: 8,
   gap: 8,

--- a/packages/diffs/src/types.ts
+++ b/packages/diffs/src/types.ts
@@ -788,12 +788,12 @@ export interface VirtualFileMetrics {
   paddingBottom?: number;
 }
 
-export interface CodeViewMetrics {
-  /** Top padding applied to the viewer's sticky container offset. */
+export interface CodeViewLayout {
+  /** Top padding applied to the CodeView sticky container offset. */
   paddingTop: number;
-  /** Bottom padding added after the final rendered item in the viewer. */
+  /** Bottom padding added after the final rendered item in CodeView. */
   paddingBottom: number;
-  /** Vertical gap between virtualized items in the viewer. */
+  /** Vertical gap between virtualized CodeView items. */
   gap: number;
 }
 

--- a/packages/diffs/test/CodeView.rangeScroll.test.ts
+++ b/packages/diffs/test/CodeView.rangeScroll.test.ts
@@ -4,7 +4,7 @@ import { JSDOM } from 'jsdom';
 import { CodeView } from '../src/components/CodeView';
 import {
   DEFAULT_CODE_VIEW_FILE_METRICS,
-  DEFAULT_CODE_VIEW_METRICS,
+  DEFAULT_CODE_VIEW_LAYOUT,
 } from '../src/constants';
 import type { CodeViewItem, FileContents } from '../src/types';
 import { parseDiffFromFile } from '../src/utils/parseDiffFromFile';
@@ -181,7 +181,7 @@ function getFileLineTop(lineNumber: number): number {
 }
 
 function getViewportTopForLocalTop(localTop: number): number {
-  return DEFAULT_CODE_VIEW_METRICS.paddingTop + localTop;
+  return DEFAULT_CODE_VIEW_LAYOUT.paddingTop + localTop;
 }
 
 describe('CodeView range scrolling', () => {

--- a/packages/diffs/test/CodeView.scrollAnchoring.test.ts
+++ b/packages/diffs/test/CodeView.scrollAnchoring.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { JSDOM } from 'jsdom';
 
 import { CodeView } from '../src/components/CodeView';
-import { DEFAULT_CODE_VIEW_METRICS } from '../src/constants';
+import { DEFAULT_CODE_VIEW_LAYOUT } from '../src/constants';
 import type { CodeViewItem, FileContents } from '../src/types';
 import { parseDiffFromFile } from '../src/utils/parseDiffFromFile';
 
@@ -207,7 +207,7 @@ describe('CodeView scroll anchoring', () => {
       await renderItems(viewer, items);
 
       const splitAnchorTop =
-        DEFAULT_CODE_VIEW_METRICS.paddingTop +
+        DEFAULT_CODE_VIEW_LAYOUT.paddingTop +
         (viewer.getTopForItem(anchorItem.id) ?? 0);
       const splitMaxScrollTop = getRootMaxScrollTop(root);
       expect(splitMaxScrollTop).toBeGreaterThan(splitAnchorTop);
@@ -220,7 +220,7 @@ describe('CodeView scroll anchoring', () => {
       viewer.render(true);
 
       const unifiedAnchorTop =
-        DEFAULT_CODE_VIEW_METRICS.paddingTop +
+        DEFAULT_CODE_VIEW_LAYOUT.paddingTop +
         (viewer.getTopForItem(anchorItem.id) ?? 0);
       expect(unifiedAnchorTop).toBeGreaterThan(splitMaxScrollTop);
       expect(root.scrollTop).toBe(unifiedAnchorTop);
@@ -234,8 +234,8 @@ describe('CodeView scroll anchoring', () => {
   test('rebases the DOM scroll position while preserving logical scroll progress', async () => {
     const { cleanup } = installDom();
     const viewer = new CodeView({
-      viewerMetrics: {
-        ...DEFAULT_CODE_VIEW_METRICS,
+      layout: {
+        ...DEFAULT_CODE_VIEW_LAYOUT,
         gap: 1_000_000,
       },
     });
@@ -273,7 +273,7 @@ describe('CodeView scroll anchoring', () => {
       viewer.render(true);
 
       const finalFileTop =
-        DEFAULT_CODE_VIEW_METRICS.paddingTop +
+        DEFAULT_CODE_VIEW_LAYOUT.paddingTop +
         (viewer.getTopForItem('file:39') ?? 0);
       expect(viewer.getScrollTop()).toBeGreaterThan(finalFileTop - ROOT_HEIGHT);
       expect(viewer.getScrollTop()).toBeLessThanOrEqual(finalFileTop);
@@ -291,8 +291,8 @@ describe('CodeView scroll anchoring', () => {
   test('restores the paged scroll height after clearing and reusing the viewer', async () => {
     const { cleanup } = installDom();
     const viewer = new CodeView({
-      viewerMetrics: {
-        ...DEFAULT_CODE_VIEW_METRICS,
+      layout: {
+        ...DEFAULT_CODE_VIEW_LAYOUT,
         gap: 1_000_000,
       },
     });
@@ -330,8 +330,8 @@ describe('CodeView scroll anchoring', () => {
   test('moves the physical spacer before applying a programmatic rebase jump', async () => {
     const { cleanup } = installDom();
     const viewer = new CodeView({
-      viewerMetrics: {
-        ...DEFAULT_CODE_VIEW_METRICS,
+      layout: {
+        ...DEFAULT_CODE_VIEW_LAYOUT,
         gap: 1_000_000,
       },
     });


### PR DESCRIPTION
Since valid item metrics are so important, I've added a new prop to help validate any use of custom CSS, a prop that runs only in dev mode the validate this logic.

Additionally this got me thinking that `viewerMetrics` was not a good name for this prop as it really actually controlled layout things (like paddings and gap) and to be named similarly to itemMetrics was confusing (since itemMetrics should ONLY be used with unsafeCSS and doesn't actually control the values specfied).

Also added and updated docs as necessary.