### PR TITLE
[diffshub] comments sidebar polish

### DIFF
--- a/apps/docs/app/(diffshub)/(view)/_components/CodeViewCommentsList.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/CodeViewCommentsList.tsx
@@ -2,34 +2,78 @@
 
 import type { AnnotationSide } from '@pierre/diffs';
 import { IconConvoFill, IconPlus } from '@pierre/icons';
-import { memo } from 'react';
+import { memo, type MouseEvent } from 'react';
 
 import { CommentAuthorAvatar } from './annotation-shared';
 import type {
   CodeViewSavedCommentEntry,
   CodeViewSavedCommentItem,
+  CommentLineType,
 } from './types';
 import { cn } from '@/lib/utils';
 
 interface CodeViewCommentsListProps {
   commentSections: readonly CodeViewSavedCommentItem[];
   onSelectComment?(comment: CodeViewSavedCommentEntry): void;
+  onSelectItem?(itemId: string): void;
 }
 
-function getCommentLineLabel(side: AnnotationSide, lineNumber: number): string {
+function getCommentLineLabel(
+  side: AnnotationSide,
+  lineNumber: number,
+  lineType: CommentLineType
+): string {
+  if (lineType === 'context') {
+    return `Line ${lineNumber}`;
+  }
   const sigil = side === 'additions' ? '+' : '-';
   return `Line ${sigil}${lineNumber}`;
 }
 
-function getCommentLineClassName(side: AnnotationSide): string {
+function getCommentLineClassName(
+  side: AnnotationSide,
+  lineType: CommentLineType
+): string {
+  if (lineType === 'context') {
+    return 'text-muted-foreground';
+  }
   return side === 'additions'
     ? 'text-emerald-700 dark:text-emerald-400'
     : 'text-rose-700 dark:text-rose-400';
 }
 
+// Wraps a click handler so users can drag-select text inside the row without
+// also triggering navigation. mouseup after a selection fires click on the
+// button; bail out only when the resulting selection is anchored inside this
+// row, so a pre-existing selection elsewhere on the page (e.g. in the diff
+// viewer) does not block keyboard/mouse activation of the row.
+function handleRowClick(
+  event: MouseEvent<HTMLButtonElement>,
+  run: () => void
+): void {
+  if (event.button !== 0) {
+    return;
+  }
+  const selection =
+    typeof window !== 'undefined' ? window.getSelection() : null;
+  if (selection != null && selection.toString().length > 0) {
+    const row = event.currentTarget;
+    const anchorInRow =
+      selection.anchorNode != null && row.contains(selection.anchorNode);
+    const focusInRow =
+      selection.focusNode != null && row.contains(selection.focusNode);
+    if (anchorInRow || focusInRow) {
+      event.preventDefault();
+      return;
+    }
+  }
+  run();
+}
+
 export const CodeViewCommentsList = memo(function CodeViewCommentsList({
   commentSections,
   onSelectComment,
+  onSelectItem,
 }: CodeViewCommentsListProps) {
   if (commentSections.length === 0) {
     return (
@@ -58,29 +102,50 @@ export const CodeViewCommentsList = memo(function CodeViewCommentsList({
     >
       {commentSections.map((section) => (
         <section key={section.itemId}>
-          <div className="text-muted-foreground p-3 pb-2 text-sm font-medium break-all">
-            {section.path}
-          </div>
+          {onSelectItem != null ? (
+            <button
+              type="button"
+              className="text-muted-foreground hover:text-foreground focus-visible:ring-ring block w-full cursor-pointer p-3 pb-2 text-left text-sm font-medium break-all outline-none focus-visible:ring-2"
+              onClick={(event) =>
+                handleRowClick(event, () => onSelectItem(section.itemId))
+              }
+            >
+              <span className="select-text">{section.path}</span>
+            </button>
+          ) : (
+            <div className="text-muted-foreground p-3 pb-2 text-sm font-medium break-all">
+              {section.path}
+            </div>
+          )}
           <div className="rounded-lg border border-[rgb(0_0_0_/_0.1)] dark:border-[rgb(255_255_255_/_0.15)]">
             {section.comments.map((comment) => (
               <button
                 key={comment.key}
                 type="button"
                 className="focus-visible:ring-ring hover:bg-muted bg-card flex w-full cursor-pointer items-start gap-2 border-b border-[rgb(0_0_0_/_0.1)] p-3 text-left text-sm transition-colors outline-none first:rounded-t-lg last:rounded-b-lg last:border-b-0 focus-visible:ring-2 dark:border-[rgb(255_255_255_/_0.15)] dark:bg-neutral-800 dark:hover:bg-[var(--diffshub-sidebar-bg)]"
-                onClick={() => onSelectComment?.(comment)}
+                onClick={(event) =>
+                  handleRowClick(event, () => onSelectComment?.(comment))
+                }
               >
                 <CommentAuthorAvatar seed={comment.author} className="size-5" />
-                <div className="flex flex-col items-center gap-0.5">
-                  <div className="flex items-center gap-2">
+                <div className="flex flex-col gap-0.5 select-text">
+                  <div className="flex gap-2">
                     <span className="text-muted-foreground">
                       {comment.author} commented on{' '}
                       <span
                         className={cn(
-                          getCommentLineClassName(comment.side),
+                          getCommentLineClassName(
+                            comment.side,
+                            comment.lineType
+                          ),
                           'font-medium'
                         )}
                       >
-                        {getCommentLineLabel(comment.side, comment.lineNumber)}
+                        {getCommentLineLabel(
+                          comment.side,
+                          comment.lineNumber,
+                          comment.lineType
+                        )}
                       </span>
                     </span>
                   </div>

--- a/apps/docs/app/(diffshub)/(view)/_components/CodeViewSidebar.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/CodeViewSidebar.tsx
@@ -62,6 +62,10 @@ export const CodeViewSidebar = memo(function CodeViewSidebar({
   streaming,
 }: CodeViewSidebarProps) {
   const [activeTab, setActiveTab] = useState<SidebarTab>('files');
+  let totalCommentCount = 0;
+  for (const section of commentSections) {
+    totalCommentCount += section.comments.length;
+  }
   const [activeStatusPanel, setActiveStatusPanel] =
     useState<SidebarStatusPanel | null>('diffStats');
   const [fileTreeModel, setFileTreeModel] = useState<FileTree | null>(null);
@@ -143,10 +147,21 @@ export const CodeViewSidebar = memo(function CodeViewSidebar({
             <ButtonGroupItem
               value="comments"
               size="icon-only"
-              className="shadow-none"
+              className={cn(
+                'shadow-none',
+                totalCommentCount > 0 && 'w-auto gap-1 pr-1'
+              )}
             >
               <IconComment className="size-4 md:size-3" />
               <span className="sr-only">Comments</span>
+              {totalCommentCount > 0 && (
+                <span
+                  aria-hidden="true"
+                  className="inline-flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-neutral-200 px-1 text-[10px] leading-none font-medium text-neutral-700 tabular-nums dark:bg-neutral-700 dark:text-neutral-200"
+                >
+                  {totalCommentCount}
+                </span>
+              )}
             </ButtonGroupItem>
           </ButtonGroup>
           {activeTab === 'files' && fileTreeModel != null && (
@@ -186,6 +201,7 @@ export const CodeViewSidebar = memo(function CodeViewSidebar({
             <CodeViewCommentsList
               commentSections={commentSections}
               onSelectComment={onSelectComment}
+              onSelectItem={onSelectItem}
             />
           </div>
         </div>

--- a/apps/docs/app/(diffshub)/(view)/_components/CodeViewWrapper.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/CodeViewWrapper.tsx
@@ -27,6 +27,7 @@ import type {
   CommentMetadata,
 } from './types';
 import {
+  classifyCommentLineType,
   isDiffItem,
   isDraftAnnotation,
   isDraftMetadata,
@@ -313,6 +314,11 @@ export const CodeViewWrapper = memo(function CodeViewWrapper({
         itemId,
         key,
         lineNumber: draftAnnotation.lineNumber,
+        lineType: classifyCommentLineType(
+          item.fileDiff,
+          draftAnnotation.side,
+          draftAnnotation.lineNumber
+        ),
         message: trimmedMessage,
         range: draftAnnotation.metadata.range,
         side: draftAnnotation.side,

--- a/apps/docs/app/(diffshub)/(view)/_components/types.ts
+++ b/apps/docs/app/(diffshub)/(view)/_components/types.ts
@@ -39,11 +39,17 @@ export type CodeViewCommentFileByItemId = ReadonlyMap<
   CodeViewCommentSidebarFile
 >;
 
+// Whether the line the comment is anchored to is a real addition/deletion or
+// an unchanged context line shown in the diff. Tracked so the sidebar can
+// render "Line N" without a misleading + / - sigil for context lines.
+export type CommentLineType = 'change' | 'context';
+
 export interface CodeViewSavedCommentEvent {
   author: string;
   itemId: string;
   key: string;
   lineNumber: number;
+  lineType: CommentLineType;
   message: string;
   range: SelectedLineRange;
   side: AnnotationSide;
@@ -59,6 +65,7 @@ export interface CodeViewSavedCommentEntry {
   itemId: string;
   key: string;
   lineNumber: number;
+  lineType: CommentLineType;
   message: string;
   range: SelectedLineRange;
   side: AnnotationSide;

--- a/apps/docs/app/(diffshub)/(view)/_components/utils.ts
+++ b/apps/docs/app/(diffshub)/(view)/_components/utils.ts
@@ -1,8 +1,10 @@
 import type {
+  AnnotationSide,
   ChangeTypes,
   CodeViewDiffItem,
   CodeViewItem,
   DiffLineAnnotation,
+  FileDiffMetadata,
 } from '@pierre/diffs';
 import type { GitStatus } from '@pierre/trees';
 
@@ -13,6 +15,7 @@ import type {
   CodeViewSavedCommentEntry,
   CodeViewSavedCommentEvent,
   CodeViewSavedCommentItem,
+  CommentLineType,
   CommentMetadata,
   DraftCommentMetadata,
   SavedCommentMetadata,
@@ -337,6 +340,7 @@ export function upsertSavedCommentSidebarEntry(
     itemId: entry.itemId,
     key: entry.key,
     lineNumber: entry.lineNumber,
+    lineType: entry.lineType,
     message: entry.message,
     range: entry.range,
     side: entry.side,
@@ -422,4 +426,49 @@ export function removeSavedCommentSidebarEntry(
     comments: nextComments,
   };
   return nextSections;
+}
+
+// Classifies a 1-based line number on a given diff side as either an actual
+// addition/deletion or an unchanged context line. The sidebar uses this to
+// avoid rendering "+13" / "-13" for comments anchored to lines that are
+// rendered as context (and therefore weren't actually added or removed).
+//
+// Walks each hunk's ordered `hunkContent` while tracking the running line
+// number on the requested side. A context block of N lines advances by N on
+// both sides; a change block advances by `additions` on the addition side and
+// `deletions` on the deletion side. Mirrors the walk pattern used by
+// FileDiff.getLineIndex inside `@pierre/diffs`.
+export function classifyCommentLineType(
+  fileDiff: FileDiffMetadata,
+  side: AnnotationSide,
+  lineNumber: number
+): CommentLineType {
+  for (const hunk of fileDiff.hunks) {
+    let currentLineNumber =
+      side === 'additions' ? hunk.additionStart : hunk.deletionStart;
+    const hunkCount =
+      side === 'additions' ? hunk.additionCount : hunk.deletionCount;
+    if (
+      lineNumber < currentLineNumber ||
+      lineNumber >= currentLineNumber + hunkCount
+    ) {
+      continue;
+    }
+    for (const content of hunk.hunkContent) {
+      const blockLength =
+        content.type === 'context'
+          ? content.lines
+          : side === 'additions'
+            ? content.additions
+            : content.deletions;
+      if (blockLength === 0) {
+        continue;
+      }
+      if (lineNumber < currentLineNumber + blockLength) {
+        return content.type === 'context' ? 'context' : 'change';
+      }
+      currentLineNumber += blockLength;
+    }
+  }
+  return 'change';
 }


### PR DESCRIPTION
- Show a numeric count badge on the sidebar comment icon when there are saved comments, sized so the icon-only button widens just enough to fit the count.
- Make each file-path header in the comments list a clickable button that scrolls the viewer to that file (reusing the existing onSelectItem flow), and allow drag-selecting text inside the path and comment rows by guarding onClick against a non-empty window.getSelection().
- Classify each saved comment's anchor line as 'change' or 'context' at save time by walking the hunkContent, and render context-line comments as a muted "Line N" instead of a misleading "Line +N" / "Line -N".