### PR TITLE
[diffshub] add header toggle to collapse/expand all files

### DIFF
--- a/apps/docs/app/(diffshub)/(view)/_components/CodeViewHeader.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/CodeViewHeader.tsx
@@ -1,8 +1,10 @@
 import type { DiffIndicators } from '@pierre/diffs';
 import {
   IconCodeStyleBars,
+  IconCollapsedRow,
   IconDiffSplit,
   IconDiffUnified,
+  IconExpandAll,
   IconEyeSlash,
   IconFileTreeFill,
   IconGearFill,
@@ -30,6 +32,7 @@ const SETTING_ROW_CLASS =
 
 interface HeaderProps {
   className?: string;
+  collapseMode: 'expanded' | 'collapsed';
   diffIndicators: DiffIndicators;
   diffStyle: 'split' | 'unified';
   fileTreeAvailable: boolean;
@@ -37,6 +40,7 @@ interface HeaderProps {
   initialUrl: string;
   lineNumbers: boolean;
   overflow: 'wrap' | 'scroll';
+  onToggleCollapseMode(): void;
   onToggleFileTreeOverlay(): void;
   setDiffIndicators: Dispatch<SetStateAction<DiffIndicators>>;
   setDiffStyle: Dispatch<SetStateAction<'split' | 'unified'>>;
@@ -48,6 +52,7 @@ interface HeaderProps {
 
 export const CodeViewHeader = memo(function CodeViewHeader({
   className,
+  collapseMode,
   diffIndicators,
   diffStyle,
   fileTreeAvailable,
@@ -55,6 +60,7 @@ export const CodeViewHeader = memo(function CodeViewHeader({
   initialUrl,
   lineNumbers,
   overflow,
+  onToggleCollapseMode,
   onToggleFileTreeOverlay,
   setDiffIndicators,
   setDiffStyle,
@@ -137,6 +143,25 @@ export const CodeViewHeader = memo(function CodeViewHeader({
                 <IconDiffSplit className="size-4 md:size-3" />
               ) : (
                 <IconDiffUnified className="size-4 md:size-3" />
+              )}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-md"
+              aria-pressed={collapseMode === 'collapsed'}
+              title={
+                collapseMode === 'expanded'
+                  ? 'Collapse all files'
+                  : 'Expand all files'
+              }
+              className="hover:text-muted-foreground hover:bg-transparent"
+              onClick={onToggleCollapseMode}
+            >
+              {collapseMode === 'expanded' ? (
+                <IconExpandAll className="size-4 md:size-3" />
+              ) : (
+                <IconCollapsedRow className="size-4 md:size-3" />
               )}
             </Button>
             <DropdownMenu>

--- a/apps/docs/app/(diffshub)/(view)/_components/ReviewUI.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/ReviewUI.tsx
@@ -38,6 +38,9 @@ export function ReviewUI({ domain, initialUrl, path }: ReviewUIProps) {
 
   const isWorkerPoolReadyOrDisable = useIsWorkerPoolReadyOrDisabled();
   const [diffStyle, setDiffStyle] = useState<'split' | 'unified'>('split');
+  const [collapseMode, setCollapseMode] = useState<'expanded' | 'collapsed'>(
+    'expanded'
+  );
   const [fileTreeOverlayOpen, setFileTreeOverlayOpen] = useState(false);
   const [overflow, setOverflow] = useState<'wrap' | 'scroll'>('scroll');
   const [showBackgrounds, setShowBackgrounds] = useState(true);
@@ -49,6 +52,7 @@ export function ReviewUI({ domain, initialUrl, path }: ReviewUIProps) {
     setFileTreeOverlayOpen(false);
   }, []);
   const {
+    applyCollapseModeToLoaded,
     commentFileByItemId,
     commentSections,
     diffStats,
@@ -62,6 +66,7 @@ export function ReviewUI({ domain, initialUrl, path }: ReviewUIProps) {
     treeSource,
     viewerKey,
   } = usePatchLoader({
+    collapseMode,
     domain,
     onLoadStart: handlePatchLoadStart,
     path,
@@ -84,13 +89,28 @@ export function ReviewUI({ domain, initialUrl, path }: ReviewUIProps) {
   }, []);
   const handleSelectTreeItem = useCallback((itemId: string) => {
     setFileTreeOverlayOpen(false);
-    viewerRef.current?.scrollTo({
+    const viewer = viewerRef.current;
+    if (viewer == null) {
+      return;
+    }
+    const item = viewer.getItem(itemId);
+    if (item != null && item.collapsed === true) {
+      item.collapsed = false;
+      item.version = typeof item.version === 'number' ? item.version + 1 : 1;
+      viewer.updateItem(item);
+    }
+    viewer.scrollTo({
       type: 'item',
       id: itemId,
       align: 'start',
       behavior: 'smooth',
     });
   }, []);
+  const handleToggleCollapseMode = useCallback(() => {
+    const next = collapseMode === 'expanded' ? 'collapsed' : 'expanded';
+    setCollapseMode(next);
+    applyCollapseModeToLoaded(next);
+  }, [applyCollapseModeToLoaded, collapseMode]);
   const handleCommentSaved = useCallback(
     (comment: CodeViewSavedCommentEvent) => {
       setCommentSections((prev) =>
@@ -140,6 +160,7 @@ export function ReviewUI({ domain, initialUrl, path }: ReviewUIProps) {
     <ReviewGrid>
       <CodeViewHeader
         className="[grid-area:header]"
+        collapseMode={collapseMode}
         diffIndicators={diffIndicators}
         diffStyle={diffStyle}
         initialUrl={initialUrl}
@@ -147,6 +168,7 @@ export function ReviewUI({ domain, initialUrl, path }: ReviewUIProps) {
         overflow={overflow}
         fileTreeOverlayOpen={fileTreeOverlayOpen}
         fileTreeAvailable={treeSource != null}
+        onToggleCollapseMode={handleToggleCollapseMode}
         onToggleFileTreeOverlay={handleToggleFileTreeOverlay}
         setDiffIndicators={setDiffIndicators}
         setDiffStyle={setDiffStyle}

--- a/apps/docs/app/(diffshub)/(view)/_components/usePatchLoader.ts
+++ b/apps/docs/app/(diffshub)/(view)/_components/usePatchLoader.ts
@@ -54,6 +54,7 @@ const GENERIC_PATCH_LOAD_ERROR_MESSAGE =
   'We couldn’t load that diff. Check the URL and try again.';
 
 interface UsePatchLoaderOptions {
+  collapseMode: 'expanded' | 'collapsed';
   domain?: string;
   onLoadStart(): void;
   path: string;
@@ -61,6 +62,7 @@ interface UsePatchLoaderOptions {
 }
 
 interface UsePatchLoaderResult {
+  applyCollapseModeToLoaded(mode: 'expanded' | 'collapsed'): void;
   commentFileByItemId: CodeViewCommentFileByItemId | null;
   commentSections: CodeViewSavedCommentItem[];
   diffStats: CodeViewDiffStats | null;
@@ -76,6 +78,7 @@ interface UsePatchLoaderResult {
 }
 
 export function usePatchLoader({
+  collapseMode,
   domain,
   onLoadStart,
   path,
@@ -103,6 +106,76 @@ export function usePatchLoader({
   const requestIdRef = useRef(0);
   const appliedLineHashKeyRef = useRef<string | null>(null);
   const viewerKeyRef = useRef(0);
+  // Tracks the ids of every item that has been handed to the viewer so we can
+  // walk the full set when the user toggles collapse mode. The viewer handle
+  // does not expose an enumeration API, so we maintain our own index.
+  const loadedItemIdsRef = useRef<Set<string>>(new Set());
+  // Mirrors the latest collapse mode so the streaming code path (which lives
+  // inside a long-lived effect/closure) can read the live value without us
+  // having to re-bind it on every change.
+  const collapseModeRef = useRef(collapseMode);
+  collapseModeRef.current = collapseMode;
+
+  // Pre-mutates fresh items so they arrive in the viewer matching the current
+  // collapse mode, then records their ids for later bulk updates. Diff items
+  // are normalized in both directions because the accumulator initializes
+  // deleted-file diffs as collapsed by default — without an unconditional
+  // overwrite, those would stay collapsed even when the user is in expanded
+  // mode.
+  const prepareItemsForViewer = (
+    items: readonly CodeViewItem<CommentMetadata>[]
+  ): void => {
+    const targetCollapsed = collapseModeRef.current === 'collapsed';
+    for (const item of items) {
+      loadedItemIdsRef.current.add(item.id);
+      if (item.type === 'diff') {
+        item.collapsed = targetCollapsed;
+      }
+    }
+  };
+
+  const applyCollapseModeToLoaded = useStableCallback(
+    (mode: 'expanded' | 'collapsed') => {
+      const targetCollapsed = mode === 'collapsed';
+      const viewer = viewerRef.current;
+      if (viewer == null) {
+        // The viewer hasn't mounted yet (e.g. the worker pool is still warming
+        // up while the header is already interactive). Rewrite any items
+        // already buffered in initialItems so they arrive in the right state
+        // once the viewer mounts. New items still streaming in pick up the
+        // live collapse mode through prepareItemsForViewer.
+        setInitialItems((prev) => {
+          let changed = false;
+          const next = prev.map((item) => {
+            if (
+              item.type !== 'diff' ||
+              (item.collapsed === true) === targetCollapsed
+            ) {
+              return item;
+            }
+            changed = true;
+            return { ...item, collapsed: targetCollapsed };
+          });
+          return changed ? next : prev;
+        });
+        return;
+      }
+
+      for (const itemId of loadedItemIdsRef.current) {
+        const item = viewer.getItem(itemId);
+        if (item == null || item.type !== 'diff') {
+          continue;
+        }
+        const current = item.collapsed === true;
+        if (current === targetCollapsed) {
+          continue;
+        }
+        item.collapsed = targetCollapsed;
+        item.version = getNextItemVersion(item);
+        viewer.updateItem(item);
+      }
+    }
+  );
 
   const tryApplyLineHashTarget = useStableCallback(() => {
     const { hash } = window.location;
@@ -153,6 +226,7 @@ export function usePatchLoader({
 
     viewerKeyRef.current = requestId;
     appliedLineHashKeyRef.current = null;
+    loadedItemIdsRef.current = new Set();
     setViewerKey(requestId);
     setInitialItems([]);
     setTreeSource(null);
@@ -185,6 +259,7 @@ export function usePatchLoader({
           setCommentFileByItemId(loadedData.itemIdToFile);
           setCommentSections([]);
           setDiffStats(loadedData.diffStats);
+          prepareItemsForViewer(loadedData.items);
           setInitialItems(loadedData.items);
           setLoadState('ready');
           await yieldToBrowser();
@@ -258,6 +333,7 @@ export function usePatchLoader({
           pendingPublishFileCount = 0;
           lastPublishTime = performance.now();
           const pendingItems = takePendingCodeViewItems(accumulator);
+          prepareItemsForViewer(pendingItems);
           if (!hasPublishedInitialItems) {
             hasPublishedInitialItems = true;
             publishTreeSource();
@@ -354,6 +430,9 @@ export function usePatchLoader({
           );
           if (itemIdRename != null) {
             applyCodeViewItemIdRename(viewerRef.current, itemIdRename);
+            if (loadedItemIdsRef.current.delete(itemIdRename.oldId)) {
+              loadedItemIdsRef.current.add(itemIdRename.newId);
+            }
           }
           pendingPublishFileCount++;
           pendingTreePublishFileCount++;
@@ -429,6 +508,7 @@ export function usePatchLoader({
   }, []);
 
   return {
+    applyCollapseModeToLoaded,
     commentFileByItemId,
     commentSections,
     diffStats,


### PR DESCRIPTION
Adds a two-state button next to the split/unified toggle that flips between expanded (default) and collapsed for every loaded file. New files streamed in while the toggle is in collapsed mode arrive collapsed. Clicking a file in the sidebar tree expands it (cumulative) in addition to scrolling.

New icon in header:

<img width="129" height="49" alt="image" src="https://github.com/user-attachments/assets/3d44d31b-dbf4-444b-9ee8-9a85b7a88904" />

