### PR TITLE
[diffshub] stop cloning paths and pathToItemId per tree-source publish

### DIFF
--- a/apps/docs/app/(diffshub)/(view)/_components/CodeViewFileTree.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/CodeViewFileTree.tsx
@@ -44,6 +44,14 @@ export const CodeViewFileTree = memo(function CodeViewFileTree({
   const previousSourceRef = useRef(source);
   const [initialVisibleRowCount] = useState(getInitialBatchSize);
   sourceRef.current = source;
+  // `source.paths` aliases the streaming accumulator's live array, so it keeps
+  // growing on later publishes. The FileTree model consumes its path list
+  // exactly once via useFileTree's useState initializer; capture a bounded
+  // snapshot here so the first model build uses only what `pathCount`
+  // describes and so subsequent streaming re-renders don't re-slice the
+  // ever-growing live array.
+  const initialPathsRef = useRef<readonly string[] | null>(null);
+  initialPathsRef.current ??= source.paths.slice(0, source.pathCount);
   const sort = useStableCallback<CodeViewFileTreeSource['sort']>(
     (left, right) => sourceRef.current.sort(left, right)
   );
@@ -53,7 +61,7 @@ export const CodeViewFileTree = memo(function CodeViewFileTree({
         return;
       }
       const [path] = selectedPaths;
-      const itemId = source?.pathToItemId.get(path);
+      const itemId = sourceRef.current.pathToItemId.get(path);
       if (itemId != null) {
         onSelectItem(itemId);
       }
@@ -63,7 +71,7 @@ export const CodeViewFileTree = memo(function CodeViewFileTree({
   const { model } = useFileTree({
     ...BASE_FILE_TREE_OPTIONS,
     gitStatus: source.gitStatus,
-    paths: source.paths,
+    paths: initialPathsRef.current,
     sort,
     onSelectionChange,
     itemHeight: CODE_VIEW_FILE_TREE_ITEM_HEIGHT,
@@ -85,18 +93,18 @@ export const CodeViewFileTree = memo(function CodeViewFileTree({
     // turns tree publishes from O(N) each (where N is the total accumulated
     // path count) into O(delta), which keeps the Diff Stats counter fast as
     // more files stream in.
+    //
+    // Both snapshots alias the live accumulator's paths array, so we read the
+    // delta bounds from each snapshot's captured `pathCount` instead of the
+    // shared array's current length.
     if (
       source.previousSource != null &&
       source.previousSource === previousSource
     ) {
-      const previousPathCount = previousSource.paths.length;
-      if (source.paths.length > previousPathCount) {
+      const previousPathCount = previousSource.pathCount;
+      if (source.pathCount > previousPathCount) {
         const operations: FileTreeBatchOperation[] = [];
-        for (
-          let index = previousPathCount;
-          index < source.paths.length;
-          index++
-        ) {
+        for (let index = previousPathCount; index < source.pathCount; index++) {
           operations.push({ type: 'add', path: source.paths[index] });
         }
         if (operations.length > 0) {
@@ -104,7 +112,7 @@ export const CodeViewFileTree = memo(function CodeViewFileTree({
         }
       }
     } else {
-      model.resetPaths(source.paths);
+      model.resetPaths(source.paths.slice(0, source.pathCount));
     }
     model.setGitStatus(source.gitStatus);
   }, [model, source]);

--- a/apps/docs/app/(diffshub)/(view)/_components/codeViewDataAccumulator.ts
+++ b/apps/docs/app/(diffshub)/(view)/_components/codeViewDataAccumulator.ts
@@ -183,8 +183,9 @@ export function snapshotCodeViewTreeSource(
 ): CodeViewFileTreeSource {
   const snapshot: CodeViewFileTreeSource = {
     gitStatus: Array.from(accumulator.gitStatusByPath.values()),
-    paths: accumulator.paths.slice(),
-    pathToItemId: new Map(accumulator.pathToItemId),
+    pathCount: accumulator.paths.length,
+    paths: accumulator.paths,
+    pathToItemId: accumulator.pathToItemId,
     previousSource: accumulator.lastTreeSource,
     sort: accumulator.sort,
   };

--- a/apps/docs/app/(diffshub)/(view)/_components/types.ts
+++ b/apps/docs/app/(diffshub)/(view)/_components/types.ts
@@ -82,8 +82,16 @@ export interface CodeViewSavedCommentItem {
 // present only on snapshots that share the same underlying accumulator; the
 // initial publish and any non-streamed source leave it undefined and force a
 // full reset.
+//
+// `paths` and `pathToItemId` may alias the live accumulator state for
+// streamed sources, so consumers must treat them as read-only and must use
+// `pathCount` (captured at snapshot time) as the exclusive upper bound when
+// iterating `paths`. The `readonly` markers and ReadonlyMap type enforce the
+// read-only side; pathCount is what keeps later in-place growth invisible to
+// this snapshot.
 export interface CodeViewFileTreeSource {
   gitStatus: readonly GitStatusEntry[];
+  pathCount: number;
   paths: readonly string[];
   pathToItemId: ReadonlyMap<string, string>;
   previousSource?: CodeViewFileTreeSource;


### PR DESCRIPTION
Every tree publish allocated a fresh `paths.slice()` and a fresh `new Map(pathToItemId)`. For the torvalds/linux v6.0..v7.0 stream that is roughly a ~640 KB array copy and a ~4 MB Map clone per publish. Maths to something like ~370 MB of potential GC churn.

`snapshotCodeViewTreeSource` now aliases the accumulator's live `paths` and `pathToItemId` directly. To stay race-free against later in-place growth, the snapshot also captures the exclusive upper bound for the array as `pathCount`. CodeViewFileTree reads bounds for the incremental-add delta and for the fallback `resetPaths` slice from `pathCount` instead of `paths.length`, and the initial path list handed to useFileTree is captured once in a ref so re-renders don't re-slice the growing live array. `pathToItemId` is read at click time through the same live reference (`sourceRef`), which is what the typed ReadonlyMap was already implying.

Per-publish allocations shrink from O(N) to O(M) (only the small added/deleted/renamed gitStatus array still copies), removing a sizable allocation in the streaming hot path.