### PR TITLE
[diffs] Fix gutter utility rendering quirk

### DIFF
--- a/packages/diffs/src/style.css
+++ b/packages/diffs/src/style.css
@@ -1712,7 +1712,13 @@
     position: relative;
     z-index: 4;
     touch-action: none;
-    overflow: hidden;
+
+    &::before {
+      content: '';
+      display: block;
+      position: absolute;
+      inset: 0 -4px;
+    }
   }
 
   /* Decoration Bars */

--- a/packages/diffs/src/style.css
+++ b/packages/diffs/src/style.css
@@ -1717,7 +1717,7 @@
       content: '';
       display: block;
       position: absolute;
-      inset: 0 -4px;
+      inset: 0 0 0 -4px;
     }
   }
 


### PR DESCRIPTION
<img width="1904" height="1256" alt="CleanShot 2026-05-20 at 15 49 41" src="https://github.com/user-attachments/assets/b6d86c28-0d9c-436a-a0df-154913b45e59" />

this only appears to happen on chrome, and it's some very bizarro rendering quirk. This feels like a better fix than the earlier one I had