### PR TITLE
Add exact-path and custom-color icon remaps to Trees

### DIFF
--- a/apps/docs/app/(trees)/docs/Guides/CustomizeIcons/content.mdx
+++ b/apps/docs/app/(trees)/docs/Guides/CustomizeIcons/content.mdx
@@ -33,6 +33,7 @@ practical remap surfaces are:
 
 - `remap` for built-in slots such as the generic file icon, chevron, dot, or
   lock
+- `byFilePath` for exact relative paths such as `docs/README.md`
 - `byFileName` for exact basenames such as `package.json`
 - `byFileExtension` for suffixes such as `ts` or `spec.ts`
 - `byFileNameContains` for broader patterns such as `dockerfile`
@@ -46,11 +47,12 @@ That keeps the built-in mapping for everything you did not customize.
 File-specific rules beat broader ones. In practice, Trees resolves icons in this
 order:
 
-1. exact basename matches
-2. basename-contains matches
-3. extension matches, with more specific suffixes winning
-4. the chosen built-in set
-5. the generic file-slot remap or fallback
+1. exact relative path matches
+2. exact basename matches
+3. basename-contains matches
+4. extension matches, with more specific suffixes winning
+5. the chosen built-in set
+6. the generic file-slot remap or fallback
 
 If you want the full lookup contract, read [Icons](#icons-resolution-order).
 

--- a/apps/docs/app/(trees)/docs/Reference/Icons/content.mdx
+++ b/apps/docs/app/(trees)/docs/Reference/Icons/content.mdx
@@ -39,6 +39,7 @@ Built-in slot remapping:
 
 File-specific remapping:
 
+- `byFilePath` for exact relative path matches such as `docs/README.md`
 - `byFileName` for exact basename matches such as `package.json`
 - `byFileNameContains` for basename substring rules such as `dockerfile`
 - `byFileExtension` for extension rules without a leading dot, including
@@ -48,11 +49,12 @@ File-specific remapping:
 
 File icon lookup resolves in this order:
 
-1. exact basename match from `byFileName`
-2. basename-contains match from `byFileNameContains`
-3. extension match from `byFileExtension`, with more specific suffixes winning
-4. built-in set mapping
-5. generic file-slot remap or fallback
+1. exact relative path match from `byFilePath`
+2. exact basename match from `byFileName`
+3. basename-contains match from `byFileNameContains`
+4. extension match from `byFileExtension`, with more specific suffixes winning
+5. built-in set mapping
+6. generic file-slot remap or fallback
 
 That means `spec.ts` should beat `ts` when both rules exist.
 
@@ -61,7 +63,7 @@ That means `spec.ts` should beat `ts` when both rules exist.
 `RemappedIcon` supports two forms:
 
 - a string symbol id
-- an object with `name`, plus optional `width`, `height`, and `viewBox`
+- an object with `name`, plus optional `color`, `width`, `height`, and `viewBox`
 
 Use the object form when the replacement symbol needs non-default geometry
 metadata.

--- a/packages/trees/src/components/Icon.tsx
+++ b/packages/trees/src/components/Icon.tsx
@@ -13,6 +13,7 @@ export function Icon({
   name,
   remappedFrom,
   token,
+  color: propColor,
   width: propWidth,
   height: propHeight,
   viewBox: propViewBox,
@@ -22,6 +23,7 @@ export function Icon({
   name: string;
   remappedFrom?: string;
   token?: string;
+  color?: string;
   width?: number;
   height?: number;
   viewBox?: string;
@@ -55,6 +57,7 @@ export function Icon({
       data-icon-token={token}
       data-align-capitals={alignCapitals}
       {...a11yProps}
+      style={propColor != null ? { color: propColor } : undefined}
       viewBox={viewBox}
       width={width}
       height={height}

--- a/packages/trees/src/iconConfig.ts
+++ b/packages/trees/src/iconConfig.ts
@@ -2,6 +2,7 @@ export type RemappedIcon =
   | string
   | {
       name: string;
+      color?: string;
       width?: number;
       height?: number;
       viewBox?: string;
@@ -18,6 +19,8 @@ export interface FileTreeIconConfig {
   spriteSheet?: string;
   /** Remap built-in tree icon slots (file, chevron, dot, lock). */
   remap?: Record<string, RemappedIcon>;
+  /** Remap file icons by exact relative path; directory paths should end in `/`. */
+  byFilePath?: Record<string, RemappedIcon>;
   /** Remap file icons by exact basename (e.g. "package.json", ".gitignore"). */
   byFileName?: Record<string, RemappedIcon>;
   /** Remap file icons by extension without a leading dot (e.g. "ts", "spec.ts"). */
@@ -37,6 +40,7 @@ function hasCustomIconOverrides(icons: FileTreeIconConfig): boolean {
   return (
     icons.spriteSheet != null ||
     icons.remap != null ||
+    icons.byFilePath != null ||
     icons.byFileName != null ||
     icons.byFileExtension != null ||
     icons.byFileNameContains != null

--- a/packages/trees/src/render/iconResolver.ts
+++ b/packages/trees/src/render/iconResolver.ts
@@ -10,6 +10,7 @@ import {
 import type { SVGSpriteNames } from '../sprite';
 
 export interface FileTreeResolvedIcon {
+  color?: string;
   height?: number;
   name: string;
   remappedFrom?: string;
@@ -56,6 +57,13 @@ export function createFileTreeIconResolver(icons?: FileTreeIcons): {
 } {
   const normalizedIcons = normalizeFileTreeIcons(icons);
   const iconRemap = normalizedIcons.remap;
+  const iconByFilePath = new Map<string, RemappedIcon>();
+  for (const [filePath, icon] of Object.entries(
+    normalizedIcons.byFilePath ?? {}
+  )) {
+    iconByFilePath.set(filePath, icon);
+  }
+
   const iconByFileName = new Map<string, RemappedIcon>();
   for (const [fileName, icon] of Object.entries(
     normalizedIcons.byFileName ?? {}
@@ -82,6 +90,11 @@ export function createFileTreeIconResolver(icons?: FileTreeIcons): {
     filePath?: string
   ): FileTreeResolvedIcon => {
     if (name === 'file-tree-icon-file' && filePath != null) {
+      const filePathEntry = iconByFilePath.get(filePath);
+      if (filePathEntry != null) {
+        return remapEntryToIcon(filePathEntry, name);
+      }
+
       const fileName = getBaseFileName(filePath);
       const lowerFileName = fileName.toLowerCase();
       const fileNameEntry = iconByFileName.get(lowerFileName);

--- a/packages/trees/test/file-tree-icon-config.test.ts
+++ b/packages/trees/test/file-tree-icon-config.test.ts
@@ -73,6 +73,94 @@ describe('file-tree icon config', () => {
     }
   });
 
+  test('prefers exact file-path icon remaps before basename rules', async () => {
+    const { cleanup, dom } = installDom();
+    try {
+      const { FileTree } = await import('../src/render/FileTree');
+      const mount = dom.window.document.createElement('div');
+      dom.window.document.body.appendChild(mount);
+
+      const fileTree = new FileTree({
+        flattenEmptyDirectories: true,
+        icons: {
+          byFilePath: {
+            'docs/README.md': 'pst-test-doc-readme',
+          },
+          byFileName: {
+            'readme.md': 'pst-test-readme',
+          },
+          spriteSheet:
+            '<svg data-icon-sprite aria-hidden="true" width="0" height="0"><symbol id="pst-test-readme" viewBox="0 0 16 16"><circle cx="8" cy="8" r="7" fill="currentColor" /></symbol><symbol id="pst-test-doc-readme" viewBox="0 0 16 16"><rect x="2" y="2" width="12" height="12" fill="currentColor" /></symbol></svg>',
+        },
+        initialExpansion: 'open',
+        paths: ['README.md', 'docs/README.md', 'src/index.ts'],
+        initialVisibleRowCount: 120 / 30,
+      });
+
+      fileTree.render({ containerWrapper: mount });
+      await flushDom();
+
+      const shadowRoot = fileTree.getFileTreeContainer()?.shadowRoot;
+      const rootReadmeButton = getItemButton(shadowRoot, dom, 'README.md');
+      const nestedReadmeButton = getItemButton(
+        shadowRoot,
+        dom,
+        'docs/README.md'
+      );
+
+      expect(rootReadmeButton.querySelector('use')?.getAttribute('href')).toBe(
+        '#pst-test-readme'
+      );
+      expect(
+        nestedReadmeButton.querySelector('use')?.getAttribute('href')
+      ).toBe('#pst-test-doc-readme');
+
+      fileTree.cleanUp();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('applies explicit colors on remapped icons', async () => {
+    const { cleanup, dom } = installDom();
+    try {
+      const { FileTree } = await import('../src/render/FileTree');
+      const mount = dom.window.document.createElement('div');
+      dom.window.document.body.appendChild(mount);
+
+      const fileTree = new FileTree({
+        flattenEmptyDirectories: true,
+        icons: {
+          byFileName: {
+            'readme.md': {
+              name: 'pst-test-readme',
+              color: 'var(--brand-icon-color)',
+            },
+          },
+          spriteSheet:
+            '<svg data-icon-sprite aria-hidden="true" width="0" height="0"><symbol id="pst-test-readme" viewBox="0 0 16 16"><circle cx="8" cy="8" r="7" fill="currentColor" /></symbol></svg>',
+        },
+        initialExpansion: 'open',
+        paths: ['README.md', 'src/index.ts'],
+        initialVisibleRowCount: 120 / 30,
+      });
+
+      fileTree.render({ containerWrapper: mount });
+      await flushDom();
+
+      const shadowRoot = fileTree.getFileTreeContainer()?.shadowRoot;
+      const readmeButton = getItemButton(shadowRoot, dom, 'README.md');
+      const icon = readmeButton.querySelector('svg');
+
+      expect(icon?.getAttribute('style')).toContain(
+        'color: var(--brand-icon-color);'
+      );
+      fileTree.cleanUp();
+    } finally {
+      cleanup();
+    }
+  });
+
   test('falls back to built-in file icon tiers when overrides are absent', async () => {
     const { cleanup, dom } = installDom();
     try {


### PR DESCRIPTION
## Description

This PR adds two small extensions to the Trees icon remapping system:

- exact file-path icon remaps via `icons.byFilePath`
- explicit color overrides for remapped icons via `RemappedIcon.color`

The icon resolver now checks exact relative paths before basename, basename-contains, extension, and built-in fallbacks. The icon component also forwards an explicit color override to the rendered SVG.

This PR also adds tests for both behaviors and updates the icon documentation.

## Motivation & Context

The current Trees icon customization API does not cover two cases I need:

- remapping icons by exact relative file path
- assigning an explicit color to a remapped custom icon

The existing configuration already supports remaps by basename, basename substring, and extension, but those surfaces are not precise enough when the same filename appears in multiple locations and only one path should render differently. Likewise, custom remaps can replace the icon symbol, but they cannot currently carry their own color override.

This PR adds the smallest source change needed to cover those gaps while preserving the existing icon resolution model and fallback behavior for current consumers.

## Type of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality). You must have
      first discussed with the dev team and they should be aware that this PR is
      being opened
- [ ] Breaking change (fix or feature that would change existing functionality).
      You must have first discussed with the dev team and they should be aware
      that this PR is being opened
- [x] Documentation update

## Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/pierrecomputer/pierre/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project (`bun run lint`)
- [x] My code is formatted properly (`bun run format`)
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have added tests to cover my changes (if applicable)
- [ ] All new and existing tests pass (`bun run diffs:test`)

Repository-wide lint currently reports existing baseline issues outside the scope of this change.

## How was AI used in generating this PR

AI assistance was used to help port the change into the upstream source, update tests, and update documentation. I reviewed the resulting changes and validation steps manually before opening this PR.

## Related issues

None.
