### PR TITLE
[diffs] Fix computation with 'simple' hunkSeparators in VirtualizedFile/Diffs

### DIFF
--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -527,9 +527,7 @@ export class CodeView<LAnnotation = undefined> {
       diffHeaderHeight:
         itemMetrics?.diffHeaderHeight ??
         DEFAULT_CODE_VIEW_FILE_METRICS.diffHeaderHeight,
-      hunkSeparatorHeight:
-        itemMetrics?.hunkSeparatorHeight ??
-        DEFAULT_CODE_VIEW_FILE_METRICS.hunkSeparatorHeight,
+      hunkSeparatorHeight: itemMetrics?.hunkSeparatorHeight,
       spacing: itemMetrics?.spacing ?? DEFAULT_CODE_VIEW_FILE_METRICS.spacing,
       paddingTop: itemMetrics?.paddingTop,
       paddingBottom: itemMetrics?.paddingBottom,

--- a/packages/diffs/src/components/VirtualizedFile.ts
+++ b/packages/diffs/src/components/VirtualizedFile.ts
@@ -9,11 +9,11 @@ import type {
 } from '../types';
 import { areObjectsEqual } from '../utils/areObjectsEqual';
 import { areOptionsEqual } from '../utils/areOptionsEqual';
-import { iterateOverFile } from '../utils/iterateOverFile';
 import {
   getVirtualFileHeaderRegion,
   getVirtualFilePaddingBottom,
-} from '../utils/resolveVirtualFileMetrics';
+} from '../utils/computeVirtualFileMetrics';
+import { iterateOverFile } from '../utils/iterateOverFile';
 import type { WorkerPoolManager } from '../worker';
 import type { CodeView } from './CodeView';
 import { File, type FileOptions, type FileRenderProps } from './File';

--- a/packages/diffs/src/components/VirtualizedFileDiff.ts
+++ b/packages/diffs/src/components/VirtualizedFileDiff.ts
@@ -2,6 +2,7 @@ import { DEFAULT_COLLAPSED_CONTEXT_THRESHOLD } from '../constants';
 import type {
   ExpansionDirections,
   FileDiffMetadata,
+  HunkSeparators,
   NumericScrollLineAnchor,
   RenderRange,
   RenderWindow,
@@ -11,13 +12,14 @@ import type {
 } from '../types';
 import { areObjectsEqual } from '../utils/areObjectsEqual';
 import { areOptionsEqual } from '../utils/areOptionsEqual';
-import { iterateOverDiff } from '../utils/iterateOverDiff';
-import { parseDiffFromFile } from '../utils/parseDiffFromFile';
 import {
+  computeVirtualFileMetrics,
+  getDefaultHunkSeparatorHeight,
   getVirtualFileHeaderRegion,
   getVirtualFilePaddingBottom,
-  resolveVirtualFileMetrics,
-} from '../utils/resolveVirtualFileMetrics';
+} from '../utils/computeVirtualFileMetrics';
+import { iterateOverDiff } from '../utils/iterateOverDiff';
+import { parseDiffFromFile } from '../utils/parseDiffFromFile';
 import type { WorkerPoolManager } from '../worker';
 import type { CodeView } from './CodeView';
 import {
@@ -83,23 +85,15 @@ export class VirtualizedFileDiff<
     isContainerManaged = false
   ) {
     super(options, workerManager, isContainerManaged);
-    const { hunkSeparators = 'line-info' } = this.options;
     this.virtualizer = virtualizer;
-    this.metrics = resolveVirtualFileMetrics(
-      typeof hunkSeparators === 'function' ? 'custom' : hunkSeparators,
-      metrics
-    );
+    this.metrics = computeVirtualFileMetrics(metrics);
   }
 
   public setMetrics(
     metrics?: Partial<VirtualFileMetrics>,
     force = false
   ): void {
-    const { hunkSeparators = 'line-info' } = this.options;
-    const nextMetrics = resolveVirtualFileMetrics(
-      typeof hunkSeparators === 'function' ? 'custom' : hunkSeparators,
-      metrics
-    );
+    const nextMetrics = computeVirtualFileMetrics(metrics);
     if (!force && areObjectsEqual(this.metrics, nextMetrics)) {
       return;
     }
@@ -282,16 +276,11 @@ export class VirtualizedFileDiff<
       expandUnchanged = false,
       collapsed = false,
       collapsedContextThreshold = DEFAULT_COLLAPSED_CONTEXT_THRESHOLD,
-      hunkSeparators = 'line-info',
     } = this.options;
-    const { hunkSeparatorHeight, spacing } = this.metrics;
     const diffStyle = this.getDiffStyle();
-    const separatorGap =
-      hunkSeparators !== 'simple' &&
-      hunkSeparators !== 'metadata' &&
-      hunkSeparators !== 'line-info-basic'
-        ? spacing
-        : 0;
+    const hunkSeparators = this.getHunkSeparatorType();
+    const hunkSeparatorHeight = this.getHunkSeparatorHeight(hunkSeparators);
+    const separatorGap = this.getSeparatorGap(hunkSeparators);
     const targetLineIndex =
       diffStyle === 'split' ? targetLineIndexes[1] : targetLineIndexes[0];
     const checkpoint = this.getLayoutCheckpointBeforeLineIndex(targetLineIndex);
@@ -314,6 +303,7 @@ export class VirtualizedFileDiff<
       collapsedContextThreshold,
       callback: ({
         hunkIndex,
+        hunk,
         collapsedBefore,
         collapsedAfter,
         deletionLine,
@@ -330,7 +320,14 @@ export class VirtualizedFileDiff<
           );
         }
 
-        if (collapsedBefore > 0) {
+        if (
+          collapsedBefore > 0 &&
+          this.hasLeadingHunkSeparator(
+            hunkIndex,
+            hunk?.hunkSpecs,
+            hunkSeparators
+          )
+        ) {
           if (hunkIndex > 0) {
             top += separatorGap;
           }
@@ -360,7 +357,10 @@ export class VirtualizedFileDiff<
         }
         top += lineHeight;
 
-        if (collapsedAfter > 0 && hunkSeparators !== 'simple') {
+        if (
+          collapsedAfter > 0 &&
+          this.hasTrailingHunkSeparator(hunkSeparators)
+        ) {
           if (
             targetLineIndex > lineIndex &&
             targetLineIndex <= lineIndex + collapsedAfter
@@ -393,20 +393,15 @@ export class VirtualizedFileDiff<
       expandUnchanged = false,
       collapsed = false,
       collapsedContextThreshold = DEFAULT_COLLAPSED_CONTEXT_THRESHOLD,
-      hunkSeparators = 'line-info',
     } = this.options;
     if (collapsed) {
       return undefined;
     }
 
-    const { hunkSeparatorHeight, spacing } = this.metrics;
     const diffStyle = this.getDiffStyle();
-    const separatorGap =
-      hunkSeparators !== 'simple' &&
-      hunkSeparators !== 'metadata' &&
-      hunkSeparators !== 'line-info-basic'
-        ? spacing
-        : 0;
+    const hunkSeparators = this.getHunkSeparatorType();
+    const hunkSeparatorHeight = this.getHunkSeparatorHeight(hunkSeparators);
+    const separatorGap = this.getSeparatorGap(hunkSeparators);
 
     const checkpoint = this.getLayoutCheckpointBeforeTop(localViewportTop);
     let top =
@@ -427,6 +422,7 @@ export class VirtualizedFileDiff<
       collapsedContextThreshold,
       callback: ({
         hunkIndex,
+        hunk,
         collapsedBefore,
         collapsedAfter,
         deletionLine,
@@ -443,7 +439,14 @@ export class VirtualizedFileDiff<
           );
         }
 
-        if (collapsedBefore > 0) {
+        if (
+          collapsedBefore > 0 &&
+          this.hasLeadingHunkSeparator(
+            hunkIndex,
+            hunk?.hunkSpecs,
+            hunkSeparators
+          )
+        ) {
           if (hunkIndex > 0) {
             top += separatorGap;
           }
@@ -475,7 +478,10 @@ export class VirtualizedFileDiff<
         );
         top += lineHeight;
 
-        if (collapsedAfter > 0 && hunkSeparators !== 'simple') {
+        if (
+          collapsedAfter > 0 &&
+          this.hasTrailingHunkSeparator(hunkSeparators)
+        ) {
           top += separatorGap + hunkSeparatorHeight;
         }
 
@@ -597,16 +603,11 @@ export class VirtualizedFileDiff<
       expandUnchanged = false,
       collapsed = false,
       collapsedContextThreshold = DEFAULT_COLLAPSED_CONTEXT_THRESHOLD,
-      hunkSeparators = 'line-info',
     } = this.options;
-    const { spacing, hunkSeparatorHeight } = this.metrics;
     const diffStyle = this.getDiffStyle();
-    const separatorGap =
-      hunkSeparators !== 'simple' &&
-      hunkSeparators !== 'metadata' &&
-      hunkSeparators !== 'line-info-basic'
-        ? spacing
-        : 0;
+    const hunkSeparators = this.getHunkSeparatorType();
+    const hunkSeparatorHeight = this.getHunkSeparatorHeight(hunkSeparators);
+    const separatorGap = this.getSeparatorGap(hunkSeparators);
     const headerRegion = getVirtualFileHeaderRegion(
       this.metrics,
       disableFileHeader
@@ -629,6 +630,7 @@ export class VirtualizedFileDiff<
       collapsedContextThreshold,
       callback: ({
         hunkIndex,
+        hunk,
         collapsedBefore,
         collapsedAfter,
         deletionLine,
@@ -647,7 +649,14 @@ export class VirtualizedFileDiff<
         const lineIndex =
           diffStyle === 'split' ? splitLineIndex : unifiedLineIndex;
         this.addLayoutCheckpoint(renderedLineIndex, lineIndex, this.height);
-        if (collapsedBefore > 0) {
+        if (
+          collapsedBefore > 0 &&
+          this.hasLeadingHunkSeparator(
+            hunkIndex,
+            hunk?.hunkSpecs,
+            hunkSeparators
+          )
+        ) {
           if (hunkIndex > 0) {
             this.height += separatorGap;
           }
@@ -656,7 +665,10 @@ export class VirtualizedFileDiff<
 
         this.height += this.getLineHeight(lineIndex, hasMetadata);
 
-        if (collapsedAfter > 0 && hunkSeparators !== 'simple') {
+        if (
+          collapsedAfter > 0 &&
+          this.hasTrailingHunkSeparator(hunkSeparators)
+        ) {
           this.height += separatorGap + hunkSeparatorHeight;
         }
         renderedLineIndex++;
@@ -799,6 +811,47 @@ export class VirtualizedFileDiff<
 
   private getDiffStyle(): 'split' | 'unified' {
     return this.options.diffStyle ?? 'split';
+  }
+
+  private getHunkSeparatorType(): HunkSeparators {
+    return getOptionHunkSeparatorType(this.options.hunkSeparators);
+  }
+
+  private getHunkSeparatorHeight(type = this.getHunkSeparatorType()): number {
+    return (
+      this.metrics.hunkSeparatorHeight ?? getDefaultHunkSeparatorHeight(type)
+    );
+  }
+
+  private getSeparatorGap(type = this.getHunkSeparatorType()): number {
+    return type === 'simple' ||
+      type === 'metadata' ||
+      type === 'line-info-basic'
+      ? 0
+      : this.metrics.spacing;
+  }
+
+  private hasLeadingHunkSeparator(
+    hunkIndex: number,
+    hunkSpecs: string | undefined,
+    type = this.getHunkSeparatorType()
+  ): boolean {
+    switch (type) {
+      case 'simple':
+        return hunkIndex > 0;
+      case 'metadata':
+        return hunkSpecs != null;
+      case 'line-info':
+      case 'line-info-basic':
+      case 'custom':
+        return true;
+    }
+  }
+
+  private hasTrailingHunkSeparator(
+    type = this.getHunkSeparatorType()
+  ): boolean {
+    return type !== 'simple' && type !== 'metadata';
   }
 
   private addLayoutCheckpoint(
@@ -991,11 +1044,11 @@ export class VirtualizedFileDiff<
       disableFileHeader = false,
       expandUnchanged = false,
       collapsedContextThreshold = DEFAULT_COLLAPSED_CONTEXT_THRESHOLD,
-      hunkSeparators = 'line-info',
     } = this.options;
-    const { spacing, hunkLineCount, hunkSeparatorHeight, lineHeight } =
-      this.metrics;
+    const { hunkLineCount, lineHeight } = this.metrics;
     const diffStyle = this.getDiffStyle();
+    const hunkSeparators = this.getHunkSeparatorType();
+    const hunkSeparatorHeight = this.getHunkSeparatorHeight(hunkSeparators);
     const fileHeight = this.height;
     const lineCount =
       this.cache.totalLines > 0
@@ -1039,12 +1092,7 @@ export class VirtualizedFileDiff<
     const hunkOffsets: number[] = [];
     // Halfway between top & bottom, represented as an absolute position
     const viewportCenter = (top + bottom) / 2;
-    const separatorGap =
-      hunkSeparators === 'simple' ||
-      hunkSeparators === 'metadata' ||
-      hunkSeparators === 'line-info-basic'
-        ? 0
-        : spacing;
+    const separatorGap = this.getSeparatorGap(hunkSeparators);
     // Start the scan before the viewport so we collect hunk offsets that may be
     // needed for bufferBefore. This only chooses the scan origin; the returned
     // render range is still computed from the visible window below.
@@ -1069,6 +1117,7 @@ export class VirtualizedFileDiff<
       collapsedContextThreshold,
       callback: ({
         hunkIndex,
+        hunk,
         collapsedBefore,
         collapsedAfter,
         deletionLine,
@@ -1084,15 +1133,17 @@ export class VirtualizedFileDiff<
             : deletionLine.unifiedLineIndex;
         const hasMetadata =
           (additionLine?.noEOFCR ?? false) || (deletionLine?.noEOFCR ?? false);
-        let gapAdjustment =
-          collapsedBefore > 0
+        const gapAdjustment =
+          collapsedBefore > 0 &&
+          this.hasLeadingHunkSeparator(
+            hunkIndex,
+            hunk?.hunkSpecs,
+            hunkSeparators
+          )
             ? hunkSeparatorHeight +
               separatorGap +
               (hunkIndex > 0 ? separatorGap : 0)
             : 0;
-        if (hunkIndex === 0 && hunkSeparators === 'simple') {
-          gapAdjustment = 0;
-        }
 
         absoluteLineTop += gapAdjustment;
 
@@ -1145,7 +1196,10 @@ export class VirtualizedFileDiff<
         currentLine++;
         absoluteLineTop += lineHeight;
 
-        if (collapsedAfter > 0 && hunkSeparators !== 'simple') {
+        if (
+          collapsedAfter > 0 &&
+          this.hasTrailingHunkSeparator(hunkSeparators)
+        ) {
           absoluteLineTop += hunkSeparatorHeight + separatorGap;
         }
 
@@ -1235,6 +1289,14 @@ function hasDiffLayoutOptionChanged<LAnnotation>(
         DEFAULT_COLLAPSED_CONTEXT_THRESHOLD) ||
     previousOptions.unsafeCSS !== nextOptions.unsafeCSS
   );
+}
+
+function getOptionHunkSeparatorType<LAnnotation>(
+  hunkSeparators: FileDiffOptions<LAnnotation>['hunkSeparators'] | undefined
+): HunkSeparators {
+  return typeof hunkSeparators === 'function'
+    ? 'custom'
+    : (hunkSeparators ?? 'line-info');
 }
 
 function hasFinalHunk(fileDiff: FileDiffMetadata): boolean {

--- a/packages/diffs/src/constants.ts
+++ b/packages/diffs/src/constants.ts
@@ -62,7 +62,6 @@ export const DEFAULT_VIRTUAL_FILE_METRICS: VirtualFileMetrics = {
   hunkLineCount: 50,
   lineHeight: 20,
   diffHeaderHeight: 44,
-  hunkSeparatorHeight: 32,
   spacing: 8,
 };
 

--- a/packages/diffs/src/types.ts
+++ b/packages/diffs/src/types.ts
@@ -772,8 +772,9 @@ export interface VirtualFileMetrics {
   lineHeight: number;
   /** Height reserved for the file or diff header region. */
   diffHeaderHeight: number;
-  /** Height reserved for each collapsed-context separator row. */
-  hunkSeparatorHeight: number;
+  /** Height reserved for each collapsed-context separator row. Only set this
+   * if you customized the size of hunk separators via unsafeCSS */
+  hunkSeparatorHeight?: number;
   /** Vertical spacing used around hunks and file-level padding. You should not
    * change this from the default if you aren't applying custom CSS */
   spacing: number;

--- a/packages/diffs/src/utils/computeVirtualFileMetrics.ts
+++ b/packages/diffs/src/utils/computeVirtualFileMetrics.ts
@@ -1,19 +1,13 @@
 import { DEFAULT_VIRTUAL_FILE_METRICS } from '../constants';
 import type { HunkSeparators, VirtualFileMetrics } from '../types';
 
-export function resolveVirtualFileMetrics(
-  hunkSeparators: HunkSeparators,
-  metricsOverride?: Partial<VirtualFileMetrics>
+export function computeVirtualFileMetrics(
+  metrics?: Partial<VirtualFileMetrics>
 ): VirtualFileMetrics {
-  const metrics: VirtualFileMetrics = {
+  return {
     ...DEFAULT_VIRTUAL_FILE_METRICS,
-    ...metricsOverride,
+    ...metrics,
   };
-  metrics.hunkSeparatorHeight = getHunkSeparatorHeight(
-    hunkSeparators,
-    metricsOverride?.hunkSeparatorHeight
-  );
-  return metrics;
 }
 
 export function getVirtualFileHeaderRegion(
@@ -37,13 +31,7 @@ export function getVirtualFilePaddingBottom(
   return metrics.paddingBottom ?? metrics.spacing;
 }
 
-function getHunkSeparatorHeight(
-  type: HunkSeparators,
-  customHeight: number | undefined
-): number {
-  if (customHeight != null) {
-    return customHeight;
-  }
+export function getDefaultHunkSeparatorHeight(type: HunkSeparators): number {
   switch (type) {
     case 'simple':
       return 4;

--- a/packages/diffs/test/sparseLayoutCheckpoints.test.ts
+++ b/packages/diffs/test/sparseLayoutCheckpoints.test.ts
@@ -7,7 +7,7 @@ import type { FileContents, VirtualFileMetrics } from '../src/types';
 import { iterateOverDiff } from '../src/utils/iterateOverDiff';
 import { parseDiffFromFile } from '../src/utils/parseDiffFromFile';
 
-const metrics: VirtualFileMetrics = {
+const metrics: VirtualFileMetrics & { hunkSeparatorHeight: number } = {
   ...DEFAULT_VIRTUAL_FILE_METRICS,
   hunkLineCount: 1,
   lineHeight: 10,

--- a/packages/diffs/test/virtualFileMetricsPadding.test.ts
+++ b/packages/diffs/test/virtualFileMetricsPadding.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, test } from 'bun:test';
 
 import { VirtualizedFile } from '../src/components/VirtualizedFile';
 import { VirtualizedFileDiff } from '../src/components/VirtualizedFileDiff';
-import { DEFAULT_VIRTUAL_FILE_METRICS } from '../src/constants';
+import {
+  DEFAULT_CODE_VIEW_FILE_METRICS,
+  DEFAULT_VIRTUAL_FILE_METRICS,
+} from '../src/constants';
 import type { FileContents, VirtualFileMetrics } from '../src/types';
 import { parseDiffFromFile } from '../src/utils/parseDiffFromFile';
 
-const baseMetrics: VirtualFileMetrics = {
+const baseMetrics: VirtualFileMetrics & { hunkSeparatorHeight: number } = {
   ...DEFAULT_VIRTUAL_FILE_METRICS,
   hunkLineCount: 2,
   lineHeight: 10,
@@ -36,6 +39,28 @@ const file: FileContents = {
   name: 'file.ts',
   contents: 'one\ntwo\nthree',
 };
+
+const codeViewLikeMetrics: VirtualFileMetrics = {
+  ...DEFAULT_CODE_VIEW_FILE_METRICS,
+  hunkLineCount: 2,
+  lineHeight: 10,
+  diffHeaderHeight: 30,
+  spacing: 4,
+};
+
+function createTwoHunkDiff() {
+  const oldLines = Array.from({ length: 140 }, (_, index) => `${index + 1}`);
+  const newLines = oldLines.map((line, index) => {
+    if (index === 39) return 'changed-40';
+    if (index === 99) return 'changed-100';
+    return line;
+  });
+
+  return parseDiffFromFile(
+    { name: 'two-hunks.ts', contents: `${oldLines.join('\n')}\n` },
+    { name: 'two-hunks.ts', contents: `${newLines.join('\n')}\n` }
+  );
+}
 
 function createVirtualizedFile(
   metrics: Partial<VirtualFileMetrics> = {},
@@ -190,6 +215,102 @@ describe('virtual file padding metrics', () => {
           firstHunk.splitLineCount * baseMetrics.lineHeight +
           baseMetrics.hunkSeparatorHeight +
           baseMetrics.spacing * 2
+      );
+    });
+
+    test('uses built-in simple separator measurements with CodeView metrics', () => {
+      const fileDiff = createTwoHunkDiff();
+      const [firstHunk, secondHunk] = fileDiff.hunks;
+      if (firstHunk == null || secondHunk == null) {
+        throw new Error('Expected two hunks');
+      }
+      const instance = new VirtualizedFileDiff(
+        { hunkSeparators: 'simple' },
+        virtualizer,
+        codeViewLikeMetrics
+      );
+
+      instance.prepareVirtualizedItem(fileDiff);
+
+      expect(firstHunk.collapsedBefore).toBeGreaterThan(0);
+      expect(secondHunk.collapsedBefore).toBeGreaterThan(0);
+      expect(
+        instance.getLinePosition(firstHunk.additionStart, 'additions')?.top
+      ).toBe(codeViewLikeMetrics.diffHeaderHeight);
+      expect(
+        instance.getLinePosition(secondHunk.additionStart, 'additions')?.top
+      ).toBe(
+        codeViewLikeMetrics.diffHeaderHeight +
+          firstHunk.splitLineCount * codeViewLikeMetrics.lineHeight +
+          4
+      );
+      expect(instance.getVirtualizedHeight()).toBe(
+        codeViewLikeMetrics.diffHeaderHeight +
+          (firstHunk.splitLineCount + secondHunk.splitLineCount) *
+            codeViewLikeMetrics.lineHeight +
+          4 +
+          codeViewLikeMetrics.spacing
+      );
+    });
+
+    test('re-resolves built-in separator measurements when options change', () => {
+      const fileDiff = createTwoHunkDiff();
+      const [firstHunk, secondHunk] = fileDiff.hunks;
+      if (firstHunk == null || secondHunk == null) {
+        throw new Error('Expected two hunks');
+      }
+      const instance = new VirtualizedFileDiff(
+        { hunkSeparators: 'line-info-basic' },
+        virtualizer,
+        codeViewLikeMetrics
+      );
+
+      instance.prepareVirtualizedItem(fileDiff);
+      expect(
+        instance.getLinePosition(secondHunk.additionStart, 'additions')?.top
+      ).toBe(
+        codeViewLikeMetrics.diffHeaderHeight +
+          32 +
+          firstHunk.splitLineCount * codeViewLikeMetrics.lineHeight +
+          32
+      );
+
+      instance.setOptions({ hunkSeparators: 'simple' });
+
+      expect(
+        instance.getLinePosition(secondHunk.additionStart, 'additions')?.top
+      ).toBe(
+        codeViewLikeMetrics.diffHeaderHeight +
+          firstHunk.splitLineCount * codeViewLikeMetrics.lineHeight +
+          4
+      );
+    });
+
+    test('does not reserve metadata separator height for final collapsed context', () => {
+      const fileDiff = createTwoHunkDiff();
+      const [firstHunk, secondHunk] = fileDiff.hunks;
+      if (firstHunk == null || secondHunk == null) {
+        throw new Error('Expected two hunks');
+      }
+      const instance = new VirtualizedFileDiff(
+        { hunkSeparators: 'metadata' },
+        virtualizer,
+        codeViewLikeMetrics
+      );
+
+      instance.prepareVirtualizedItem(fileDiff);
+
+      expect(firstHunk.collapsedBefore).toBeGreaterThan(0);
+      expect(secondHunk.collapsedBefore).toBeGreaterThan(0);
+      expect(
+        instance.getLinePosition(firstHunk.additionStart, 'additions')?.top
+      ).toBe(codeViewLikeMetrics.diffHeaderHeight + 32);
+      expect(instance.getVirtualizedHeight()).toBe(
+        codeViewLikeMetrics.diffHeaderHeight +
+          32 * 2 +
+          (firstHunk.splitLineCount + secondHunk.splitLineCount) *
+            codeViewLikeMetrics.lineHeight +
+          codeViewLikeMetrics.spacing
       );
     });
   });


### PR DESCRIPTION
Lmao, I really fucked up on this one... 

Basically virtualizers didn't properly compute 'simple' type 'hunkSeparators'

Wild nobody has really found this bug yet.