### PR TITLE
fix(diffs): handle quoted git diff headers

### DIFF
--- a/packages/diffs/src/utils/parsePatchFiles.ts
+++ b/packages/diffs/src/utils/parsePatchFiles.ts
@@ -188,8 +188,17 @@ function _processFile(
 
       for (const line of lines) {
         if (line.startsWith('diff --git')) {
-          const [, , prevName, , name] =
-            line.trim().match(ALTERNATE_FILE_NAMES_GIT) ?? [];
+          const filenameMatch = line.trim().match(ALTERNATE_FILE_NAMES_GIT);
+          const prevName = filenameMatch?.[1] ?? filenameMatch?.[2];
+          const name = filenameMatch?.[3] ?? filenameMatch?.[4];
+          if (prevName == null || name == null) {
+            if (throwOnError) {
+              throw Error('parsePatchContent: invalid git diff header');
+            } else {
+              console.error('parsePatchContent: invalid git diff header', line);
+            }
+            continue;
+          }
           currentFile.name = detachString(name.trim());
           if (prevName !== name) {
             currentFile.prevName = detachString(prevName.trim());

--- a/packages/diffs/test/parsePatchFiles.test.ts
+++ b/packages/diffs/test/parsePatchFiles.test.ts
@@ -2,7 +2,7 @@ import { afterAll, describe, expect, spyOn, test } from 'bun:test';
 
 import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
 import { DiffHunksRenderer } from '../src/renderers/DiffHunksRenderer';
-import { parsePatchFiles } from '../src/utils/parsePatchFiles';
+import { parsePatchFiles, processFile } from '../src/utils/parsePatchFiles';
 import {
   diffPatch,
   finalBlankLinePatch,
@@ -115,6 +115,24 @@ describe('parsePatchFiles', () => {
     const file = result[0]?.files[0];
     expect(file?.deletionLines[0]).toBe('old\ud800\n');
     expect(file?.additionLines[0]).toBe('new\ud800\n');
+  });
+
+  test('parses quoted git diff headers with escaped file names', () => {
+    const oldName =
+      'test/integration/image-optimizer/app/public/\\303\\244\\303\\266\\303\\274\\305\\241\\304\\215\\305\\231\\303\\255.png';
+    const newName =
+      'test/e2e/image-optimizer/app/public/\\303\\244\\303\\266\\303\\274\\305\\241\\304\\215\\305\\231\\303\\255.png';
+    const file = processFile(
+      [
+        `diff --git "a/${oldName}" "b/${newName}"\n`,
+        'similarity index 100%\n',
+      ].join(''),
+      { isGitDiff: true }
+    );
+
+    expect(file?.name).toBe(newName);
+    expect(file?.prevName).toBe(oldName);
+    expect(file?.type).toBe('rename-pure');
   });
 
   test(


### PR DESCRIPTION
Git can emit quoted diff headers for escaped non-ASCII paths, such as `diff --git "a/..." "b/..."`. The parser regex accepted this form, but the capture destructuring only read the unquoted capture slots, causing `name` to be undefined and crashing on `.trim()`.

Select the quoted or unquoted capture groups explicitly, fail softly for invalid git diff headers, and add regression coverage for quoted escaped file names.

A bug that was exposed by this PR: https://github.com/vercel/next.js/pull/93247