### PR TITLE
[diffs] Improve CodeView recalculation costs

### DIFF
--- a/packages/diffs/src/components/VirtualizedFile.ts
+++ b/packages/diffs/src/components/VirtualizedFile.ts
@@ -63,6 +63,7 @@ export class VirtualizedFile<
   private cache: FileLayoutCache = { heights: new Map(), checkpoints: [] };
   private isVisible: boolean = false;
   private isSetup: boolean = false;
+  private layoutDirty = true;
   private forceRenderOverride: true | undefined;
 
   constructor(
@@ -118,6 +119,7 @@ export class VirtualizedFile<
   }
 
   private resetLayoutCache(recompute = false): void {
+    this.layoutDirty = true;
     this.cache.heights.clear();
     this.cache.checkpoints = [];
     this.renderRange = undefined;
@@ -203,7 +205,7 @@ export class VirtualizedFile<
     }
 
     if (hasHeightChange || this.isResizeDebuggingEnabled()) {
-      this.computeApproximateSize();
+      this.computeApproximateSize(true);
     }
     return hasHeightChange;
   }
@@ -218,7 +220,14 @@ export class VirtualizedFile<
     return this.render({ file: this.file });
   };
 
+  // Prepares this item for CodeView layout by binding the latest file, syncing
+  // its virtualized top, and returning an approximate height. This method is
+  // called while downstream items are being re-positioned, so later changes
+  // should keep clean instances on a cached-height fast path.
   public prepareVirtualizedItem(file: FileContents): number {
+    if (this.file !== file) {
+      this.layoutDirty = true;
+    }
     this.file = file;
     this.top = this.getVirtualizedTop();
     this.computeApproximateSize();
@@ -380,17 +389,26 @@ export class VirtualizedFile<
     if (this.fileContainer != null && this.isSimpleMode()) {
       this.getSimpleVirtualizer()?.disconnect(this.fileContainer);
     }
+    if (!recycle) {
+      this.layoutDirty = true;
+    }
     this.isSetup = false;
     super.cleanUp(recycle);
   }
 
   // Compute the approximate size of the file using cached line heights.
   // Uses lineHeight for lines without cached measurements.
-  private computeApproximateSize(): void {
+  private computeApproximateSize(force = false): void {
+    const shouldValidateSize = this.isResizeDebuggingEnabled();
+    if (!force && !this.layoutDirty && !shouldValidateSize) {
+      return;
+    }
+
     const isFirstCompute = this.height === 0;
     this.height = 0;
     this.cache.checkpoints = [];
     if (this.file == null) {
+      this.layoutDirty = false;
       return;
     }
 
@@ -409,6 +427,7 @@ export class VirtualizedFile<
 
     this.height += headerRegion;
     if (collapsed) {
+      this.layoutDirty = false;
       return;
     }
 
@@ -428,11 +447,7 @@ export class VirtualizedFile<
       this.height += paddingBottom;
     }
 
-    if (
-      this.fileContainer != null &&
-      this.isResizeDebuggingEnabled() &&
-      !isFirstCompute
-    ) {
+    if (this.fileContainer != null && shouldValidateSize && !isFirstCompute) {
       const rect = this.fileContainer.getBoundingClientRect();
       if (rect.height !== this.height) {
         console.log(
@@ -449,6 +464,7 @@ export class VirtualizedFile<
         );
       }
     }
+    this.layoutDirty = false;
   }
 
   public setVisibility(visible: boolean): void {

--- a/packages/diffs/src/components/VirtualizedFileDiff.ts
+++ b/packages/diffs/src/components/VirtualizedFileDiff.ts
@@ -72,6 +72,7 @@ export class VirtualizedFileDiff<
   private isVisible: boolean = false;
   private isSetup: boolean = false;
   private virtualizer: Virtualizer | CodeView<LAnnotation>;
+  private layoutDirty = true;
   private forceRenderOverride: true | undefined;
 
   constructor(
@@ -141,6 +142,7 @@ export class VirtualizedFileDiff<
   }
 
   private resetLayoutCache(recompute = false): void {
+    this.layoutDirty = true;
     this.cache.heights.clear();
     this.cache.checkpoints = [];
     this.cache.totalLines = 0;
@@ -233,7 +235,7 @@ export class VirtualizedFileDiff<
     }
 
     if (hasHeightChange || this.isResizeDebuggingEnabled()) {
-      this.computeApproximateSize();
+      this.computeApproximateSize(true);
     }
     return hasHeightChange;
   }
@@ -248,7 +250,14 @@ export class VirtualizedFileDiff<
     return this.render();
   };
 
+  // Prepares this item for CodeView layout by binding the latest diff, syncing
+  // its virtualized top, and returning an approximate height. This method is
+  // called while downstream items are being re-positioned, so later changes
+  // should keep clean instances on a cached-height fast path.
   public prepareVirtualizedItem(fileDiff: FileDiffMetadata): number {
+    if (this.fileDiff !== fileDiff) {
+      this.layoutDirty = true;
+    }
     this.fileDiff = fileDiff;
     this.top = this.getVirtualizedTop();
     this.computeApproximateSize();
@@ -512,6 +521,9 @@ export class VirtualizedFileDiff<
     if (this.fileContainer != null && this.isSimpleMode()) {
       this.getSimpleVirtualizer()?.disconnect(this.fileContainer);
     }
+    if (!recycle) {
+      this.layoutDirty = true;
+    }
     this.isSetup = false;
     super.cleanUp(recycle);
   }
@@ -526,6 +538,7 @@ export class VirtualizedFileDiff<
       direction,
       expansionLineCountOverride
     );
+    this.layoutDirty = true;
     this.computeApproximateSize();
     this.renderRange = undefined;
     this.virtualizer.instanceChanged(this, true);
@@ -564,12 +577,18 @@ export class VirtualizedFileDiff<
   // The reason we refer to this as `approximate size` is because heights my
   // dynamically change for a number of reasons so we can never be fully sure
   // if the height is 100% accurate
-  private computeApproximateSize(): void {
+  private computeApproximateSize(force = false): void {
+    const shouldValidateSize = this.isResizeDebuggingEnabled();
+    if (!force && !this.layoutDirty && !shouldValidateSize) {
+      return;
+    }
+
     const isFirstCompute = this.height === 0;
     this.height = 0;
     this.cache.checkpoints = [];
     this.cache.totalLines = 0;
     if (this.fileDiff == null) {
+      this.layoutDirty = false;
       return;
     }
 
@@ -596,6 +615,7 @@ export class VirtualizedFileDiff<
 
     this.height += headerRegion;
     if (collapsed) {
+      this.layoutDirty = false;
       return;
     }
 
@@ -649,11 +669,7 @@ export class VirtualizedFileDiff<
       this.height += paddingBottom;
     }
 
-    if (
-      this.fileContainer != null &&
-      this.isResizeDebuggingEnabled() &&
-      !isFirstCompute
-    ) {
+    if (this.fileContainer != null && shouldValidateSize && !isFirstCompute) {
       const rect = this.fileContainer.getBoundingClientRect();
       if (rect.height !== this.height) {
         console.log(
@@ -670,6 +686,7 @@ export class VirtualizedFileDiff<
         );
       }
     }
+    this.layoutDirty = false;
   }
 
   override render({


### PR DESCRIPTION
Add a bit more intelligence around full recalculations (i.e. most of the time we just need to set a new top value and call it a day, we only need to fully recalculate if something about our internal layout changes)