### PR TITLE
Fix iOS scroll jitters

### DIFF
--- a/apps/docs/app/(diffshub)/_home/Home.tsx
+++ b/apps/docs/app/(diffshub)/_home/Home.tsx
@@ -44,8 +44,8 @@ const SOCIAL_LINKS = [
 
 export default function DiffshubHome() {
   return (
-    <div className="flex min-h-screen min-w-screen flex-col items-center justify-center md:bg-[var(--diffshub-sidebar-bg)] md:py-12">
-      <section className="relative flex min-h-[100dvh] w-2xl max-w-[100vw] flex-col justify-center space-y-4 px-6 pt-8 md:block md:min-h-0">
+    <div className="flex min-h-[100svh] min-w-screen flex-col items-center justify-center md:bg-[var(--diffshub-sidebar-bg)] md:py-12">
+      <section className="relative flex min-h-[100svh] w-2xl max-w-[100vw] flex-col justify-center space-y-4 px-6 pt-8 md:block md:min-h-0">
         <h2 className="flex items-center gap-1.5 text-2xl font-semibold tracking-tight">
           <DiffsHubLogo />
           DiffsHub


### PR DESCRIPTION
`dvh` apparently causes some jitters, but `svh` saves the day.