### PR TITLE
[diffshub] Even Moar Polish

### DIFF
--- a/apps/docs/app/(diffshub)/(view)/_components/CodeViewCommentsList.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/CodeViewCommentsList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { AnnotationSide } from '@pierre/diffs';
-import { IconConvoFill } from '@pierre/icons';
+import { IconConvoFill, IconPlus } from '@pierre/icons';
 import { memo } from 'react';
 
 import { CommentAuthorAvatar } from './annotation-shared';
@@ -38,8 +38,11 @@ export const CodeViewCommentsList = memo(function CodeViewCommentsList({
         <div className="flex flex-col">
           <strong className="font-medium">No comments yet</strong>
           <p>
-            Hover over a line and click the blue + button to add fake code
-            comments.
+            Hover over a line and click the{' '}
+            <span className="light:text-white light:bg-[rgb(0,159,255)] inline-flex h-[20px] w-[20px] items-center justify-center rounded-[4px] align-top dark:bg-[rgb(0,159,255)] dark:text-black">
+              <IconPlus />
+            </span>{' '}
+            button to add fake code comments.
           </p>
         </div>
       </div>

--- a/apps/docs/app/(diffshub)/(view)/_components/CodeViewCommentsList.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/CodeViewCommentsList.tsx
@@ -12,7 +12,6 @@ import type {
 import { cn } from '@/lib/utils';
 
 interface CodeViewCommentsListProps {
-  className?: string;
   commentSections: readonly CodeViewSavedCommentItem[];
   onSelectComment?(comment: CodeViewSavedCommentEntry): void;
 }
@@ -29,23 +28,17 @@ function getCommentLineClassName(side: AnnotationSide): string {
 }
 
 export const CodeViewCommentsList = memo(function CodeViewCommentsList({
-  className,
   commentSections,
   onSelectComment,
 }: CodeViewCommentsListProps) {
   if (commentSections.length === 0) {
     return (
-      <div
-        className={cn(
-          'text-muted-foreground flex flex-col gap-2 h-full min-h-0 items-center justify-center px-7 text-center text-sm',
-          className
-        )}
-      >
+      <div className="text-muted-foreground flex h-full min-h-0 flex-col items-center justify-center gap-2 px-7 text-center text-sm">
         <IconConvoFill size={24} className="mb-2" />
         <div className="flex flex-col">
           <strong className="font-medium">No comments yet</strong>
           <p>
-            Hover over a line and click the blue button to add fake code
+            Hover over a line and click the blue + button to add fake code
             comments.
           </p>
         </div>
@@ -56,8 +49,8 @@ export const CodeViewCommentsList = memo(function CodeViewCommentsList({
   return (
     <div
       className={cn(
-        'h-full min-h-0 overflow-auto overscroll-contain',
-        className
+        'cv-mini-scrollbar',
+        'h-full min-h-0 overflow-auto overscroll-contain pl-3 pb-3 pr-[max(0px,calc(12px-var(--cv-mini-gutter-vertical)))]'
       )}
     >
       {commentSections.map((section) => (
@@ -65,7 +58,7 @@ export const CodeViewCommentsList = memo(function CodeViewCommentsList({
           <div className="text-muted-foreground p-3 pb-2 text-sm font-medium break-all">
             {section.path}
           </div>
-          <div className="mx-3 rounded-lg border border-[rgb(0_0_0_/_0.1)] dark:border-[rgb(255_255_255_/_0.15)]">
+          <div className="rounded-lg border border-[rgb(0_0_0_/_0.1)] dark:border-[rgb(255_255_255_/_0.15)]">
             {section.comments.map((comment) => (
               <button
                 key={comment.key}

--- a/apps/docs/app/(diffshub)/(view)/_components/CodeViewWrapper.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/CodeViewWrapper.tsx
@@ -469,7 +469,7 @@ export const CodeViewWrapper = memo(function CodeViewWrapper({
       containerRef={scrollRef}
       initialItems={initialItems}
       className={cn(
-        'cv-scrollbar relative h-full min-h-0 min-w-0 flex-1 overflow-auto overscroll-contain border-b border-border w-full [contain:strict] [overflow-anchor:none] [will-change:scroll-position] md:mt-[-12px] md:h-[calc(100%_+_12px)] md:border-b-0 md:pl-[1px] md:pr-[max(0px,calc(13px-var(--cv-gutter-vertical)))] [&_diffs-container]:overflow-clip [&_diffs-container]:[contain:layout_paint_style] md:[&_diffs-container]:rounded-lg [&_diffs-container]:shadow-[0_0_0_1px_var(--color-border)]',
+        'cv-scrollbar relative h-full min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-clip overscroll-contain border-b border-border w-full [contain:strict] [overflow-anchor:none] [will-change:scroll-position] md:mt-[-12px] md:h-[calc(100%_+_12px)] md:border-b-0 md:pl-[1px] md:pr-[max(0px,calc(13px-var(--cv-gutter-vertical)))] [&_diffs-container]:overflow-clip [&_diffs-container]:[contain:layout_paint_style] md:[&_diffs-container]:rounded-lg [&_diffs-container]:shadow-[0_0_0_1px_var(--color-border)]',
         className
       )}
       options={options}

--- a/apps/docs/app/(diffshub)/(view)/_components/ExampleAnnotation.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/ExampleAnnotation.tsx
@@ -55,7 +55,7 @@ export const ExampleAnnotation = memo(function ExampleAnnotation({
         <strong className="mt-1 block text-[14px]">
           {annotation.metadata.author}
         </strong>
-        <p className="m-0 text-[14px] whitespace-normal">
+        <p className="m-0 text-[14px] whitespace-pre-wrap">
           {annotation.metadata.message}
         </p>
       </div>

--- a/apps/docs/app/(diffshub)/(view)/_components/constants.ts
+++ b/apps/docs/app/(diffshub)/(view)/_components/constants.ts
@@ -86,8 +86,13 @@ const HIDDEN_SEARCH_UNSAFE_CSS = `
       opacity: 0.5;
     }
 
-    > [data-file-tree-sticky-path]:last-of-type [data-item-section="spacing"] {
-      margin-bottom: 4px;
+    > [data-file-tree-sticky-path]:last-of-type {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+
+      [data-item-section="spacing"] {
+        margin-bottom: 4px;
+      }
     }
   }
 

--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -168,6 +168,8 @@
   --diffs-font-family: var(--font-berkeley-mono);
   --cv-gutter-vertical: 0px;
   --cv-gutter-horizontal: 0px;
+  --cv-mini-gutter-vertical: 0px;
+  --cv-mini-gutter-horizontal: 0px;
   color-scheme: light;
   -webkit-font-smoothing: antialiased;
 }
@@ -287,9 +289,41 @@
   }
 }
 
+.cv-mini-scrollbar {
+  --cv-mini-scrollbar-thumb-bg: transparent;
+  scrollbar-gutter: stable;
+}
+
+.cv-mini-scrollbar::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+.cv-mini-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.cv-mini-scrollbar:hover {
+  --cv-mini-scrollbar-thumb-bg: light-dark(
+    color-mix(in lab, var(--background) 85%, black),
+    color-mix(in lab, var(--background) 80%, white)
+  );
+}
+
+.cv-mini-scrollbar::-webkit-scrollbar-thumb {
+  background-color: var(--cv-mini-scrollbar-thumb-bg);
+  background-clip: content-box;
+  border: 3px solid transparent;
+  border-radius: 5px;
+}
+
 @supports (-moz-appearance: none) {
   .cv-scrollbar {
     scrollbar-color: var(--cv-scrollbar-thumb-bg) transparent;
+  }
+  .cv-mini-scrollbar {
+    scrollbar-color: var(--cv-mini-scrollbar-thumb-bg) transparent;
+    scrollbar-width: thin;
   }
 }
 

--- a/apps/docs/components/ScrollbarGutterVariables.tsx
+++ b/apps/docs/components/ScrollbarGutterVariables.tsx
@@ -4,24 +4,22 @@ import { useLayoutEffect } from 'react';
 
 import { detectGutterSize } from '@/lib/gutterDetector';
 
-const CODE_VIEW_SCROLLBAR_CLASS = 'cv-scrollbar';
-const CODE_VIEW_SCROLLBAR_GUTTER_VERTICAL_VARIABLE = '--cv-gutter-vertical';
-const CODE_VIEW_SCROLLBAR_GUTTER_HORIZONTAL_VARIABLE = '--cv-gutter-horizontal';
+const SCROLLBARS_TO_MEASURE: string[] = ['cv', 'cv-mini'];
 
 export function ScrollbarGutterVariables() {
   useLayoutEffect(() => {
-    const { vertical, horizontal } = detectGutterSize(
-      CODE_VIEW_SCROLLBAR_CLASS
-    );
     const { documentElement: root } = document;
-    root.style.setProperty(
-      CODE_VIEW_SCROLLBAR_GUTTER_VERTICAL_VARIABLE,
-      `${vertical}px`
-    );
-    root.style.setProperty(
-      CODE_VIEW_SCROLLBAR_GUTTER_HORIZONTAL_VARIABLE,
-      `${horizontal}px`
-    );
+    for (const prefix of SCROLLBARS_TO_MEASURE) {
+      const size = detectGutterSize(`${prefix}-scrollbar`);
+      root.style.setProperty(
+        `--${prefix}-gutter-vertical`,
+        `${size.vertical}px`
+      );
+      root.style.setProperty(
+        `--${prefix}-gutter-horizontal`,
+        `${size.horizontal}px`
+      );
+    }
   }, []);
 
   return null;


### PR DESCRIPTION
A bunch of small tweaks/improvements:
* Add custom scrollbars that match files for the comments section
* Adds an example + button icon thing to the empty state for the comments to better describe how to add them
* Use `whitespace-pre-wrap` on comments in code to allow them to be multi-line
* There was a small bug with macOS on a trackpad where once a drag was started, you could add some horizontal drag to it shifting the code left or right while swiping (fixed with only overflow-auto-y)
* Fix bottom rounded corners on last sticky item to have the hover state better match with the dropshadow/layering