### PR TITLE
[diffs] tolerate stale IntersectionObserver entries after disconnect

### DIFF
--- a/packages/diffs/src/components/Virtualizer.ts
+++ b/packages/diffs/src/components/Virtualizer.ts
@@ -551,10 +551,10 @@ export class Virtualizer {
         );
       }
       const instance = this.observers.get(target);
+      // IntersectionObserver delivers entries asynchronously, so an entry can
+      // arrive after the target was unobserved via disconnect() or releaseElement().
       if (instance == null) {
-        throw new Error(
-          'Virtualizer.handleIntersectionChange: no instance for target'
-        );
+        continue;
       }
       if (isIntersecting && !this.visibleInstances.has(target)) {
         instance.setVisibility(true);


### PR DESCRIPTION
IntersectionObserver delivers entries asynchronously, so the callback can fire for a target the Virtualizer has already released via disconnect() or releaseElement() — at which point the target is no longer in this.observers and the previous code threw.

Replace the throw with continue so stale entries are ignored. The target-not-HTMLElement throw above is left as-is since real browsers won't deliver non-Element targets.
