### PR TITLE
[diffs] Fix for theme changes on collapsed files

### DIFF
--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -472,7 +472,8 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
       };
       forceHighlight = false;
     }
-    const forcePlainText = isDiffMassive(diff, this.getTokenizeMaxLength());
+    const forcePlainText =
+      isDiffPlainText(diff) || isDiffMassive(diff, this.getTokenizeMaxLength());
     this.renderCache ??= {
       diff,
       highlighted: false,
@@ -507,9 +508,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
         this.renderCache.renderRange = renderRange;
       }
       if (
-        // We should only attempt to kick off the worker highlighter if there
-        // are lines to render
-        renderRange.totalLines > 0 &&
+        (diff.additionLines.length > 0 || diff.deletionLines.length > 0) &&
         !forcePlainText &&
         (!this.renderCache.highlighted || forceHighlight)
       ) {

--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -472,8 +472,6 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
       };
       forceHighlight = false;
     }
-    const forcePlainText =
-      isDiffPlainText(diff) || isDiffMassive(diff, this.getTokenizeMaxLength());
     this.renderCache ??= {
       diff,
       highlighted: false,
@@ -481,35 +479,53 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
       result: undefined,
       renderRange: undefined,
     };
+    const hasContent =
+      diff.additionLines.length > 0 || diff.deletionLines.length > 0;
+    const forcePlainText =
+      !hasContent ||
+      isDiffPlainText(diff) ||
+      isDiffMassive(diff, this.getTokenizeMaxLength());
+    const newContent = !areDiffTargetsEqual(diff, this.renderCache.diff);
+    const newRenderRange = !areRenderRangesEqual(
+      this.renderCache.renderRange,
+      renderRange
+    );
     if (this.workerManager?.isWorkingPool() === true) {
       if (
         forcePlainText ||
         this.renderCache.result == null ||
-        (!this.renderCache.highlighted &&
-          (!areDiffTargetsEqual(diff, this.renderCache.diff) ||
-            !areRenderRangesEqual(this.renderCache.renderRange, renderRange)))
+        (!this.renderCache.highlighted && (newContent || newRenderRange))
       ) {
         this.renderCache.diff = diff;
         this.renderCache.options = options;
         this.renderCache.highlighted = false;
-        this.renderCache.result = this.workerManager.getPlainDiffAST(
-          diff,
-          renderRange.startingLine,
-          renderRange.totalLines,
-          // If we aren't using a windowed render, then we need to render
-          // everything
-          isDefaultRenderRange(renderRange)
-            ? true
-            : expandUnchanged
+        if (
+          this.renderCache.result == null ||
+          newContent ||
+          newRenderRange ||
+          forceHighlight
+        ) {
+          this.renderCache.result = this.workerManager.getPlainDiffAST(
+            diff,
+            renderRange.startingLine,
+            renderRange.totalLines,
+            // If we aren't using a windowed render, then we need to render
+            // everything
+            isDefaultRenderRange(renderRange)
               ? true
-              : this.expandedHunks,
-          collapsedContextThreshold
-        );
+              : expandUnchanged
+                ? true
+                : this.expandedHunks,
+            collapsedContextThreshold
+          );
+        }
         this.renderCache.renderRange = renderRange;
       }
+
+      // Should we kick off an async highlight process
       if (
-        (diff.additionLines.length > 0 || diff.deletionLines.length > 0) &&
         !forcePlainText &&
+        hasContent &&
         (!this.renderCache.highlighted || forceHighlight)
       ) {
         this.workerManager.highlightDiffAST(this, diff);

--- a/packages/diffs/src/renderers/FileRenderer.ts
+++ b/packages/diffs/src/renderers/FileRenderer.ts
@@ -234,10 +234,9 @@ export class FileRenderer<LAnnotation = undefined> {
       forceHighlight = false;
     }
     const lines = this.getOrCreateLineCache(file);
-    const forcePlainText = isFileMassive(
-      lines.length,
-      this.getTokenizeMaxLength()
-    );
+    const forcePlainText =
+      isFilePlainText(file) ||
+      isFileMassive(lines.length, this.getTokenizeMaxLength());
     this.renderCache ??= {
       file,
       highlighted: false,
@@ -267,9 +266,7 @@ export class FileRenderer<LAnnotation = undefined> {
       }
 
       if (
-        // We should only attempt to kick off the worker highlighter if there
-        // are lines to render
-        renderRange.totalLines > 0 &&
+        file.contents.length > 0 &&
         !forcePlainText &&
         (!this.renderCache.highlighted || forceHighlight)
       ) {

--- a/packages/diffs/src/renderers/FileRenderer.ts
+++ b/packages/diffs/src/renderers/FileRenderer.ts
@@ -233,10 +233,6 @@ export class FileRenderer<LAnnotation = undefined> {
       };
       forceHighlight = false;
     }
-    const lines = this.getOrCreateLineCache(file);
-    const forcePlainText =
-      isFilePlainText(file) ||
-      isFileMassive(lines.length, this.getTokenizeMaxLength());
     this.renderCache ??= {
       file,
       highlighted: false,
@@ -244,30 +240,46 @@ export class FileRenderer<LAnnotation = undefined> {
       result: undefined,
       renderRange: undefined,
     };
+    const lines = this.getOrCreateLineCache(file);
+    const hasContent = file.contents.length > 0;
+    const forcePlainText =
+      !hasContent ||
+      isFilePlainText(file) ||
+      isFileMassive(lines.length, this.getTokenizeMaxLength());
+    const newContent = !areFilesEqual(file, this.renderCache.file);
+    const newRenderRange = !areRenderRangesEqual(
+      this.renderCache.renderRange,
+      renderRange
+    );
     if (this.workerManager?.isWorkingPool() === true) {
       // Cache invalidation based on renderRange comparison
       if (
-        this.renderCache.result == null ||
         forcePlainText ||
-        (!this.renderCache.highlighted &&
-          (!areFilesEqual(file, this.renderCache.file) ||
-            !areRenderRangesEqual(this.renderCache.renderRange, renderRange)))
+        this.renderCache.result == null ||
+        (!this.renderCache.highlighted && (newContent || newRenderRange))
       ) {
         this.renderCache.file = file;
         this.renderCache.options = options;
         this.renderCache.highlighted = false;
-        this.renderCache.result = this.workerManager.getPlainFileAST(
-          file,
-          renderRange.startingLine,
-          renderRange.totalLines,
-          lines
-        );
+        if (
+          this.renderCache.result == null ||
+          newContent ||
+          newRenderRange ||
+          forceHighlight
+        ) {
+          this.renderCache.result = this.workerManager.getPlainFileAST(
+            file,
+            renderRange.startingLine,
+            renderRange.totalLines,
+            lines
+          );
+        }
         this.renderCache.renderRange = renderRange;
       }
 
       if (
-        file.contents.length > 0 &&
         !forcePlainText &&
+        hasContent &&
         (!this.renderCache.highlighted || forceHighlight)
       ) {
         this.workerManager.highlightFileAST(this, file);


### PR DESCRIPTION
Some of my render optimizations actually didn't make sense, and caused some funky side effects when changing themes, especially with collapsed files.

Also, found found some issues where we would aggressively attempt to render highlight plain text files when we probably shouldn't.