### PR TITLE
Diffs: respect prefers-reduced-motion and prewarm syntax highlights

### DIFF
--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -765,13 +765,13 @@ export class CodeView<LAnnotation = undefined> {
     }
   }
 
-  private prewarmScrollTarget(target: PendingScrollTarget): void {
+  private primeScrollTarget(target: PendingScrollTarget): void {
     if (target.type === 'position') return;
 
     const item = this.idToItem.get(target.id);
     if (item == null) return;
 
-    item.instance.prewarmWorkerHighlight();
+    item.instance.primeHighlightCache();
   }
 
   private resolveEffectiveScrollBehavior(
@@ -806,7 +806,7 @@ export class CodeView<LAnnotation = undefined> {
       return;
     }
 
-    this.prewarmScrollTarget(pendingTarget);
+    this.primeScrollTarget(pendingTarget);
 
     const behavior = this.resolveEffectiveScrollBehavior(
       pendingTarget,

--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -771,11 +771,7 @@ export class CodeView<LAnnotation = undefined> {
     const item = this.idToItem.get(target.id);
     if (item == null) return;
 
-    if (item.type === 'file') {
-      item.instance.prewarmWorkerHighlight(item.item.file);
-    } else {
-      item.instance.prewarmWorkerHighlight(item.item.fileDiff);
-    }
+    item.instance.prewarmWorkerHighlight();
   }
 
   private resolveEffectiveScrollBehavior(

--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -32,6 +32,7 @@ import type {
 import { areObjectsEqual } from '../utils/areObjectsEqual';
 import { areSelectionsEqual } from '../utils/areSelectionsEqual';
 import { createWindowFromScrollPosition } from '../utils/createWindowFromScrollPosition';
+import { prefersReducedMotion } from '../utils/prefersReducedMotion';
 import { roundToDevicePixel } from '../utils/roundToDevicePixel';
 import type { WorkerPoolManager } from '../worker';
 import type { FileOptions } from './File';
@@ -764,10 +765,27 @@ export class CodeView<LAnnotation = undefined> {
     }
   }
 
+  private prewarmScrollTarget(target: PendingScrollTarget): void {
+    if (target.type === 'position') return;
+
+    const item = this.idToItem.get(target.id);
+    if (item == null) return;
+
+    if (item.type === 'file') {
+      item.instance.prewarmWorkerHighlight(item.item.file);
+    } else {
+      item.instance.prewarmWorkerHighlight(item.item.fileDiff);
+    }
+  }
+
   private resolveEffectiveScrollBehavior(
     target: CodeViewScrollTarget,
     destination: number
   ): Exclude<CodeViewScrollBehavior, 'smooth-auto'> {
+    if (prefersReducedMotion()) {
+      return 'instant';
+    }
+
     if (target.behavior !== 'smooth-auto') {
       return target.behavior ?? 'instant';
     }
@@ -791,6 +809,8 @@ export class CodeView<LAnnotation = undefined> {
     if (destination == null) {
       return;
     }
+
+    this.prewarmScrollTarget(pendingTarget);
 
     const behavior = this.resolveEffectiveScrollBehavior(
       pendingTarget,

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -295,7 +295,9 @@ export class File<LAnnotation = undefined> {
     this.placeHolder = undefined;
     this.unsafeCSSStyle = undefined;
 
-    if (!recycle) {
+    if (recycle) {
+      this.fileRenderer.recycle();
+    } else {
       this.fileRenderer.cleanUp();
       this.workerManager = undefined;
       this.file = undefined;

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -4,6 +4,7 @@ import { toHtml } from 'hast-util-to-html';
 import {
   CUSTOM_HEADER_SLOT_ID,
   DEFAULT_THEMES,
+  DEFAULT_TOKENIZE_MAX_LENGTH,
   DIFFS_TAG_NAME,
   EMPTY_RENDER_RANGE,
   HEADER_METADATA_SLOT_ID,
@@ -48,6 +49,7 @@ import {
 import { getLineAnnotationName } from '../utils/getLineAnnotationName';
 import { getOrCreateCodeNode } from '../utils/getOrCreateCodeNode';
 import { upsertHostThemeStyle } from '../utils/hostTheme';
+import { isFilePlainText } from '../utils/isFilePlainText';
 import { prerenderHTMLIfNecessary } from '../utils/prerenderHTMLIfNecessary';
 import { getMeasuredScrollbarGutter } from '../utils/scrollbarGutter';
 import { setPreNodeProperties } from '../utils/setWrapperNodeProps';
@@ -637,8 +639,18 @@ export class File<LAnnotation = undefined> {
   }
 
   public prewarmWorkerHighlight(): void {
-    if (this.file == null) return;
-    this.fileRenderer.prewarmWorkerHighlight(this.file);
+    const { file, workerManager } = this;
+    if (file == null || workerManager == null || isFilePlainText(file)) {
+      return;
+    }
+    const lines = this.fileRenderer.getOrCreateLineCache(file);
+    if (
+      lines.length >
+      (this.options.tokenizeMaxLength ?? DEFAULT_TOKENIZE_MAX_LENGTH)
+    ) {
+      return;
+    }
+    workerManager.prewarmFileAST(file);
   }
 
   private cleanChildNodes() {

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -634,6 +634,11 @@ export class File<LAnnotation = undefined> {
     return true;
   }
 
+  public prewarmWorkerHighlight(file: FileContents): void {
+    if (this.workerManager?.isWorkingPool() !== true) return;
+    this.workerManager.highlightFileAST(this.fileRenderer, file);
+  }
+
   private cleanChildNodes() {
     this.resizeManager.cleanUp();
     this.interactionManager.cleanUp();

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -638,7 +638,7 @@ export class File<LAnnotation = undefined> {
     return true;
   }
 
-  public prewarmWorkerHighlight(): void {
+  public primeHighlightCache(): void {
     const { file, workerManager } = this;
     if (file == null || workerManager == null || isFilePlainText(file)) {
       return;
@@ -650,7 +650,7 @@ export class File<LAnnotation = undefined> {
     ) {
       return;
     }
-    workerManager.prewarmFileAST(file);
+    workerManager.primeFileHighlightCache(file);
   }
 
   private cleanChildNodes() {

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -634,8 +634,9 @@ export class File<LAnnotation = undefined> {
     return true;
   }
 
-  public prewarmWorkerHighlight(file: FileContents): void {
-    this.fileRenderer.prewarmWorkerHighlight(file);
+  public prewarmWorkerHighlight(): void {
+    if (this.file == null) return;
+    this.fileRenderer.prewarmWorkerHighlight(this.file);
   }
 
   private cleanChildNodes() {

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -640,7 +640,12 @@ export class File<LAnnotation = undefined> {
 
   public primeHighlightCache(): void {
     const { file, workerManager } = this;
-    if (file == null || workerManager == null || isFilePlainText(file)) {
+    if (
+      file == null ||
+      file.cacheKey == null ||
+      workerManager == null ||
+      isFilePlainText(file)
+    ) {
       return;
     }
     const lines = this.fileRenderer.getOrCreateLineCache(file);

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -635,8 +635,7 @@ export class File<LAnnotation = undefined> {
   }
 
   public prewarmWorkerHighlight(file: FileContents): void {
-    if (this.workerManager?.isWorkingPool() !== true) return;
-    this.workerManager.highlightFileAST(this.fileRenderer, file);
+    this.fileRenderer.prewarmWorkerHighlight(file);
   }
 
   private cleanChildNodes() {

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -962,6 +962,11 @@ export class FileDiff<LAnnotation = undefined> {
     return true;
   }
 
+  public prewarmWorkerHighlight(fileDiff: FileDiffMetadata): void {
+    if (this.workerManager?.isWorkingPool() !== true) return;
+    this.workerManager.highlightDiffAST(this.hunksRenderer, fileDiff);
+  }
+
   private cleanChildNodes() {
     this.resizeManager.cleanUp();
     this.scrollSyncManager.cleanUp();

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -962,8 +962,9 @@ export class FileDiff<LAnnotation = undefined> {
     return true;
   }
 
-  public prewarmWorkerHighlight(fileDiff: FileDiffMetadata): void {
-    this.hunksRenderer.prewarmWorkerHighlight(fileDiff);
+  public prewarmWorkerHighlight(): void {
+    if (this.fileDiff == null) return;
+    this.hunksRenderer.prewarmWorkerHighlight(this.fileDiff);
   }
 
   private cleanChildNodes() {

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -4,6 +4,7 @@ import { toHtml } from 'hast-util-to-html';
 import {
   CUSTOM_HEADER_SLOT_ID,
   DEFAULT_THEMES,
+  DEFAULT_TOKENIZE_MAX_LENGTH,
   DIFFS_TAG_NAME,
   EMPTY_RENDER_RANGE,
   HEADER_METADATA_SLOT_ID,
@@ -62,6 +63,7 @@ import {
 import { getLineAnnotationName } from '../utils/getLineAnnotationName';
 import { getOrCreateCodeNode } from '../utils/getOrCreateCodeNode';
 import { upsertHostThemeStyle } from '../utils/hostTheme';
+import { isDiffPlainText } from '../utils/isDiffPlainText';
 import { parseDiffFromFile } from '../utils/parseDiffFromFile';
 import { prerenderHTMLIfNecessary } from '../utils/prerenderHTMLIfNecessary';
 import { getMeasuredScrollbarGutter } from '../utils/scrollbarGutter';
@@ -963,8 +965,23 @@ export class FileDiff<LAnnotation = undefined> {
   }
 
   public prewarmWorkerHighlight(): void {
-    if (this.fileDiff == null) return;
-    this.hunksRenderer.prewarmWorkerHighlight(this.fileDiff);
+    const { fileDiff, workerManager } = this;
+    if (
+      fileDiff == null ||
+      workerManager == null ||
+      isDiffPlainText(fileDiff)
+    ) {
+      return;
+    }
+    const tokenizeMaxLength =
+      this.options.tokenizeMaxLength ?? DEFAULT_TOKENIZE_MAX_LENGTH;
+    if (
+      Math.max(fileDiff.additionLines.length, fileDiff.deletionLines.length) >
+      tokenizeMaxLength
+    ) {
+      return;
+    }
+    workerManager.prewarmDiffAST(fileDiff);
   }
 
   private cleanChildNodes() {

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -964,7 +964,7 @@ export class FileDiff<LAnnotation = undefined> {
     return true;
   }
 
-  public prewarmWorkerHighlight(): void {
+  public primeHighlightCache(): void {
     const { fileDiff, workerManager } = this;
     if (
       fileDiff == null ||
@@ -981,7 +981,7 @@ export class FileDiff<LAnnotation = undefined> {
     ) {
       return;
     }
-    workerManager.prewarmDiffAST(fileDiff);
+    workerManager.primeDiffHighlightCache(fileDiff);
   }
 
   private cleanChildNodes() {

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -963,8 +963,7 @@ export class FileDiff<LAnnotation = undefined> {
   }
 
   public prewarmWorkerHighlight(fileDiff: FileDiffMetadata): void {
-    if (this.workerManager?.isWorkingPool() !== true) return;
-    this.workerManager.highlightDiffAST(this.hunksRenderer, fileDiff);
+    this.hunksRenderer.prewarmWorkerHighlight(fileDiff);
   }
 
   private cleanChildNodes() {

--- a/packages/diffs/src/index.ts
+++ b/packages/diffs/src/index.ts
@@ -44,6 +44,8 @@ export * from './shiki-stream';
 export * from './sprite';
 export * from './utils/areDiffLineAnnotationsEqual';
 export * from './utils/areDiffRenderOptionsEqual';
+export * from './utils/areDiffTargetsEqual';
+export * from './utils/areFileRenderOptionsEqual';
 export * from './utils/areFilesEqual';
 export * from './utils/areHunkDataEqual';
 export * from './utils/areLineAnnotationsEqual';

--- a/packages/diffs/src/index.ts
+++ b/packages/diffs/src/index.ts
@@ -93,6 +93,7 @@ export * from './utils/parseDiffDecorations';
 export * from './utils/parseDiffFromFile';
 export * from './utils/parseLineType';
 export * from './utils/parsePatchFiles';
+export * from './utils/prefersReducedMotion';
 export * from './utils/prerenderHTMLIfNecessary';
 export * from './utils/processLine';
 export * from './utils/renderDiffWithHighlighter';

--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -226,13 +226,8 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
   }
 
   public cleanUp(): void {
-    this.highlighter = undefined;
-    this.diff = undefined;
-    this.renderCache = undefined;
-    this.additionAnnotations = {};
-    this.deletionAnnotations = {};
+    this.recycle();
     this.expandedHunks.clear();
-    this.workerManager?.cleanUpPendingTasks(this);
     this.workerManager = undefined;
     this.onRenderUpdate = undefined;
   }
@@ -243,7 +238,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
     this.renderCache = undefined;
     this.additionAnnotations = {};
     this.deletionAnnotations = {};
-    this.workerManager?.cleanUpPendingTasks(this);
+    this.workerManager?.cleanUpTasks(this);
   }
 
   public setOptions(options: DiffHunksRendererOptions): void {

--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -38,6 +38,7 @@ import type {
   ThemedDiffResult,
 } from '../types';
 import { areDiffRenderOptionsEqual } from '../utils/areDiffRenderOptionsEqual';
+import { areDiffTargetsEqual } from '../utils/areDiffTargetsEqual';
 import { areRenderRangesEqual } from '../utils/areRenderRangesEqual';
 import { createAnnotationElement as createDefaultAnnotationElement } from '../utils/createAnnotationElement';
 import { createContentColumn } from '../utils/createContentColumn';
@@ -82,7 +83,7 @@ interface PushLineWithAnnotation {
 
 interface GetRenderOptionsReturn {
   options: RenderDiffOptions;
-  forceRender: boolean;
+  forceHighlight: boolean;
 }
 
 interface PushSeparatorProps {
@@ -445,15 +446,15 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
     this.getOptionsWithDefaults();
     const { renderCache } = this;
     if (renderCache?.result == null) {
-      return { options, forceRender: true };
+      return { options, forceHighlight: true };
     }
     if (
-      diff !== renderCache.diff ||
+      !areDiffTargetsEqual(diff, renderCache.diff) ||
       !areDiffRenderOptionsEqual(options, renderCache.options)
     ) {
-      return { options, forceRender: true };
+      return { options, forceHighlight: true };
     }
-    return { options, forceRender: false };
+    return { options, forceHighlight: false };
   }
 
   public renderDiff(
@@ -465,16 +466,17 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
     }
     const { expandUnchanged = false, collapsedContextThreshold } =
       this.getOptionsWithDefaults();
-    const cache = this.workerManager?.getDiffResultCache(diff);
-    if (cache != null && this.renderCache == null) {
+    let { options, forceHighlight } = this.getRenderOptions(diff);
+    const cache = this.getMatchingWorkerResultCache(diff, options);
+    if (cache != null && !this.hasHighlightedRenderCache(diff, options)) {
       this.renderCache = {
         diff,
         highlighted: true,
         renderRange: undefined,
         ...cache,
       };
+      forceHighlight = false;
     }
-    const { options, forceRender } = this.getRenderOptions(diff);
     const forcePlainText = isDiffMassive(diff, this.getTokenizeMaxLength());
     this.renderCache ??= {
       diff,
@@ -488,7 +490,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
         forcePlainText ||
         this.renderCache.result == null ||
         (!this.renderCache.highlighted &&
-          (diff !== this.renderCache.diff ||
+          (!areDiffTargetsEqual(diff, this.renderCache.diff) ||
             !areRenderRangesEqual(this.renderCache.renderRange, renderRange)))
       ) {
         this.renderCache.diff = diff;
@@ -514,7 +516,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
         // are lines to render
         renderRange.totalLines > 0 &&
         !forcePlainText &&
-        (!this.renderCache.highlighted || forceRender)
+        (!this.renderCache.highlighted || forceHighlight)
       ) {
         this.workerManager.highlightDiffAST(this, diff);
       }
@@ -533,7 +535,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
       if (
         this.highlighter != null &&
         hasThemes &&
-        (forceRender ||
+        (forceHighlight ||
           forcePlainText ||
           (!this.renderCache.highlighted && canHighlight) ||
           this.renderCache.result == null)
@@ -573,6 +575,42 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
           this.renderCache.result
         )
       : undefined;
+  }
+
+  public prewarmWorkerHighlight(diff: FileDiffMetadata): void {
+    if (this.workerManager?.isWorkingPool() !== true) {
+      return;
+    }
+
+    const { options } = this.getRenderOptions(diff);
+    if (
+      isDiffPlainText(diff) ||
+      isDiffMassive(diff, this.getTokenizeMaxLength()) ||
+      this.hasHighlightedRenderCache(diff, options)
+    ) {
+      return;
+    }
+
+    if (
+      this.renderCache == null ||
+      !areDiffTargetsEqual(diff, this.renderCache.diff) ||
+      !areDiffRenderOptionsEqual(options, this.renderCache.options)
+    ) {
+      this.renderCache = {
+        diff,
+        options,
+        highlighted: false,
+        result: undefined,
+        renderRange: undefined,
+      };
+    }
+
+    const cache = this.getMatchingWorkerResultCache(diff, options);
+    if (cache != null) {
+      this.onHighlightSuccess(diff, cache.result, cache.options);
+    } else {
+      this.workerManager.highlightDiffAST(this, diff);
+    }
   }
 
   public async asyncRender(
@@ -649,8 +687,8 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
     highlighted = true
   ): void {
     // NOTE(amadeus): This is a bad assumption, and I should figure out
-    // something better...
-    // If renderCache was blown away, we can assume we've run cleanUp()
+    // something better... If renderCache was blown away, we can assume we've
+    // run cleanUp()
     if (this.renderCache == null) {
       return;
     }
@@ -658,7 +696,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
     const triggerRenderUpdate =
       !this.renderCache.highlighted ||
       !areDiffRenderOptionsEqual(this.renderCache.options, options) ||
-      this.renderCache.diff !== diff;
+      !areDiffTargetsEqual(this.renderCache.diff, diff);
 
     this.renderCache = {
       diff,
@@ -670,6 +708,30 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
     if (triggerRenderUpdate) {
       this.onRenderUpdate?.();
     }
+  }
+
+  private getMatchingWorkerResultCache(
+    diff: FileDiffMetadata,
+    options: RenderDiffOptions
+  ): RenderDiffResult | undefined {
+    const cache = this.workerManager?.getDiffResultCache(diff);
+    if (cache == null || !areDiffRenderOptionsEqual(options, cache.options)) {
+      return undefined;
+    }
+    return cache;
+  }
+
+  private hasHighlightedRenderCache(
+    diff: FileDiffMetadata,
+    options: RenderDiffOptions
+  ): boolean {
+    const { renderCache } = this;
+    return (
+      renderCache?.result != null &&
+      renderCache.highlighted &&
+      areDiffTargetsEqual(diff, renderCache.diff) &&
+      areDiffRenderOptionsEqual(options, renderCache.options)
+    );
   }
 
   public onHighlightError(error: unknown): void {

--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -591,24 +591,26 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
       return;
     }
 
-    if (
-      this.renderCache == null ||
-      !areDiffTargetsEqual(diff, this.renderCache.diff) ||
-      !areDiffRenderOptionsEqual(options, this.renderCache.options)
-    ) {
-      this.renderCache = {
+    const cache = this.getMatchingWorkerResultCache(diff, options);
+    if (cache != null) {
+      if (this.renderCache == null) {
+        this.renderCache = {
+          diff,
+          highlighted: true,
+          renderRange: undefined,
+          ...cache,
+        };
+      } else {
+        this.onHighlightSuccess(diff, cache.result, cache.options);
+      }
+    } else {
+      this.renderCache ??= {
         diff,
         options,
         highlighted: false,
         result: undefined,
         renderRange: undefined,
       };
-    }
-
-    const cache = this.getMatchingWorkerResultCache(diff, options);
-    if (cache != null) {
-      this.onHighlightSuccess(diff, cache.result, cache.options);
-    } else {
       this.workerManager.highlightDiffAST(this, diff);
     }
   }

--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -577,44 +577,6 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
       : undefined;
   }
 
-  public prewarmWorkerHighlight(diff: FileDiffMetadata): void {
-    if (this.workerManager?.isWorkingPool() !== true) {
-      return;
-    }
-
-    const { options } = this.getRenderOptions(diff);
-    if (
-      isDiffPlainText(diff) ||
-      isDiffMassive(diff, this.getTokenizeMaxLength()) ||
-      this.hasHighlightedRenderCache(diff, options)
-    ) {
-      return;
-    }
-
-    const cache = this.getMatchingWorkerResultCache(diff, options);
-    if (cache != null) {
-      if (this.renderCache == null) {
-        this.renderCache = {
-          diff,
-          highlighted: true,
-          renderRange: undefined,
-          ...cache,
-        };
-      } else {
-        this.onHighlightSuccess(diff, cache.result, cache.options);
-      }
-    } else {
-      this.renderCache ??= {
-        diff,
-        options,
-        highlighted: false,
-        result: undefined,
-        renderRange: undefined,
-      };
-      this.workerManager.highlightDiffAST(this, diff);
-    }
-  }
-
   public async asyncRender(
     diff: FileDiffMetadata,
     renderRange: RenderRange = DEFAULT_RENDER_RANGE

--- a/packages/diffs/src/renderers/FileRenderer.ts
+++ b/packages/diffs/src/renderers/FileRenderer.ts
@@ -26,8 +26,9 @@ import type {
   SupportedLanguages,
   ThemedFileResult,
 } from '../types';
+import { areFileRenderOptionsEqual } from '../utils/areFileRenderOptionsEqual';
+import { areFilesEqual } from '../utils/areFilesEqual';
 import { areRenderRangesEqual } from '../utils/areRenderRangesEqual';
-import { areThemesEqual } from '../utils/areThemesEqual';
 import { createAnnotationElement } from '../utils/createAnnotationElement';
 import { createContentColumn } from '../utils/createContentColumn';
 import { createFileHeaderElement } from '../utils/createFileHeaderElement';
@@ -56,7 +57,7 @@ type AnnotationLineMap<LAnnotation> = Record<
 
 interface GetRenderOptionsReturn {
   options: RenderFileOptions;
-  forceRender: boolean;
+  forceHighlight: boolean;
 }
 
 export interface FileRenderResult {
@@ -140,7 +141,7 @@ export class FileRenderer<LAnnotation = undefined> {
       this.getTokenizeMaxLength()
     );
     let cache = this.workerManager?.getFileResultCache(file);
-    if (cache != null && !areRenderOptionsEqual(options, cache.options)) {
+    if (cache != null && !areFileRenderOptionsEqual(options, cache.options)) {
       cache = undefined;
     }
     this.renderCache ??= {
@@ -179,15 +180,15 @@ export class FileRenderer<LAnnotation = undefined> {
     })();
     const { renderCache } = this;
     if (renderCache?.result == null) {
-      return { options, forceRender: true };
+      return { options, forceHighlight: true };
     }
     if (
-      file !== renderCache.file ||
-      !areRenderOptionsEqual(options, renderCache.options)
+      !areFilesEqual(file, renderCache.file) ||
+      !areFileRenderOptionsEqual(options, renderCache.options)
     ) {
-      return { options, forceRender: true };
+      return { options, forceHighlight: true };
     }
-    return { options, forceRender: false };
+    return { options, forceHighlight: false };
   }
 
   public getOrCreateLineCache(file: FileContents): string[] {
@@ -216,16 +217,17 @@ export class FileRenderer<LAnnotation = undefined> {
     if (file == null) {
       return undefined;
     }
-    const cache = this.workerManager?.getFileResultCache(file);
-    if (cache != null && this.renderCache == null) {
+    let { options, forceHighlight } = this.getRenderOptions(file);
+    const cache = this.getMatchingWorkerResultCache(file, options);
+    if (cache != null && !this.hasHighlightedRenderCache(file, options)) {
       this.renderCache = {
         file,
         highlighted: true,
         renderRange: undefined,
         ...cache,
       };
+      forceHighlight = false;
     }
-    const { options, forceRender } = this.getRenderOptions(file);
     const lines = this.getOrCreateLineCache(file);
     const forcePlainText = isFileMassive(
       lines.length,
@@ -244,7 +246,7 @@ export class FileRenderer<LAnnotation = undefined> {
         this.renderCache.result == null ||
         forcePlainText ||
         (!this.renderCache.highlighted &&
-          (file !== this.renderCache.file ||
+          (!areFilesEqual(file, this.renderCache.file) ||
             !areRenderRangesEqual(this.renderCache.renderRange, renderRange)))
       ) {
         this.renderCache.file = file;
@@ -264,7 +266,7 @@ export class FileRenderer<LAnnotation = undefined> {
         // are lines to render
         renderRange.totalLines > 0 &&
         !forcePlainText &&
-        (!this.renderCache.highlighted || forceRender)
+        (!this.renderCache.highlighted || forceHighlight)
       ) {
         this.workerManager.highlightFileAST(this, file);
       }
@@ -283,7 +285,7 @@ export class FileRenderer<LAnnotation = undefined> {
       if (
         this.highlighter != null &&
         hasThemes &&
-        (forceRender ||
+        (forceHighlight ||
           forcePlainText ||
           (!this.renderCache.highlighted && canHighlight) ||
           this.renderCache.result == null)
@@ -324,6 +326,43 @@ export class FileRenderer<LAnnotation = undefined> {
           this.renderCache.result
         )
       : undefined;
+  }
+
+  public prewarmWorkerHighlight(file: FileContents): void {
+    if (this.workerManager?.isWorkingPool() !== true) {
+      return;
+    }
+
+    const { options } = this.getRenderOptions(file);
+    const lines = this.getOrCreateLineCache(file);
+    if (
+      isFilePlainText(file) ||
+      isFileMassive(lines.length, this.getTokenizeMaxLength()) ||
+      this.hasHighlightedRenderCache(file, options)
+    ) {
+      return;
+    }
+
+    if (
+      this.renderCache == null ||
+      !areFilesEqual(file, this.renderCache.file) ||
+      !areFileRenderOptionsEqual(options, this.renderCache.options)
+    ) {
+      this.renderCache = {
+        file,
+        options,
+        highlighted: false,
+        result: undefined,
+        renderRange: undefined,
+      };
+    }
+
+    const cache = this.getMatchingWorkerResultCache(file, options);
+    if (cache != null) {
+      this.onHighlightSuccess(file, cache.result, cache.options);
+    } else {
+      this.workerManager.highlightFileAST(this, file);
+    }
   }
 
   async asyncRender(
@@ -518,9 +557,9 @@ export class FileRenderer<LAnnotation = undefined> {
       return;
     }
     const triggerRenderUpdate =
-      this.renderCache.file !== file ||
+      !areFilesEqual(file, this.renderCache.file) ||
       !this.renderCache.highlighted ||
-      !areRenderOptionsEqual(options, this.renderCache.options);
+      !areFileRenderOptionsEqual(options, this.renderCache.options);
 
     this.renderCache = {
       file,
@@ -533,6 +572,30 @@ export class FileRenderer<LAnnotation = undefined> {
     if (triggerRenderUpdate) {
       this.onRenderUpdate?.();
     }
+  }
+
+  private getMatchingWorkerResultCache(
+    file: FileContents,
+    options: RenderFileOptions
+  ): RenderFileResult | undefined {
+    const cache = this.workerManager?.getFileResultCache(file);
+    if (cache == null || !areFileRenderOptionsEqual(options, cache.options)) {
+      return undefined;
+    }
+    return cache;
+  }
+
+  private hasHighlightedRenderCache(
+    file: FileContents,
+    options: RenderFileOptions
+  ): boolean {
+    const { renderCache } = this;
+    return (
+      renderCache?.result != null &&
+      renderCache.highlighted &&
+      areFilesEqual(file, renderCache.file) &&
+      areFileRenderOptionsEqual(options, renderCache.options)
+    );
   }
 
   public onHighlightError(error: unknown): void {
@@ -555,17 +618,6 @@ export class FileRenderer<LAnnotation = undefined> {
       totalLines,
     });
   }
-}
-
-function areRenderOptionsEqual(
-  optionsA: RenderFileOptions,
-  optionsB: RenderFileOptions
-): boolean {
-  return (
-    areThemesEqual(optionsA.theme, optionsB.theme) &&
-    optionsA.useTokenTransformer === optionsB.useTokenTransformer &&
-    optionsA.tokenizeMaxLineLength === optionsB.tokenizeMaxLineLength
-  );
 }
 
 function isFileMassive(lineCount: number, tokenizeMaxLength: number): boolean {

--- a/packages/diffs/src/renderers/FileRenderer.ts
+++ b/packages/diffs/src/renderers/FileRenderer.ts
@@ -333,45 +333,6 @@ export class FileRenderer<LAnnotation = undefined> {
       : undefined;
   }
 
-  public prewarmWorkerHighlight(file: FileContents): void {
-    if (this.workerManager?.isWorkingPool() !== true) {
-      return;
-    }
-
-    const { options } = this.getRenderOptions(file);
-    const lines = this.getOrCreateLineCache(file);
-    if (
-      isFilePlainText(file) ||
-      isFileMassive(lines.length, this.getTokenizeMaxLength()) ||
-      this.hasHighlightedRenderCache(file, options)
-    ) {
-      return;
-    }
-
-    const cache = this.getMatchingWorkerResultCache(file, options);
-    if (cache != null) {
-      if (this.renderCache == null) {
-        this.renderCache = {
-          file,
-          highlighted: true,
-          renderRange: undefined,
-          ...cache,
-        };
-      } else {
-        this.onHighlightSuccess(file, cache.result, cache.options);
-      }
-    } else {
-      this.renderCache ??= {
-        file,
-        options,
-        highlighted: false,
-        result: undefined,
-        renderRange: undefined,
-      };
-      this.workerManager.highlightFileAST(this, file);
-    }
-  }
-
   async asyncRender(
     file: FileContents,
     renderRange: RenderRange = DEFAULT_RENDER_RANGE

--- a/packages/diffs/src/renderers/FileRenderer.ts
+++ b/packages/diffs/src/renderers/FileRenderer.ts
@@ -126,10 +126,15 @@ export class FileRenderer<LAnnotation = undefined> {
   }
 
   public cleanUp(): void {
-    this.renderCache = undefined;
-    this.highlighter = undefined;
+    this.recycle();
     this.workerManager = undefined;
     this.onRenderUpdate = undefined;
+  }
+
+  public recycle(): void {
+    this.renderCache = undefined;
+    this.highlighter = undefined;
+    this.workerManager?.cleanUpPendingTasks(this);
     this.lineCache = undefined;
   }
 

--- a/packages/diffs/src/renderers/FileRenderer.ts
+++ b/packages/diffs/src/renderers/FileRenderer.ts
@@ -134,7 +134,7 @@ export class FileRenderer<LAnnotation = undefined> {
   public recycle(): void {
     this.renderCache = undefined;
     this.highlighter = undefined;
-    this.workerManager?.cleanUpPendingTasks(this);
+    this.workerManager?.cleanUpTasks(this);
     this.lineCache = undefined;
   }
 

--- a/packages/diffs/src/renderers/FileRenderer.ts
+++ b/packages/diffs/src/renderers/FileRenderer.ts
@@ -343,24 +343,26 @@ export class FileRenderer<LAnnotation = undefined> {
       return;
     }
 
-    if (
-      this.renderCache == null ||
-      !areFilesEqual(file, this.renderCache.file) ||
-      !areFileRenderOptionsEqual(options, this.renderCache.options)
-    ) {
-      this.renderCache = {
+    const cache = this.getMatchingWorkerResultCache(file, options);
+    if (cache != null) {
+      if (this.renderCache == null) {
+        this.renderCache = {
+          file,
+          highlighted: true,
+          renderRange: undefined,
+          ...cache,
+        };
+      } else {
+        this.onHighlightSuccess(file, cache.result, cache.options);
+      }
+    } else {
+      this.renderCache ??= {
         file,
         options,
         highlighted: false,
         result: undefined,
         renderRange: undefined,
       };
-    }
-
-    const cache = this.getMatchingWorkerResultCache(file, options);
-    if (cache != null) {
-      this.onHighlightSuccess(file, cache.result, cache.options);
-    } else {
       this.workerManager.highlightFileAST(this, file);
     }
   }

--- a/packages/diffs/src/utils/areDiffTargetsEqual.ts
+++ b/packages/diffs/src/utils/areDiffTargetsEqual.ts
@@ -1,0 +1,14 @@
+import type { FileDiffMetadata } from '../types';
+
+// Because FileDiffMetadata is a potentially unbounded and structurally deep
+// object, we only check for top level equality or a cache key, otherwise we
+// just assume it's different every time
+export function areDiffTargetsEqual(
+  diffA: FileDiffMetadata | undefined,
+  diffB: FileDiffMetadata | undefined
+): boolean {
+  return (
+    diffA === diffB ||
+    (diffA?.cacheKey != null && diffA.cacheKey === diffB?.cacheKey)
+  );
+}

--- a/packages/diffs/src/utils/areFileRenderOptionsEqual.ts
+++ b/packages/diffs/src/utils/areFileRenderOptionsEqual.ts
@@ -1,0 +1,13 @@
+import type { RenderFileOptions } from '../types';
+import { areThemesEqual } from './areThemesEqual';
+
+export function areFileRenderOptionsEqual(
+  optionsA: RenderFileOptions,
+  optionsB: RenderFileOptions
+): boolean {
+  return (
+    areThemesEqual(optionsA.theme, optionsB.theme) &&
+    optionsA.useTokenTransformer === optionsB.useTokenTransformer &&
+    optionsA.tokenizeMaxLineLength === optionsB.tokenizeMaxLineLength
+  );
+}

--- a/packages/diffs/src/utils/areWorkerStatsEqual.ts
+++ b/packages/diffs/src/utils/areWorkerStatsEqual.ts
@@ -12,7 +12,7 @@ export function areWorkerStatsEqual(
     statsA.diffCacheSize === statsB.diffCacheSize &&
     statsA.fileCacheSize === statsB.fileCacheSize &&
     statsA.managerState === statsB.managerState &&
-    statsA.pendingTasks === statsB.pendingTasks &&
+    statsA.activeTasks === statsB.activeTasks &&
     statsA.queuedTasks === statsB.queuedTasks &&
     statsA.themeSubscribers === statsB.themeSubscribers &&
     statsA.totalWorkers === statsB.totalWorkers &&

--- a/packages/diffs/src/utils/prefersReducedMotion.ts
+++ b/packages/diffs/src/utils/prefersReducedMotion.ts
@@ -1,0 +1,9 @@
+export function prefersReducedMotion(): boolean {
+  if (
+    typeof window === 'undefined' ||
+    typeof window.matchMedia !== 'function'
+  ) {
+    return false;
+  }
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}

--- a/packages/diffs/src/worker/WorkerPoolManager.ts
+++ b/packages/diffs/src/worker/WorkerPoolManager.ts
@@ -364,17 +364,16 @@ export class WorkerPoolManager {
   public cleanUpTasks(instance: RenderTaskInstance): void {
     this.detachInstanceFromQueuedTasks(instance);
     const requestId = this.activeRequestByInstance.get(instance);
-    if (requestId == null) {
-      return;
-    }
-    const task = this.activeTaskById.get(requestId);
-    if (isRenderTask(task)) {
-      this.detachInstanceFromRenderTask(task, instance);
-      if (!task.primeCache && task.instances.size === 0) {
-        this.removeActiveTask(task);
+    if (requestId != null) {
+      const task = this.activeTaskById.get(requestId);
+      if (isRenderTask(task)) {
+        this.detachInstanceFromRenderTask(task, instance);
+        if (!task.primeCache && task.instances.size === 0) {
+          this.removeActiveTask(task);
+        }
+      } else {
+        this.activeTaskById.delete(requestId);
       }
-    } else {
-      this.activeTaskById.delete(requestId);
     }
     this.activeRequestByInstance.delete(instance);
     this.queueBroadcastStateChanges();

--- a/packages/diffs/src/worker/WorkerPoolManager.ts
+++ b/packages/diffs/src/worker/WorkerPoolManager.ts
@@ -85,24 +85,35 @@ interface ThemeSubscriber {
   rerender(): void;
 }
 
+type RenderTask = RenderFileTask | RenderDiffTask;
+
+type RenderTaskInstance = FileRendererInstance | DiffRendererInstance;
+
 export class WorkerPoolManager {
   private highlighter: DiffsHighlighter | undefined;
   private readonly preferredHighlighter: HighlighterTypes;
   private renderOptions: WorkerRenderingOptions;
+  private renderOptionsVersion = 0;
   private initialized: Promise<void> | boolean = false;
   private workers: ManagedWorker[] = [];
-  private taskQueue = new Map<
-    FileRendererInstance | DiffRendererInstance,
-    RenderDiffTask | RenderFileTask
+  // Tasks that are waiting to get processed by a worker
+  private queuedTasks: RenderTask[] = [];
+  private queuedTaskByInstance = new Map<RenderTaskInstance, RenderTask>();
+
+  // Tasks that map to highlightKey are essentially singular, so we only
+  // need one map to include queued and active
+  private taskByHighlightKey = new Map<string, RenderTask>();
+
+  // Tasks that have already been sent to a worker and are awaiting a response.
+  private activeTaskById = new Map<WorkerRequestId, AllWorkerTasks>();
+  private activeRequestByInstance = new Map<
+    RenderTaskInstance,
+    WorkerRequestId
   >();
-  private pendingTasks = new Map<WorkerRequestId, AllWorkerTasks>();
+
   private nextRequestId = 0;
   private themeSubscribers = new Set<ThemeSubscriber>();
   private workersFailed = false;
-  private instanceRequestMap = new Map<
-    FileRendererInstance | DiffRendererInstance,
-    string
-  >();
   private statSubscribers = new Set<(stats: WorkerStats) => unknown>();
   private fileCache: LRUMapPkg.LRUMap<string, RenderFileResult>;
   private diffCache: LRUMapPkg.LRUMap<string, RenderDiffResult>;
@@ -237,6 +248,7 @@ export class WorkerPoolManager {
       }
 
       this.renderOptions = newRenderOptions;
+      this.renderOptionsVersion++;
       this.diffCache.clear();
       this.fileCache.clear();
 
@@ -298,10 +310,10 @@ export class WorkerPoolManager {
             reject,
             requestStart: Date.now(),
           };
-          // NOTE(amadeus): We intentionally ignore the normal pending requests
+          // NOTE(amadeus): We intentionally ignore the normal active requests
           // infra because these tasks should technically interrupt the normal
           // flow and should be processed by the worker when ready immediately
-          this.pendingTasks.set(id, task);
+          this.activeTaskById.set(id, task);
           managedWorker.worker.postMessage(task.request);
         })
       );
@@ -349,15 +361,22 @@ export class WorkerPoolManager {
     }
   };
 
-  public cleanUpPendingTasks(
-    instance: FileRendererInstance | DiffRendererInstance
-  ): void {
-    this.taskQueue.delete(instance);
-    const requestId = this.instanceRequestMap.get(instance);
-    if (requestId != null) {
-      this.pendingTasks.delete(requestId);
-      this.instanceRequestMap.delete(instance);
+  public cleanUpTasks(instance: RenderTaskInstance): void {
+    this.detachInstanceFromQueuedTasks(instance);
+    const requestId = this.activeRequestByInstance.get(instance);
+    if (requestId == null) {
+      return;
     }
+    const task = this.activeTaskById.get(requestId);
+    if (isRenderTask(task)) {
+      this.detachInstanceFromRenderTask(task, instance);
+      if (!task.prewarm && task.instances.size === 0) {
+        this.removeActiveTask(task);
+      }
+    } else {
+      this.activeTaskById.delete(requestId);
+    }
+    this.activeRequestByInstance.delete(instance);
     this.queueBroadcastStateChanges();
   }
 
@@ -493,7 +512,7 @@ export class WorkerPoolManager {
             reject,
             requestStart: Date.now(),
           };
-          this.pendingTasks.set(id, task);
+          this.activeTaskById.set(id, task);
           this.executeTask(managedWorker, task);
         })
       );
@@ -505,13 +524,15 @@ export class WorkerPoolManager {
     this._queuedDrain = undefined;
     // If we are initializing or things got cancelled while initializing, we
     // should not attempt to drain the queue
-    if (this.initialized !== true || this.taskQueue.size === 0) {
+    if (this.initialized !== true || this.queuedTasks.length === 0) {
       return;
     }
-    for (const [instance, task] of this.taskQueue) {
-      // If we have a request in progress for the same instance, we should wait
-      // for it to finish
-      if (this.instanceRequestMap.has(instance)) {
+    for (let i = 0; i < this.queuedTasks.length; ) {
+      const task = this.queuedTasks[i];
+      // If any instance has a request in progress, we should wait for it to
+      // finish before starting work that would notify that instance.
+      if (this.hasActiveRequest(task)) {
+        i++;
         continue;
       }
       const langs = getLangsFromTask(task);
@@ -519,6 +540,7 @@ export class WorkerPoolManager {
       if (availableWorker == null) {
         break;
       }
+      this.queuedTasks.splice(i, 1);
       this.assignWorkerToTask(task, availableWorker);
       void this.resolveLanguagesAndExecuteTask(availableWorker, task, langs);
     }
@@ -543,21 +565,37 @@ export class WorkerPoolManager {
     ) {
       return;
     }
-    // If we already have a task in progress for this same file content, we
-    // should drop it
-    for (const tasks of [this.taskQueue, this.pendingTasks.values()]) {
-      for (const task of tasks) {
-        if (
-          'instance' in task &&
-          task.instance === instance &&
-          task.request.type === 'file' &&
-          areFilesEqual(file, task.request.file)
-        ) {
-          return;
-        }
-      }
+    if (!this.hasMatchingFileInstanceTask(instance, file)) {
+      this.submitTask(instance, { type: 'file', file });
     }
-    this.submitTask(instance, { type: 'file', file });
+  }
+
+  public primeFileHighlightCache(file: FileContents): void {
+    if (file.cacheKey == null) {
+      console.warn(
+        `WorkerPoolManager.primeFileHighlightCache: priming highlight cache requires file.cacheKey; skipping "${file.name}".`
+      );
+      return;
+    }
+    const cachedResult = this.getFileResultCache(file);
+    const highlightKey = this.getFileHighlightKey(file);
+    if (
+      highlightKey == null ||
+      isFilePlainText(file) ||
+      (cachedResult != null &&
+        areFileRenderOptionsEqual(
+          cachedResult.options,
+          this.getFileRenderOptions()
+        ))
+    ) {
+      return;
+    }
+    const existingTask = this.getTaskByHighlightKey(highlightKey);
+    if (existingTask != null) {
+      existingTask.prewarm = true;
+    } else {
+      this.submitCacheTask({ type: 'file', file }, highlightKey);
+    }
   }
 
   public getPlainFileAST(
@@ -596,21 +634,37 @@ export class WorkerPoolManager {
     ) {
       return;
     }
-    // If we already have a task in progress for this same diff content, we
-    // should ignore executing it again
-    for (const tasks of [this.taskQueue, this.pendingTasks.values()]) {
-      for (const task of tasks) {
-        if (
-          'instance' in task &&
-          task.instance === instance &&
-          task.request.type === 'diff' &&
-          areDiffTargetsEqual(task.request.diff, diff)
-        ) {
-          return;
-        }
-      }
+    if (!this.hasMatchingDiffInstanceTask(instance, diff)) {
+      this.submitTask(instance, { type: 'diff', diff });
     }
-    this.submitTask(instance, { type: 'diff', diff });
+  }
+
+  public primeDiffHighlightCache(diff: FileDiffMetadata): void {
+    if (diff.cacheKey == null) {
+      console.warn(
+        `WorkerPoolManager.primeDiffHighlightCache: priming highlight cache requires diff.cacheKey; skipping "${diff.prevName ?? diff.name}" -> "${diff.name}".`
+      );
+      return;
+    }
+    const cachedResult = this.getDiffResultCache(diff);
+    const highlightKey = this.getDiffHighlightKey(diff);
+    if (
+      highlightKey == null ||
+      isDiffPlainText(diff) ||
+      (cachedResult != null &&
+        areDiffRenderOptionsEqual(
+          cachedResult.options,
+          this.getDiffRenderOptions()
+        ))
+    ) {
+      return;
+    }
+    const existingTask = this.getTaskByHighlightKey(highlightKey);
+    if (existingTask != null) {
+      existingTask.prewarm = true;
+    } else {
+      this.submitCacheTask({ type: 'diff', diff }, highlightKey);
+    }
   }
 
   public getPlainDiffAST(
@@ -633,13 +687,15 @@ export class WorkerPoolManager {
 
   public terminate(): void {
     this.lifecycleGeneration++;
-    this.cancelPendingAsyncWorkerTasks();
+    this.cancelActiveWorkerTasks();
     this.terminateWorkers();
     this.fileCache.clear();
     this.diffCache.clear();
-    this.instanceRequestMap.clear();
-    this.taskQueue.clear();
-    this.pendingTasks.clear();
+    this.activeRequestByInstance.clear();
+    this.queuedTasks.length = 0;
+    this.queuedTaskByInstance.clear();
+    this.taskByHighlightKey.clear();
+    this.activeTaskById.clear();
     this.highlighter = undefined;
     this.initialized = false;
     this.workersFailed = false;
@@ -656,9 +712,9 @@ export class WorkerPoolManager {
     });
   }
 
-  private cancelPendingAsyncWorkerTasks(): void {
+  private cancelActiveWorkerTasks(): void {
     const error = new WorkerPoolTerminatedError();
-    for (const task of this.pendingTasks.values()) {
+    for (const task of this.activeTaskById.values()) {
       if ('reject' in task) {
         task.reject(error);
       }
@@ -686,8 +742,8 @@ export class WorkerPoolManager {
       totalWorkers: this.workers.length,
       workersFailed: this.workersFailed,
       busyWorkers: this.workers.filter((w) => w.request_id != null).length,
-      queuedTasks: this.taskQueue.size,
-      pendingTasks: this.pendingTasks.size,
+      queuedTasks: this.queuedTasks.length,
+      activeTasks: this.activeTaskById.size,
       themeSubscribers: this.themeSubscribers.size,
       fileCacheSize: this.fileCache.size,
       diffCacheSize: this.diffCache.size,
@@ -710,16 +766,31 @@ export class WorkerPoolManager {
       this.queueInitialization();
     }
 
+    const highlightKey = this.getHighlightKeyForRequest(request);
+    const existingTask =
+      highlightKey != null
+        ? this.getTaskByHighlightKey(highlightKey)
+        : undefined;
+    if (existingTask != null) {
+      this.detachInstanceFromQueuedTasks(instance, existingTask);
+      this.addInstanceToTask(existingTask, instance);
+      this.queueBroadcastStateChanges();
+      return;
+    }
+
+    this.detachInstanceFromQueuedTasks(instance);
     const id = this.generateRequestId();
     const requestStart = Date.now();
-    const task: RenderFileTask | RenderDiffTask = (() => {
+    const task: RenderTask = (() => {
       switch (request.type) {
         case 'file':
           return {
             type: 'file',
             id,
             request: { ...request, id },
-            instance: instance as FileRendererInstance,
+            instances: new Set([instance as FileRendererInstance]),
+            prewarm: false,
+            highlightKey,
             requestStart,
           };
         case 'diff':
@@ -727,13 +798,60 @@ export class WorkerPoolManager {
             type: 'diff',
             id,
             request: { ...request, id },
-            instance: instance as DiffRendererInstance,
+            instances: new Set([instance as DiffRendererInstance]),
+            prewarm: false,
+            highlightKey,
             requestStart,
           };
       }
     })();
+    this.enqueueRenderTask(task, instance);
+  }
 
-    this.taskQueue.set(instance, task);
+  private submitCacheTask(request: SubmitRequest, highlightKey: string): void {
+    if (this.initialized === false) {
+      this.queueInitialization();
+    }
+    const id = this.generateRequestId();
+    const requestStart = Date.now();
+    const task: RenderTask = (() => {
+      switch (request.type) {
+        case 'file':
+          return {
+            type: 'file',
+            id,
+            request: { ...request, id },
+            instances: new Set<FileRendererInstance>(),
+            prewarm: true,
+            highlightKey,
+            requestStart,
+          };
+        case 'diff':
+          return {
+            type: 'diff',
+            id,
+            request: { ...request, id },
+            instances: new Set<DiffRendererInstance>(),
+            prewarm: true,
+            highlightKey,
+            requestStart,
+          };
+      }
+    })();
+    this.enqueueRenderTask(task);
+  }
+
+  private enqueueRenderTask(
+    task: RenderTask,
+    instance?: RenderTaskInstance
+  ): void {
+    this.queuedTasks.push(task);
+    if (instance != null) {
+      this.queuedTaskByInstance.set(instance, task);
+    }
+    if (task.highlightKey != null) {
+      this.taskByHighlightKey.set(task.highlightKey, task);
+    }
     this.queueDrain();
   }
 
@@ -757,9 +875,25 @@ export class WorkerPoolManager {
             await resolveLanguages(workerMissingLangs);
         }
       }
+      // If the task has been cleaned up after awaiting language resolving,
+      // lets fully clean it up
+      if (!this.activeTaskById.has(task.id)) {
+        if (availableWorker.request_id === task.id) {
+          this.cleanWorkerAndTask(availableWorker, task);
+          this.queueBroadcastStateChanges();
+          if (this.queuedTasks.length > 0) {
+            this.queueDrain();
+          }
+        }
+        return;
+      }
       this.executeTask(availableWorker, task);
     } catch {
       this.cleanWorkerAndTask(availableWorker, task);
+      this.queueBroadcastStateChanges();
+      if (this.queuedTasks.length > 0) {
+        this.queueDrain();
+      }
     }
   }
 
@@ -767,7 +901,7 @@ export class WorkerPoolManager {
     managedWorker: ManagedWorker,
     response: WorkerResponse
   ): void {
-    const task = this.pendingTasks.get(response.id);
+    const task = this.activeTaskById.get(response.id);
     try {
       if (task == null) {
         // If we can't find a task for this response, it probably means the
@@ -780,20 +914,13 @@ export class WorkerPoolManager {
         }
         if ('reject' in task) {
           task.reject(error);
+        } else if (isRenderTask(task)) {
+          this.notifyHighlightError(task, error);
         } else {
-          task.instance.onHighlightError(error);
+          throw new Error('handleWorkerMessage: unknown task type');
         }
         throw error;
       } else {
-        // If we've gotten a newer request from the same instance, we should
-        // ignore this response either because it's out of order or because we
-        // have a newer more important request
-        if (
-          'instance' in task &&
-          this.instanceRequestMap.get(task.instance) !== response.id
-        ) {
-          throw IGNORE_RESPONSE;
-        }
         switch (response.requestType) {
           case 'initialize':
             if (task.type !== 'initialize') {
@@ -813,12 +940,12 @@ export class WorkerPoolManager {
               throw new Error('handleWorkerMessage: task/response dont match');
             }
             const { result, options } = response;
-            const { instance, request } = task;
+            const { request } = task;
             this.syncCustomExtensionVersion(managedWorker, request);
             if (request.file.cacheKey != null) {
               this.fileCache.set(request.file.cacheKey, { result, options });
             }
-            instance.onHighlightSuccess(request.file, result, options);
+            this.notifyFileInstances(task, result, options);
             break;
           }
           case 'diff': {
@@ -826,12 +953,12 @@ export class WorkerPoolManager {
               throw new Error('handleWorkerMessage: task/response dont match');
             }
             const { result, options } = response;
-            const { instance, request } = task;
+            const { request } = task;
             this.syncCustomExtensionVersion(managedWorker, request);
             if (request.diff.cacheKey != null) {
               this.diffCache.set(request.diff.cacheKey, { result, options });
             }
-            instance.onHighlightSuccess(request.diff, result, options);
+            this.notifyDiffInstances(task, result, options);
             break;
           }
         }
@@ -844,7 +971,7 @@ export class WorkerPoolManager {
 
     this.cleanWorkerAndTask(managedWorker, task);
     this.queueBroadcastStateChanges();
-    if (this.taskQueue.size > 0) {
+    if (this.queuedTasks.length > 0) {
       // We queue drain so that potentially multiple workers can free up
       // allowing for better language matches if possible
       this.queueDrain();
@@ -863,11 +990,11 @@ export class WorkerPoolManager {
     managedWorker: ManagedWorker
   ) {
     managedWorker.request_id = task.id;
-    if ('instance' in task) {
-      this.taskQueue.delete(task.instance);
-      this.instanceRequestMap.set(task.instance, task.id);
+    if (isRenderTask(task)) {
+      this.clearQueuedInstanceRequests(task);
+      this.trackInstanceRequests(task);
     }
-    this.pendingTasks.set(task.id, task);
+    this.activeTaskById.set(task.id, task);
   }
 
   private cleanWorkerAndTask(
@@ -876,10 +1003,11 @@ export class WorkerPoolManager {
   ) {
     managedWorker.request_id = undefined;
     if (task != null) {
-      if ('instance' in task) {
-        this.instanceRequestMap.delete(task.instance);
+      if (isRenderTask(task)) {
+        this.clearInstanceRequests(task);
+        this.clearHighlightKey(task);
       }
-      this.pendingTasks.delete(task.id);
+      this.activeTaskById.delete(task.id);
     }
   }
 
@@ -890,19 +1018,24 @@ export class WorkerPoolManager {
     if (shouldSyncCustomExtensions(task.request)) {
       this.maybeAttachCustomExtensions(managedWorker, task.request);
     }
-    this.assignWorkerToTask(task, managedWorker);
+    if (!this.activeTaskById.has(task.id)) {
+      this.assignWorkerToTask(task, managedWorker);
+    }
     for (const lang of getLangsFromTask(task)) {
       managedWorker.langs.add(lang);
     }
     try {
       managedWorker.worker.postMessage(task.request);
     } catch (error) {
-      this.cleanWorkerAndTask(managedWorker, task);
       console.error('Failed to post message to worker:', error);
-      if ('instance' in task) {
-        task.instance.onHighlightError(error);
+      if (isRenderTask(task)) {
+        this.notifyHighlightError(task, error);
       } else if ('reject' in task) {
         task.reject(error as Error);
+      }
+      this.cleanWorkerAndTask(managedWorker, task);
+      if (this.queuedTasks.length > 0) {
+        this.queueDrain();
       }
     }
     this.queueBroadcastStateChanges();
@@ -959,6 +1092,207 @@ export class WorkerPoolManager {
     return worker;
   }
 
+  private getFileHighlightKey(file: FileContents): string | undefined {
+    if (file.cacheKey == null) {
+      return undefined;
+    }
+    return `file:${file.cacheKey}:${this.renderOptionsVersion}`;
+  }
+
+  private getDiffHighlightKey(diff: FileDiffMetadata): string | undefined {
+    if (diff.cacheKey == null) {
+      return undefined;
+    }
+    return `diff:${diff.cacheKey}:${this.renderOptionsVersion}`;
+  }
+
+  private getHighlightKeyForRequest(
+    request: SubmitRequest
+  ): string | undefined {
+    switch (request.type) {
+      case 'file':
+        return this.getFileHighlightKey(request.file);
+      case 'diff':
+        return this.getDiffHighlightKey(request.diff);
+    }
+  }
+
+  private hasActiveRequest(task: RenderTask): boolean {
+    for (const instance of getInstances(task)) {
+      if (this.activeRequestByInstance.has(instance)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private addInstanceToTask(
+    task: RenderTask,
+    instance: FileRendererInstance | DiffRendererInstance
+  ): void {
+    if (task.type === 'file') {
+      task.instances.add(instance as FileRendererInstance);
+    } else {
+      task.instances.add(instance as DiffRendererInstance);
+    }
+    if (this.activeTaskById.has(task.id)) {
+      this.activeRequestByInstance.set(instance, task.id);
+    } else {
+      this.queuedTaskByInstance.set(instance, task);
+    }
+  }
+
+  private detachInstanceFromQueuedTasks(
+    instance: RenderTaskInstance,
+    exceptTask?: RenderTask
+  ): void {
+    const task = this.queuedTaskByInstance.get(instance);
+    if (task == null || task === exceptTask) {
+      return;
+    }
+    this.queuedTaskByInstance.delete(instance);
+    this.detachInstanceFromRenderTask(task, instance);
+    if (!task.prewarm && task.instances.size === 0) {
+      this.removeQueuedTask(task);
+    }
+  }
+
+  private detachInstanceFromRenderTask(
+    task: RenderTask,
+    instance: RenderTaskInstance
+  ): void {
+    if (task.type === 'file') {
+      task.instances.delete(instance as FileRendererInstance);
+    } else {
+      task.instances.delete(instance as DiffRendererInstance);
+    }
+  }
+
+  private removeQueuedTask(task: RenderTask): void {
+    const index = this.queuedTasks.indexOf(task);
+    if (index !== -1) {
+      this.queuedTasks.splice(index, 1);
+    }
+    this.clearQueuedInstanceRequests(task);
+    this.clearHighlightKey(task);
+  }
+
+  private removeActiveTask(task: RenderTask): void {
+    this.clearInstanceRequests(task);
+    this.clearHighlightKey(task);
+    this.activeTaskById.delete(task.id);
+  }
+
+  private clearQueuedInstanceRequests(task: RenderTask): void {
+    for (const instance of getInstances(task)) {
+      if (this.queuedTaskByInstance.get(instance) === task) {
+        this.queuedTaskByInstance.delete(instance);
+      }
+    }
+  }
+
+  private clearHighlightKey(task: RenderTask): void {
+    if (
+      task.highlightKey != null &&
+      this.taskByHighlightKey.get(task.highlightKey) === task
+    ) {
+      this.taskByHighlightKey.delete(task.highlightKey);
+    }
+  }
+
+  private trackInstanceRequests(task: RenderTask): void {
+    for (const instance of getInstances(task)) {
+      this.activeRequestByInstance.set(instance, task.id);
+    }
+  }
+
+  private clearInstanceRequests(task: RenderTask): void {
+    for (const instance of getInstances(task)) {
+      if (this.activeRequestByInstance.get(instance) === task.id) {
+        this.activeRequestByInstance.delete(instance);
+      }
+    }
+  }
+
+  private notifyFileInstances(
+    task: RenderFileTask,
+    result: ThemedFileResult,
+    options: RenderFileOptions
+  ): void {
+    for (const instance of task.instances) {
+      if (this.activeRequestByInstance.get(instance) === task.id) {
+        instance.onHighlightSuccess(task.request.file, result, options);
+      }
+    }
+  }
+
+  private notifyDiffInstances(
+    task: RenderDiffTask,
+    result: ThemedDiffResult,
+    options: RenderDiffOptions
+  ): void {
+    for (const instance of task.instances) {
+      if (this.activeRequestByInstance.get(instance) === task.id) {
+        instance.onHighlightSuccess(task.request.diff, result, options);
+      }
+    }
+  }
+
+  private notifyHighlightError(task: RenderTask, error: unknown): void {
+    for (const instance of getInstances(task)) {
+      if (this.activeRequestByInstance.get(instance) === task.id) {
+        instance.onHighlightError(error);
+      }
+    }
+  }
+
+  private hasMatchingFileInstanceTask(
+    instance: FileRendererInstance,
+    file: FileContents
+  ): boolean {
+    for (const task of this.iterateRenderTasks()) {
+      if (
+        task.type === 'file' &&
+        task.instances.has(instance) &&
+        areFilesEqual(file, task.request.file)
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private hasMatchingDiffInstanceTask(
+    instance: DiffRendererInstance,
+    diff: FileDiffMetadata
+  ): boolean {
+    for (const task of this.iterateRenderTasks()) {
+      if (
+        task.type === 'diff' &&
+        task.instances.has(instance) &&
+        areDiffTargetsEqual(task.request.diff, diff)
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private getTaskByHighlightKey(highlightKey: string): RenderTask | undefined {
+    return this.taskByHighlightKey.get(highlightKey);
+  }
+
+  private *iterateRenderTasks(): Generator<RenderTask> {
+    for (const task of this.queuedTasks) {
+      yield task;
+    }
+    for (const task of this.activeTaskById.values()) {
+      if (isRenderTask(task)) {
+        yield task;
+      }
+    }
+  }
+
   private generateRequestId(): WorkerRequestId {
     return `req_${++this.nextRequestId}`;
   }
@@ -1001,4 +1335,14 @@ function getLangsFromTask(task: AllWorkerTasks): SupportedLanguages[] {
   }
   langs.delete('text');
   return Array.from(langs);
+}
+
+function isRenderTask(task: AllWorkerTasks | undefined): task is RenderTask {
+  return task?.type === 'file' || task?.type === 'diff';
+}
+
+function getInstances(
+  task: RenderTask
+): Set<FileRendererInstance | DiffRendererInstance> {
+  return task.instances as Set<FileRendererInstance | DiffRendererInstance>;
 }

--- a/packages/diffs/src/worker/WorkerPoolManager.ts
+++ b/packages/diffs/src/worker/WorkerPoolManager.ts
@@ -370,7 +370,7 @@ export class WorkerPoolManager {
     const task = this.activeTaskById.get(requestId);
     if (isRenderTask(task)) {
       this.detachInstanceFromRenderTask(task, instance);
-      if (!task.prewarm && task.instances.size === 0) {
+      if (!task.primeCache && task.instances.size === 0) {
         this.removeActiveTask(task);
       }
     } else {
@@ -592,7 +592,7 @@ export class WorkerPoolManager {
     }
     const existingTask = this.getTaskByHighlightKey(highlightKey);
     if (existingTask != null) {
-      existingTask.prewarm = true;
+      existingTask.primeCache = true;
     } else {
       this.submitCacheTask({ type: 'file', file }, highlightKey);
     }
@@ -661,7 +661,7 @@ export class WorkerPoolManager {
     }
     const existingTask = this.getTaskByHighlightKey(highlightKey);
     if (existingTask != null) {
-      existingTask.prewarm = true;
+      existingTask.primeCache = true;
     } else {
       this.submitCacheTask({ type: 'diff', diff }, highlightKey);
     }
@@ -789,7 +789,7 @@ export class WorkerPoolManager {
             id,
             request: { ...request, id },
             instances: new Set([instance as FileRendererInstance]),
-            prewarm: false,
+            primeCache: false,
             highlightKey,
             requestStart,
           };
@@ -799,7 +799,7 @@ export class WorkerPoolManager {
             id,
             request: { ...request, id },
             instances: new Set([instance as DiffRendererInstance]),
-            prewarm: false,
+            primeCache: false,
             highlightKey,
             requestStart,
           };
@@ -822,7 +822,7 @@ export class WorkerPoolManager {
             id,
             request: { ...request, id },
             instances: new Set<FileRendererInstance>(),
-            prewarm: true,
+            primeCache: true,
             highlightKey,
             requestStart,
           };
@@ -832,7 +832,7 @@ export class WorkerPoolManager {
             id,
             request: { ...request, id },
             instances: new Set<DiffRendererInstance>(),
-            prewarm: true,
+            primeCache: true,
             highlightKey,
             requestStart,
           };
@@ -1152,7 +1152,7 @@ export class WorkerPoolManager {
     }
     this.queuedTaskByInstance.delete(instance);
     this.detachInstanceFromRenderTask(task, instance);
-    if (!task.prewarm && task.instances.size === 0) {
+    if (!task.primeCache && task.instances.size === 0) {
       this.removeQueuedTask(task);
     }
   }

--- a/packages/diffs/src/worker/WorkerPoolManager.ts
+++ b/packages/diffs/src/worker/WorkerPoolManager.ts
@@ -25,6 +25,8 @@ import type {
   ThemeRegistrationResolved,
 } from '../types';
 import { areDiffRenderOptionsEqual } from '../utils/areDiffRenderOptionsEqual';
+import { areDiffTargetsEqual } from '../utils/areDiffTargetsEqual';
+import { areFileRenderOptionsEqual } from '../utils/areFileRenderOptionsEqual';
 import { areFilesEqual } from '../utils/areFilesEqual';
 import { areThemesEqual } from '../utils/areThemesEqual';
 import {
@@ -527,7 +529,18 @@ export class WorkerPoolManager {
     instance: FileRendererInstance,
     file: FileContents
   ): void {
-    if (isFilePlainText(file)) {
+    const cachedResult = this.getFileResultCache(file);
+    // If we've already highlighted the file or it's plain text, we should not
+    // attempt to highlight. This should be mostly never hit, but it's just an
+    // extra level of safety
+    if (
+      isFilePlainText(file) ||
+      (cachedResult != null &&
+        areFileRenderOptionsEqual(
+          cachedResult.options,
+          this.getFileRenderOptions()
+        ))
+    ) {
       return;
     }
     // If we already have a task in progress for this same file content, we
@@ -569,7 +582,18 @@ export class WorkerPoolManager {
     instance: DiffRendererInstance,
     diff: FileDiffMetadata
   ): void {
-    if (isDiffPlainText(diff)) {
+    const cachedResult = this.getDiffResultCache(diff);
+    // If we've already highlighted the diff or it's plain text, we should not
+    // attempt to highlight. This should be mostly never hit, but it's just an
+    // extra level of safety
+    if (
+      isDiffPlainText(diff) ||
+      (cachedResult != null &&
+        areDiffRenderOptionsEqual(
+          cachedResult.options,
+          this.getDiffRenderOptions()
+        ))
+    ) {
       return;
     }
     // If we already have a task in progress for this same diff content, we
@@ -580,7 +604,7 @@ export class WorkerPoolManager {
           'instance' in task &&
           task.instance === instance &&
           task.request.type === 'diff' &&
-          task.request.diff === diff
+          areDiffTargetsEqual(task.request.diff, diff)
         ) {
           return;
         }

--- a/packages/diffs/src/worker/types.ts
+++ b/packages/diffs/src/worker/types.ts
@@ -188,9 +188,9 @@ export interface RenderFileTask {
   type: 'file';
   id: WorkerRequestId;
   request: RenderFileRequest;
-  subscribers: Set<FileRendererInstance>;
-  cacheOnly: boolean;
-  workKey?: string;
+  instances: Set<FileRendererInstance>;
+  prewarm: boolean;
+  highlightKey?: string;
   requestStart: number;
 }
 
@@ -198,9 +198,9 @@ export interface RenderDiffTask {
   type: 'diff';
   id: WorkerRequestId;
   request: RenderDiffRequest;
-  subscribers: Set<DiffRendererInstance>;
-  cacheOnly: boolean;
-  workKey?: string;
+  instances: Set<DiffRendererInstance>;
+  prewarm: boolean;
+  highlightKey?: string;
   requestStart: number;
 }
 
@@ -216,7 +216,7 @@ export interface WorkerStats {
   totalWorkers: number;
   busyWorkers: number;
   queuedTasks: number;
-  pendingTasks: number;
+  activeTasks: number;
   themeSubscribers: number;
   fileCacheSize: number;
   diffCacheSize: number;

--- a/packages/diffs/src/worker/types.ts
+++ b/packages/diffs/src/worker/types.ts
@@ -189,7 +189,9 @@ export interface RenderFileTask {
   id: WorkerRequestId;
   request: RenderFileRequest;
   instances: Set<FileRendererInstance>;
-  prewarm: boolean;
+  // If primeCache is true, then the request will still be sent to workers
+  // regardless of whether there's any instances subscribed to the task
+  primeCache: boolean;
   highlightKey?: string;
   requestStart: number;
 }
@@ -199,7 +201,9 @@ export interface RenderDiffTask {
   id: WorkerRequestId;
   request: RenderDiffRequest;
   instances: Set<DiffRendererInstance>;
-  prewarm: boolean;
+  // If primeCache is true, then the request will still be sent to workers
+  // regardless of whether there's any instances subscribed to the task
+  primeCache: boolean;
   highlightKey?: string;
   requestStart: number;
 }

--- a/packages/diffs/src/worker/types.ts
+++ b/packages/diffs/src/worker/types.ts
@@ -188,7 +188,9 @@ export interface RenderFileTask {
   type: 'file';
   id: WorkerRequestId;
   request: RenderFileRequest;
-  instance: FileRendererInstance;
+  subscribers: Set<FileRendererInstance>;
+  cacheOnly: boolean;
+  workKey?: string;
   requestStart: number;
 }
 
@@ -196,7 +198,9 @@ export interface RenderDiffTask {
   type: 'diff';
   id: WorkerRequestId;
   request: RenderDiffRequest;
-  instance: DiffRendererInstance;
+  subscribers: Set<DiffRendererInstance>;
+  cacheOnly: boolean;
+  workKey?: string;
   requestStart: number;
 }
 

--- a/packages/diffs/test/WorkerPoolManager.test.ts
+++ b/packages/diffs/test/WorkerPoolManager.test.ts
@@ -84,14 +84,14 @@ describe('WorkerPoolManager lifecycle', () => {
     await withTimeout(initialization);
     expect(manager.getStats()).toMatchObject({
       managerState: 'waiting',
-      pendingTasks: 0,
+      activeTasks: 0,
       totalWorkers: 0,
       workersFailed: false,
     });
     expect(worker.terminated).toBe(true);
   });
 
-  test('settles initialization when terminate cancels pending worker setup', async () => {
+  test('settles initialization when terminate cancels active worker setup', async () => {
     const { initialization, manager, worker } = createInitializingManager();
     await worker.waitForInitializeRequest();
 
@@ -100,7 +100,7 @@ describe('WorkerPoolManager lifecycle', () => {
     await withTimeout(initialization);
     expect(manager.getStats()).toMatchObject({
       managerState: 'waiting',
-      pendingTasks: 0,
+      activeTasks: 0,
       totalWorkers: 0,
       workersFailed: false,
     });


### PR DESCRIPTION
### Description

Implements #679 

Two little changes across two areas:

diffs:
- `resolveEffectiveScrollBehavior` uses `'instant'` when `prefers-reduced-motion` is enabled
- prewarm in `scrollTo` to trigger the syntax highlighting as soon as we can, reducing the length of the FOUC. It's scoped to only warm the file(s) or line(s) that will be visible, ignoring previous and following stuff

### Motivation & Context

See #679 
Saw [the demo on Twitter](https://x.com/fat/status/2055062500996202579), played with it, and saw that this was missing (I use it frequently). Then the syntax highlighting taking too much time bothered me and figured I might as well propose a small fix

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality). You must have
      first discussed with the dev team and they should be aware that this PR is
      being opened
- [ ] Breaking change (fix or feature that would change existing functionality).
      You must have first discussed with the dev team and they should be aware
      that this PR is being opened
- [ ] Documentation update

(discussed in #679, happy to split into 2 PRs if you want, but I feel like that small and related enough for just 1)

### Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/pierrecomputer/pierre/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project (`bun run lint`)
- [x] My code is formatted properly (`bun run format`)
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have added tests to cover my changes (if applicable)
- [x] All new and existing tests pass (`bun run diffs:test`)

### How was AI used in generating this PR

I used CC to review my changes and to test many times with large diffs to confirm I wasn't crazy thinking prewarm was actually useful
Code, issue and PR are human-made

### Related issues

Discussion: #679 
