### PR TITLE
[diffshub] rewrite PR-scoped commit URLs to /commit/{sha}

### DIFF
--- a/apps/docs/app/(diffshub)/(view)/[...path]/page.tsx
+++ b/apps/docs/app/(diffshub)/(view)/[...path]/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
 
 import { ReviewUI } from '../_components/ReviewUI';
+import { resolveDiffshubViewerRoute } from '../_components/utils';
 
 // Viewer route that mirrors the upstream path. GitHub is the public default,
 // while hidden alternate domains can opt in through the `domain` query param.
@@ -13,20 +14,19 @@ export default async function DiffshubViewByPathPage({
 }) {
   const { path } = await params;
   const { domain } = await searchParams;
-  if (path.length === 0) {
-    redirect('/');
-  }
   const requestedDomain = Array.isArray(domain) ? domain[0] : domain;
-  const upstreamPath = `/${path.join('/')}`;
-  const host =
-    requestedDomain == null || requestedDomain === ''
-      ? 'github.com'
-      : requestedDomain;
-  const url = `https://${host}${upstreamPath}`;
+  const route = resolveDiffshubViewerRoute(path, requestedDomain);
+  if (route.kind === 'redirect') {
+    redirect(route.target);
+  }
 
   return (
     <div className="flex h-dvh flex-col gap-2">
-      <ReviewUI domain={requestedDomain} initialUrl={url} path={upstreamPath} />
+      <ReviewUI
+        domain={route.domain}
+        initialUrl={route.url}
+        path={route.upstreamPath}
+      />
     </div>
   );
 }

--- a/apps/docs/app/(diffshub)/(view)/_components/utils.ts
+++ b/apps/docs/app/(diffshub)/(view)/_components/utils.ts
@@ -25,6 +25,8 @@ const RAW_GITHUB_DIFF_PATH_PATTERN =
   /^\/raw\/([^/]+)\/([^/]+)\/pull\/([^/]+\.(?:diff|patch))$/;
 const GITHUB_PULL_TAB_PATH_PATTERN =
   /^\/([^/]+)\/([^/]+)\/pull\/(\d+)\/(?:changes|files)$/;
+const GITHUB_PULL_COMMIT_PATH_PATTERN =
+  /^\/([^/]+)\/([^/]+)\/pull\/\d+\/(?:changes|files)\/([0-9a-f]{4,40})$/i;
 
 // Matches GitHub shorthand "owner/repo#123" → /owner/repo/pull/123.
 const GITHUB_SHORTHAND_PATTERN = /^([^/\s]+)\/([^/\s#]+)#(\d+)$/;
@@ -127,6 +129,51 @@ export function getPatchViewerHref(input: string): string | undefined {
   return undefined;
 }
 
+export type DiffshubViewerRoute =
+  | { kind: 'redirect'; target: string }
+  | {
+      kind: 'render';
+      upstreamPath: string;
+      url: string;
+      domain: string | undefined;
+    };
+
+// Resolves the catch-all viewer route into either a redirect or the props the
+// viewer needs to render. Extracted from the route page so it can be unit
+// tested without spinning up Next.js. Empty paths redirect to the home page;
+// GitHub paths are canonicalized via normalizeGitHubPath so direct navigation
+// matches the hrefs getPatchViewerHref produces from form input. Non-GitHub
+// hosts are passed through unchanged because their canonical form is unknown.
+export function resolveDiffshubViewerRoute(
+  pathSegments: readonly string[],
+  requestedDomainInput: string | undefined
+): DiffshubViewerRoute {
+  if (pathSegments.length === 0) {
+    return { kind: 'redirect', target: '/' };
+  }
+
+  const domain =
+    requestedDomainInput == null || requestedDomainInput === ''
+      ? undefined
+      : requestedDomainInput;
+  const joinedPath = `/${pathSegments.join('/')}`;
+  const upstreamPath =
+    domain == null ? normalizeGitHubPath(joinedPath) : joinedPath;
+
+  if (upstreamPath !== joinedPath) {
+    const query = domain == null ? '' : `?domain=${encodeURIComponent(domain)}`;
+    return { kind: 'redirect', target: `${upstreamPath}${query}` };
+  }
+
+  const host = domain ?? GITHUB_HOST;
+  return {
+    domain,
+    kind: 'render',
+    upstreamPath,
+    url: `https://${host}${upstreamPath}`,
+  };
+}
+
 function getGitHubPathFromURL(parsedURL: URL): string | undefined {
   if (parsedURL.hostname === GITHUB_HOST) {
     if (parsedURL.pathname === '/') {
@@ -154,10 +201,15 @@ function getGitHubPathFromURL(parsedURL: URL): string | undefined {
   return `/${owner}/${repo}/pull/${pullFile}`;
 }
 
-function normalizeGitHubPath(path: string): string {
+export function normalizeGitHubPath(path: string): string {
   const pathWithoutTrailingSlash = path.replace(/\/+$/, '');
   const trimmedPath =
     pathWithoutTrailingSlash === '' ? '/' : pathWithoutTrailingSlash;
+  const pullCommitMatch = GITHUB_PULL_COMMIT_PATH_PATTERN.exec(trimmedPath);
+  if (pullCommitMatch != null) {
+    return `/${pullCommitMatch[1]}/${pullCommitMatch[2]}/commit/${pullCommitMatch[3]}`;
+  }
+
   const pullTabMatch = GITHUB_PULL_TAB_PATH_PATTERN.exec(trimmedPath);
   if (pullTabMatch == null) {
     return trimmedPath;

--- a/apps/docs/test/getPatchViewerHref.test.ts
+++ b/apps/docs/test/getPatchViewerHref.test.ts
@@ -36,6 +36,24 @@ describe('getPatchViewerHref', () => {
       ).toBe('/owner/repo/commit/abc123def');
     });
 
+    test('PR changes tab scoped to a commit SHA', () => {
+      expect(
+        getPatchViewerHref(
+          'https://github.com/pierrecomputer/pierre/pull/692/changes/83fea5e63ef8751ddbcfabe33154bc2e096c3d85'
+        )
+      ).toBe(
+        '/pierrecomputer/pierre/commit/83fea5e63ef8751ddbcfabe33154bc2e096c3d85'
+      );
+    });
+
+    test('PR files tab scoped to a commit SHA', () => {
+      expect(
+        getPatchViewerHref(
+          'https://github.com/owner/repo/pull/123/files/abc1234'
+        )
+      ).toBe('/owner/repo/commit/abc1234');
+    });
+
     test('root github.com returns undefined', () => {
       expect(getPatchViewerHref('https://github.com/')).toBeUndefined();
     });
@@ -65,6 +83,16 @@ describe('getPatchViewerHref', () => {
     test('owner/repo/pull/123/changes', () => {
       expect(getPatchViewerHref('pierrecomputer/pierre/pull/673/changes')).toBe(
         '/pierrecomputer/pierre/pull/673'
+      );
+    });
+
+    test('owner/repo/pull/123/changes/{sha}', () => {
+      expect(
+        getPatchViewerHref(
+          'pierrecomputer/pierre/pull/692/changes/83fea5e63ef8751ddbcfabe33154bc2e096c3d85'
+        )
+      ).toBe(
+        '/pierrecomputer/pierre/commit/83fea5e63ef8751ddbcfabe33154bc2e096c3d85'
       );
     });
 

--- a/apps/docs/test/resolveDiffshubViewerRoute.test.ts
+++ b/apps/docs/test/resolveDiffshubViewerRoute.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveDiffshubViewerRoute } from '../app/(diffshub)/(view)/_components/utils';
+
+describe('resolveDiffshubViewerRoute', () => {
+  describe('empty path', () => {
+    test('redirects to home', () => {
+      expect(resolveDiffshubViewerRoute([], undefined)).toEqual({
+        kind: 'redirect',
+        target: '/',
+      });
+    });
+  });
+
+  describe('GitHub (default host) canonical paths', () => {
+    test('PR path renders without rewrite', () => {
+      expect(
+        resolveDiffshubViewerRoute(['owner', 'repo', 'pull', '123'], undefined)
+      ).toEqual({
+        domain: undefined,
+        kind: 'render',
+        upstreamPath: '/owner/repo/pull/123',
+        url: 'https://github.com/owner/repo/pull/123',
+      });
+    });
+
+    test('commit path renders without rewrite', () => {
+      expect(
+        resolveDiffshubViewerRoute(
+          ['owner', 'repo', 'commit', 'abc1234'],
+          undefined
+        )
+      ).toEqual({
+        domain: undefined,
+        kind: 'render',
+        upstreamPath: '/owner/repo/commit/abc1234',
+        url: 'https://github.com/owner/repo/commit/abc1234',
+      });
+    });
+
+    test('empty-string domain is treated as default GitHub', () => {
+      expect(
+        resolveDiffshubViewerRoute(['owner', 'repo', 'pull', '123'], '')
+      ).toEqual({
+        domain: undefined,
+        kind: 'render',
+        upstreamPath: '/owner/repo/pull/123',
+        url: 'https://github.com/owner/repo/pull/123',
+      });
+    });
+  });
+
+  describe('GitHub (default host) redirects', () => {
+    test('PR changes tab redirects to canonical PR path', () => {
+      expect(
+        resolveDiffshubViewerRoute(
+          ['owner', 'repo', 'pull', '123', 'changes'],
+          undefined
+        )
+      ).toEqual({
+        kind: 'redirect',
+        target: '/owner/repo/pull/123',
+      });
+    });
+
+    test('PR files tab redirects to canonical PR path', () => {
+      expect(
+        resolveDiffshubViewerRoute(
+          ['owner', 'repo', 'pull', '123', 'files'],
+          undefined
+        )
+      ).toEqual({
+        kind: 'redirect',
+        target: '/owner/repo/pull/123',
+      });
+    });
+
+    test('PR changes tab scoped to a SHA redirects to commit path', () => {
+      expect(
+        resolveDiffshubViewerRoute(
+          [
+            'pierrecomputer',
+            'pierre',
+            'pull',
+            '692',
+            'changes',
+            '83fea5e63ef8751ddbcfabe33154bc2e096c3d85',
+          ],
+          undefined
+        )
+      ).toEqual({
+        kind: 'redirect',
+        target:
+          '/pierrecomputer/pierre/commit/83fea5e63ef8751ddbcfabe33154bc2e096c3d85',
+      });
+    });
+
+    test('PR files tab scoped to a SHA redirects to commit path', () => {
+      expect(
+        resolveDiffshubViewerRoute(
+          ['owner', 'repo', 'pull', '123', 'files', 'abc1234'],
+          undefined
+        )
+      ).toEqual({
+        kind: 'redirect',
+        target: '/owner/repo/commit/abc1234',
+      });
+    });
+
+    test('non-hex SHA-shaped segment is left unrewritten', () => {
+      // Defensive: GitHub may add real PR subroutes in the future. If the
+      // trailing segment isn't hex, we want to pass it through rather than
+      // misinterpret it as a commit.
+      expect(
+        resolveDiffshubViewerRoute(
+          ['owner', 'repo', 'pull', '123', 'changes', 'reviews'],
+          undefined
+        )
+      ).toEqual({
+        domain: undefined,
+        kind: 'render',
+        upstreamPath: '/owner/repo/pull/123/changes/reviews',
+        url: 'https://github.com/owner/repo/pull/123/changes/reviews',
+      });
+    });
+  });
+
+  describe('alternate domain', () => {
+    test('renders against the requested host without rewriting', () => {
+      expect(
+        resolveDiffshubViewerRoute(
+          ['owner', 'repo', 'pull', '123', 'changes'],
+          'gitlab.com'
+        )
+      ).toEqual({
+        domain: 'gitlab.com',
+        kind: 'render',
+        upstreamPath: '/owner/repo/pull/123/changes',
+        url: 'https://gitlab.com/owner/repo/pull/123/changes',
+      });
+    });
+
+    test('array-typed domain handling is the caller responsibility', () => {
+      // Caller resolves Array → single string before calling. This test
+      // documents that an unexpected empty string falls back to GitHub.
+      expect(
+        resolveDiffshubViewerRoute(['owner', 'repo', 'pull', '123'], '')
+      ).toEqual({
+        domain: undefined,
+        kind: 'render',
+        upstreamPath: '/owner/repo/pull/123',
+        url: 'https://github.com/owner/repo/pull/123',
+      });
+    });
+  });
+});


### PR DESCRIPTION
Map `/owner/repo/pull/N/(changes|files)/{sha}` to `/owner/repo/commit/{sha}` so a GitHub PR URL scoped to a specific commit resolves to the standalone commit view, which is the only form the diff loader can fetch.

The rewrite runs in two places:
- `normalizeGitHubPath` covers form input via `getPatchViewerHref`.
- The catch-all viewer route now redirects to the canonical path when someone navigates directly, fixing the "couldn't load the diff" failure on pasted URLs.

Extracts `resolveDiffshubViewerRoute` from the route page so the redirect/render decision is unit-testable.

Example of successful mapping (and redirect):

https://pierre-docs-diffshub-git-nicolas-4fb69f-pierre-computer-company.vercel.app/pierrecomputer/pierre/pull/692/changes/3bbb3d55da7bbc1b290e1c4c0c5430016ec4d0cf
 
<img width="1172" height="654" alt="image" src="https://github.com/user-attachments/assets/257871c1-cfd3-46f6-802d-7f123c880410" />

