### PR TITLE
[diffs] WorkerPool & Element Pool Hardening

### DIFF
--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -464,8 +464,6 @@ const SCROLL_REBASE_TARGET_BOTTOM =
   SCROLL_REBASE_CONTAINER_HEIGHT - SCROLL_REBASE_TARGET_TOP;
 const SCROLL_REBASE_THRESHOLD =
   SCROLL_REBASE_CONTAINER_HEIGHT - SCROLL_REBASE_TRIGGER_TOP;
-const CODE_VIEW_ELEMENT_POOL_LIMIT = 32;
-
 interface ScrollToAnimation {
   position: number;
   velocity: number;
@@ -591,6 +589,8 @@ export class CodeView<LAnnotation = undefined> {
   private stickyContainer = document.createElement('div');
   private stickyOffset = document.createElement('div');
   private elementPool: HTMLElement[] = [];
+  private elementPoolVersion = 0;
+  private elementPoolTracker = new WeakMap<HTMLElement, number>();
   // Container-managed elements may still have externally-owned light DOM slot
   // children after release, so hold them here until they are safe to reuse.
   // i.e. the react CodeView component will require a separate react cleanup
@@ -907,9 +907,30 @@ export class CodeView<LAnnotation = undefined> {
     item.instance.primeHighlightCache();
   }
 
+  private getElementPoolLimit() {
+    const viewportSize = this.getHeight() + this.config.overscrollSize * 2;
+    const { diffHeaderHeight } = this.itemMetricsCache;
+    // The goal here roughly is to hold an element pool that's maxed out at
+    // around the size of all collapsed files, doubled if `isContainerManaged`
+    // because we have to wait an additional render tick to actually re-use the
+    // elements
+    return (
+      Math.max(
+        8,
+        Math.ceil(viewportSize / Math.max(diffHeaderHeight, 10)) + 1
+      ) * (this.isContainerManaged ? 2 : 1)
+    );
+  }
+
   private acquireElement(): HTMLElement {
     this.promotePendingPooledElements();
-    return this.elementPool.pop() ?? document.createElement(DIFFS_TAG_NAME);
+    let element = this.elementPool.pop();
+    while (element != null && !this.isElementPoolGenerationCurrent(element)) {
+      element = this.elementPool.pop();
+    }
+    element ??= document.createElement(DIFFS_TAG_NAME);
+    this.markElementPoolGenerationCurrent(element);
+    return element;
   }
 
   private releaseRenderedItem(item: CodeViewContextItem<LAnnotation>): void {
@@ -921,13 +942,14 @@ export class CodeView<LAnnotation = undefined> {
     }
 
     element.remove();
-    this.cleanElementForPool(element);
+    this.cleanElement(element);
     this.queueElementForPool(element);
   }
 
   // Strip item-specific DOM while keeping the expensive shared shell assets
-  // that are valid for every item in this CodeView until shared options change.
-  private cleanElementForPool(element: HTMLElement): void {
+  // that are valid for every item in this CodeView until shared options
+  // change.
+  private cleanElement(element: HTMLElement): void {
     const { shadowRoot } = element;
     if (shadowRoot != null) {
       for (const child of Array.from(shadowRoot.children)) {
@@ -943,7 +965,11 @@ export class CodeView<LAnnotation = undefined> {
   }
 
   private queueElementForPool(element: HTMLElement): void {
-    if (this.getElementPoolSize() >= CODE_VIEW_ELEMENT_POOL_LIMIT) {
+    const poolLimit = this.getElementPoolLimit();
+    if (
+      !this.isElementPoolGenerationCurrent(element) ||
+      this.getElementPoolSize() >= poolLimit
+    ) {
       return;
     }
 
@@ -961,13 +987,18 @@ export class CodeView<LAnnotation = undefined> {
 
     const { pendingElementPool: pendingElements } = this;
     this.pendingElementPool = [];
+    const poolLimit = this.getElementPoolLimit();
     for (const element of pendingElements) {
       if (
+        this.isElementPoolGenerationCurrent(element) &&
         this.isElementClean(element) &&
-        this.elementPool.length < CODE_VIEW_ELEMENT_POOL_LIMIT
+        this.elementPool.length < poolLimit
       ) {
         this.elementPool.push(element);
-      } else if (this.getElementPoolSize() < CODE_VIEW_ELEMENT_POOL_LIMIT) {
+      } else if (
+        this.isElementPoolGenerationCurrent(element) &&
+        this.getElementPoolSize() < poolLimit
+      ) {
         this.pendingElementPool.push(element);
       }
     }
@@ -984,6 +1015,19 @@ export class CodeView<LAnnotation = undefined> {
   private clearElementPool(): void {
     this.elementPool.length = 0;
     this.pendingElementPool.length = 0;
+  }
+
+  private invalidateElementPool(): void {
+    this.elementPoolVersion++;
+    this.clearElementPool();
+  }
+
+  private markElementPoolGenerationCurrent(element: HTMLElement): void {
+    this.elementPoolTracker.set(element, this.elementPoolVersion);
+  }
+
+  private isElementPoolGenerationCurrent(element: HTMLElement): boolean {
+    return this.elementPoolTracker.get(element) === this.elementPoolVersion;
   }
 
   private resolveEffectiveScrollBehavior(
@@ -1192,7 +1236,7 @@ export class CodeView<LAnnotation = undefined> {
   }
 
   public onThemeChange(): void {
-    this.clearElementPool();
+    this.invalidateElementPool();
   }
 
   public setOptions(options: CodeViewOptions<LAnnotation> | undefined): void {
@@ -1206,7 +1250,7 @@ export class CodeView<LAnnotation = undefined> {
     const { itemMetricsCache: previousItemMetrics } = this;
 
     if (shouldClearPool(prevOptions, options)) {
-      this.clearElementPool();
+      this.invalidateElementPool();
     }
 
     this.options = options;

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -192,6 +192,7 @@ export class File<LAnnotation = undefined> {
   }
 
   public onThemeChange(): void {
+    this.fileRenderer.clearRenderCache();
     this.rerender();
   }
 

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -674,6 +674,7 @@ export class FileDiff<LAnnotation = undefined> {
   }
 
   public onThemeChange(): void {
+    this.hunksRenderer.clearRenderCache();
     this.rerender();
   }
 

--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -235,10 +235,14 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
   public recycle(): void {
     this.highlighter = undefined;
     this.diff = undefined;
-    this.renderCache = undefined;
+    this.clearRenderCache();
     this.additionAnnotations = {};
     this.deletionAnnotations = {};
     this.workerManager?.cleanUpTasks(this);
+  }
+
+  public clearRenderCache(): void {
+    this.renderCache = undefined;
   }
 
   public setOptions(options: DiffHunksRendererOptions): void {
@@ -270,7 +274,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
     // NOTE(amadeus): If our render cache is not highlighted, we need to clear
     // it, otherwise we won't have the correct AST lines
     if (this.renderCache?.highlighted !== true) {
-      this.renderCache = undefined;
+      this.clearRenderCache();
     }
     this.expandedHunks.set(index, region);
   }

--- a/packages/diffs/src/renderers/FileRenderer.ts
+++ b/packages/diffs/src/renderers/FileRenderer.ts
@@ -132,10 +132,14 @@ export class FileRenderer<LAnnotation = undefined> {
   }
 
   public recycle(): void {
-    this.renderCache = undefined;
+    this.clearRenderCache();
     this.highlighter = undefined;
     this.workerManager?.cleanUpTasks(this);
     this.lineCache = undefined;
+  }
+
+  public clearRenderCache(): void {
+    this.renderCache = undefined;
   }
 
   public hydrate(file: FileContents): void {

--- a/packages/diffs/src/worker/WorkerPoolManager.ts
+++ b/packages/diffs/src/worker/WorkerPoolManager.ts
@@ -75,7 +75,8 @@ interface GetCachesResult {
 
 interface ManagedWorker {
   worker: Worker;
-  request_id: string | undefined;
+  requestId: string | undefined;
+  pendingSetupRequestId: WorkerRequestId | undefined;
   initialized: boolean;
   langs: Set<SupportedLanguages>;
   customExtensionsVersion: number;
@@ -93,6 +94,7 @@ export class WorkerPoolManager {
   private highlighter: DiffsHighlighter | undefined;
   private readonly preferredHighlighter: HighlighterTypes;
   private renderOptions: WorkerRenderingOptions;
+  private renderOptionsRequestVersion = 0;
   private renderOptionsVersion = 0;
   private initialized: Promise<void> | boolean = false;
   private workers: ManagedWorker[] = [];
@@ -193,6 +195,10 @@ export class WorkerPoolManager {
     tokenizeMaxLineLength = 1000,
   }: Partial<WorkerRenderingOptions>): Promise<void> {
     const { lifecycleGeneration } = this;
+    const renderOptionsRequestVersion = ++this.renderOptionsRequestVersion;
+    const isCurrentRequest = (): boolean =>
+      this.isCurrentLifecycle(lifecycleGeneration) &&
+      this.renderOptionsRequestVersion === renderOptionsRequestVersion;
     try {
       const newRenderOptions: WorkerRenderingOptions = {
         theme,
@@ -205,7 +211,7 @@ export class WorkerPoolManager {
         await this.initialize();
       }
       if (
-        !this.isCurrentLifecycle(lifecycleGeneration) ||
+        !isCurrentRequest() ||
         areDiffRenderOptionsEqual(newRenderOptions, this.renderOptions)
       ) {
         return;
@@ -221,45 +227,42 @@ export class WorkerPoolManager {
         }
       }
 
-      if (!this.isCurrentLifecycle(lifecycleGeneration)) {
+      if (!isCurrentRequest()) {
         return;
       }
 
       if (this.highlighter != null) {
         attachResolvedThemes(resolvedThemes, this.highlighter);
-        await this.setRenderOptionsOnWorkers(newRenderOptions, resolvedThemes);
       } else {
-        const [highlighter] = await Promise.all([
-          getSharedHighlighter({
-            themes: themeNames,
-            langs: ['text'],
-            preferredHighlighter: this.preferredHighlighter,
-          }),
-          this.setRenderOptionsOnWorkers(newRenderOptions, resolvedThemes),
-        ]);
-        if (!this.isCurrentLifecycle(lifecycleGeneration)) {
+        const highlighter = await getSharedHighlighter({
+          themes: themeNames,
+          langs: ['text'],
+          preferredHighlighter: this.preferredHighlighter,
+        });
+        if (!isCurrentRequest()) {
           return;
         }
         this.highlighter = highlighter;
       }
 
-      if (!this.isCurrentLifecycle(lifecycleGeneration)) {
-        return;
-      }
+      const workerSetup = this.setRenderOptionsOnWorkers(
+        newRenderOptions,
+        resolvedThemes
+      );
 
       this.renderOptions = newRenderOptions;
       this.renderOptionsVersion++;
       this.diffCache.clear();
       this.fileCache.clear();
+      this.invalidateRenderTasks();
 
       for (const instance of this.themeSubscribers) {
         instance.onThemeChange();
       }
+
+      await workerSetup;
     } catch (error) {
-      if (
-        error instanceof WorkerPoolTerminatedError ||
-        !this.isCurrentLifecycle(lifecycleGeneration)
-      ) {
+      if (error instanceof WorkerPoolTerminatedError || !isCurrentRequest()) {
         return;
       }
       throw error;
@@ -310,10 +313,10 @@ export class WorkerPoolManager {
             reject,
             requestStart: Date.now(),
           };
-          // NOTE(amadeus): We intentionally ignore the normal active requests
-          // infra because these tasks should technically interrupt the normal
-          // flow and should be processed by the worker when ready immediately
+          // Render-option updates are posted immediately, but the worker stays
+          // unavailable for new render work until it acknowledges this message.
           this.activeTaskById.set(id, task);
+          managedWorker.pendingSetupRequestId = id;
           managedWorker.worker.postMessage(task.request);
         })
       );
@@ -472,7 +475,8 @@ export class WorkerPoolManager {
       const worker = this.options.workerFactory();
       const managedWorker: ManagedWorker = {
         worker,
-        request_id: undefined,
+        requestId: undefined,
+        pendingSetupRequestId: undefined,
         initialized: false,
         langs: new Set(['text', ...resolvedLanguages.map(({ name }) => name)]),
         customExtensionsVersion: 0,
@@ -740,7 +744,9 @@ export class WorkerPoolManager {
       })(),
       totalWorkers: this.workers.length,
       workersFailed: this.workersFailed,
-      busyWorkers: this.workers.filter((w) => w.request_id != null).length,
+      busyWorkers: this.workers.filter(
+        (w) => w.requestId != null || w.pendingSetupRequestId != null
+      ).length,
       queuedTasks: this.queuedTasks.length,
       activeTasks: this.activeTaskById.size,
       themeSubscribers: this.themeSubscribers.size,
@@ -780,6 +786,7 @@ export class WorkerPoolManager {
     this.detachInstanceFromQueuedTasks(instance);
     const id = this.generateRequestId();
     const requestStart = Date.now();
+    const { renderOptionsVersion } = this;
     const task: RenderTask = (() => {
       switch (request.type) {
         case 'file':
@@ -790,6 +797,7 @@ export class WorkerPoolManager {
             instances: new Set([instance as FileRendererInstance]),
             primeCache: false,
             highlightKey,
+            renderOptionsVersion,
             requestStart,
           };
         case 'diff':
@@ -800,6 +808,7 @@ export class WorkerPoolManager {
             instances: new Set([instance as DiffRendererInstance]),
             primeCache: false,
             highlightKey,
+            renderOptionsVersion,
             requestStart,
           };
       }
@@ -813,6 +822,7 @@ export class WorkerPoolManager {
     }
     const id = this.generateRequestId();
     const requestStart = Date.now();
+    const { renderOptionsVersion } = this;
     const task: RenderTask = (() => {
       switch (request.type) {
         case 'file':
@@ -823,6 +833,7 @@ export class WorkerPoolManager {
             instances: new Set<FileRendererInstance>(),
             primeCache: true,
             highlightKey,
+            renderOptionsVersion,
             requestStart,
           };
         case 'diff':
@@ -833,6 +844,7 @@ export class WorkerPoolManager {
             instances: new Set<DiffRendererInstance>(),
             primeCache: true,
             highlightKey,
+            renderOptionsVersion,
             requestStart,
           };
       }
@@ -877,7 +889,7 @@ export class WorkerPoolManager {
       // If the task has been cleaned up after awaiting language resolving,
       // lets fully clean it up
       if (!this.activeTaskById.has(task.id)) {
-        if (availableWorker.request_id === task.id) {
+        if (availableWorker.requestId === task.id) {
           this.cleanWorkerAndTask(availableWorker, task);
           this.queueBroadcastStateChanges();
           if (this.queuedTasks.length > 0) {
@@ -939,6 +951,12 @@ export class WorkerPoolManager {
               throw new Error('handleWorkerMessage: task/response dont match');
             }
             const { result, options } = response;
+            if (
+              !this.isCurrentRenderTask(task) ||
+              !areFileRenderOptionsEqual(options, this.getFileRenderOptions())
+            ) {
+              throw IGNORE_RESPONSE;
+            }
             const { request } = task;
             this.syncCustomExtensionVersion(managedWorker, request);
             if (request.file.cacheKey != null) {
@@ -952,6 +970,12 @@ export class WorkerPoolManager {
               throw new Error('handleWorkerMessage: task/response dont match');
             }
             const { result, options } = response;
+            if (
+              !this.isCurrentRenderTask(task) ||
+              !areDiffRenderOptionsEqual(options, this.getDiffRenderOptions())
+            ) {
+              throw IGNORE_RESPONSE;
+            }
             const { request } = task;
             this.syncCustomExtensionVersion(managedWorker, request);
             if (request.diff.cacheKey != null) {
@@ -968,7 +992,7 @@ export class WorkerPoolManager {
       }
     }
 
-    this.cleanWorkerAndTask(managedWorker, task);
+    this.cleanWorkerAndTask(managedWorker, task, response.id);
     this.queueBroadcastStateChanges();
     if (this.queuedTasks.length > 0) {
       // We queue drain so that potentially multiple workers can free up
@@ -988,7 +1012,7 @@ export class WorkerPoolManager {
     task: AllWorkerTasks,
     managedWorker: ManagedWorker
   ) {
-    managedWorker.request_id = task.id;
+    managedWorker.requestId = task.id;
     if (isRenderTask(task)) {
       this.clearQueuedInstanceRequests(task);
       this.trackInstanceRequests(task);
@@ -998,9 +1022,15 @@ export class WorkerPoolManager {
 
   private cleanWorkerAndTask(
     managedWorker: ManagedWorker,
-    task?: AllWorkerTasks
+    task?: AllWorkerTasks,
+    requestId: WorkerRequestId | undefined = task?.id
   ) {
-    managedWorker.request_id = undefined;
+    if (managedWorker.requestId === requestId) {
+      managedWorker.requestId = undefined;
+    }
+    if (managedWorker.pendingSetupRequestId === requestId) {
+      managedWorker.pendingSetupRequestId = undefined;
+    }
     if (task != null) {
       if (isRenderTask(task)) {
         this.clearInstanceRequests(task);
@@ -1070,7 +1100,11 @@ export class WorkerPoolManager {
   ): ManagedWorker | undefined {
     let worker: ManagedWorker | undefined;
     for (const managedWorker of this.workers) {
-      if (managedWorker.request_id != null || !managedWorker.initialized) {
+      if (
+        managedWorker.requestId != null ||
+        managedWorker.pendingSetupRequestId != null ||
+        !managedWorker.initialized
+      ) {
         continue;
       }
       worker = managedWorker;
@@ -1182,6 +1216,24 @@ export class WorkerPoolManager {
     this.activeTaskById.delete(task.id);
   }
 
+  private invalidateRenderTasks(): void {
+    for (let index = this.queuedTasks.length - 1; index >= 0; index--) {
+      const task = this.queuedTasks[index];
+      if (task.renderOptionsVersion !== this.renderOptionsVersion) {
+        this.removeQueuedTask(task);
+      }
+    }
+
+    for (const task of Array.from(this.activeTaskById.values())) {
+      if (
+        isRenderTask(task) &&
+        task.renderOptionsVersion !== this.renderOptionsVersion
+      ) {
+        this.removeActiveTask(task);
+      }
+    }
+  }
+
   private clearQueuedInstanceRequests(task: RenderTask): void {
     for (const instance of getInstances(task)) {
       if (this.queuedTaskByInstance.get(instance) === task) {
@@ -1252,6 +1304,7 @@ export class WorkerPoolManager {
     for (const task of this.iterateRenderTasks()) {
       if (
         task.type === 'file' &&
+        this.isCurrentRenderTask(task) &&
         task.instances.has(instance) &&
         areFilesEqual(file, task.request.file)
       ) {
@@ -1268,6 +1321,7 @@ export class WorkerPoolManager {
     for (const task of this.iterateRenderTasks()) {
       if (
         task.type === 'diff' &&
+        this.isCurrentRenderTask(task) &&
         task.instances.has(instance) &&
         areDiffTargetsEqual(task.request.diff, diff)
       ) {
@@ -1278,7 +1332,12 @@ export class WorkerPoolManager {
   }
 
   private getTaskByHighlightKey(highlightKey: string): RenderTask | undefined {
-    return this.taskByHighlightKey.get(highlightKey);
+    const task = this.taskByHighlightKey.get(highlightKey);
+    return task != null && this.isCurrentRenderTask(task) ? task : undefined;
+  }
+
+  private isCurrentRenderTask(task: RenderTask): boolean {
+    return task.renderOptionsVersion === this.renderOptionsVersion;
   }
 
   private *iterateRenderTasks(): Generator<RenderTask> {

--- a/packages/diffs/src/worker/types.ts
+++ b/packages/diffs/src/worker/types.ts
@@ -193,6 +193,7 @@ export interface RenderFileTask {
   // regardless of whether there's any instances subscribed to the task
   primeCache: boolean;
   highlightKey?: string;
+  renderOptionsVersion: number;
   requestStart: number;
 }
 
@@ -205,6 +206,7 @@ export interface RenderDiffTask {
   // regardless of whether there's any instances subscribed to the task
   primeCache: boolean;
   highlightKey?: string;
+  renderOptionsVersion: number;
   requestStart: number;
 }
 


### PR DESCRIPTION
Basically the theme switcher branch for diffshub has exposed a ton of flaws in my WorkerPoolManager and element pooling architecture that are essentially fixed here.

The fixes are grouped into 3 commits that address a few important scenarios.

### Clean `renderCache` on worker pool theme change
When the worker pool has a theme change, we need to blow away our existing render cache to ensure we never render from a stale theme. Additionally this helps the theme change feel instant/responsive because we can render plain text right away and not wait for a response from the worker.

### `WorkPoolManager.setRenderOptions` race conditions
The core change here was that given the async nature of loading/setting themes (both to load the theme and update the workers), we needed better validation under rapid theme changes to ensure that tasks are properly dropped and if things come back out of order they can be properly ignored.

### Fixing poisoned elements
While we were clearing the element pool correctly on theme changes, there was another bug wherein if we were recycling on that tick we were then pooling invalid elements. So this added a sort of version tracker for the element pool that gets incremented and tied to versioned renders to ensure that pooled element contract is always correct with its children