### PR TITLE
[diffs] cancel previous source stream in FileStream.setupStream

### DIFF
--- a/packages/diffs/src/components/FileStream.ts
+++ b/packages/diffs/src/components/FileStream.ts
@@ -152,6 +152,9 @@ export class FileStream {
     this.abortController?.abort();
     this.abortController = new AbortController();
     const { onStreamStart, onStreamClose, onStreamAbort } = this.options;
+    // Cancel the prior source so upstream producers stop generating tokens.
+    // Swallow AbortError / locked-stream rejections since we're tearing down.
+    this.stream?.cancel().catch(() => {});
     this.stream = stream;
     this.stream
       .pipeThrough(


### PR DESCRIPTION
Be sure that a second setupStream cancels the first, rather than simply overwriting it.