### PR TITLE
fix(trees): I want to use `remap` when the set is `standard` or `complete` but ATM those sets skip over `remap`

### DIFF
--- a/packages/trees/src/render/iconResolver.ts
+++ b/packages/trees/src/render/iconResolver.ts
@@ -109,6 +109,15 @@ export function createFileTreeIconResolver(icons?: FileTreeIcons): {
         extensionCandidates
       );
       if (builtInToken != null && normalizedIcons.set !== 'none') {
+        // When the resolved token is the generic 'default' fallback, let the
+        // user's remap['file-tree-icon-file'] win — that slot is explicitly
+        // meant to override the generic file placeholder.
+        if (builtInToken === 'default') {
+          const remappedEntry = iconRemap?.[name];
+          if (remappedEntry != null) {
+            return remapEntryToIcon(remappedEntry, name);
+          }
+        }
         return {
           name: getBuiltInFileIconName(builtInToken),
           remappedFrom: name,

--- a/packages/trees/test/file-tree-icon-config.test.ts
+++ b/packages/trees/test/file-tree-icon-config.test.ts
@@ -102,6 +102,53 @@ describe('file-tree icon config', () => {
     }
   });
 
+  test('remap[file-tree-icon-file] overrides the default built-in fallback when set is complete', async () => {
+    const { cleanup, dom } = installDom();
+    try {
+      const { FileTree } = await import('../src/render/FileTree');
+      const mount = dom.window.document.createElement('div');
+      dom.window.document.body.appendChild(mount);
+
+      const fileTree = new FileTree({
+        flattenEmptyDirectories: true,
+        icons: {
+          set: 'complete',
+          spriteSheet:
+            '<svg data-icon-sprite aria-hidden="true" width="0" height="0"><symbol id="pst-test-generic-file" viewBox="0 0 16 16"><rect width="16" height="16" fill="currentColor" /></symbol></svg>',
+          remap: {
+            'file-tree-icon-file': 'pst-test-generic-file',
+          },
+        },
+        initialExpansion: 'open',
+        paths: ['unknown.xyz', 'src/index.ts'],
+        initialVisibleRowCount: 120 / 30,
+      });
+
+      fileTree.render({ containerWrapper: mount });
+      await flushDom();
+
+      const shadowRoot = fileTree.getFileTreeContainer()?.shadowRoot;
+
+      // Unknown extension has no specific built-in token — remap should win
+      // over the generic 'default' fallback.
+      const unknownButton = getItemButton(shadowRoot, dom, 'unknown.xyz');
+      expect(unknownButton.querySelector('use')?.getAttribute('href')).toBe(
+        '#pst-test-generic-file'
+      );
+
+      // Known extension has a specific built-in token — remap must not
+      // override it.
+      const tsButton = getItemButton(shadowRoot, dom, 'src/index.ts');
+      expect(tsButton.querySelector('use')?.getAttribute('href')).toBe(
+        '#file-tree-builtin-typescript'
+      );
+
+      fileTree.cleanUp();
+    } finally {
+      cleanup();
+    }
+  });
+
   test('setIcons swaps icon modes without resetting expanded state', async () => {
     const { cleanup, dom } = installDom();
     try {


### PR DESCRIPTION
### Description

`remap` is a great way to quickly override icons. But remap only works when the `set` is `minimal`. Specifically I am trying to remap `file-tree-icon-file`. [The docs seem to suggest this should work](https://trees.software/docs#customize-icons) but it did not.

### Motivation & Context

With `set:'standard'` or `set:'complete'`, `resolveBuiltInFileIconToken` always returns a token — including `'default'` for files with no specific extension match. This causes the `iconRemap` check to be skipped entirely, making `remap['file-tree-icon-file']` unreachable as a generic file icon fallback unless the caller uses `set:'minimal'`.

**Root cause:** In `iconResolver.ts`, the built-in token path returns early before the `iconRemap` check whenever `builtInToken != null`. Since `resolveBuiltInFileIconToken` returns `'default'` as a catch-all for `standard`/`complete`, the remap is never consulted.

When the resolved built-in token is the generic `'default'`, we now check `iconRemap['file-tree-icon-file']` first. Specific tokens (`typescript`, `python`, etc.) are unaffected — they continue to short-circuit before the remap check. Falls back to `file-tree-builtin-default` if no remap entry is defined, preserving existing behaviour.

| Scenario | Before | After |
|---|---|---|
| `set:'complete'` + unknown extension + remap defined | `#file-tree-builtin-default` | remap icon ✓ |
| `set:'complete'` + known extension (`.ts`) + remap defined | `#file-tree-builtin-typescript` | `#file-tree-builtin-typescript` ✓ |
| `set:'complete'` + unknown extension + no remap | `#file-tree-builtin-default` | `#file-tree-builtin-default` ✓ |
| `set:'minimal'` + remap defined | remap icon ✓ | remap icon ✓ |

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality). You must have
      first discussed with the dev team and they should be aware that this PR is
      being opened
- [ ] Breaking change (fix or feature that would change existing functionality).
      You must have first discussed with the dev team and they should be aware
      that this PR is being opened
- [ ] Documentation update

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/pierrecomputer/pierre/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project (`bun run lint`)
- [x] My code is formatted properly (`bun run format`)
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass (`bun test`)

### How was AI used in generating this PR

I found this issue while using claude and trying to replace the default file icon while using the complete set. After reading the docs and looking at the code with claude's help I found that rename only works in the minimal set. So I set minimal and my remap and then rebuilt my own set by exporting all the svg icons and css styles. While this worked it was very awkward.

I then used claude to help write the bug ticket and finally to write the code for this PR, which I carefully reviewed, and help with parts of the explanation of the technical details. I hope my balance of human work and LLMs is acceptable and if not I apologize.

### Related issues

pierrecomputer/pierre#707