### PR TITLE
[diffs] Disable overflow scroll while scrolling

### DIFF
--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -378,7 +378,8 @@ export interface CodeViewOptions<LAnnotation>
   __devOnlyValidateItemHeights?: boolean;
 }
 
-const DEFAULT_POINTER_EVENTS_RESTORE_DELAY_MS = 120;
+const DEFAULT_SCROLL_INTERACTION_RESTORE_DELAY_MS = 120;
+const SCROLLING_CODE_OVERFLOW_FIX_VARIABLE = '--diffs-overflow-override';
 const SCROLL_REBASE_CONTAINER_HEIGHT = 12_000_000;
 const SCROLL_REBASE_TRIGGER_TOP = 1_000_000;
 const SCROLL_REBASE_TARGET_TOP = 2_000_000;
@@ -397,6 +398,23 @@ interface SpringStepResult {
   position: number;
   velocity: number;
 }
+
+// A vibe slopped heuristic to detect mobile safari only
+const MOBILE_SAFARI = (() => {
+  const { navigator } = globalThis;
+
+  const userAgent = navigator.userAgent;
+  const isIOS = /iP(?:hone|ad|od)/.test(userAgent);
+  const isIPadOS =
+    navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
+
+  return (
+    (isIOS || isIPadOS) &&
+    /AppleWebKit/.test(userAgent) &&
+    /Safari/.test(userAgent) &&
+    !/(CriOS|FxiOS|EdgiOS|OPiOS)/.test(userAgent)
+  );
+})();
 
 type PendingAlignTypes = Exclude<CodeViewLineScrollTarget['align'], 'nearest'>;
 
@@ -446,8 +464,9 @@ export class CodeView<LAnnotation = undefined> {
   private scrollTop: number = 0;
   private scrollPageOffset: number = 0;
   private scrollDirty = true;
-  private pointerEventsRestoreTimer: ReturnType<typeof setTimeout> | undefined;
+  private scrollInteractionFixTimer: ReturnType<typeof setTimeout> | undefined;
   private pointerEventsDisabled = false;
+  private codeOverflowFix = false;
   private height: number = 0;
   private heightDirty = true;
   private windowSpecs: VirtualWindowSpecs = { top: 0, bottom: 0 };
@@ -591,36 +610,56 @@ export class CodeView<LAnnotation = undefined> {
     );
   }
 
-  private clearPointerEventsTimer(): void {
-    if (this.pointerEventsRestoreTimer != null) {
-      clearTimeout(this.pointerEventsRestoreTimer);
-      this.pointerEventsRestoreTimer = undefined;
+  private clearScrollInteractionTimer(): void {
+    if (this.scrollInteractionFixTimer != null) {
+      clearTimeout(this.scrollInteractionFixTimer);
+      this.scrollInteractionFixTimer = undefined;
     }
   }
 
-  private suspendPointerEvents(): void {
-    if (!this.shouldDisablePointerEvents()) {
-      return;
-    }
+  private suspendScrollInteractions(): void {
+    this.clearScrollInteractionTimer();
 
-    this.clearPointerEventsTimer();
-    if (!this.pointerEventsDisabled) {
+    if (this.shouldDisablePointerEvents() && !this.pointerEventsDisabled) {
       this.stickyContainer.style.pointerEvents = 'none';
       this.pointerEventsDisabled = true;
     }
-    this.pointerEventsRestoreTimer = setTimeout(
-      this.restorePointerEvents,
-      DEFAULT_POINTER_EVENTS_RESTORE_DELAY_MS
+
+    // This is a really important fix for mobile safari; under aggressive scroll
+    // conditions we'll eventually crash/reload the page. It appears to be
+    // caused by the fact that the code wrapper elements are horizontally
+    // scrollable, so while aggressively scrolling, we disable scrolling. We
+    // don't want to apply this fix to good browsers since in those cases it
+    // can fuck with layout in ways that aren't appropriate
+    if (MOBILE_SAFARI && !this.codeOverflowFix) {
+      this.stickyContainer.style.setProperty(
+        SCROLLING_CODE_OVERFLOW_FIX_VARIABLE,
+        'hidden'
+      );
+      this.codeOverflowFix = true;
+    }
+
+    this.scrollInteractionFixTimer = setTimeout(
+      this.restoreScrollInteractions,
+      DEFAULT_SCROLL_INTERACTION_RESTORE_DELAY_MS
     );
   }
 
-  private restorePointerEvents = (): void => {
-    this.clearPointerEventsTimer();
-    if (!this.pointerEventsDisabled) {
-      return;
+  private restoreScrollInteractions = (): void => {
+    this.clearScrollInteractionTimer();
+
+    if (this.pointerEventsDisabled) {
+      this.stickyContainer.style.removeProperty('pointer-events');
+      this.pointerEventsDisabled = false;
     }
-    this.stickyContainer.style.removeProperty('pointer-events');
-    this.pointerEventsDisabled = false;
+
+    if (this.codeOverflowFix) {
+      this.stickyContainer.style.setProperty(
+        SCROLLING_CODE_OVERFLOW_FIX_VARIABLE,
+        'auto'
+      );
+      this.codeOverflowFix = false;
+    }
   };
 
   private syncLayout(): void {
@@ -699,7 +738,7 @@ export class CodeView<LAnnotation = undefined> {
   }
 
   public reset(): void {
-    this.restorePointerEvents();
+    this.restoreScrollInteractions();
     this.cleanAllRenderedItems();
     this.selectedLines = null;
     this.items.length = 0;
@@ -729,7 +768,7 @@ export class CodeView<LAnnotation = undefined> {
 
   public cleanUp(): void {
     this.reset();
-    this.restorePointerEvents();
+    this.restoreScrollInteractions();
     this.resizeObserver?.disconnect();
     this.resizeObserver = undefined;
     this.root?.removeEventListener('scroll', this.handleScroll);
@@ -828,7 +867,7 @@ export class CodeView<LAnnotation = undefined> {
     }
 
     // We'll attempt to scroll to this new target on the next render frame
-    this.suspendPointerEvents();
+    this.suspendScrollInteractions();
     this.pendingLayoutAnchor = undefined;
     this.pendingScrollTarget = pendingTarget;
     this.render();
@@ -2485,7 +2524,7 @@ export class CodeView<LAnnotation = undefined> {
     if (CodeView.__STOP) {
       return;
     }
-    this.suspendPointerEvents();
+    this.suspendScrollInteractions();
     this.scrollDirty = true;
     this.notifyScroll();
     this.render();
@@ -2701,7 +2740,7 @@ export class CodeView<LAnnotation = undefined> {
     ) {
       return;
     }
-    this.suspendPointerEvents();
+    this.suspendScrollInteractions();
     if (targetPagedScrollTop !== syncedPagedScrollTop || rebaseChanged) {
       this.scrollPageOffset = scrollPageOffset;
       this.syncPagedScrollScaffolding(windowSpecs);

--- a/packages/diffs/src/style.css
+++ b/packages/diffs/src/style.css
@@ -773,7 +773,7 @@
     display: grid;
     grid-auto-flow: dense;
     grid-template-columns: var(--diffs-code-grid);
-    overflow: scroll clip;
+    overflow: var(--diffs-overflow-override, scroll) clip;
     overscroll-behavior-x: none;
     tab-size: var(--diffs-tab-size, 2);
     align-self: flex-start;

--- a/packages/diffs/test/CodeView.pointerEvents.test.ts
+++ b/packages/diffs/test/CodeView.pointerEvents.test.ts
@@ -3,10 +3,22 @@ import { JSDOM } from 'jsdom';
 
 import { CodeView } from '../src/components/CodeView';
 
-function installDom() {
+function installDom({
+  maxTouchPoints = 0,
+  platform = 'MacIntel',
+  userAgent,
+}: {
+  maxTouchPoints?: number;
+  platform?: string;
+  userAgent?: string;
+} = {}) {
   const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
     url: 'http://localhost',
   });
+  const originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    'navigator'
+  );
   const originalValues = {
     cancelAnimationFrame: Reflect.get(globalThis, 'cancelAnimationFrame'),
     document: Reflect.get(globalThis, 'document'),
@@ -18,6 +30,22 @@ function installDom() {
     ResizeObserver: Reflect.get(globalThis, 'ResizeObserver'),
     window: Reflect.get(globalThis, 'window'),
   };
+
+  const navigator = Object.create(dom.window.navigator) as Navigator;
+  Object.defineProperties(navigator, {
+    maxTouchPoints: {
+      configurable: true,
+      value: maxTouchPoints,
+    },
+    platform: {
+      configurable: true,
+      value: platform,
+    },
+    userAgent: {
+      configurable: true,
+      value: userAgent ?? dom.window.navigator.userAgent,
+    },
+  });
 
   class MockResizeObserver {
     observe(_target: Element): void {}
@@ -53,6 +81,10 @@ function installDom() {
     ResizeObserver: MockResizeObserver,
     window: dom.window,
   });
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: navigator,
+  });
 
   return {
     cleanup() {
@@ -67,6 +99,15 @@ function installDom() {
         } else {
           Object.assign(globalThis, { [key]: value });
         }
+      }
+      if (originalNavigatorDescriptor == null) {
+        Reflect.deleteProperty(globalThis, 'navigator');
+      } else {
+        Object.defineProperty(
+          globalThis,
+          'navigator',
+          originalNavigatorDescriptor
+        );
       }
       dom.window.close();
     },
@@ -83,6 +124,10 @@ function getPointerEventsTarget(root: HTMLElement): HTMLDivElement {
     throw new Error('missing CodeView sticky container');
   }
   return stickyContainer;
+}
+
+function getCodeOverflowBlock(target: HTMLElement): string {
+  return target.style.getPropertyValue('--diffs-overflow-override');
 }
 
 function dispatchScroll(root: HTMLElement): void {
@@ -105,8 +150,10 @@ describe('CodeView pointer events while scrolling', () => {
       dispatchScroll(root);
 
       expect(pointerEventsTarget.style.pointerEvents).toBe('none');
+      expect(getCodeOverflowBlock(pointerEventsTarget)).toBe('');
       await wait(150);
       expect(pointerEventsTarget.style.pointerEvents).toBe('');
+      expect(getCodeOverflowBlock(pointerEventsTarget)).toBe('');
     } finally {
       viewer.cleanUp();
       await wait(0);
@@ -127,7 +174,9 @@ describe('CodeView pointer events while scrolling', () => {
       dispatchScroll(root);
 
       expect(pointerEventsTarget.style.pointerEvents).toBe('');
-      await wait(0);
+      expect(getCodeOverflowBlock(pointerEventsTarget)).toBe('');
+      await wait(150);
+      expect(getCodeOverflowBlock(pointerEventsTarget)).toBe('');
     } finally {
       viewer.cleanUp();
       await wait(0);
@@ -145,12 +194,15 @@ describe('CodeView pointer events while scrolling', () => {
 
       dispatchScroll(root);
       expect(pointerEventsTarget.style.pointerEvents).toBe('none');
+      expect(getCodeOverflowBlock(pointerEventsTarget)).toBe('');
 
       viewer.cleanUp();
 
       expect(pointerEventsTarget.style.pointerEvents).toBe('');
+      expect(getCodeOverflowBlock(pointerEventsTarget)).toBe('');
       await wait(150);
       expect(pointerEventsTarget.style.pointerEvents).toBe('');
+      expect(getCodeOverflowBlock(pointerEventsTarget)).toBe('');
     } finally {
       viewer.cleanUp();
       await wait(0);
@@ -188,12 +240,44 @@ describe('CodeView pointer events while scrolling', () => {
 
       dispatchScroll(root);
       expect(pointerEventsTarget.style.pointerEvents).toBe('none');
+      expect(getCodeOverflowBlock(pointerEventsTarget)).toBe('');
 
       viewer.setOptions({ pointerEventsOnScroll: true });
 
       expect(pointerEventsTarget.style.pointerEvents).toBe('none');
+      expect(getCodeOverflowBlock(pointerEventsTarget)).toBe('');
       await wait(150);
       expect(pointerEventsTarget.style.pointerEvents).toBe('');
+      expect(getCodeOverflowBlock(pointerEventsTarget)).toBe('');
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+
+  test('applies overflow override while scrolling on mobile Safari only', async () => {
+    const { cleanup } = installDom({
+      maxTouchPoints: 5,
+      platform: 'iPhone',
+      userAgent:
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+    });
+    const modulePath = '../src/components/CodeView.ts?mobile-safari-test';
+    const { CodeView: MobileSafariCodeView } = await import(modulePath);
+    const viewer = new MobileSafariCodeView();
+    try {
+      const root = document.createElement('div');
+      viewer.setup(root);
+      const pointerEventsTarget = getPointerEventsTarget(root);
+
+      dispatchScroll(root);
+
+      expect(pointerEventsTarget.style.pointerEvents).toBe('none');
+      expect(getCodeOverflowBlock(pointerEventsTarget)).toBe('hidden');
+      await wait(150);
+      expect(pointerEventsTarget.style.pointerEvents).toBe('');
+      expect(getCodeOverflowBlock(pointerEventsTarget)).toBe('auto');
     } finally {
       viewer.cleanUp();
       await wait(0);


### PR DESCRIPTION
I was just going through a bunch of random removals and stuff to see if i could fix the mobile safari crash, and eventually landed on the overflow scroll for code elements. i set it to overflow clip, and now the crashes seem to have gone away 👀 

~I AI slopped the initial implementation of this, but since it works, will clean it up and get it shipped.~