### PR TITLE
[trees] add support for incremental git status

### DIFF
--- a/packages/trees/src/index.ts
+++ b/packages/trees/src/index.ts
@@ -50,6 +50,7 @@ export type {
   FileTreeDropResult,
   FileTreeDropTarget,
   FileTreeFileHandle,
+  FileTreeGitStatusPatch,
   FileTreeHeaderCompositionOptions,
   FileTreeHydrationProps,
   FileTreeInitialExpansion,

--- a/packages/trees/src/model/gitStatus.ts
+++ b/packages/trees/src/model/gitStatus.ts
@@ -1,8 +1,10 @@
 import type { GitStatus, GitStatusEntry } from '../publicTypes';
 import { getGitStatusSignature } from '../utils/getGitStatusSignature';
 import { normalizeInputPath } from '../utils/normalizeInputPath';
+import type { FileTreeGitStatusPatch } from './publicTypes';
 
 export interface FileTreeGitStatusState {
+  readonly changeCountByDirectoryPath: ReadonlyMap<string, number>;
   readonly directoriesWithChanges: ReadonlySet<string>;
   readonly ignoredDirectoryPaths: ReadonlySet<string>;
   readonly signature: string;
@@ -17,10 +19,18 @@ function getAncestorDirectoryPaths(path: string): readonly string[] {
     return [];
   }
 
-  const segments = normalizedPath.split('/');
-  return segments
-    .slice(0, -1)
-    .map((_, index) => `${segments.slice(0, index + 1).join('/')}/`);
+  const ancestors: string[] = [];
+  let searchIndex = 0;
+  for (;;) {
+    const slashIndex = normalizedPath.indexOf('/', searchIndex);
+    if (slashIndex === -1) {
+      break;
+    }
+
+    ancestors.push(normalizedPath.slice(0, slashIndex + 1));
+    searchIndex = slashIndex + 1;
+  }
+  return ancestors;
 }
 
 function getCanonicalGitStatusPath(path: string, isDirectory: boolean): string {
@@ -45,33 +55,239 @@ export function resolveFileTreeGitStatusState(
   const statusByPath = new Map<string, GitStatus>();
   const directoriesWithChanges = new Set<string>();
   const ignoredDirectoryPaths = new Set<string>();
+  const changeCountByDirectoryPath = new Map<string, number>();
 
   for (const entry of entries ?? []) {
-    const normalizedPath = normalizeInputPath(entry.path);
-    if (normalizedPath == null) {
+    const resolved = resolveGitStatusEntry(entry);
+    if (resolved == null) {
       continue;
     }
 
-    const canonicalPath = getCanonicalGitStatusPath(
-      normalizedPath.path,
-      normalizedPath.isDirectory
-    );
-    statusByPath.set(canonicalPath, entry.status);
-    if (entry.status === 'ignored' && normalizedPath.isDirectory) {
-      ignoredDirectoryPaths.add(canonicalPath);
-    } else if (normalizedPath.isDirectory) {
-      ignoredDirectoryPaths.delete(canonicalPath);
-    }
+    setGitStatusPath({
+      canonicalPath: resolved.canonicalPath,
+      changeCountByDirectoryPath,
+      directoriesWithChanges,
+      ignoredDirectoryPaths,
+      isDirectory: resolved.isDirectory,
+      status: entry.status,
+      statusByPath,
+    });
+  }
 
-    for (const ancestorPath of getAncestorDirectoryPaths(normalizedPath.path)) {
-      directoriesWithChanges.add(ancestorPath);
-    }
+  if (statusByPath.size === 0) {
+    return null;
   }
 
   return {
+    changeCountByDirectoryPath,
     directoriesWithChanges,
     ignoredDirectoryPaths,
     signature,
     statusByPath,
   };
+}
+
+export function applyFileTreeGitStatusPatch(
+  previous: FileTreeGitStatusState | null,
+  patch: FileTreeGitStatusPatch | undefined
+): FileTreeGitStatusState | null {
+  const removeEntries = patch?.remove ?? [];
+  const setEntries = patch?.set ?? [];
+  if (removeEntries.length === 0 && setEntries.length === 0) {
+    return previous;
+  }
+
+  const statusByPath = new Map(previous?.statusByPath);
+  const directoriesWithChanges = new Set(previous?.directoriesWithChanges);
+  const ignoredDirectoryPaths = new Set(previous?.ignoredDirectoryPaths);
+  const changeCountByDirectoryPath = new Map(
+    previous?.changeCountByDirectoryPath
+  );
+  let changed = false;
+
+  for (const path of removeEntries) {
+    const resolved = resolveGitStatusPath(path);
+    if (resolved == null) {
+      continue;
+    }
+
+    changed =
+      removeGitStatusPath({
+        canonicalPath: resolved.canonicalPath,
+        changeCountByDirectoryPath,
+        directoriesWithChanges,
+        ignoredDirectoryPaths,
+        statusByPath,
+      }) || changed;
+  }
+
+  for (const entry of setEntries) {
+    const resolved = resolveGitStatusEntry(entry);
+    if (resolved == null) {
+      continue;
+    }
+
+    changed =
+      setGitStatusPath({
+        canonicalPath: resolved.canonicalPath,
+        changeCountByDirectoryPath,
+        directoriesWithChanges,
+        ignoredDirectoryPaths,
+        isDirectory: resolved.isDirectory,
+        status: entry.status,
+        statusByPath,
+      }) || changed;
+  }
+
+  if (!changed) {
+    return previous;
+  }
+  if (statusByPath.size === 0) {
+    return null;
+  }
+
+  return {
+    changeCountByDirectoryPath,
+    directoriesWithChanges,
+    ignoredDirectoryPaths,
+    signature: getGitStatusStateSignature(statusByPath),
+    statusByPath,
+  };
+}
+
+interface GitStatusPathResolution {
+  canonicalPath: string;
+  isDirectory: boolean;
+}
+
+function resolveGitStatusEntry(
+  entry: GitStatusEntry
+): GitStatusPathResolution | undefined {
+  return resolveGitStatusPath(entry.path);
+}
+
+function resolveGitStatusPath(
+  path: string
+): GitStatusPathResolution | undefined {
+  const normalizedPath = normalizeInputPath(path);
+  if (normalizedPath == null) {
+    return undefined;
+  }
+
+  return {
+    canonicalPath: getCanonicalGitStatusPath(
+      normalizedPath.path,
+      normalizedPath.isDirectory
+    ),
+    isDirectory: normalizedPath.isDirectory,
+  };
+}
+
+function removeGitStatusPath({
+  canonicalPath,
+  changeCountByDirectoryPath,
+  directoriesWithChanges,
+  ignoredDirectoryPaths,
+  statusByPath,
+}: {
+  canonicalPath: string;
+  changeCountByDirectoryPath: Map<string, number>;
+  directoriesWithChanges: Set<string>;
+  ignoredDirectoryPaths: Set<string>;
+  statusByPath: Map<string, GitStatus>;
+}): boolean {
+  const previousStatus = statusByPath.get(canonicalPath);
+  if (previousStatus == null) {
+    return false;
+  }
+
+  statusByPath.delete(canonicalPath);
+  if (previousStatus === 'ignored' && canonicalPath.endsWith('/')) {
+    ignoredDirectoryPaths.delete(canonicalPath);
+  }
+  decrementAncestorChangeCounts(
+    changeCountByDirectoryPath,
+    directoriesWithChanges,
+    canonicalPath
+  );
+  return true;
+}
+
+function setGitStatusPath({
+  canonicalPath,
+  changeCountByDirectoryPath,
+  directoriesWithChanges,
+  ignoredDirectoryPaths,
+  isDirectory,
+  status,
+  statusByPath,
+}: {
+  canonicalPath: string;
+  changeCountByDirectoryPath: Map<string, number>;
+  directoriesWithChanges: Set<string>;
+  ignoredDirectoryPaths: Set<string>;
+  isDirectory: boolean;
+  status: GitStatus;
+  statusByPath: Map<string, GitStatus>;
+}): boolean {
+  const previousStatus = statusByPath.get(canonicalPath);
+  if (previousStatus === status) {
+    return false;
+  }
+
+  if (previousStatus == null) {
+    incrementAncestorChangeCounts(
+      changeCountByDirectoryPath,
+      directoriesWithChanges,
+      canonicalPath
+    );
+  }
+
+  statusByPath.set(canonicalPath, status);
+  if (status === 'ignored' && isDirectory) {
+    ignoredDirectoryPaths.add(canonicalPath);
+  } else if (isDirectory) {
+    ignoredDirectoryPaths.delete(canonicalPath);
+  }
+  return true;
+}
+
+function incrementAncestorChangeCounts(
+  changeCountByDirectoryPath: Map<string, number>,
+  directoriesWithChanges: Set<string>,
+  path: string
+): void {
+  for (const ancestorPath of getAncestorDirectoryPaths(path)) {
+    changeCountByDirectoryPath.set(
+      ancestorPath,
+      (changeCountByDirectoryPath.get(ancestorPath) ?? 0) + 1
+    );
+    directoriesWithChanges.add(ancestorPath);
+  }
+}
+
+function decrementAncestorChangeCounts(
+  changeCountByDirectoryPath: Map<string, number>,
+  directoriesWithChanges: Set<string>,
+  path: string
+): void {
+  for (const ancestorPath of getAncestorDirectoryPaths(path)) {
+    const nextCount = (changeCountByDirectoryPath.get(ancestorPath) ?? 0) - 1;
+    if (nextCount > 0) {
+      changeCountByDirectoryPath.set(ancestorPath, nextCount);
+    } else {
+      changeCountByDirectoryPath.delete(ancestorPath);
+      directoriesWithChanges.delete(ancestorPath);
+    }
+  }
+}
+
+function getGitStatusStateSignature(
+  statusByPath: ReadonlyMap<string, GitStatus>
+): string {
+  let signature = `${statusByPath.size}`;
+  for (const [path, status] of statusByPath) {
+    signature += `\0${path}\0${status}`;
+  }
+  return signature;
 }

--- a/packages/trees/src/model/publicTypes.ts
+++ b/packages/trees/src/model/publicTypes.ts
@@ -59,6 +59,11 @@ export type FileTreeBatchOperation =
       type: 'move';
     } & FileTreeMoveOptions);
 
+export interface FileTreeGitStatusPatch {
+  remove?: readonly FileTreePublicId[];
+  set?: readonly GitStatusEntry[];
+}
+
 // Mirrors the subset of PathStoreConstructorOptions that trees forwards to its
 // underlying store. See the duplication note above the FileTree* type cluster.
 interface FileTreeStoreOptions {

--- a/packages/trees/src/render/FileTree.ts
+++ b/packages/trees/src/render/FileTree.ts
@@ -22,6 +22,7 @@ import {
 } from '../model/density';
 import { FileTreeController } from '../model/FileTreeController';
 import {
+  applyFileTreeGitStatusPatch,
   type FileTreeGitStatusState,
   resolveFileTreeGitStatusState,
 } from '../model/gitStatus';
@@ -29,6 +30,7 @@ import type { FileTreeViewProps } from '../model/internalTypes';
 import type {
   FileTreeBatchOperation,
   FileTreeCompositionOptions,
+  FileTreeGitStatusPatch,
   FileTreeHydrationProps,
   FileTreeItemHandle,
   FileTreeListener,
@@ -347,6 +349,25 @@ export class FileTree
     this.#controller.batch(operations);
   }
 
+  public applyGitStatusPatch(patch: FileTreeGitStatusPatch): void {
+    const nextGitStatusState = applyFileTreeGitStatusPatch(
+      this.#gitStatusState,
+      patch
+    );
+    if (nextGitStatusState === this.#gitStatusState) {
+      return;
+    }
+
+    this.#gitStatusState = nextGitStatusState;
+
+    const mountedTree = this.#getMountedTreeElements();
+    if (mountedTree == null) {
+      return;
+    }
+
+    renderFileTreeRoot(mountedTree.wrapper, this.#getViewProps());
+  }
+
   public move(
     fromPath: string,
     toPath: string,
@@ -428,10 +449,15 @@ export class FileTree
   }
 
   public setGitStatus(gitStatus?: FileTreeOptions['gitStatus']): void {
-    this.#gitStatusState = resolveFileTreeGitStatusState(
+    const nextGitStatusState = resolveFileTreeGitStatusState(
       gitStatus,
       this.#gitStatusState
     );
+    if (nextGitStatusState === this.#gitStatusState) {
+      return;
+    }
+
+    this.#gitStatusState = nextGitStatusState;
 
     const mountedTree = this.#getMountedTreeElements();
     if (mountedTree == null) {

--- a/packages/trees/test/file-tree-git-status.test.ts
+++ b/packages/trees/test/file-tree-git-status.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 import { JSDOM } from 'jsdom';
 
-import { resolveFileTreeGitStatusState } from '../src/model/gitStatus';
+import {
+  applyFileTreeGitStatusPatch,
+  resolveFileTreeGitStatusState,
+} from '../src/model/gitStatus';
 import type { GitStatusEntry } from '../src/publicTypes';
 import { serializeFileTreeSsrPayload } from '../src/ssr';
 import { flushDom, installDom } from './helpers/dom';
@@ -56,6 +59,69 @@ describe('file-tree git status', () => {
     expect(state).not.toBeNull();
     expect(state?.statusByPath.get('src/')).toBe('modified');
     expect(state?.ignoredDirectoryPaths.has('src/')).toBe(false);
+  });
+
+  test('incremental patches update only changed status entries', () => {
+    const initialState = resolveFileTreeGitStatusState([
+      { path: 'src/index.ts', status: 'modified' },
+      { path: 'src/components/Button.tsx', status: 'added' },
+    ]);
+    if (initialState == null) {
+      throw new Error('expected initial git status state');
+    }
+
+    const noOpState = applyFileTreeGitStatusPatch(initialState, {
+      set: [{ path: 'src/index.ts', status: 'modified' }],
+    });
+    expect(noOpState).toBe(initialState);
+
+    const oneRemovedState = applyFileTreeGitStatusPatch(initialState, {
+      remove: ['src/index.ts'],
+    });
+    if (oneRemovedState == null) {
+      throw new Error('expected remaining git status state');
+    }
+
+    expect(oneRemovedState.statusByPath.has('src/index.ts')).toBe(false);
+    expect(oneRemovedState.statusByPath.get('src/components/Button.tsx')).toBe(
+      'added'
+    );
+    expect(oneRemovedState.directoriesWithChanges.has('src/')).toBe(true);
+    expect(oneRemovedState.directoriesWithChanges.has('src/components/')).toBe(
+      true
+    );
+
+    const emptyState = applyFileTreeGitStatusPatch(oneRemovedState, {
+      remove: ['src/components/Button.tsx'],
+    });
+    expect(emptyState).toBeNull();
+  });
+
+  test('incremental patches update ignored directory status inheritance', () => {
+    const initialState = resolveFileTreeGitStatusState([
+      { path: 'src/', status: 'ignored' },
+    ]);
+    if (initialState == null) {
+      throw new Error('expected initial git status state');
+    }
+
+    expect(initialState.ignoredDirectoryPaths.has('src/')).toBe(true);
+
+    const modifiedState = applyFileTreeGitStatusPatch(initialState, {
+      set: [{ path: 'src/', status: 'modified' }],
+    });
+    if (modifiedState == null) {
+      throw new Error('expected modified git status state');
+    }
+
+    expect(modifiedState.statusByPath.get('src/')).toBe('modified');
+    expect(modifiedState.ignoredDirectoryPaths.has('src/')).toBe(false);
+    expect(modifiedState.directoriesWithChanges.has('src/')).toBe(false);
+
+    const emptyState = applyFileTreeGitStatusPatch(modifiedState, {
+      remove: ['src/'],
+    });
+    expect(emptyState).toBeNull();
   });
 
   test('renders markers for all supported file git statuses and folder change attrs', async () => {
@@ -392,6 +458,86 @@ describe('file-tree git status', () => {
       expect(
         shadowRoot?.querySelector('[data-item-contains-git-change="true"]')
       ).toBeNull();
+
+      fileTree.cleanUp();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('applyGitStatusPatch refreshes decorations without replacing the tree wrapper', async () => {
+    const { cleanup, dom } = installDom();
+    try {
+      const { FileTree } = await import('../src/render/FileTree');
+      const mount = dom.window.document.createElement('div');
+      dom.window.document.body.appendChild(mount);
+      const fileTree = new FileTree({
+        flattenEmptyDirectories: false,
+        initialExpansion: 'open',
+        paths: FILES,
+        initialVisibleRowCount: 180 / 30,
+      });
+
+      fileTree.render({ containerWrapper: mount });
+      await flushDom();
+
+      const shadowRoot = fileTree.getFileTreeContainer()?.shadowRoot;
+      const wrapperBefore = shadowRoot?.querySelector(
+        '[data-file-tree-virtualized-wrapper="true"]'
+      );
+
+      fileTree.applyGitStatusPatch({
+        set: [
+          { path: 'src/index.ts', status: 'modified' },
+          { path: 'src/components/Button.tsx', status: 'added' },
+        ],
+      });
+      await flushDom();
+
+      expect(
+        getItemButton(shadowRoot, dom, 'src/index.ts').getAttribute(
+          'data-item-git-status'
+        )
+      ).toBe('modified');
+      expect(
+        getItemButton(
+          shadowRoot,
+          dom,
+          'src/components/Button.tsx'
+        ).getAttribute('data-item-git-status')
+      ).toBe('added');
+      expect(
+        getItemButton(shadowRoot, dom, 'src/').getAttribute(
+          'data-item-contains-git-change'
+        )
+      ).toBe('true');
+
+      fileTree.applyGitStatusPatch({ remove: ['src/index.ts'] });
+      await flushDom();
+
+      expect(
+        getItemButton(shadowRoot, dom, 'src/index.ts').getAttribute(
+          'data-item-git-status'
+        )
+      ).toBeNull();
+      expect(
+        getItemButton(shadowRoot, dom, 'src/').getAttribute(
+          'data-item-contains-git-change'
+        )
+      ).toBe('true');
+
+      fileTree.applyGitStatusPatch({ remove: ['src/components/Button.tsx'] });
+      await flushDom();
+
+      expect(shadowRoot?.querySelector('[data-item-git-status]')).toBeNull();
+      expect(
+        getItemButton(shadowRoot, dom, 'src/').getAttribute(
+          'data-item-contains-git-change'
+        )
+      ).toBeNull();
+      expect(
+        shadowRoot?.querySelector('[data-file-tree-virtualized-wrapper="true"]')
+      ).toBe(wrapperBefore);
 
       fileTree.cleanUp();
     } finally {


### PR DESCRIPTION
One thing that would be nice to have for diffshub, is the ability to partially update git statuses while incrementally adding files.

This was completely AI generated, so not sure if it's even the right way/desired way to do this.

I have another PR that utilizes this that I can merge after if you're happy with this.