### PR TITLE
[diffs] CodeView Element Pooling

### DIFF
--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -1,10 +1,13 @@
 import {
+  CORE_CSS_ATTRIBUTE,
   DEFAULT_CODE_VIEW_FILE_METRICS,
   DEFAULT_CODE_VIEW_LAYOUT,
   DEFAULT_SMOOTH_SCROLL_SETTINGS,
   DEFAULT_THEMES,
   DIFFS_DEVELOPMENT_BUILD,
   DIFFS_TAG_NAME,
+  THEME_CSS_ATTRIBUTE,
+  UNSAFE_CSS_ATTRIBUTE,
 } from '../constants';
 import type { SelectionWriteOptions } from '../managers/InteractionManager';
 import {
@@ -31,7 +34,9 @@ import type {
 } from '../types';
 import { areObjectsEqual } from '../utils/areObjectsEqual';
 import { areSelectionsEqual } from '../utils/areSelectionsEqual';
+import { areThemesEqual } from '../utils/areThemesEqual';
 import { createWindowFromScrollPosition } from '../utils/createWindowFromScrollPosition';
+import { isStyleNode } from '../utils/isStyleNode';
 import { prefersReducedMotion } from '../utils/prefersReducedMotion';
 import { roundToDevicePixel } from '../utils/roundToDevicePixel';
 import type { WorkerPoolManager } from '../worker';
@@ -387,6 +392,7 @@ const SCROLL_REBASE_TARGET_BOTTOM =
   SCROLL_REBASE_CONTAINER_HEIGHT - SCROLL_REBASE_TARGET_TOP;
 const SCROLL_REBASE_THRESHOLD =
   SCROLL_REBASE_CONTAINER_HEIGHT - SCROLL_REBASE_TRIGGER_TOP;
+const CODE_VIEW_ELEMENT_POOL_LIMIT = 32;
 
 interface ScrollToAnimation {
   position: number;
@@ -508,6 +514,12 @@ export class CodeView<LAnnotation = undefined> {
   private container: HTMLDivElement | undefined = document.createElement('div');
   private stickyContainer = document.createElement('div');
   private stickyOffset = document.createElement('div');
+  private elementPool: HTMLElement[] = [];
+  // Container-managed elements may still have externally-owned light DOM slot
+  // children after release, so hold them here until they are safe to reuse.
+  // i.e. the react CodeView component will require a separate react cleanup
+  // phase that we don't want to interrupt
+  private pendingElementPool: HTMLElement[] = [];
   private options: CodeViewOptions<LAnnotation>;
   private workerManager: WorkerPoolManager | undefined;
   private isContainerManaged: boolean;
@@ -768,6 +780,7 @@ export class CodeView<LAnnotation = undefined> {
 
   public cleanUp(): void {
     this.reset();
+    this.clearElementPool();
     this.restoreScrollInteractions();
     this.resizeObserver?.disconnect();
     this.resizeObserver = undefined;
@@ -800,7 +813,7 @@ export class CodeView<LAnnotation = undefined> {
           `CodeView.cleanAllRenderedItems: Item does not exist at index: ${index}`
         );
       }
-      cleanRenderedItem(item);
+      this.releaseRenderedItem(item);
     }
   }
 
@@ -811,6 +824,85 @@ export class CodeView<LAnnotation = undefined> {
     if (item == null) return;
 
     item.instance.primeHighlightCache();
+  }
+
+  private acquireElement(): HTMLElement {
+    this.promotePendingPooledElements();
+    return this.elementPool.pop() ?? document.createElement(DIFFS_TAG_NAME);
+  }
+
+  private releaseRenderedItem(item: CodeViewContextItem<LAnnotation>): void {
+    const { element } = item;
+    item.instance.cleanUp(true);
+    item.element = undefined;
+    if (element == null) {
+      return;
+    }
+
+    element.remove();
+    this.cleanElementForPool(element);
+    this.queueElementForPool(element);
+  }
+
+  // Strip item-specific DOM while keeping the expensive shared shell assets
+  // that are valid for every item in this CodeView until shared options change.
+  private cleanElementForPool(element: HTMLElement): void {
+    const { shadowRoot } = element;
+    if (shadowRoot != null) {
+      for (const child of Array.from(shadowRoot.children)) {
+        if (!isPooledShadowChild(child)) {
+          child.remove();
+        }
+      }
+    }
+
+    if (!this.isContainerManaged) {
+      element.replaceChildren();
+    }
+  }
+
+  private queueElementForPool(element: HTMLElement): void {
+    if (this.getElementPoolSize() >= CODE_VIEW_ELEMENT_POOL_LIMIT) {
+      return;
+    }
+
+    if (this.isElementClean(element)) {
+      this.elementPool.push(element);
+    } else {
+      this.pendingElementPool.push(element);
+    }
+  }
+
+  private promotePendingPooledElements(): void {
+    if (this.pendingElementPool.length === 0) {
+      return;
+    }
+
+    const { pendingElementPool: pendingElements } = this;
+    this.pendingElementPool = [];
+    for (const element of pendingElements) {
+      if (
+        this.isElementClean(element) &&
+        this.elementPool.length < CODE_VIEW_ELEMENT_POOL_LIMIT
+      ) {
+        this.elementPool.push(element);
+      } else if (this.getElementPoolSize() < CODE_VIEW_ELEMENT_POOL_LIMIT) {
+        this.pendingElementPool.push(element);
+      }
+    }
+  }
+
+  private isElementClean(element: HTMLElement): boolean {
+    return element.childNodes.length === 0;
+  }
+
+  private getElementPoolSize(): number {
+    return this.elementPool.length + this.pendingElementPool.length;
+  }
+
+  private clearElementPool(): void {
+    this.elementPool.length = 0;
+    this.pendingElementPool.length = 0;
   }
 
   private resolveEffectiveScrollBehavior(
@@ -1031,6 +1123,9 @@ export class CodeView<LAnnotation = undefined> {
     const previousLayout = this.getLayout();
     const { itemMetricsCache: previousItemMetrics } = this;
 
+    if (shouldClearPool(this.options, options)) {
+      this.clearElementPool();
+    }
     // NOTE(amadeus): This is also something that's probably ridiculously
     // expensive to pull off, and we should probably figure out some way to
     // incrementally version/render stuff
@@ -1593,7 +1688,7 @@ export class CodeView<LAnnotation = undefined> {
       if (removedItem == null || !removedItems.has(removedItem)) {
         continue;
       }
-      cleanRenderedItem(removedItem);
+      this.releaseRenderedItem(removedItem);
       const dirtyIndex = Math.max(nextItems.length - 1, 0);
       firstDirtyIndex = Math.min(firstDirtyIndex ?? dirtyIndex, dirtyIndex);
     }
@@ -2240,10 +2335,7 @@ export class CodeView<LAnnotation = undefined> {
         const isVisible = item.top > top - item.height && item.top <= bottom;
         // If not visible, we should unmount it and clean it up
         if (!isVisible) {
-          // TODO(amadeus): Should probably experiment with dom element
-          // recycling here (since things like the css files and svg stuff is
-          // probably some level of cost that we shouldn't need to pay...)
-          cleanRenderedItem(item);
+          this.releaseRenderedItem(item);
         }
       }
     }
@@ -2266,7 +2358,7 @@ export class CodeView<LAnnotation = undefined> {
       // If the item isn't rendered yet, we need to create a wrapper element
       // for it and render it
       if (item.element == null) {
-        item.element = document.createElement(DIFFS_TAG_NAME);
+        item.element = this.acquireElement();
         syncRenderedItemOrder(this.stickyContainer, item.element, prevElement);
         instance.virtualizedSetup();
         if (renderItem(item, item.element)) {
@@ -2940,14 +3032,6 @@ export class CodeView<LAnnotation = undefined> {
   }
 }
 
-function cleanRenderedItem<LAnnotation>(
-  item: CodeViewContextItem<LAnnotation>
-) {
-  item.instance.cleanUp(true);
-  item.element?.remove();
-  item.element = undefined;
-}
-
 function prepareItemInstance<LAnnotation>(
   item: CodeViewContextItem<LAnnotation>
 ): number {
@@ -2957,6 +3041,33 @@ function prepareItemInstance<LAnnotation>(
   } else {
     return item.instance.prepareVirtualizedItem(item.item.file);
   }
+}
+
+function shouldClearPool<LAnnotation>(
+  previousOptions: CodeViewOptions<LAnnotation>,
+  nextOptions: CodeViewOptions<LAnnotation>
+): boolean {
+  return (
+    !areThemesEqual(
+      previousOptions.theme ?? DEFAULT_THEMES,
+      nextOptions.theme ?? DEFAULT_THEMES
+    ) ||
+    (previousOptions.themeType ?? 'system') !==
+      (nextOptions.themeType ?? 'system') ||
+    previousOptions.unsafeCSS !== nextOptions.unsafeCSS
+  );
+}
+
+function isPooledShadowChild(child: Element): boolean {
+  if (child instanceof SVGElement) {
+    return true;
+  }
+  return (
+    isStyleNode(child) &&
+    (child.hasAttribute(CORE_CSS_ATTRIBUTE) ||
+      child.hasAttribute(THEME_CSS_ATTRIBUTE) ||
+      child.hasAttribute(UNSAFE_CSS_ATTRIBUTE))
+  );
 }
 
 function formatSelectedLineRange(range: SelectedLineRange): string {

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -50,6 +50,7 @@ import { getLineAnnotationName } from '../utils/getLineAnnotationName';
 import { getOrCreateCodeNode } from '../utils/getOrCreateCodeNode';
 import { upsertHostThemeStyle } from '../utils/hostTheme';
 import { isFilePlainText } from '../utils/isFilePlainText';
+import { isStyleNode } from '../utils/isStyleNode';
 import { prerenderHTMLIfNecessary } from '../utils/prerenderHTMLIfNecessary';
 import { getMeasuredScrollbarGutter } from '../utils/scrollbarGutter';
 import { setPreNodeProperties } from '../utils/setWrapperNodeProps';
@@ -129,6 +130,7 @@ export class File<LAnnotation = undefined> {
   protected bufferAfter: HTMLElement | undefined;
   protected themeCSSStyle: HTMLStyleElement | undefined;
   protected appliedThemeCSS: AppliedThemeStyleCache | undefined;
+  protected hasAdoptedThemeCSS = false;
   protected unsafeCSSStyle: HTMLStyleElement | undefined;
   protected appliedUnsafeCSS: string | undefined;
   protected gutterUtilityContent: HTMLElement | undefined;
@@ -292,6 +294,7 @@ export class File<LAnnotation = undefined> {
     this.errorWrapper = undefined;
     this.themeCSSStyle = undefined;
     this.appliedThemeCSS = undefined;
+    this.hasAdoptedThemeCSS = false;
     this.unsafeCSSStyle = undefined;
     this.appliedUnsafeCSS = undefined;
     this.placeHolder = undefined;
@@ -689,6 +692,7 @@ export class File<LAnnotation = undefined> {
     this.spriteSVG = undefined;
     this.themeCSSStyle = undefined;
     this.appliedThemeCSS = undefined;
+    this.hasAdoptedThemeCSS = false;
     this.unsafeCSSStyle = undefined;
     this.appliedUnsafeCSS = undefined;
 
@@ -814,6 +818,20 @@ export class File<LAnnotation = undefined> {
       this.appliedThemeCSS.scrollbarGutter === scrollbarGutter
     ) {
       this.appliedThemeCSS.theme = theme;
+      return;
+    }
+    if (
+      this.hasAdoptedThemeCSS &&
+      this.themeCSSStyle?.parentNode === shadowRoot
+    ) {
+      this.hasAdoptedThemeCSS = false;
+      this.appliedThemeCSS = {
+        theme,
+        themeStyles,
+        themeType: effectiveThemeType,
+        baseThemeType,
+        scrollbarGutter,
+      };
       return;
     }
     this.themeCSSStyle = upsertHostThemeStyle({
@@ -1224,23 +1242,67 @@ export class File<LAnnotation = undefined> {
       fileContainer ??
       this.fileContainer ??
       document.createElement(DIFFS_TAG_NAME);
-    if (previousContainer != null && previousContainer !== this.fileContainer) {
+    const containerChanged = previousContainer !== this.fileContainer;
+    if (previousContainer != null && containerChanged) {
       this.lastRenderedHeaderHTML = undefined;
       this.headerElement = undefined;
     }
     if (parentNode != null && this.fileContainer.parentNode !== parentNode) {
       parentNode.appendChild(this.fileContainer);
     }
+    if (containerChanged) {
+      this.adoptReusableShellElements(this.fileContainer);
+    }
+    this.ensureSpriteSVG(this.fileContainer);
+    return this.fileContainer;
+  }
+
+  // NOTE(amadeus): Technically this method is not safe for use outside of
+  // the CodeView component, however I don't think in practice it really
+  // should matter, but maybe there's some system we need in place to prevent
+  // this from running outside of that environment?
+  //
+  // It's making very specific assumptions that all the elements will have the
+  // correct content based on CodeView global options
+  private adoptReusableShellElements(fileContainer: HTMLElement): void {
+    const { shadowRoot } = fileContainer;
+    if (shadowRoot == null) {
+      return;
+    }
+
+    for (const element of shadowRoot.children) {
+      if (element instanceof SVGElement) {
+        this.spriteSVG ??= element;
+      } else if (
+        isStyleNode(element) &&
+        element.hasAttribute(THEME_CSS_ATTRIBUTE)
+      ) {
+        this.themeCSSStyle ??= element;
+        this.hasAdoptedThemeCSS = true;
+      } else if (
+        isStyleNode(element) &&
+        element.hasAttribute(UNSAFE_CSS_ATTRIBUTE)
+      ) {
+        this.unsafeCSSStyle ??= element;
+        this.appliedUnsafeCSS ??= this.options.unsafeCSS ?? undefined;
+      }
+    }
+  }
+
+  private ensureSpriteSVG(fileContainer: HTMLElement): void {
+    const shadowRoot =
+      fileContainer.shadowRoot ?? fileContainer.attachShadow({ mode: 'open' });
     if (this.spriteSVG == null) {
       const fragment = document.createElement('div');
       fragment.innerHTML = SVGSpriteSheet;
       const firstChild = fragment.firstChild;
       if (firstChild instanceof SVGElement) {
         this.spriteSVG = firstChild;
-        this.fileContainer.shadowRoot?.appendChild(this.spriteSVG);
       }
     }
-    return this.fileContainer;
+    if (this.spriteSVG != null && this.spriteSVG.parentNode !== shadowRoot) {
+      shadowRoot.appendChild(this.spriteSVG);
+    }
   }
 
   private getOrCreatePreNode(container: HTMLElement): HTMLPreElement {

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -64,6 +64,7 @@ import { getLineAnnotationName } from '../utils/getLineAnnotationName';
 import { getOrCreateCodeNode } from '../utils/getOrCreateCodeNode';
 import { upsertHostThemeStyle } from '../utils/hostTheme';
 import { isDiffPlainText } from '../utils/isDiffPlainText';
+import { isStyleNode } from '../utils/isStyleNode';
 import { parseDiffFromFile } from '../utils/parseDiffFromFile';
 import { prerenderHTMLIfNecessary } from '../utils/prerenderHTMLIfNecessary';
 import { getMeasuredScrollbarGutter } from '../utils/scrollbarGutter';
@@ -183,6 +184,7 @@ export class FileDiff<LAnnotation = undefined> {
   protected bufferAfter: HTMLElement | undefined;
   protected themeCSSStyle: HTMLStyleElement | undefined;
   protected appliedThemeCSS: AppliedThemeStyleCache | undefined;
+  protected hasAdoptedThemeCSS = false;
   protected unsafeCSSStyle: HTMLStyleElement | undefined;
   protected appliedUnsafeCSS: string | undefined;
   protected gutterUtilityContent: HTMLElement | undefined;
@@ -501,6 +503,7 @@ export class FileDiff<LAnnotation = undefined> {
     this.lastRowCount = undefined;
     this.themeCSSStyle = undefined;
     this.appliedThemeCSS = undefined;
+    this.hasAdoptedThemeCSS = false;
     this.unsafeCSSStyle = undefined;
     this.appliedUnsafeCSS = undefined;
 
@@ -1019,6 +1022,7 @@ export class FileDiff<LAnnotation = undefined> {
     this.spriteSVG = undefined;
     this.themeCSSStyle = undefined;
     this.appliedThemeCSS = undefined;
+    this.hasAdoptedThemeCSS = false;
     this.unsafeCSSStyle = undefined;
     this.appliedUnsafeCSS = undefined;
 
@@ -1138,29 +1142,67 @@ export class FileDiff<LAnnotation = undefined> {
       fileContainer ??
       this.fileContainer ??
       document.createElement(DIFFS_TAG_NAME);
-    // NOTE(amadeus): If the container changes, we should reset the rendered
-    // HTML
-    if (previousContainer != null && previousContainer !== this.fileContainer) {
+    const containerChanged = previousContainer !== this.fileContainer;
+    if (previousContainer != null && containerChanged) {
       this.lastRenderedHeaderHTML = undefined;
       this.headerElement = undefined;
     }
     if (parentNode != null && this.fileContainer.parentNode !== parentNode) {
       parentNode.appendChild(this.fileContainer);
     }
+    if (containerChanged) {
+      this.adoptReusableShellElements(this.fileContainer);
+    }
+    this.ensureSpriteSVG(this.fileContainer);
+    return this.fileContainer;
+  }
+
+  // NOTE(amadeus): Technically this method is not safe for use outside of
+  // the CodeView component, however I don't think in practice it really
+  // should matter, but maybe there's some system we need in place to prevent
+  // this from running outside of that environment?
+  //
+  // It's making very specific assumptions that all the elements will have the
+  // correct content based on CodeView global options
+  private adoptReusableShellElements(fileContainer: HTMLElement): void {
+    const { shadowRoot } = fileContainer;
+    if (shadowRoot == null) {
+      return;
+    }
+
+    for (const element of shadowRoot.children) {
+      if (element instanceof SVGElement) {
+        this.spriteSVG ??= element;
+      } else if (
+        isStyleNode(element) &&
+        element.hasAttribute(THEME_CSS_ATTRIBUTE)
+      ) {
+        this.themeCSSStyle ??= element;
+        this.hasAdoptedThemeCSS = true;
+      } else if (
+        isStyleNode(element) &&
+        element.hasAttribute(UNSAFE_CSS_ATTRIBUTE)
+      ) {
+        this.unsafeCSSStyle ??= element;
+        this.appliedUnsafeCSS ??= this.options.unsafeCSS ?? undefined;
+      }
+    }
+  }
+
+  private ensureSpriteSVG(fileContainer: HTMLElement): void {
+    const shadowRoot =
+      fileContainer.shadowRoot ?? fileContainer.attachShadow({ mode: 'open' });
     if (this.spriteSVG == null) {
       const fragment = document.createElement('div');
       fragment.innerHTML = SVGSpriteSheet;
       const firstChild = fragment.firstChild;
       if (firstChild instanceof SVGElement) {
         this.spriteSVG = firstChild;
-        this.fileContainer.shadowRoot?.appendChild(this.spriteSVG);
       }
     }
-    return this.fileContainer;
-  }
-
-  protected getFileContainer(): HTMLElement | undefined {
-    return this.fileContainer;
+    if (this.spriteSVG != null && this.spriteSVG.parentNode !== shadowRoot) {
+      shadowRoot.appendChild(this.spriteSVG);
+    }
   }
 
   private getOrCreatePreNode(container: HTMLElement): HTMLPreElement {
@@ -1370,6 +1412,20 @@ export class FileDiff<LAnnotation = undefined> {
       this.appliedThemeCSS.scrollbarGutter === scrollbarGutter
     ) {
       this.appliedThemeCSS.theme = theme;
+      return;
+    }
+    if (
+      this.hasAdoptedThemeCSS &&
+      this.themeCSSStyle?.parentNode === shadowRoot
+    ) {
+      this.hasAdoptedThemeCSS = false;
+      this.appliedThemeCSS = {
+        theme,
+        themeStyles,
+        themeType: effectiveThemeType,
+        baseThemeType,
+        scrollbarGutter,
+      };
       return;
     }
     this.themeCSSStyle = upsertHostThemeStyle({

--- a/packages/diffs/src/utils/isStyleNode.ts
+++ b/packages/diffs/src/utils/isStyleNode.ts
@@ -1,0 +1,11 @@
+export function isStyleNode(element: Element): element is HTMLStyleElement {
+  if (
+    typeof HTMLStyleElement !== 'undefined' &&
+    element instanceof HTMLStyleElement
+  ) {
+    return true;
+  }
+
+  const tagName = element.tagName ?? element.nodeName;
+  return typeof tagName === 'string' && tagName.toLowerCase() === 'style';
+}

--- a/packages/diffs/test/CodeView.elementPooling.test.ts
+++ b/packages/diffs/test/CodeView.elementPooling.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, test } from 'bun:test';
+import { JSDOM } from 'jsdom';
+
+import { CodeView, type CodeViewCoordinator } from '../src/components/CodeView';
+import { DEFAULT_THEMES } from '../src/constants';
+import type { CodeViewItem, FileContents } from '../src/types';
+
+function installDom() {
+  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+    url: 'http://localhost',
+  });
+  const originalValues = {
+    cancelAnimationFrame: Reflect.get(globalThis, 'cancelAnimationFrame'),
+    document: Reflect.get(globalThis, 'document'),
+    DocumentFragment: Reflect.get(globalThis, 'DocumentFragment'),
+    Element: Reflect.get(globalThis, 'Element'),
+    HTMLDivElement: Reflect.get(globalThis, 'HTMLDivElement'),
+    HTMLElement: Reflect.get(globalThis, 'HTMLElement'),
+    HTMLPreElement: Reflect.get(globalThis, 'HTMLPreElement'),
+    HTMLStyleElement: Reflect.get(globalThis, 'HTMLStyleElement'),
+    Node: Reflect.get(globalThis, 'Node'),
+    requestAnimationFrame: Reflect.get(globalThis, 'requestAnimationFrame'),
+    ResizeObserver: Reflect.get(globalThis, 'ResizeObserver'),
+    SVGElement: Reflect.get(globalThis, 'SVGElement'),
+    window: Reflect.get(globalThis, 'window'),
+  };
+
+  class MockResizeObserver {
+    observe(_target: Element): void {}
+    unobserve(_target: Element): void {}
+    disconnect(): void {}
+  }
+
+  let nextFrameId = 0;
+  const frames = new Map<number, ReturnType<typeof setTimeout>>();
+
+  Object.assign(globalThis, {
+    cancelAnimationFrame: ((id: number) => {
+      const timeout = frames.get(id);
+      if (timeout != null) {
+        clearTimeout(timeout);
+        frames.delete(id);
+      }
+    }) as typeof cancelAnimationFrame,
+    document: dom.window.document,
+    DocumentFragment: dom.window.DocumentFragment,
+    Element: dom.window.Element,
+    HTMLDivElement: dom.window.HTMLDivElement,
+    HTMLElement: dom.window.HTMLElement,
+    HTMLPreElement: dom.window.HTMLPreElement,
+    HTMLStyleElement: dom.window.HTMLStyleElement,
+    Node: dom.window.Node,
+    requestAnimationFrame: ((callback: FrameRequestCallback) => {
+      const id = ++nextFrameId;
+      const timeout = setTimeout(() => {
+        frames.delete(id);
+        callback(performance.now());
+      }, 0);
+      frames.set(id, timeout);
+      return id;
+    }) as typeof requestAnimationFrame,
+    ResizeObserver: MockResizeObserver,
+    SVGElement: dom.window.SVGElement,
+    window: dom.window,
+  });
+
+  return {
+    cleanup() {
+      for (const timeout of frames.values()) {
+        clearTimeout(timeout);
+      }
+      frames.clear();
+
+      for (const [key, value] of Object.entries(originalValues)) {
+        if (value === undefined) {
+          Reflect.deleteProperty(globalThis, key);
+        } else {
+          Object.assign(globalThis, { [key]: value });
+        }
+      }
+      dom.window.close();
+    },
+  };
+}
+
+function createRoot(height: number): HTMLDivElement {
+  const root = document.createElement('div');
+  root.scrollTo = (options?: ScrollToOptions | number, y?: number) => {
+    root.scrollTop =
+      typeof options === 'number' ? (y ?? 0) : (options?.top ?? root.scrollTop);
+  };
+  Object.defineProperty(root, 'getBoundingClientRect', {
+    value: () => ({
+      bottom: height,
+      height,
+      left: 0,
+      right: 1000,
+      top: 0,
+      width: 1000,
+      x: 0,
+      y: 0,
+      toJSON() {
+        return {};
+      },
+    }),
+  });
+  document.body.appendChild(root);
+  return root;
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function dispatchScroll(root: HTMLElement): void {
+  root.dispatchEvent(new window.Event('scroll'));
+}
+
+function makeFile(
+  name: string,
+  label: string,
+  lineCount: number
+): FileContents {
+  return {
+    name,
+    contents: Array.from(
+      { length: lineCount },
+      (_, index) => `${label} line ${index + 1}`
+    ).join('\n'),
+  };
+}
+
+function makeFileItem(
+  id: string,
+  label: string,
+  lineCount: number
+): CodeViewItem<undefined> {
+  return {
+    id,
+    type: 'file',
+    file: makeFile(`${id}.ts`, label, lineCount),
+  };
+}
+
+async function renderItems(
+  viewer: CodeView,
+  items: readonly CodeViewItem[]
+): Promise<void> {
+  viewer.setItems(items);
+  viewer.render(true);
+  await wait(0);
+}
+
+function getShadowText(element: HTMLElement): string {
+  return element.shadowRoot?.textContent ?? '';
+}
+
+function getShellCounts(element: HTMLElement): {
+  pre: number;
+  svg: number;
+  theme: number;
+  unsafe: number;
+} {
+  const { shadowRoot } = element;
+  expect(shadowRoot).not.toBeNull();
+  return {
+    pre: shadowRoot?.querySelectorAll('pre').length ?? 0,
+    svg: shadowRoot?.querySelectorAll('svg[data-icon-sprite]').length ?? 0,
+    theme: shadowRoot?.querySelectorAll('style[data-theme-css]').length ?? 0,
+    unsafe: shadowRoot?.querySelectorAll('style[data-unsafe-css]').length ?? 0,
+  };
+}
+
+async function waitForShellCounts(
+  element: HTMLElement,
+  expected: ReturnType<typeof getShellCounts>
+): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    try {
+      expect(getShellCounts(element)).toEqual(expected);
+      return;
+    } catch {
+      await wait(10);
+    }
+  }
+  expect(getShellCounts(element)).toEqual(expected);
+}
+
+describe('CodeView element pooling', () => {
+  test('reuses sanitized item shells without duplicating shared assets', async () => {
+    const { cleanup } = installDom();
+    const viewer = new CodeView({
+      disableFileHeader: true,
+      theme: DEFAULT_THEMES,
+      unsafeCSS: ':host { --pooled-shell: 1; }',
+    });
+    const root = createRoot(120);
+    const items = [
+      makeFileItem('file:first', 'first pooled content', 100),
+      makeFileItem('file:second', 'second pooled content', 100),
+    ];
+
+    try {
+      viewer.setup(root);
+      await renderItems(viewer, items);
+
+      let renderedItems = viewer.getRenderedItems();
+      expect(renderedItems.map((item) => item.id)).toEqual(['file:first']);
+      const firstElement = renderedItems[0].element;
+      await waitForShellCounts(firstElement, {
+        pre: 1,
+        svg: 1,
+        theme: 1,
+        unsafe: 1,
+      });
+      expect(getShadowText(firstElement)).toContain('first pooled content');
+
+      root.scrollTop = 2_400;
+      dispatchScroll(root);
+      viewer.render(true);
+      await wait(0);
+
+      renderedItems = viewer.getRenderedItems();
+      expect(renderedItems.map((item) => item.id)).toEqual(['file:second']);
+      const secondElement = renderedItems[0].element;
+      expect(secondElement).toBe(firstElement);
+      await waitForShellCounts(secondElement, {
+        pre: 1,
+        svg: 1,
+        theme: 1,
+        unsafe: 1,
+      });
+      expect(getShadowText(secondElement)).toContain('second pooled content');
+      expect(getShadowText(secondElement)).not.toContain(
+        'first pooled content'
+      );
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+
+  test('clears pooled shells when shared css options change', async () => {
+    const { cleanup } = installDom();
+    const viewer = new CodeView({
+      disableFileHeader: true,
+      theme: DEFAULT_THEMES,
+      themeType: 'light',
+    });
+
+    try {
+      viewer.setup(createRoot(1000));
+      await renderItems(viewer, [
+        makeFileItem('file:first', 'first content', 5),
+        makeFileItem('file:second', 'second content', 5),
+      ]);
+
+      const pooledCandidates = viewer
+        .getRenderedItems()
+        .map((item) => item.element);
+      expect(pooledCandidates).toHaveLength(2);
+
+      viewer.setItems([]);
+      viewer.setOptions({
+        disableFileHeader: true,
+        theme: DEFAULT_THEMES,
+        themeType: 'dark',
+      });
+      await renderItems(viewer, [
+        makeFileItem('file:third', 'third content', 5),
+      ]);
+
+      const nextElement = viewer.getRenderedItems()[0]?.element;
+      expect(nextElement).toBeDefined();
+      expect(pooledCandidates).not.toContain(nextElement);
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+
+  test('waits for managed slot children to clear before reusing a shell', async () => {
+    const { cleanup } = installDom();
+    const viewer = new CodeView({ disableFileHeader: true }, undefined, true);
+    const root = createRoot(120);
+    const coordinator: CodeViewCoordinator<undefined> = {
+      hasAnnotationRenderer: false,
+      hasGutterRenderer: false,
+      hasHeaderRenderers: true,
+      onSnapshotChange() {},
+    };
+
+    try {
+      viewer.setSlotCoordinator(coordinator);
+      viewer.setup(root);
+      await renderItems(viewer, [
+        makeFileItem('file:first', 'first managed content', 100),
+        makeFileItem('file:second', 'second managed content', 100),
+      ]);
+
+      const firstItem = viewer.getRenderedItems()[0];
+      expect(firstItem?.id).toBe('file:first');
+      const firstElement = firstItem.element;
+      firstElement.appendChild(document.createElement('div'));
+
+      root.scrollTop = 2_400;
+      dispatchScroll(root);
+      viewer.render(true);
+      await wait(0);
+
+      const secondItem = viewer.getRenderedItems()[0];
+      expect(secondItem?.id).toBe('file:second');
+      expect(secondItem.element).not.toBe(firstElement);
+
+      firstElement.replaceChildren();
+      root.scrollTop = 0;
+      dispatchScroll(root);
+      viewer.render(true);
+      await wait(0);
+
+      const remountedFirstItem = viewer.getRenderedItems()[0];
+      expect(remountedFirstItem?.id).toBe('file:first');
+      expect(remountedFirstItem.element).toBe(firstElement);
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
TL;DR: Automatically pool the diffs-container elements and their re-usable children (style and svg nodes)

Originally I was hoping this could provide some performance improvements, however after it proved mostly neutral there, i just sat on it. However this evening in some other tests, I found it had pretty significant memory improvements so cleaned it up to actually ship.