### PR TITLE
[diffs] Cache serialized file header HTML on recycled File and FileDiff instances

### DIFF
--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -135,6 +135,7 @@ export class File<LAnnotation = undefined> {
   protected errorWrapper: HTMLElement | undefined;
   protected placeHolder: HTMLElement | undefined;
   protected lastRenderedHeaderHTML: string | undefined;
+  protected cachedHeaderHTML: string | undefined;
   protected appliedPreAttributes: PrePropertiesConfig | undefined;
   protected lastRowCount: number | undefined;
 
@@ -190,6 +191,7 @@ export class File<LAnnotation = undefined> {
   public setOptions(options: FileOptions<LAnnotation> | undefined): void {
     if (options == null) return;
     this.options = options;
+    this.cachedHeaderHTML = undefined;
     this.interactionManager.setOptions(pluckInteractionOptions(options));
   }
 
@@ -289,6 +291,9 @@ export class File<LAnnotation = undefined> {
     this.headerMetadata = undefined;
     this.headerCustom = undefined;
     this.lastRenderedHeaderHTML = undefined;
+    if (!recycle) {
+      this.cachedHeaderHTML = undefined;
+    }
     this.errorWrapper = undefined;
     this.themeCSSStyle = undefined;
     this.appliedThemeCSS = undefined;
@@ -457,6 +462,9 @@ export class File<LAnnotation = undefined> {
     }
 
     this.renderRange = nextRenderRange;
+    if (didFileChange) {
+      this.cachedHeaderHTML = undefined;
+    }
     this.file = file;
     this.fileRenderer.setOptions({
       ...this.options,
@@ -1115,7 +1123,8 @@ export class File<LAnnotation = undefined> {
     this.cleanupErrorWrapper();
     this.placeHolder?.remove();
     this.placeHolder = undefined;
-    const headerHTML = toHtml(headerAST);
+    const headerHTML = this.cachedHeaderHTML ?? toHtml(headerAST);
+    this.cachedHeaderHTML = headerHTML;
     if (headerHTML !== this.lastRenderedHeaderHTML) {
       const tempDiv = document.createElement('div');
       tempDiv.innerHTML = headerHTML;

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -211,6 +211,7 @@ export class FileDiff<LAnnotation = undefined> {
   protected renderRange: RenderRange | undefined;
   protected appliedPreAttributes: PrePropertiesConfig | undefined;
   protected lastRenderedHeaderHTML: string | undefined;
+  protected cachedHeaderHTML: string | undefined;
   protected lastRowCount: number | undefined;
 
   protected enabled = true;
@@ -356,6 +357,7 @@ export class FileDiff<LAnnotation = undefined> {
   public setOptions(options: FileDiffOptions<LAnnotation> | undefined): void {
     if (options == null) return;
     this.options = options;
+    this.cachedHeaderHTML = undefined;
     this.hunksRenderer.setOptions(this.getHunksRendererOptions(options));
     this.interactionManager.setOptions(
       pluckInteractionOptions(
@@ -496,6 +498,9 @@ export class FileDiff<LAnnotation = undefined> {
     this.headerCustom = undefined;
     this.placeHolder = undefined;
     this.lastRenderedHeaderHTML = undefined;
+    if (!recycle) {
+      this.cachedHeaderHTML = undefined;
+    }
     this.errorWrapper = undefined;
     this.spriteSVG = undefined;
     this.lastRowCount = undefined;
@@ -757,6 +762,9 @@ export class FileDiff<LAnnotation = undefined> {
         newFile,
         this.options.parseDiffOptions
       );
+    }
+    if (diffDidChange) {
+      this.cachedHeaderHTML = undefined;
     }
 
     if (lineAnnotations != null) {
@@ -1214,7 +1222,8 @@ export class FileDiff<LAnnotation = undefined> {
     this.placeHolder?.remove();
     this.placeHolder = undefined;
     const { fileDiff } = this;
-    const headerHTML = toHtml(headerAST);
+    const headerHTML = this.cachedHeaderHTML ?? toHtml(headerAST);
+    this.cachedHeaderHTML = headerHTML;
     if (headerHTML !== this.lastRenderedHeaderHTML) {
       const tempDiv = document.createElement('div');
       tempDiv.innerHTML = headerHTML;


### PR DESCRIPTION
 ## Summary

 This PR caches serialized file header HTML on recycled File and FileDiff instances.

 Diffshub’s large-jump profile showed repeated work in applyHeaderToDOM, especially converting stable header HAST back into HTML during virtualized recycle. The rendered DOM is still rebuilt as before, but stable header HTML no longer pays repeated toHtml(headerAST) serialization cost while the same virtualized instance is reused for the same file or diff.

 ## What changed

 - Added cachedHeaderHTML to:
     - packages/diffs/src/components/File.ts
     - packages/diffs/src/components/FileDiff.ts
 - Updated applyHeaderToDOM to reuse cached serialized header HTML:

   ```ts
     const headerHTML = this.cachedHeaderHTML ?? toHtml(headerAST);
     this.cachedHeaderHTML = headerHTML;
   ```
 - Preserved the cache across virtualized recycle cleanup:

   ```ts
     if (!recycle) {
       this.cachedHeaderHTML = undefined;
     }
   ```
 - Invalidated the cache when header output may change:
     - setOptions(...)
     - file identity/content changes in File
     - diff identity/content changes in FileDiff
     - non-recycle cleanup

 ## Why

 During CodeView jumps, virtualized items are cleaned up and remounted often. The header content for a given file/diff is
 usually stable, but the old code serialized its header AST every time applyHeaderToDOM ran.

 This keeps the visual and DOM behavior the same while avoiding repeated HAST-to-HTML conversion for stable headers.

 ## Performance

 ### Autoresearch profile:

 ```text
   actionDurationMs: 1415ms → 1345.2ms (-4.9%)
 ```

 ## Workload:

 ```bash
   bun run diffshub:profile -- --action jump --json
 ```

 This benchmark jumps between sections of a large diff outside the current virtual window, so each target requires fresh
 rendered code.

 ## Correctness notes

 This caches only the serialized header string, not DOM nodes. Header DOM is still created, replaced, and mounted through
 the existing path.

 The cache is cleared when options or file/diff identity changes, so custom header modes, metadata changes through new
 file/diff objects, and non-recycle cleanup continue to render fresh header HTML.

 ## Validation

 The finalized branch was created with the autoresearch finalizer, which ran the repo’s precommit checks while committing:

 - `tsgo --noEmit --pretty`
 - `oxfmt --write`
 - `oxlint --type-aware --tsconfig tsconfig.oxlint.json --fix`

 The finalizer also verified that the review branch contains no autoresearch session artifacts.