### PR TITLE
[diffs] Remove necessary set shorthands and defaults

### DIFF
--- a/packages/diffs/src/style.css
+++ b/packages/diffs/src/style.css
@@ -222,7 +222,7 @@
     margin: 0;
     padding: 0;
     display: block;
-    outline: none;
+    outline-style: none;
     font-family: var(--diffs-font-family, var(--diffs-font-fallback));
   }
 
@@ -811,7 +811,7 @@
   }
 
   [data-code]::-webkit-scrollbar-track {
-    background: transparent;
+    background-color: transparent;
   }
 
   [data-code]::-webkit-scrollbar-thumb {
@@ -1048,7 +1048,6 @@
   [data-expand-button],
   [data-separator-content] {
     display: flex;
-    flex: 0 0 auto;
     align-items: center;
     background-color: var(--diffs-bg-separator);
   }
@@ -1081,7 +1080,7 @@
   }
 
   [data-separator-content] {
-    flex: 1 1 auto;
+    flex-grow: 1;
     padding: 0 1ch;
     height: 100%;
     color: var(--diffs-fg-number);
@@ -1105,7 +1104,6 @@
     min-width: 0;
     text-overflow: ellipsis;
     white-space: nowrap;
-    flex: 0 1 auto;
   }
 
   @supports (width: 1cqi) {
@@ -1525,7 +1523,7 @@
   [data-merge-conflict-actions-content] {
     display: flex;
     align-items: center;
-    gap: 0.25rem;
+    column-gap: 0.25rem;
     padding-inline: 0.5rem;
     min-height: 1.75rem;
     font-family: var(
@@ -1539,8 +1537,8 @@
 
   [data-merge-conflict-action] {
     appearance: none;
-    border: 0;
-    background: transparent;
+    border-style: none;
+    background-color: transparent;
     color: var(--diffs-fg-number);
     font: inherit;
     font-style: normal;
@@ -1572,10 +1570,9 @@
     position: relative;
     background-color: var(--diffs-bg);
     display: flex;
-    flex-direction: row;
     justify-content: space-between;
     align-items: center;
-    gap: var(--diffs-gap-inline, var(--diffs-gap-fallback));
+    column-gap: var(--diffs-gap-inline, var(--diffs-gap-fallback));
     min-height: calc(
       1lh + (var(--diffs-gap-block, var(--diffs-gap-fallback)) * 3)
     );
@@ -1586,9 +1583,8 @@
 
   [data-header-content] {
     display: flex;
-    flex-direction: row;
     align-items: center;
-    gap: var(--diffs-gap-inline, var(--diffs-gap-fallback));
+    column-gap: var(--diffs-gap-inline, var(--diffs-gap-fallback));
     min-width: 0;
     white-space: nowrap;
   }
@@ -1615,7 +1611,7 @@
   [data-diffs-header='default'] [data-metadata] {
     display: flex;
     align-items: center;
-    gap: 1ch;
+    column-gap: 1ch;
     white-space: nowrap;
   }
 
@@ -1696,7 +1692,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    border: none;
+    border-style: none;
     appearance: none;
     width: 1lh;
     height: 1lh;


### PR DESCRIPTION
### Description

This is the first of a couple isolated PRs to improve the stylings of diffs.

It removes necessary shorthands that under the hood set or reset way too many properties that aren't even used and also removes a couple of stylings that I stumbled upon that are user agent defaults across browsers anyways. 

<!-- Describe your changes in detail -->

I'll comment each individual change in the PR, check there for more info

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality). You must have
      first discussed with the dev team and they should be aware that this PR is
      being opened
- [ ] Breaking change (fix or feature that would change existing functionality).
      You must have first discussed with the dev team and they should be aware
      that this PR is being opened
- [ ] Documentation update

### Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/pierrecomputer/pierre/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project (`bun run lint`)
- [x] My code is formatted properly (`bun run format`)
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have added tests to cover my changes (if applicable)
- [x] All new and existing tests pass (`bun run diffs:test`)

### How was AI used in generating this PR

Not at all. 