### PR TITLE
[diffshub] Misc Fixes

### DIFF
--- a/apps/docs/app/(diffshub)/(view)/_components/CodeViewFileTree.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/CodeViewFileTree.tsx
@@ -6,6 +6,7 @@ import lightSoftTheme from '@pierre/theme/pierre-light-soft';
 import type {
   FileTreeBatchOperation,
   FileTree as FileTreeModel,
+  FileTreeOptions,
 } from '@pierre/trees';
 import { themeToTreeStyles } from '@pierre/trees';
 import { FileTree, useFileTree } from '@pierre/trees/react';
@@ -30,6 +31,13 @@ import { useTheme } from '@/components/theme-provider';
 // Computed once at module level so they're never re-derived on every render.
 const LIGHT_SOFT_TREE_STYLES = themeToTreeStyles(lightSoftTheme);
 const DARK_SOFT_TREE_STYLES = themeToTreeStyles(darkSoftTheme);
+type FileTreeSortComparator = Exclude<
+  NonNullable<FileTreeOptions['sort']>,
+  'default'
+>;
+// Keeps @pierre/trees from applying its default semantic sort so the sidebar
+// follows the same patch path sequence that drives the code view.
+const PRESERVE_INPUT_ORDER_SORT: FileTreeSortComparator = () => 0;
 
 // These override vars take precedence over the --trees-theme-* vars set by
 // themeToTreeStyles, so diffshub-specific layout tweaks are always preserved.
@@ -79,9 +87,6 @@ export const CodeViewFileTree = memo(function CodeViewFileTree({
   // ever-growing live array.
   const initialPathsRef = useRef<readonly string[] | null>(null);
   initialPathsRef.current ??= source.paths.slice(0, source.pathCount);
-  const sort = useStableCallback<CodeViewFileTreeSource['sort']>(
-    (left, right) => sourceRef.current.sort(left, right)
-  );
   const onSelectionChange = useStableCallback(
     (selectedPaths: readonly FileTreePublicId[]) => {
       if (selectedPaths.length !== 1 || onSelectItem == null) {
@@ -99,7 +104,7 @@ export const CodeViewFileTree = memo(function CodeViewFileTree({
     ...BASE_FILE_TREE_OPTIONS,
     gitStatus: source.gitStatus,
     paths: initialPathsRef.current,
-    sort,
+    sort: PRESERVE_INPUT_ORDER_SORT,
     onSelectionChange,
     itemHeight: CODE_VIEW_FILE_TREE_ITEM_HEIGHT,
     initialVisibleRowCount,

--- a/apps/docs/app/(diffshub)/(view)/_components/codeViewDataAccumulator.ts
+++ b/apps/docs/app/(diffshub)/(view)/_components/codeViewDataAccumulator.ts
@@ -11,15 +11,10 @@ import type {
   CodeViewCommentFileByItemId,
   CodeViewCommentSidebarFile,
   CodeViewDiffStats,
-  CodeViewFileTreeSort,
   CodeViewFileTreeSource,
   CommentMetadata,
 } from './types';
-import {
-  createPatchOrderSortFromRankMap,
-  extendPatchOrderRanks,
-  mapChangeTypeToGitStatus,
-} from './utils';
+import { mapChangeTypeToGitStatus } from './utils';
 
 export interface CodeViewDataAccumulator {
   diffStats: CodeViewDiffStats;
@@ -37,13 +32,6 @@ export interface CodeViewDataAccumulator {
   pathToItemId: Map<string, string>;
   pathStateByTreePath: Map<string, CodeViewPathState>;
   paths: string[];
-  // Patch-order ranks for every path and directory ancestor we have ever
-  // appended. Extended incrementally so the sort comparator below stays valid
-  // across publishes without rebuilding the map.
-  rankByPath: Map<string, number>;
-  // Stable comparator that reads from rankByPath. Reused across snapshots so
-  // each publish does not allocate a fresh closure or repopulate a rank map.
-  sort: CodeViewFileTreeSort;
 }
 
 export interface CodeViewItemIdRename {
@@ -66,7 +54,6 @@ export interface LoadedCodeViewData {
 }
 
 export function createCodeViewDataAccumulator(): CodeViewDataAccumulator {
-  const rankByPath = new Map<string, number>();
   return {
     diffStats: {
       addedLines: 0,
@@ -85,8 +72,6 @@ export function createCodeViewDataAccumulator(): CodeViewDataAccumulator {
     pathToItemId: new Map(),
     pathStateByTreePath: new Map(),
     paths: [],
-    rankByPath,
-    sort: createPatchOrderSortFromRankMap(rankByPath),
   };
 }
 
@@ -139,11 +124,6 @@ export function appendFileDiffToCodeViewData(
 
   if (previousPathState == null) {
     accumulator.paths.push(treePath);
-    extendPatchOrderRanks(
-      accumulator.rankByPath,
-      treePath,
-      accumulator.paths.length - 1
-    );
   }
   accumulator.pathToItemId.set(treePath, id);
   updateGitStatusByPath(
@@ -187,7 +167,6 @@ export function snapshotCodeViewTreeSource(
     paths: accumulator.paths,
     pathToItemId: accumulator.pathToItemId,
     previousSource: accumulator.lastTreeSource,
-    sort: accumulator.sort,
   };
   accumulator.lastTreeSource = snapshot;
   return snapshot;

--- a/apps/docs/app/(diffshub)/(view)/_components/constants.ts
+++ b/apps/docs/app/(diffshub)/(view)/_components/constants.ts
@@ -150,6 +150,7 @@ export const BASE_FILE_TREE_OPTIONS = {
   flattenEmptyDirectories: true,
   id: 'gh-code-view-tree',
   initialExpansion: 'open',
+  presorted: true,
   search: true,
   stickyFolders: true,
   unsafeCSS: `${HIDDEN_SEARCH_UNSAFE_CSS}\n${SIDEBAR_VIRTUALIZED_SCROLL_UNSAFE_CSS}\n${SUPPRESS_FOLDER_DOT_UNSAFE_CSS}\n${FOLDER_LABEL_UNSAFE_CSS}`,

--- a/apps/docs/app/(diffshub)/(view)/_components/types.ts
+++ b/apps/docs/app/(diffshub)/(view)/_components/types.ts
@@ -1,7 +1,5 @@
 import type { AnnotationSide, SelectedLineRange } from '@pierre/diffs';
-import type { FileTreeOptions, GitStatusEntry } from '@pierre/trees';
-
-type FileTreeInputSort = NonNullable<FileTreeOptions['sort']>;
+import type { GitStatusEntry } from '@pierre/trees';
 
 export type ViewerLoadState =
   | 'fetching'
@@ -9,8 +7,6 @@ export type ViewerLoadState =
   | 'parsing'
   | 'ready'
   | 'error';
-
-export type CodeViewFileTreeSort = Exclude<FileTreeInputSort, 'default'>;
 
 export interface SavedCommentMetadata {
   kind: 'saved';
@@ -102,7 +98,6 @@ export interface CodeViewFileTreeSource {
   paths: readonly string[];
   pathToItemId: ReadonlyMap<string, string>;
   previousSource?: CodeViewFileTreeSource;
-  sort: CodeViewFileTreeSort;
 }
 
 export interface CodeViewDiffStats {

--- a/apps/docs/app/(diffshub)/(view)/_components/utils.ts
+++ b/apps/docs/app/(diffshub)/(view)/_components/utils.ts
@@ -11,7 +11,6 @@ import type { GitStatus } from '@pierre/trees';
 import type {
   CodeViewCommentFileByItemId,
   CodeViewDeletedCommentEvent,
-  CodeViewFileTreeSort,
   CodeViewSavedCommentEntry,
   CodeViewSavedCommentEvent,
   CodeViewSavedCommentItem,
@@ -21,7 +20,6 @@ import type {
   SavedCommentMetadata,
 } from './types';
 
-const PATCH_ORDER_FALLBACK_RANK = Number.MAX_SAFE_INTEGER;
 const GITHUB_HOST = 'github.com';
 const GITHUB_RAW_DIFF_HOST = 'patch-diff.githubusercontent.com';
 const RAW_GITHUB_DIFF_PATH_PATTERN =
@@ -237,62 +235,6 @@ export function mapChangeTypeToGitStatus(type: ChangeTypes): GitStatus {
     case 'change':
       return 'modified';
   }
-}
-
-// Records the patch-order rank for a path and every directory ancestor inside
-// `rankByPath`. Existing ranks are preserved so callers can fold new paths into
-// the same map without disturbing the ordering established for earlier paths.
-export function extendPatchOrderRanks(
-  rankByPath: Map<string, number>,
-  path: string,
-  index: number
-): void {
-  if (path.length === 0) {
-    return;
-  }
-
-  if (!rankByPath.has(path)) {
-    rankByPath.set(path, index);
-  }
-
-  let slashIndex = path.lastIndexOf('/');
-  while (slashIndex > 0) {
-    const directory = path.slice(0, slashIndex);
-    if (!rankByPath.has(directory)) {
-      rankByPath.set(directory, index);
-    }
-    slashIndex = directory.lastIndexOf('/');
-  }
-}
-
-// Builds a sort comparator that reads from a `rankByPath` map populated by
-// extendPatchOrderRanks. The comparator captures the map by reference so the
-// same comparator instance can be reused across incremental publishes while
-// the map continues to grow.
-export function createPatchOrderSortFromRankMap(
-  rankByPath: ReadonlyMap<string, number>
-): CodeViewFileTreeSort {
-  return (left, right) => {
-    const leftRank = rankByPath.get(left.path) ?? PATCH_ORDER_FALLBACK_RANK;
-    const rightRank = rankByPath.get(right.path) ?? PATCH_ORDER_FALLBACK_RANK;
-    if (leftRank !== rightRank) {
-      return leftRank - rightRank;
-    }
-
-    if (left.depth !== right.depth) {
-      return left.depth - right.depth;
-    }
-
-    if (left.isDirectory !== right.isDirectory) {
-      return left.isDirectory ? -1 : 1;
-    }
-
-    if (left.path === right.path) {
-      return 0;
-    }
-
-    return left.path < right.path ? -1 : 1;
-  };
 }
 
 function insertCommentInLineOrder(

--- a/packages/diffs/src/index.ts
+++ b/packages/diffs/src/index.ts
@@ -74,6 +74,7 @@ export * from './utils/createTransformerWithState';
 export * from './utils/createUnsafeCSSStyleNode';
 export * from './utils/createWindowFromScrollPosition';
 export * from './utils/cssWrappers';
+export * from './utils/detachString';
 export * from './utils/diffAcceptRejectHunk';
 export * from './utils/formatCSSVariablePrefix';
 export * from './utils/getFiletypeFromFileName';

--- a/packages/diffs/src/utils/detachString.ts
+++ b/packages/diffs/src/utils/detachString.ts
@@ -1,7 +1,16 @@
 const stringDetachEncoder = new TextEncoder();
 const stringDetachDecoder = new TextDecoder('utf-8', { ignoreBOM: true });
 const SURROGATE_CODE_UNIT_PATTERN = /[\uD800-\uDFFF]/;
-let stringDetachBuffer = new Uint8Array(1024);
+const STRING_DETACH_INITIAL_BUFFER_SIZE = 1024;
+let stringDetachBuffer = new Uint8Array(STRING_DETACH_INITIAL_BUFFER_SIZE);
+
+// Drops the reusable scratch buffer after a parsing run so one unusually long
+// line does not pin that peak allocation for the lifetime of the process.
+export function releaseStringDetachBuffer(): void {
+  if (stringDetachBuffer.length !== STRING_DETACH_INITIAL_BUFFER_SIZE) {
+    stringDetachBuffer = new Uint8Array(STRING_DETACH_INITIAL_BUFFER_SIZE);
+  }
+}
 
 // Forces a fresh backing string so a retained substring does not keep the
 // original raw patch/file text alive.

--- a/packages/diffs/src/utils/detachString.ts
+++ b/packages/diffs/src/utils/detachString.ts
@@ -1,6 +1,3 @@
-const stringDetachEncoder = new TextEncoder();
-const stringDetachDecoder = new TextDecoder('utf-8', { ignoreBOM: true });
-
 // Forces a fresh backing string so a retained substring does not keep the
 // original raw patch/file text alive.
 export function detachString(value: string): string {
@@ -8,19 +5,8 @@ export function detachString(value: string): string {
     return value;
   }
 
-  if (!hasSurrogateCodeUnit(value)) {
-    return stringDetachDecoder.decode(stringDetachEncoder.encode(value));
-  }
-
+  // JSON string round-tripping copies the string without changing lone
+  // surrogates. In browser traces this is substantially faster than a
+  // TextEncoder/TextDecoder copy and keeps the same memory-safety invariant.
   return JSON.parse(JSON.stringify(value)) as string;
-}
-
-function hasSurrogateCodeUnit(value: string): boolean {
-  for (let index = 0; index < value.length; index++) {
-    const code = value.charCodeAt(index);
-    if (code >= 0xd800 && code <= 0xdfff) {
-      return true;
-    }
-  }
-  return false;
 }

--- a/packages/diffs/src/utils/detachString.ts
+++ b/packages/diffs/src/utils/detachString.ts
@@ -1,3 +1,8 @@
+const stringDetachEncoder = new TextEncoder();
+const stringDetachDecoder = new TextDecoder('utf-8', { ignoreBOM: true });
+const SURROGATE_CODE_UNIT_PATTERN = /[\uD800-\uDFFF]/;
+let stringDetachBuffer = new Uint8Array(1024);
+
 // Forces a fresh backing string so a retained substring does not keep the
 // original raw patch/file text alive.
 export function detachString(value: string): string {
@@ -5,8 +10,23 @@ export function detachString(value: string): string {
     return value;
   }
 
-  // JSON string round-tripping copies the string without changing lone
-  // surrogates. In browser traces this is substantially faster than a
-  // TextEncoder/TextDecoder copy and keeps the same memory-safety invariant.
-  return JSON.parse(JSON.stringify(value)) as string;
+  // TextEncoder replaces lone surrogate code units with U+FFFD, but diff input
+  // can contain arbitrary text. JSON round-tripping preserves those code units
+  // while still forcing V8 to allocate a fresh backing string.
+  if (SURROGATE_CODE_UNIT_PATTERN.test(value)) {
+    return JSON.parse(JSON.stringify(value)) as string;
+  }
+
+  // Without surrogates, each UTF-16 code unit encodes to at most 3 UTF-8 bytes.
+  // Reusing this scratch buffer avoids allocating a new Uint8Array for every
+  // parsed line while keeping retained line strings detached from the raw patch.
+  const requiredByteLength = value.length * 3;
+  if (stringDetachBuffer.length < requiredByteLength) {
+    stringDetachBuffer = new Uint8Array(requiredByteLength);
+  }
+
+  const { written } = stringDetachEncoder.encodeInto(value, stringDetachBuffer);
+  // Decoding only the written bytes materializes a compact string, preserving
+  // the low post-GC memory profile that the old TextEncoder/TextDecoder path had.
+  return stringDetachDecoder.decode(stringDetachBuffer.subarray(0, written));
 }

--- a/packages/diffs/src/utils/parsePatchFiles.ts
+++ b/packages/diffs/src/utils/parsePatchFiles.ts
@@ -17,7 +17,7 @@ import type {
   ParsedPatch,
 } from '../types';
 import { cleanLastNewline } from './cleanLastNewline';
-import { detachString } from './detachString';
+import { detachString, releaseStringDetachBuffer } from './detachString';
 
 interface ParsedHunkHeader {
   additionCount: number;
@@ -28,6 +28,18 @@ interface ParsedHunkHeader {
 }
 
 export function processPatch(
+  data: string,
+  cacheKeyPrefix?: string,
+  throwOnError?: boolean
+): ParsedPatch {
+  try {
+    return _processPatch(data, cacheKeyPrefix, throwOnError);
+  } finally {
+    releaseStringDetachBuffer();
+  }
+}
+
+function _processPatch(
   data: string,
   cacheKeyPrefix?: string,
   throwOnError = false
@@ -73,7 +85,7 @@ export function processPatch(
       }
       continue;
     }
-    const currentFile = processFile(fileOrPatchMetadata, {
+    const currentFile = _processFile(fileOrPatchMetadata, {
       cacheKey:
         cacheKeyPrefix != null
           ? `${cacheKeyPrefix}-${files.length}`
@@ -97,6 +109,17 @@ interface ProcessFileOptions {
 }
 
 export function processFile(
+  fileDiffString: string,
+  options?: ProcessFileOptions
+): FileDiffMetadata | undefined {
+  try {
+    return _processFile(fileDiffString, options);
+  } finally {
+    releaseStringDetachBuffer();
+  }
+}
+
+function _processFile(
   fileDiffString: string,
   {
     cacheKey,

--- a/packages/diffs/test/parsePatchFiles.test.ts
+++ b/packages/diffs/test/parsePatchFiles.test.ts
@@ -99,6 +99,24 @@ describe('parsePatchFiles', () => {
     expect(file?.additionLines[0]).toBe('\uFEFFnew\n');
   });
 
+  test('preserves lone surrogate characters in parsed hunk lines', () => {
+    const result = parsePatchFiles(
+      [
+        'diff --git a/surrogate.txt b/surrogate.txt\n',
+        'index 1111111..2222222 100644\n',
+        '--- a/surrogate.txt\n',
+        '+++ b/surrogate.txt\n',
+        '@@ -1 +1 @@\n',
+        '-old\ud800\n',
+        '+new\ud800\n',
+      ].join('')
+    );
+
+    const file = result[0]?.files[0];
+    expect(file?.deletionLines[0]).toBe('old\ud800\n');
+    expect(file?.additionLines[0]).toBe('new\ud800\n');
+  });
+
   test(
     'splitLineCount should match rendered line count in split mode',
     async () => {


### PR DESCRIPTION
* Improve streaming performance a bit more (i think performance regressed a bit when I did some memory optimizations a while back)
  * I think this both keeps the old performance heuristics AND keeps memory lean
* Undo any pre-sorting on the file tree
  * This will ensure that the FileTree matches the diffs view. I know it's not an ideal sort order, but I think it's the best/simplest for this website
  * We'd want to think more about sorting in the future if we ever wanted to productize this stuff.