### PR TITLE
[diffs] fix ResizeManager double-delete on number element swap

### DIFF
--- a/packages/diffs/src/managers/ResizeManager.ts
+++ b/packages/diffs/src/managers/ResizeManager.ts
@@ -44,6 +44,9 @@ export class ResizeManager {
         if (item.numberElement !== numberElement) {
           if (item.numberElement != null) {
             this.resizeObserver.unobserve(item.numberElement);
+            // Mirrors the numberElement bookkeeping in the else-branch below.
+            observedNodes.delete(item.numberElement);
+            this.observedNodes.delete(item.numberElement);
           }
           if (numberElement != null) {
             this.resizeObserver.observe(numberElement);


### PR DESCRIPTION
The old numberElement was unobserved but never removed from the function-scoped snapshot, so the trailing reaping loop treated it as stale and striped inline styles.
