### PR TITLE
[diffshub] Add a Shiki theme switcher

### DIFF
--- a/apps/docs/app/(diffshub)/(view)/_components/CodeViewCommentsList.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/CodeViewCommentsList.tsx
@@ -37,9 +37,16 @@ function getCommentLineClassName(
   if (lineType === 'context') {
     return 'text-muted-foreground';
   }
+  // The themed chrome sets --diffshub-comment-add-fg / -del-fg with a shade
+  // chosen from the active Shiki surface's luminance, so addition/deletion
+  // labels stay legible even on mixed-palette themes (e.g. slack-ochin's
+  // "light" classification with a dark navy sidebar, where the global
+  // `dark:` variant would otherwise leave us with low-contrast 700 shades
+  // on a dark card). The Tailwind shades stay as fallbacks for the
+  // first-render window before the chrome style applies.
   return side === 'additions'
-    ? 'text-emerald-700 dark:text-emerald-400'
-    : 'text-rose-700 dark:text-rose-400';
+    ? 'text-[var(--diffshub-comment-add-fg,#047857)] dark:text-[var(--diffshub-comment-add-fg,#34d399)]'
+    : 'text-[var(--diffshub-comment-del-fg,#be123c)] dark:text-[var(--diffshub-comment-del-fg,#fb7185)]';
 }
 
 // Wraps a click handler so users can drag-select text inside the row without
@@ -117,12 +124,24 @@ export const CodeViewCommentsList = memo(function CodeViewCommentsList({
               {section.path}
             </div>
           )}
-          <div className="rounded-lg border border-[rgb(0_0_0_/_0.1)] dark:border-[rgb(255_255_255_/_0.15)]">
+          <div className="rounded-lg border border-[var(--diffshub-card-border,rgb(0_0_0_/_0.1))] dark:border-[var(--diffshub-card-border,rgb(255_255_255_/_0.15))]">
             {section.comments.map((comment) => (
               <button
                 key={comment.key}
                 type="button"
-                className="focus-visible:ring-ring hover:bg-muted bg-card flex w-full cursor-pointer items-start gap-2 border-b border-[rgb(0_0_0_/_0.1)] p-3 text-left text-sm transition-colors outline-none first:rounded-t-lg last:rounded-b-lg last:border-b-0 focus-visible:ring-2 dark:border-[rgb(255_255_255_/_0.15)] dark:bg-neutral-800 dark:hover:bg-[var(--diffshub-sidebar-bg)]"
+                // Card surface, hover, and border come from the themed
+                // chrome (set on the sidebar wrapper) so cards stay
+                // on-palette for mixed-light/dark themes like slack-ochin
+                // (light-typed but uses a dark navy sidebar). The
+                // hardcoded fallbacks cover the brief window before the
+                // Shiki theme resolves on first render.
+                // No `transition-colors` here: the bg / border / text
+                // colors are driven by CSS variables that flip the entire
+                // chrome on every theme swap, so a smooth color transition
+                // on each card visibly trails the rest of the UI (header,
+                // file tree, diff body) which snap instantly. Hover bg is
+                // snappy enough without an interpolated transition.
+                className="focus-visible:ring-ring flex w-full cursor-pointer items-start gap-2 border-b border-[var(--diffshub-card-border,rgb(0_0_0_/_0.1))] bg-[var(--diffshub-card-bg,var(--color-card))] p-3 text-left text-sm outline-none first:rounded-t-lg last:rounded-b-lg last:border-b-0 hover:bg-[var(--diffshub-card-hover-bg,var(--color-muted))] focus-visible:ring-2 dark:border-[var(--diffshub-card-border,rgb(255_255_255_/_0.15))]"
                 onClick={(event) =>
                   handleRowClick(event, () => onSelectComment?.(comment))
                 }

--- a/apps/docs/app/(diffshub)/(view)/_components/CodeViewFileTree.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/CodeViewFileTree.tsx
@@ -1,14 +1,12 @@
 'use client';
 
+import { type DiffsThemeNames } from '@pierre/diffs';
 import { useStableCallback } from '@pierre/diffs/react';
-import darkSoftTheme from '@pierre/theme/pierre-dark-soft';
-import lightSoftTheme from '@pierre/theme/pierre-light-soft';
 import type {
   FileTreeBatchOperation,
   FileTree as FileTreeModel,
   FileTreeOptions,
 } from '@pierre/trees';
-import { themeToTreeStyles } from '@pierre/trees';
 import { FileTree, useFileTree } from '@pierre/trees/react';
 import {
   type CSSProperties,
@@ -26,11 +24,7 @@ import {
   getInitialBatchSize,
 } from './constants';
 import type { CodeViewFileTreeSource } from './types';
-import { useTheme } from '@/components/theme-provider';
-
-// Computed once at module level so they're never re-derived on every render.
-const LIGHT_SOFT_TREE_STYLES = themeToTreeStyles(lightSoftTheme);
-const DARK_SOFT_TREE_STYLES = themeToTreeStyles(darkSoftTheme);
+import { useResolvedTreeThemeStyles } from './useResolvedTreeThemeStyles';
 type FileTreeSortComparator = Exclude<
   NonNullable<FileTreeOptions['sort']>,
   'default'
@@ -39,19 +33,23 @@ type FileTreeSortComparator = Exclude<
 // follows the same patch path sequence that drives the code view.
 const PRESERVE_INPUT_ORDER_SORT: FileTreeSortComparator = () => 0;
 
-// These override vars take precedence over the --trees-theme-* vars set by
-// themeToTreeStyles, so diffshub-specific layout tweaks are always preserved.
+// Layout-only overrides. Colors flow through from the resolved Shiki theme
+// (via themeToTreeStyles) so the sidebar matches the diff theme, but the
+// density and padding stay tuned for the diffshub layout regardless of
+// which theme the user picks. `--trees-git-renamed-color-override` is kept
+// because most Shiki themes don't define a "renamed" decoration color.
 const DENSITY_OVERRIDE_STYLES = {
-  '--trees-bg-override': 'var(--diffshub-sidebar-bg)',
   '--trees-density-override': 0.8,
-  '--trees-selected-fg-override': 'light-dark(#1c1c1e, #f0f0f2)',
   '--trees-padding-inline-override': 8,
-  '--trees-bg-muted': 'light-dark(#f5f5f5, #262626)',
-  '--trees-search-bg-override': 'light-dark(#fff, #262626)',
   '--trees-git-renamed-color-override': 'light-dark(#007aff, #007aff)',
 } as CSSProperties;
 
 interface CodeViewFileTreeProps {
+  // Themes selected in the header's theme switcher. Resolved via shiki
+  // (cached after first use) and mapped to tree CSS variables so the
+  // sidebar tracks the same Shiki theme as the diff viewer.
+  darkTheme: DiffsThemeNames;
+  lightTheme: DiffsThemeNames;
   // Callback invoked with the underlying tree model once it's mounted, and
   // again with `null` on unmount. Lets parents drive imperative APIs like
   // search open/close without owning the model creation.
@@ -61,19 +59,16 @@ interface CodeViewFileTreeProps {
 }
 
 export const CodeViewFileTree = memo(function CodeViewFileTree({
+  darkTheme,
+  lightTheme,
   onModelReady,
   onSelectItem,
   source,
 }: CodeViewFileTreeProps) {
-  const { resolvedTheme } = useTheme();
+  const activeStyles = useResolvedTreeThemeStyles(lightTheme, darkTheme);
   const themeStyles = useMemo(
-    () => ({
-      ...(resolvedTheme === 'dark'
-        ? DARK_SOFT_TREE_STYLES
-        : LIGHT_SOFT_TREE_STYLES),
-      ...DENSITY_OVERRIDE_STYLES,
-    }),
-    [resolvedTheme]
+    () => ({ ...activeStyles, ...DENSITY_OVERRIDE_STYLES }),
+    [activeStyles]
   );
   const sourceRef = useRef(source);
   const previousSourceRef = useRef(source);

--- a/apps/docs/app/(diffshub)/(view)/_components/CodeViewHeader.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/CodeViewHeader.tsx
@@ -389,7 +389,7 @@ function ThemeDropdown({
         {view === 'main' ? (
           <>
             <DropdownMenuItem
-              className="cursor-default p-1 focus:bg-transparent"
+              className="cursor-default p-0 focus:bg-transparent"
               onSelect={(event) => event.preventDefault()}
             >
               <ButtonGroup

--- a/apps/docs/app/(diffshub)/(view)/_components/CodeViewHeader.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/CodeViewHeader.tsx
@@ -1,7 +1,12 @@
 import type { DiffIndicators } from '@pierre/diffs';
 import {
+  IconCheck,
+  IconChevronSm,
   IconCodeStyleBars,
   IconCollapsedRow,
+  IconColorAuto,
+  IconColorDark,
+  IconColorLight,
   IconDiffSplit,
   IconDiffUnified,
   IconExpandAll,
@@ -12,10 +17,27 @@ import {
   IconSymbolDiffstat,
 } from '@pierre/icons';
 import Link from 'next/link';
-import { type Dispatch, memo, type SetStateAction, useState } from 'react';
+import {
+  type CSSProperties,
+  type Dispatch,
+  memo,
+  type SetStateAction,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { DiffUrlForm } from '../../_components/DiffUrlForm';
 import { DiffsHubLogo } from './DiffsHubLogo';
+import {
+  type ColorMode,
+  DARK_THEMES,
+  type DarkTheme,
+  LIGHT_THEMES,
+  type LightTheme,
+} from './themes';
+import { useThemeChromeStyle } from './useResolvedTreeThemeStyles';
 import { Button } from '@/components/ui/button';
 import { ButtonGroup, ButtonGroupItem } from '@/components/ui/button-group';
 import {
@@ -29,21 +51,29 @@ import { cn } from '@/lib/utils';
 
 const SETTING_ROW_CLASS =
   'w-full flex cursor-pointer items-center justify-between gap-4 px-2 py-1.5 text-sm';
+const THEMED_DROPDOWN_CONTENT_CLASS =
+  'border-[var(--diffshub-popover-border,var(--color-border))] bg-[var(--diffshub-popover-bg,var(--color-popover))] text-[var(--diffshub-popover-fg,var(--color-popover-foreground))] shadow-[var(--diffshub-popover-shadow,0_10px_30px_rgb(0_0_0_/_0.15))]';
 
 interface HeaderProps {
   className?: string;
   collapseMode: 'expanded' | 'collapsed';
+  colorMode: ColorMode;
+  darkTheme: DarkTheme;
   diffIndicators: DiffIndicators;
   diffStyle: 'split' | 'unified';
   fileTreeAvailable: boolean;
   fileTreeOverlayOpen: boolean;
   initialUrl: string;
+  lightTheme: LightTheme;
   lineNumbers: boolean;
   overflow: 'wrap' | 'scroll';
   onToggleCollapseMode(): void;
   onToggleFileTreeOverlay(): void;
+  setColorMode(mode: ColorMode): void;
+  setDarkTheme: Dispatch<SetStateAction<DarkTheme>>;
   setDiffIndicators: Dispatch<SetStateAction<DiffIndicators>>;
   setDiffStyle: Dispatch<SetStateAction<'split' | 'unified'>>;
+  setLightTheme: Dispatch<SetStateAction<LightTheme>>;
   setLineNumbers: Dispatch<SetStateAction<boolean>>;
   setOverflow: Dispatch<SetStateAction<'wrap' | 'scroll'>>;
   setShowBackgrounds: Dispatch<SetStateAction<boolean>>;
@@ -53,17 +83,23 @@ interface HeaderProps {
 export const CodeViewHeader = memo(function CodeViewHeader({
   className,
   collapseMode,
+  colorMode,
+  darkTheme,
   diffIndicators,
   diffStyle,
   fileTreeAvailable,
   fileTreeOverlayOpen,
   initialUrl,
+  lightTheme,
   lineNumbers,
   overflow,
   onToggleCollapseMode,
   onToggleFileTreeOverlay,
+  setColorMode,
+  setDarkTheme,
   setDiffIndicators,
   setDiffStyle,
+  setLightTheme,
   setLineNumbers,
   setOverflow,
   setShowBackgrounds,
@@ -73,12 +109,24 @@ export const CodeViewHeader = memo(function CodeViewHeader({
   // Only show the external-link button when the input still reflects the
   // committed URL — otherwise we'd be pointing at a draft the user is editing.
   const showExternalLink = currentUrl === initialUrl;
+  // Mirror the sidebar's themed chrome so the header bar lives on the same
+  // Shiki surface (background, text, icons, borders) instead of the global
+  // light/dark palette. Falls back to the diffshub-sidebar-bg CSS variable
+  // on first render while the theme is still resolving.
+  const themeChromeStyle = useThemeChromeStyle(lightTheme, darkTheme);
+  const dropdownThemeStyle = useMemo(
+    () => getDropdownThemeStyle(themeChromeStyle),
+    [themeChromeStyle]
+  );
   return (
     <div
       className={cn(
-        'z-10 contain-layout contain-paint flex flex-wrap md:flex-nowrap items-center gap-2.5 pt-3 pb-2 px-4 md:px-3 md:py-1.5 border-b border-[var(--color-border-opaque)] bg-background md:bg-[var(--diffshub-sidebar-bg)]',
+        'z-10 contain-layout contain-paint flex flex-wrap md:flex-nowrap items-center gap-2.5 pt-3 pb-2 px-4 md:px-3 md:py-1.5 border-b border-[var(--color-border-opaque)]',
+        themeChromeStyle == null &&
+          'bg-background md:bg-[var(--diffshub-sidebar-bg)]',
         className
       )}
+      style={themeChromeStyle}
     >
       <Link
         href="/"
@@ -164,17 +212,32 @@ export const CodeViewHeader = memo(function CodeViewHeader({
                 <IconCollapsedRow className="size-4 md:size-3" />
               )}
             </Button>
+            <ThemeDropdown
+              colorMode={colorMode}
+              darkTheme={darkTheme}
+              lightTheme={lightTheme}
+              setColorMode={setColorMode}
+              setDarkTheme={setDarkTheme}
+              setLightTheme={setLightTheme}
+              themeDropdownStyle={dropdownThemeStyle}
+            />
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
                   variant="ghost"
                   size="icon-md"
+                  aria-label="Display settings"
+                  title="Display settings"
                   className="hover:text-muted-foreground hover:bg-transparent"
                 >
                   <IconGearFill className="size-4 md:size-3" />
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-52">
+              <DropdownMenuContent
+                align="end"
+                className={cn('w-52', THEMED_DROPDOWN_CONTENT_CLASS)}
+                style={dropdownThemeStyle}
+              >
                 <DropdownMenuItem
                   className="cursor-default p-0"
                   onSelect={(e) => e.preventDefault()}
@@ -245,3 +308,262 @@ export const CodeViewHeader = memo(function CodeViewHeader({
     </div>
   );
 });
+
+function colorModeIcon(colorMode: ColorMode) {
+  if (colorMode === 'light') return IconColorLight;
+  if (colorMode === 'dark') return IconColorDark;
+  return IconColorAuto;
+}
+
+function getDropdownThemeStyle(
+  themeChromeStyle: CSSProperties | undefined
+): CSSProperties | undefined {
+  if (themeChromeStyle == null) {
+    return undefined;
+  }
+
+  return {
+    ...themeChromeStyle,
+    backgroundColor: 'var(--diffshub-popover-bg, var(--color-popover))',
+    borderColor: 'var(--diffshub-popover-border, var(--color-border))',
+    boxShadow: 'var(--diffshub-popover-shadow, 0 10px 30px rgb(0 0 0 / 0.15))',
+    color: 'var(--diffshub-popover-fg, var(--color-popover-foreground))',
+  };
+}
+
+interface ThemeDropdownProps {
+  colorMode: ColorMode;
+  darkTheme: DarkTheme;
+  lightTheme: LightTheme;
+  setColorMode(mode: ColorMode): void;
+  setDarkTheme: Dispatch<SetStateAction<DarkTheme>>;
+  setLightTheme: Dispatch<SetStateAction<LightTheme>>;
+  themeDropdownStyle?: CSSProperties;
+}
+
+// Theme picker shown next to the gear icon. Avoids horizontal sub-menus
+// (which overflow on narrow viewports) by re-using the same DropdownMenu
+// content for three "views" — main, light theme list, dark theme list —
+// switched via local state. The user enters a list by clicking the
+// corresponding row, picks a theme, and is returned to the main view. The
+// menu auto-resets to the main view whenever it closes so the next open
+// always starts from the top.
+function ThemeDropdown({
+  colorMode,
+  darkTheme,
+  lightTheme,
+  setColorMode,
+  setDarkTheme,
+  setLightTheme,
+  themeDropdownStyle,
+}: ThemeDropdownProps) {
+  const TriggerIcon = colorModeIcon(colorMode);
+  const [view, setView] = useState<'main' | 'light' | 'dark'>('main');
+  return (
+    // `modal={false}` lets the user scroll and click the code view while the
+    // theme picker is open. The default Radix DropdownMenu blocks pointer
+    // events outside its content (incl. wheel/scroll), which made the diff
+    // feel frozen while previewing themes.
+    <DropdownMenu
+      modal={false}
+      onOpenChange={(open) => {
+        if (!open) setView('main');
+      }}
+    >
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon-md"
+          aria-label="Theme settings"
+          title="Theme settings"
+          className="hover:text-muted-foreground hover:bg-transparent"
+        >
+          <TriggerIcon className="size-4 md:size-3" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        className={cn('w-72 p-2', THEMED_DROPDOWN_CONTENT_CLASS)}
+        style={themeDropdownStyle}
+      >
+        {view === 'main' ? (
+          <>
+            <DropdownMenuItem
+              className="cursor-default p-1 focus:bg-transparent"
+              onSelect={(event) => event.preventDefault()}
+            >
+              <ButtonGroup
+                className="w-full"
+                value={colorMode}
+                onValueChange={(value) => {
+                  if (
+                    value === 'system' ||
+                    value === 'light' ||
+                    value === 'dark'
+                  ) {
+                    setColorMode(value);
+                  }
+                }}
+              >
+                <ButtonGroupItem value="system" className="flex-1">
+                  <IconColorAuto />
+                  Auto
+                </ButtonGroupItem>
+                <ButtonGroupItem value="light" className="flex-1">
+                  <IconColorLight />
+                  Light
+                </ButtonGroupItem>
+                <ButtonGroupItem value="dark" className="flex-1">
+                  <IconColorDark />
+                  Dark
+                </ButtonGroupItem>
+              </ButtonGroup>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className="mt-1 flex cursor-pointer items-center gap-2"
+              onSelect={(event) => {
+                event.preventDefault();
+                setView('light');
+              }}
+            >
+              <IconColorLight />
+              <span className="min-w-0 flex-1 truncate">{lightTheme}</span>
+              <IconChevronSm
+                aria-hidden
+                className="text-muted-foreground -rotate-90"
+              />
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className="flex cursor-pointer items-center gap-2"
+              onSelect={(event) => {
+                event.preventDefault();
+                setView('dark');
+              }}
+            >
+              <IconColorDark />
+              <span className="min-w-0 flex-1 truncate">{darkTheme}</span>
+              <IconChevronSm
+                aria-hidden
+                className="text-muted-foreground -rotate-90"
+              />
+            </DropdownMenuItem>
+          </>
+        ) : (
+          <ThemeList
+            view={view}
+            currentLight={lightTheme}
+            currentDark={darkTheme}
+            onBack={() => setView('main')}
+            onPickLight={(theme) => {
+              setLightTheme(theme);
+              setColorMode('light');
+              setView('main');
+            }}
+            onPickDark={(theme) => {
+              setDarkTheme(theme);
+              setColorMode('dark');
+              setView('main');
+            }}
+          />
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+interface ThemeListProps {
+  view: 'light' | 'dark';
+  currentLight: LightTheme;
+  currentDark: DarkTheme;
+  onBack(): void;
+  onPickLight(theme: LightTheme): void;
+  onPickDark(theme: DarkTheme): void;
+}
+
+// Inline list of theme names shown after the user enters the light or dark
+// "view" from the main panel. The list is keyboard-friendly (each row is a
+// DropdownMenuItem) and scrolls in place so it fits inside the same
+// dropdown content even on narrow viewports.
+function ThemeList({
+  view,
+  currentLight,
+  currentDark,
+  onBack,
+  onPickLight,
+  onPickDark,
+}: ThemeListProps) {
+  const isLight = view === 'light';
+  const themes = isLight ? LIGHT_THEMES : DARK_THEMES;
+  const current = isLight ? currentLight : currentDark;
+  const HeaderIcon = isLight ? IconColorLight : IconColorDark;
+  // Auto-scroll so the currently-selected row sits at the second visible
+  // position when the list opens. The current theme lands right under the
+  // user's cursor (Radix opens the menu under the trigger) and the row
+  // above it makes the previous theme easy to reach with one tap of the
+  // up arrow — sequential browsing through themes feels natural without
+  // the user having to hunt for the active row first.
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const selectedItemRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    const container = scrollContainerRef.current;
+    const selected = selectedItemRef.current;
+    if (container == null || selected == null) return;
+    // `offsetTop` measures from the nearest positioned ancestor, which the
+    // scroll container is not — use bounding rects so the math works
+    // regardless of where ancestors set `position`. Subtract one row
+    // height so the selected row appears as the second-from-top visible
+    // row instead of flush with the top.
+    const containerTop = container.getBoundingClientRect().top;
+    const selectedTop = selected.getBoundingClientRect().top;
+    const offsetWithinScroll = selectedTop - containerTop + container.scrollTop;
+    const rowHeight = selected.offsetHeight;
+    container.scrollTop = Math.max(0, offsetWithinScroll - rowHeight);
+  }, [view]);
+  return (
+    <>
+      <DropdownMenuItem
+        className="flex cursor-pointer items-center gap-2"
+        onSelect={(event) => {
+          event.preventDefault();
+          onBack();
+        }}
+      >
+        <IconChevronSm
+          aria-hidden
+          className="text-muted-foreground rotate-90"
+        />
+        <HeaderIcon />
+        <span className="flex-1 truncate">
+          {isLight ? 'Light theme' : 'Dark theme'}
+        </span>
+      </DropdownMenuItem>
+      <div
+        ref={scrollContainerRef}
+        className="cv-mini-scrollbar mt-1 max-h-[320px] overflow-y-auto overscroll-contain"
+      >
+        {themes.map((theme) => (
+          <DropdownMenuItem
+            key={theme}
+            ref={current === theme ? selectedItemRef : undefined}
+            onSelect={(event) => {
+              event.preventDefault();
+              if (isLight) {
+                onPickLight(theme as LightTheme);
+              } else {
+                onPickDark(theme as DarkTheme);
+              }
+            }}
+            selected={current === theme}
+          >
+            <span className="flex-1 truncate">{theme}</span>
+            {current === theme ? (
+              <IconCheck className="ml-auto" />
+            ) : (
+              <div className="ml-2 h-4 w-4" />
+            )}
+          </DropdownMenuItem>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/apps/docs/app/(diffshub)/(view)/_components/CodeViewSidebar.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/CodeViewSidebar.tsx
@@ -9,6 +9,7 @@ import {
 import { FileTree } from '@pierre/trees';
 import { useFileTreeSearch } from '@pierre/trees/react';
 import {
+  type CSSProperties,
   memo,
   type ReactNode,
   type RefObject,
@@ -26,6 +27,7 @@ import type {
   CodeViewSavedCommentEntry,
   CodeViewSavedCommentItem,
 } from './types';
+import { useThemeChromeStyle } from './useResolvedTreeThemeStyles';
 import { WorkerPoolStatus } from './WorkerPoolStatus';
 import { Button } from '@/components/ui/button';
 import { ButtonGroup, ButtonGroupItem } from '@/components/ui/button-group';
@@ -39,7 +41,9 @@ const MOBILE_MEDIA_QUERY = '(max-width: 767px)';
 interface CodeViewSidebarProps {
   className?: string;
   commentSections: readonly CodeViewSavedCommentItem[];
+  darkTheme: string;
   diffStats: CodeViewDiffStatsData | null;
+  lightTheme: string;
   mobileOverlayOpen?: boolean;
   onMobileClose(): void;
   onSelectComment(comment: CodeViewSavedCommentEntry): void;
@@ -52,7 +56,9 @@ interface CodeViewSidebarProps {
 export const CodeViewSidebar = memo(function CodeViewSidebar({
   className,
   commentSections,
+  darkTheme,
   diffStats,
+  lightTheme,
   mobileOverlayOpen = false,
   onMobileClose,
   onSelectComment,
@@ -66,6 +72,12 @@ export const CodeViewSidebar = memo(function CodeViewSidebar({
   for (const section of commentSections) {
     totalCommentCount += section.comments.length;
   }
+  // Pull the resolved Shiki theme so the whole sidebar (tabs row, file
+  // tree, diff stats panel, footer) sits on the theme's sidebar surface
+  // and its chrome text follows the theme's own foreground tokens
+  // instead of an opacity-derived fade of the file-tree's muted text.
+  // Shared with the header so both chrome surfaces stay in sync.
+  const sidebarStyle = useThemeChromeStyle(lightTheme, darkTheme);
   const [activeStatusPanel, setActiveStatusPanel] =
     useState<SidebarStatusPanel | null>('diffStats');
   const [fileTreeModel, setFileTreeModel] = useState<FileTree | null>(null);
@@ -127,6 +139,7 @@ export const CodeViewSidebar = memo(function CodeViewSidebar({
       <SidebarWrapper
         className={className}
         mobileOverlayOpen={mobileOverlayOpen}
+        themeStyle={sidebarStyle}
       >
         <div className="flex items-center gap-3 px-4 pt-5 pb-2 md:px-3 md:pt-0.5 md:pb-0">
           <ButtonGroup
@@ -157,7 +170,14 @@ export const CodeViewSidebar = memo(function CodeViewSidebar({
               {totalCommentCount > 0 && (
                 <span
                   aria-hidden="true"
-                  className="inline-flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-neutral-200 px-1 text-[10px] leading-none font-medium text-neutral-700 tabular-nums dark:bg-neutral-700 dark:text-neutral-200"
+                  // Tint the badge with the chrome's current text color so
+                  // it follows the active Shiki theme instead of staying
+                  // on hardcoded neutral grays. `currentColor` resolves to
+                  // whichever fg the button inherits (chrome primaryFg
+                  // for the unselected ghost variant, accent-foreground
+                  // when this tab is selected), so the pill stays
+                  // on-palette in both states.
+                  className="inline-flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-[color-mix(in_srgb,currentColor_18%,transparent)] px-1 text-[10px] leading-none font-medium tabular-nums"
                 >
                   {totalCommentCount}
                 </span>
@@ -187,6 +207,8 @@ export const CodeViewSidebar = memo(function CodeViewSidebar({
             className="h-full min-h-0"
           >
             <CodeViewFileTree
+              darkTheme={darkTheme}
+              lightTheme={lightTheme}
               source={source}
               onModelReady={handleModelReady}
               onSelectItem={onSelectItem}
@@ -225,22 +247,29 @@ interface SidebarWrapperProps {
   children: ReactNode;
   className?: string;
   mobileOverlayOpen: boolean;
+  themeStyle?: CSSProperties;
 }
 
 function SidebarWrapper({
   children,
   className,
   mobileOverlayOpen,
+  themeStyle,
 }: SidebarWrapperProps) {
   return (
     <div
       className={cn(
         className,
-        'bg-[var(--diffshub-sidebar-bg)] contain-strict z-30 flex h-full min-h-0 flex-col transition-transform duration-300 ease-[cubic-bezier(0.32,0.72,0,1)] will-change-transform motion-reduce:transition-none md:z-auto md:translate-y-0 md:will-change-auto',
+        'contain-strict z-30 flex h-full min-h-0 flex-col transition-transform duration-300 ease-[cubic-bezier(0.32,0.72,0,1)] will-change-transform motion-reduce:transition-none md:z-auto md:translate-y-0 md:will-change-auto',
+        // Fall back to the neutral diffshub chrome background when no Shiki
+        // theme bg is available yet (initial render before the resolver
+        // returns).
+        themeStyle == null && 'bg-[var(--diffshub-sidebar-bg)]',
         mobileOverlayOpen
           ? 'pointer-events-auto translate-y-0 overflow-hidden rounded-t-xl shadow-[0_0_0_1px_var(--color-border-opaque),_0_16px_32px_rgb(0_0_0_/0.25)] md:h-full md:overflow-visible md:rounded-none md:border-0 md:shadow-none'
           : 'pointer-events-none translate-y-[calc(100%+1.5rem)] overflow-hidden rounded-xl md:pointer-events-auto md:h-full md:overflow-visible md:rounded-none pt-3 border-r border-[var(--color-border-opaque)]'
       )}
+      style={themeStyle}
     >
       {children}
     </div>

--- a/apps/docs/app/(diffshub)/(view)/_components/CodeViewSidebar.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/CodeViewSidebar.tsx
@@ -28,6 +28,7 @@ import type {
   CodeViewSavedCommentItem,
 } from './types';
 import { useThemeChromeStyle } from './useResolvedTreeThemeStyles';
+import type { ThemeCycleControls } from './useThemeCycle';
 import { WorkerPoolStatus } from './WorkerPoolStatus';
 import { Button } from '@/components/ui/button';
 import { ButtonGroup, ButtonGroupItem } from '@/components/ui/button-group';
@@ -51,6 +52,7 @@ interface CodeViewSidebarProps {
   scrollRef: RefObject<HTMLDivElement | null>;
   source: CodeViewFileTreeSource;
   streaming: boolean;
+  themeCycle: ThemeCycleControls;
 }
 
 export const CodeViewSidebar = memo(function CodeViewSidebar({
@@ -66,6 +68,7 @@ export const CodeViewSidebar = memo(function CodeViewSidebar({
   scrollRef,
   source,
   streaming,
+  themeCycle,
 }: CodeViewSidebarProps) {
   const [activeTab, setActiveTab] = useState<SidebarTab>('files');
   let totalCommentCount = 0;
@@ -237,6 +240,7 @@ export const CodeViewSidebar = memo(function CodeViewSidebar({
           expanded={activeStatusPanel === 'systemMonitor'}
           onToggle={() => toggleStatusPanel('systemMonitor')}
           scrollRef={scrollRef}
+          themeCycle={themeCycle}
         />
       </SidebarWrapper>
     </>

--- a/apps/docs/app/(diffshub)/(view)/_components/CodeViewWrapper.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/CodeViewWrapper.tsx
@@ -16,7 +16,14 @@ import {
   useStableCallback,
 } from '@pierre/diffs/react';
 import { IconChevronSm } from '@pierre/icons';
-import { memo, type RefObject, useMemo, useRef, useState } from 'react';
+import {
+  type CSSProperties,
+  memo,
+  type RefObject,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import type { AvatarName } from './annotation-shared';
 import { CODE_VIEW_CUSTOM_CSS, CODE_VIEW_LAYOUT } from './constants';
@@ -27,6 +34,7 @@ import type {
   CodeViewSavedCommentEvent,
   CommentMetadata,
 } from './types';
+import { useThemeChromeStyle } from './useResolvedTreeThemeStyles';
 import {
   classifyCommentLineType,
   isDiffItem,
@@ -65,7 +73,9 @@ interface ActiveDraftComment {
 
 interface CodeViewWrapperProps {
   className?: string;
+  darkTheme: string;
   diffStyle: 'split' | 'unified';
+  lightTheme: string;
   onCommentDeleted(comment: CodeViewDeletedCommentEvent): void;
   onCommentSaved(comment: CodeViewSavedCommentEvent): void;
   overflow: 'wrap' | 'scroll';
@@ -82,7 +92,9 @@ interface CodeViewWrapperProps {
 
 export const CodeViewWrapper = memo(function CodeViewWrapper({
   className,
+  darkTheme,
   diffStyle,
+  lightTheme,
   onCommentDeleted,
   onCommentSaved,
   overflow,
@@ -100,6 +112,11 @@ export const CodeViewWrapper = memo(function CodeViewWrapper({
   const activeDraftRef = useRef<ActiveDraftComment | null>(null);
   const [selectedLines, setSelectedLines] =
     useState<CodeViewLineSelection | null>(null);
+  const themeChromeStyle = useThemeChromeStyle(lightTheme, darkTheme);
+  const annotationThemeStyle = useMemo(
+    () => buildAnnotationThemeStyle(themeChromeStyle),
+    [themeChromeStyle]
+  );
 
   const handleSetSelection = useStableCallback(
     (selection: CodeViewLineSelection | null) => {
@@ -461,9 +478,10 @@ export const CodeViewWrapper = memo(function CodeViewWrapper({
       initialItems={initialItems}
       className={cn(
         className,
-        'cv-scrollbar relative h-full min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-clip overscroll-contain border-b border-border w-full [contain:strict] [overflow-anchor:none] [will-change:scroll-position] md:border-b-0 [&_diffs-container]:overflow-clip [&_diffs-container]:[contain:layout_paint_style] [&_diffs-container]:shadow-[0_-1px_0_var(--color-border-opaque),0_1px_0_var(--color-border-opaque)]'
+        'cv-scrollbar relative h-full min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-clip overscroll-contain border-b border-border w-full [contain:strict] [overflow-anchor:none] [will-change:scroll-position] md:border-b-0 [&_diffs-container]:overflow-clip [&_diffs-container]:[contain:layout_paint_style] [&_diffs-container]:shadow-[0_-1px_0_var(--diffshub-diff-separator,var(--color-border-opaque)),0_1px_0_var(--diffshub-diff-separator,var(--color-border-opaque))]'
       )}
       options={options}
+      style={annotationThemeStyle}
       selectedLines={selectedLines}
       onSelectedLinesChange={handleSetSelection}
       renderAnnotation={renderCommentAnnotation}
@@ -471,6 +489,39 @@ export const CodeViewWrapper = memo(function CodeViewWrapper({
     />
   );
 });
+
+const ANNOTATION_THEME_STYLE_KEYS = [
+  '--diffshub-annotation-bg',
+  '--diffshub-annotation-border',
+  '--diffshub-annotation-fg',
+  '--diffshub-annotation-hover-border',
+  '--diffshub-annotation-shadow',
+  '--diffshub-popover-muted-fg',
+  // Inter-file separator hairline. Carries the themed border-opaque value
+  // (same weight as the header/sidebar chrome borders) so it stays visible
+  // on any theme without reading darker than the surrounding chrome.
+  '--diffshub-diff-separator',
+] as const;
+
+export function buildAnnotationThemeStyle(
+  themeChromeStyle: CSSProperties | undefined
+): CSSProperties | undefined {
+  if (themeChromeStyle == null) {
+    return undefined;
+  }
+
+  const source = themeChromeStyle as CSSProperties &
+    Partial<Record<(typeof ANNOTATION_THEME_STYLE_KEYS)[number], string>>;
+  const style: Record<string, string> = {};
+  for (const key of ANNOTATION_THEME_STYLE_KEYS) {
+    const value = source[key];
+    if (typeof value === 'string') {
+      style[key] = value;
+    }
+  }
+
+  return Object.keys(style).length > 0 ? (style as CSSProperties) : undefined;
+}
 
 interface CollapseDiffButtonProps {
   disabled?: boolean;

--- a/apps/docs/app/(diffshub)/(view)/_components/CodeViewWrapper.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/CodeViewWrapper.tsx
@@ -8,6 +8,7 @@ import {
   type DiffLineAnnotation,
   type LineAnnotation,
   type SelectedLineRange,
+  type ThemeTypes,
 } from '@pierre/diffs';
 import {
   CodeView,
@@ -72,6 +73,7 @@ interface CodeViewWrapperProps {
   diffIndicators: DiffIndicators;
   lineNumbers: boolean;
   scrollRef: RefObject<HTMLDivElement | null>;
+  themeType: ThemeTypes;
   viewerRef: RefObject<CodeViewHandle<CommentMetadata> | null>;
   initialItems: CodeViewItem<CommentMetadata>[];
   onLineLinkChange(selection: CodeViewLineSelection | null): void;
@@ -88,6 +90,7 @@ export const CodeViewWrapper = memo(function CodeViewWrapper({
   diffIndicators,
   lineNumbers,
   scrollRef,
+  themeType,
   viewerRef,
   initialItems,
   onLineLinkChange,
@@ -417,7 +420,7 @@ export const CodeViewWrapper = memo(function CodeViewWrapper({
         // Use this to validate itemMetrics when changing layout with unsafeCSS.
         // __devOnlyValidateItemHeights: true,
         layout: CODE_VIEW_LAYOUT,
-        theme: { dark: 'pierre-dark-soft', light: 'pierre-light-soft' },
+        themeType,
         diffStyle,
         diffIndicators,
         overflow,
@@ -448,6 +451,7 @@ export const CodeViewWrapper = memo(function CodeViewWrapper({
       lineNumbers,
       overflow,
       showBackgrounds,
+      themeType,
     ]
   );
   return (

--- a/apps/docs/app/(diffshub)/(view)/_components/DraftAnnotation.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/DraftAnnotation.tsx
@@ -90,7 +90,7 @@ export function DraftAnnotation({
           }}
           placeholder="Add a comment…"
           rows={2}
-          className="field-sizing-content w-full resize-none rounded-sm py-1.5 text-[14px] focus:outline-none"
+          className="field-sizing-content w-full resize-none rounded-sm bg-transparent py-1.5 text-[14px] text-inherit placeholder:text-[var(--diffshub-popover-muted-fg,var(--color-muted-foreground))] focus:outline-none"
         />
       </div>
       <div className="flex w-full justify-between gap-3 pl-10.5 md:w-auto md:justify-end md:pl-0">

--- a/apps/docs/app/(diffshub)/(view)/_components/ExampleAnnotation.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/ExampleAnnotation.tsx
@@ -27,7 +27,7 @@ export const ExampleAnnotation = memo(function ExampleAnnotation({
       tabIndex={0}
       className={cn(
         annotationCardBase,
-        'group relative cursor-pointer hover:border-[rgb(0_0_0_/_0.15)]'
+        'group relative cursor-pointer hover:border-[var(--diffshub-annotation-hover-border,var(--diffshub-annotation-border,var(--color-border)))]'
       )}
       onClick={() => onToggleSelection(selection)}
       onKeyDown={(event) => {

--- a/apps/docs/app/(diffshub)/(view)/_components/ReviewUI.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/ReviewUI.tsx
@@ -6,6 +6,7 @@ import {
   type ReactNode,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
 } from 'react';
@@ -51,6 +52,7 @@ export function ReviewUI({ domain, initialUrl, path }: ReviewUIProps) {
   useEffect(preloadAvatars, []);
 
   const isWorkerPoolReadyOrDisable = useIsWorkerPoolReadyOrDisabled();
+  const workerPool = useWorkerPool();
   const [diffStyle, setDiffStyle] = useState<'split' | 'unified'>('split');
   const [collapseMode, setCollapseMode] = useState<'expanded' | 'collapsed'>(
     'expanded'
@@ -62,17 +64,22 @@ export function ReviewUI({ domain, initialUrl, path }: ReviewUIProps) {
   const [lineNumbers, setLineNumbers] = useState(true);
   // Light/dark theme picks persist across reloads via localStorage. The
   // hook reads after mount (not during render) so the SSR markup always
-  // uses the defaults and React's hydration check stays happy.
-  const [lightTheme, setLightTheme] = usePersistedState<LightTheme>(
-    LIGHT_THEME_STORAGE_KEY,
-    DEFAULT_LIGHT_THEME,
-    LIGHT_THEMES
-  );
-  const [darkTheme, setDarkTheme] = usePersistedState<DarkTheme>(
-    DARK_THEME_STORAGE_KEY,
-    DEFAULT_DARK_THEME,
-    DARK_THEMES
-  );
+  // uses the defaults and React's hydration check stays happy. The
+  // `*Hydrated` flags let downstream effects wait for the real values
+  // before pushing them through to long-lived singletons.
+  const [lightTheme, setLightTheme, lightThemeHydrated] =
+    usePersistedState<LightTheme>(
+      LIGHT_THEME_STORAGE_KEY,
+      DEFAULT_LIGHT_THEME,
+      LIGHT_THEMES
+    );
+  const [darkTheme, setDarkTheme, darkThemeHydrated] =
+    usePersistedState<DarkTheme>(
+      DARK_THEME_STORAGE_KEY,
+      DEFAULT_DARK_THEME,
+      DARK_THEMES
+    );
+  const themesHydrated = lightThemeHydrated && darkThemeHydrated;
   // The diffshub UI shares its color mode with the surrounding ThemeProvider
   // so picking Auto/Light/Dark flips both the CodeView's `themeType` and the
   // app's <html> light/dark class (the tree sidebar, header, etc.).
@@ -81,6 +88,36 @@ export function ReviewUI({ domain, initialUrl, path }: ReviewUIProps) {
   // render an empty selection.
   const { theme: appTheme, setTheme: setColorMode } = useTheme();
   const colorMode: ColorMode = (appTheme as ColorMode | undefined) ?? 'system';
+
+  // Push theme changes through the WorkerPool so background tokenizers reload
+  // the active light/dark Shiki themes. Without this, workers keep using the
+  // pair they were initialized with and the diff continues to render with the
+  // old theme even though the option object changed.
+  //
+  // The hydration gate is critical for client-side navigation: the WorkerPool
+  // is a long-lived singleton that survives across routes. On a second visit
+  // to a diff (e.g. logo → home → another PR) ReviewUI remounts with the
+  // theme state at DEFAULT_*_THEME for one render until usePersistedState
+  // rehydrates from localStorage. Without the gate, that initial pass would
+  // call setRenderOptions(DEFAULT) — clearing the pool's caches and kicking
+  // off a re-tokenization with the wrong theme — before the rehydration
+  // pass corrected it. Waiting until both themes are hydrated keeps the
+  // pool on the user's selection through the whole mount.
+  //
+  // useLayoutEffect (not useEffect) so the worker pool's synchronous
+  // rerender — which writes the new themeStyles CSS into the diff
+  // containers' shadow roots — happens in the same commit/paint as the
+  // sidebar's inline-style update. A plain useEffect runs after paint,
+  // which made the diff side trail the chrome by one frame and was
+  // visible as a flicker on the comment cards and tab badge during fast
+  // theme cycling.
+  useLayoutEffect(() => {
+    if (workerPool == null) return;
+    if (!themesHydrated) return;
+    void workerPool.setRenderOptions({
+      theme: { dark: darkTheme, light: lightTheme },
+    });
+  }, [workerPool, darkTheme, lightTheme, themesHydrated]);
   const scrollRef = useRef<HTMLDivElement>(null);
   const viewerRef = useRef<CodeViewHandle<CommentMetadata> | null>(null);
   const handlePatchLoadStart = useCallback(() => {
@@ -186,8 +223,14 @@ export function ReviewUI({ domain, initialUrl, path }: ReviewUIProps) {
     },
     []
   );
+  // Withhold the viewer until the persisted themes have been read from
+  // localStorage. Otherwise on client-side navigation back into a diff the
+  // CodeView would mount during the brief render where lightTheme/darkTheme
+  // are still at their `DEFAULT_*_THEME` initial values and tokenize the
+  // first batch of files against the wrong palette.
   const viewerAvailable =
     isWorkerPoolReadyOrDisable &&
+    themesHydrated &&
     (loadState === 'ready' ||
       (loadState === 'streaming' && initialItems.length > 0));
 
@@ -223,7 +266,9 @@ export function ReviewUI({ domain, initialUrl, path }: ReviewUIProps) {
           <CodeViewSidebar
             className="[grid-area:viewer] md:[grid-area:tree]"
             commentSections={commentSections}
+            darkTheme={darkTheme}
             diffStats={diffStats}
+            lightTheme={lightTheme}
             mobileOverlayOpen={fileTreeOverlayOpen}
             onMobileClose={handleCloseFileTreeOverlay}
             onSelectComment={handleSelectComment}
@@ -235,7 +280,9 @@ export function ReviewUI({ domain, initialUrl, path }: ReviewUIProps) {
           <CodeViewWrapper
             key={viewerKey}
             className="[grid-area:viewer]"
+            darkTheme={darkTheme}
             diffStyle={diffStyle}
+            lightTheme={lightTheme}
             overflow={overflow}
             showBackgrounds={showBackgrounds}
             diffIndicators={diffIndicators}

--- a/apps/docs/app/(diffshub)/(view)/_components/ReviewUI.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/ReviewUI.tsx
@@ -33,6 +33,7 @@ import type {
 } from './types';
 import { usePatchLoader } from './usePatchLoader';
 import { usePersistedState } from './usePersistedState';
+import { useThemeCycle } from './useThemeCycle';
 import {
   removeSavedCommentSidebarEntry,
   upsertSavedCommentSidebarEntry,
@@ -86,8 +87,24 @@ export function ReviewUI({ domain, initialUrl, path }: ReviewUIProps) {
   // `theme` from useTheme() can briefly be undefined during initial mount
   // before localStorage is read; fall back to 'system' so the header doesn't
   // render an empty selection.
-  const { theme: appTheme, setTheme: setColorMode } = useTheme();
+  const {
+    theme: appTheme,
+    resolvedTheme: appResolvedTheme,
+    setTheme: setColorMode,
+  } = useTheme();
   const colorMode: ColorMode = (appTheme as ColorMode | undefined) ?? 'system';
+  // The cycle button in the System Monitor sweeps through every Shiki
+  // theme so reviewers can preview the full set without manually picking
+  // each one. The hook captures the user's current pick when cycling
+  // starts so the visible theme anchors the rotation.
+  const themeCycle = useThemeCycle({
+    lightTheme,
+    darkTheme,
+    resolvedThemeMode: appResolvedTheme,
+    setLightTheme,
+    setDarkTheme,
+    setColorMode,
+  });
 
   // Push theme changes through the WorkerPool so background tokenizers reload
   // the active light/dark Shiki themes. Without this, workers keep using the
@@ -275,6 +292,7 @@ export function ReviewUI({ domain, initialUrl, path }: ReviewUIProps) {
             scrollRef={scrollRef}
             source={treeSource}
             streaming={loadState === 'streaming'}
+            themeCycle={themeCycle}
             onSelectItem={handleSelectTreeItem}
           />
           <CodeViewWrapper

--- a/apps/docs/app/(diffshub)/(view)/_components/ReviewUI.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/ReviewUI.tsx
@@ -15,6 +15,15 @@ import { CodeViewHeader } from './CodeViewHeader';
 import { CodeViewSidebar } from './CodeViewSidebar';
 import { CodeViewStatusPanel } from './CodeViewStatusPanel';
 import { CodeViewWrapper } from './CodeViewWrapper';
+import {
+  type ColorMode,
+  DARK_THEMES,
+  type DarkTheme,
+  DEFAULT_DARK_THEME,
+  DEFAULT_LIGHT_THEME,
+  LIGHT_THEMES,
+  type LightTheme,
+} from './themes';
 import type {
   CodeViewDeletedCommentEvent,
   CodeViewSavedCommentEntry,
@@ -22,10 +31,15 @@ import type {
   CommentMetadata,
 } from './types';
 import { usePatchLoader } from './usePatchLoader';
+import { usePersistedState } from './usePersistedState';
 import {
   removeSavedCommentSidebarEntry,
   upsertSavedCommentSidebarEntry,
 } from './utils';
+import { useTheme } from '@/components/theme-provider';
+
+const LIGHT_THEME_STORAGE_KEY = 'diffshub-light-theme';
+const DARK_THEME_STORAGE_KEY = 'diffshub-dark-theme';
 
 interface ReviewUIProps {
   domain?: string;
@@ -46,6 +60,27 @@ export function ReviewUI({ domain, initialUrl, path }: ReviewUIProps) {
   const [showBackgrounds, setShowBackgrounds] = useState(true);
   const [diffIndicators, setDiffIndicators] = useState<DiffIndicators>('bars');
   const [lineNumbers, setLineNumbers] = useState(true);
+  // Light/dark theme picks persist across reloads via localStorage. The
+  // hook reads after mount (not during render) so the SSR markup always
+  // uses the defaults and React's hydration check stays happy.
+  const [lightTheme, setLightTheme] = usePersistedState<LightTheme>(
+    LIGHT_THEME_STORAGE_KEY,
+    DEFAULT_LIGHT_THEME,
+    LIGHT_THEMES
+  );
+  const [darkTheme, setDarkTheme] = usePersistedState<DarkTheme>(
+    DARK_THEME_STORAGE_KEY,
+    DEFAULT_DARK_THEME,
+    DARK_THEMES
+  );
+  // The diffshub UI shares its color mode with the surrounding ThemeProvider
+  // so picking Auto/Light/Dark flips both the CodeView's `themeType` and the
+  // app's <html> light/dark class (the tree sidebar, header, etc.).
+  // `theme` from useTheme() can briefly be undefined during initial mount
+  // before localStorage is read; fall back to 'system' so the header doesn't
+  // render an empty selection.
+  const { theme: appTheme, setTheme: setColorMode } = useTheme();
+  const colorMode: ColorMode = (appTheme as ColorMode | undefined) ?? 'system';
   const scrollRef = useRef<HTMLDivElement>(null);
   const viewerRef = useRef<CodeViewHandle<CommentMetadata> | null>(null);
   const handlePatchLoadStart = useCallback(() => {
@@ -161,17 +196,23 @@ export function ReviewUI({ domain, initialUrl, path }: ReviewUIProps) {
       <CodeViewHeader
         className="[grid-area:header]"
         collapseMode={collapseMode}
+        colorMode={colorMode}
+        darkTheme={darkTheme}
         diffIndicators={diffIndicators}
         diffStyle={diffStyle}
         initialUrl={initialUrl}
+        lightTheme={lightTheme}
         lineNumbers={lineNumbers}
         overflow={overflow}
         fileTreeOverlayOpen={fileTreeOverlayOpen}
         fileTreeAvailable={treeSource != null}
         onToggleCollapseMode={handleToggleCollapseMode}
         onToggleFileTreeOverlay={handleToggleFileTreeOverlay}
+        setColorMode={setColorMode}
+        setDarkTheme={setDarkTheme}
         setDiffIndicators={setDiffIndicators}
         setDiffStyle={setDiffStyle}
+        setLightTheme={setLightTheme}
         setLineNumbers={setLineNumbers}
         setOverflow={setOverflow}
         setShowBackgrounds={setShowBackgrounds}
@@ -200,6 +241,7 @@ export function ReviewUI({ domain, initialUrl, path }: ReviewUIProps) {
             diffIndicators={diffIndicators}
             lineNumbers={lineNumbers}
             scrollRef={scrollRef}
+            themeType={colorMode}
             viewerRef={viewerRef}
             initialItems={initialItems}
             onCommentDeleted={handleCommentDeleted}

--- a/apps/docs/app/(diffshub)/(view)/_components/WorkerPoolStatus.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/WorkerPoolStatus.tsx
@@ -12,6 +12,7 @@ import {
   IconEye,
   IconEyeSlash,
   IconInfoFill,
+  IconRepeat,
   IconSquircleLgFill,
   IconTriangleFill,
 } from '@pierre/icons';
@@ -19,12 +20,14 @@ import Link from 'next/link';
 import {
   type ComponentType,
   memo,
+  type MouseEvent,
   type ReactNode,
   type RefObject,
   useEffect,
   useState,
 } from 'react';
 
+import type { ThemeCycleControls } from './useThemeCycle';
 import { cn } from '@/lib/utils';
 
 const NUMBER_FORMATTER = new Intl.NumberFormat('en-US');
@@ -92,12 +95,14 @@ interface WorkerPoolStatusProps {
   expanded: boolean;
   onToggle(): void;
   scrollRef: RefObject<HTMLDivElement | null>;
+  themeCycle: ThemeCycleControls;
 }
 
 export const WorkerPoolStatus = memo(function WorkerPoolStatus({
   expanded,
   onToggle,
   scrollRef,
+  themeCycle,
 }: WorkerPoolStatusProps) {
   const pool = useWorkerPool();
   const [stats, setStats] = useState<WorkerStats | undefined>(undefined);
@@ -123,6 +128,7 @@ export const WorkerPoolStatus = memo(function WorkerPoolStatus({
         onToggle={onToggle}
         stats={stats}
         scrollRef={scrollRef}
+        themeCycle={themeCycle}
       />
     )
   );
@@ -159,6 +165,7 @@ interface StatsDisplayProps {
   onToggle(): void;
   stats: WorkerStats;
   scrollRef: RefObject<HTMLDivElement | null>;
+  themeCycle: ThemeCycleControls;
 }
 
 // Map worker pool status to a single icon component + color so the legend row
@@ -201,6 +208,7 @@ function StatsDisplay({
   onToggle,
   stats,
   scrollRef,
+  themeCycle,
 }: StatsDisplayProps) {
   const [isBrrt, setIsBrrt] = useState(false);
   const [scrollTester] = useState(
@@ -237,6 +245,7 @@ function StatsDisplay({
           </span>
         </button>
         <div className="ml-auto flex shrink-0 items-center gap-1.5">
+          <ThemeCycleToggle controls={themeCycle} />
           <button
             type="button"
             onClick={scrollTester.toggleState}
@@ -284,6 +293,45 @@ function StatsDisplay({
         </div>
       </StatusRow>
     </div>
+  );
+}
+
+interface ThemeCycleToggleProps {
+  controls: ThemeCycleControls;
+}
+
+// Sweep-through-themes button. Plain click matches the neighboring
+// autoscroll button's primary affordance — it starts (and stops) the
+// rotation. Shift-click bumps the per-step duration through
+// [1s, 3s, 5s, 10s]; the current value is rendered next to the icon so
+// every shift-click visibly steps through the presets.
+function ThemeCycleToggle({ controls }: ThemeCycleToggleProps) {
+  const { cycling, stepSeconds, bumpDuration, toggleCycle } = controls;
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    if (event.shiftKey) {
+      bumpDuration();
+    } else {
+      toggleCycle();
+    }
+  };
+  const title = cycling
+    ? `Stop cycling themes (every ${stepSeconds}s) — shift+click to change speed`
+    : `Cycle themes every ${stepSeconds}s — shift+click to change speed`;
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="hover:bg-muted/50 hover:text-foreground text-muted-foreground hidden h-5 cursor-pointer items-center gap-1 rounded-md px-1 text-[10px] leading-none tabular-nums transition md:inline-flex"
+      title={title}
+      aria-label={title}
+      aria-pressed={cycling}
+    >
+      <IconRepeat
+        aria-hidden="true"
+        className={cn('size-3', cycling && 'animate-pulse')}
+      />
+      <span>{stepSeconds}s</span>
+    </button>
   );
 }
 

--- a/apps/docs/app/(diffshub)/(view)/_components/annotation-shared.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/annotation-shared.tsx
@@ -3,7 +3,7 @@
 import { cn } from '@/lib/utils';
 
 export const annotationCardBase =
-  'bg-card m-2 flex max-w-[600px] gap-2.5 rounded-xl border border-[rgb(0_0_0_/_0.1)] bg-clip-padding p-3 font-sans shadow-[0_2px_4px_rgb(0_0_0_/_0.025),0_4px_8px_rgb(0_0_0_/_0.025)] dark:border-[rgb(255_255_255_/_0.1)] dark:shadow-[0_2px_4px_rgb(0_0_0_/_0.25),0_4px_8px_rgb(0_0_0_/_0.25)] dark:bg-neutral-900/80';
+  'm-2 flex max-w-[600px] gap-2.5 rounded-xl border border-[var(--diffshub-annotation-border,var(--color-border))] bg-[var(--diffshub-annotation-bg,var(--color-card))] bg-clip-padding p-3 font-sans text-[var(--diffshub-annotation-fg,var(--color-card-foreground))] shadow-[var(--diffshub-annotation-shadow,0_2px_4px_rgb(0_0_0_/_0.025),0_4px_8px_rgb(0_0_0_/_0.025))]';
 
 // All available reviewer personas, derived from /public/diffshub-avatars/ filenames.
 const AVATAR_NAMES = [

--- a/apps/docs/app/(diffshub)/(view)/_components/constants.ts
+++ b/apps/docs/app/(diffshub)/(view)/_components/constants.ts
@@ -21,7 +21,7 @@ export const CODE_VIEW_CUSTOM_CSS = `
     width: 100%;
     height: 1px;
     content: '';
-    background-color: var(--color-border-opaque);
+    background-color: var(--diffshub-annotation-border);
   }
 }
 `;

--- a/apps/docs/app/(diffshub)/(view)/_components/themes.ts
+++ b/apps/docs/app/(diffshub)/(view)/_components/themes.ts
@@ -1,0 +1,80 @@
+// Shiki theme names available for the diffshub light/dark theme pickers.
+// Mirrors the catalog shown in the diffs docs "Adapts to any Shiki theme"
+// example so users can browse the same set of themes from the diffshub UI.
+
+export const LIGHT_THEMES = [
+  'pierre-light',
+  'pierre-light-soft',
+  'catppuccin-latte',
+  'everforest-light',
+  'github-light',
+  'github-light-default',
+  'github-light-high-contrast',
+  'gruvbox-light-hard',
+  'gruvbox-light-medium',
+  'gruvbox-light-soft',
+  'kanagawa-lotus',
+  'light-plus',
+  'material-theme-lighter',
+  'min-light',
+  'one-light',
+  'rose-pine-dawn',
+  'slack-ochin',
+  'snazzy-light',
+  'solarized-light',
+  'vitesse-light',
+] as const;
+
+export const DARK_THEMES = [
+  'pierre-dark',
+  'pierre-dark-soft',
+  'andromeeda',
+  'aurora-x',
+  'ayu-dark',
+  'catppuccin-frappe',
+  'catppuccin-macchiato',
+  'catppuccin-mocha',
+  'dark-plus',
+  'dracula',
+  'dracula-soft',
+  'everforest-dark',
+  'github-dark',
+  'github-dark-default',
+  'github-dark-dimmed',
+  'github-dark-high-contrast',
+  'gruvbox-dark-hard',
+  'gruvbox-dark-medium',
+  'gruvbox-dark-soft',
+  'houston',
+  'kanagawa-dragon',
+  'kanagawa-wave',
+  'laserwave',
+  'material-theme',
+  'material-theme-darker',
+  'material-theme-ocean',
+  'material-theme-palenight',
+  'min-dark',
+  'monokai',
+  'night-owl',
+  'nord',
+  'one-dark-pro',
+  'plastic',
+  'poimandres',
+  'red',
+  'rose-pine',
+  'rose-pine-moon',
+  'slack-dark',
+  'solarized-dark',
+  'synthwave-84',
+  'tokyo-night',
+  'vesper',
+  'vitesse-black',
+  'vitesse-dark',
+] as const;
+
+export type LightTheme = (typeof LIGHT_THEMES)[number];
+export type DarkTheme = (typeof DARK_THEMES)[number];
+export type ColorMode = 'system' | 'light' | 'dark';
+
+export const DEFAULT_LIGHT_THEME: LightTheme = 'pierre-light-soft';
+export const DEFAULT_DARK_THEME: DarkTheme = 'pierre-dark-soft';

--- a/apps/docs/app/(diffshub)/(view)/_components/usePersistedState.ts
+++ b/apps/docs/app/(diffshub)/(view)/_components/usePersistedState.ts
@@ -1,0 +1,53 @@
+'use client';
+
+import { type Dispatch, type SetStateAction, useEffect, useState } from 'react';
+
+// useState-like hook that mirrors its value to localStorage. On mount it
+// reads `storageKey`; if the stored string is included in `validValues` it
+// replaces the default, otherwise the default is kept. The initial read
+// happens in an effect (not the useState initializer) so the server-rendered
+// markup always uses the default and React's hydration check stays happy.
+// localStorage access is wrapped in try/catch because it can throw under
+// private browsing or denied permissions.
+//
+// The third tuple element exposes whether the rehydration effect has run.
+// Callers that wire the stored value into shared singletons (e.g. the
+// diffshub WorkerPool) gate side effects on this flag so the brief initial
+// window where the hook still returns `defaultValue` doesn't clobber the
+// singleton's current state. The flag also doubles as the write guard so
+// the first `setItem` can't fire with the default before the rehydrating
+// `setItem` has had a chance to land.
+export function usePersistedState<T extends string>(
+  storageKey: string,
+  defaultValue: T,
+  validValues: readonly T[]
+): [T, Dispatch<SetStateAction<T>>, boolean] {
+  const [value, setValue] = useState<T>(defaultValue);
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem(storageKey);
+      if (
+        stored != null &&
+        (validValues as readonly string[]).includes(stored)
+      ) {
+        setValue(stored as T);
+      }
+    } catch {
+      // localStorage unavailable; keep the default.
+    }
+    setIsHydrated(true);
+  }, [storageKey, validValues]);
+
+  useEffect(() => {
+    if (!isHydrated) return;
+    try {
+      window.localStorage.setItem(storageKey, value);
+    } catch {
+      // See note above.
+    }
+  }, [storageKey, value, isHydrated]);
+
+  return [value, setValue, isHydrated];
+}

--- a/apps/docs/app/(diffshub)/(view)/_components/useResolvedTreeThemeStyles.ts
+++ b/apps/docs/app/(diffshub)/(view)/_components/useResolvedTreeThemeStyles.ts
@@ -36,6 +36,14 @@ export interface ResolvedTreeTheme {
   // sideBarSectionHeader.foreground, which on some themes is brighter
   // than the primary text and inverts the muted/primary hierarchy.
   mutedFg?: string;
+  // editor.background / editor.foreground — the surface and text color the
+  // diff body itself renders on. Kept separately from the sidebar pair
+  // because some themes use opposite palettes for the two (slack-ochin:
+  // white editor, dark navy sidebar). The inter-file separator is derived
+  // from these so it contrasts the *diff* surface at the same perceptual
+  // weight as the chrome borders do against the sidebar.
+  editorBg?: string;
+  editorFg?: string;
 }
 
 // Defaults used while the user-selected Shiki theme is still resolving.
@@ -43,6 +51,8 @@ function buildResolvedTheme(theme: ResolvedShikiTheme): ResolvedTreeTheme {
   const c = theme.colors ?? {};
   const sideBarBg =
     c['sideBar.background'] ?? c['editor.background'] ?? theme.bg;
+  const editorBg = c['editor.background'] ?? theme.bg ?? sideBarBg;
+  const editorFg = c['editor.foreground'] ?? theme.fg;
   // Pick the foreground that's actually legible on the sidebar surface.
   // Some themes (slack-ochin) want sideBar.foreground because their editor
   // foreground is the opposite palette; others (material-theme-ocean) ship
@@ -106,6 +116,8 @@ function buildResolvedTheme(theme: ResolvedShikiTheme): ResolvedTreeTheme {
     treeStyles,
     primaryFg,
     mutedFg: c['descriptionForeground'],
+    editorBg,
+    editorFg: editorFg ?? primaryFg,
   };
 }
 
@@ -137,6 +149,13 @@ const MIN_READABLE_RATIO = 3;
 // hierarchy on those themes than ship sidebar text that fades into the
 // background.
 const MIN_MUTED_RATIO = 4.5;
+
+// Mix weight (percent of the surface's own foreground blended into its
+// background) for the opaque chrome borders and the inter-file diff
+// separator. Shared so both lines carry the same visual weight across
+// themes. Tuned up from an initial 15%, which was too faint to register
+// the header/sidebar edges and file boundaries on most surfaces.
+const DIFF_BORDER_MIX = 22;
 
 function pickReadableForeground(
   bg: string | undefined,
@@ -415,7 +434,11 @@ export function buildThemeChromeStyle(
     const border = `color-mix(in srgb, ${primaryFg} 20%, transparent)`;
     style['--color-border'] = border;
     style['--border'] = border;
-    const borderOpaque = `color-mix(in srgb, ${primaryFg} 15%, ${bg ?? 'transparent'})`;
+    // Opaque chrome border (header bottom, sidebar edge). Mixing the theme
+    // foreground into its surface keeps the line on-palette; the weight is
+    // shared with the diff separator (DIFF_BORDER_MIX) so the two read as
+    // one system. 15% was too faint to register against most surfaces.
+    const borderOpaque = `color-mix(in srgb, ${primaryFg} ${DIFF_BORDER_MIX}%, ${bg ?? 'transparent'})`;
     style['--color-border-opaque'] = borderOpaque;
     style['--border-opaque'] = borderOpaque;
     // Card surface tokens for chrome elements that sit on top of the
@@ -428,7 +451,16 @@ export function buildThemeChromeStyle(
     const popoverHoverBg = `color-mix(in srgb, ${primaryFg} 14%, ${cardSurfaceBase})`;
     const popoverSelectedBg = `color-mix(in srgb, ${primaryFg} 20%, ${cardSurfaceBase})`;
     const popoverBorder = `color-mix(in srgb, ${primaryFg} 18%, ${cardSurfaceBase})`;
-    const popoverShadow = `0 18px 44px color-mix(in srgb, ${cardSurfaceBase} 72%, transparent), 0 0 0 1px ${popoverBorder}`;
+    // A real elevation drop shadow. It must read as "lifted off the page"
+    // on every theme, so the color is occlusion-black (translucent) rather
+    // than derived from the surface — a surface-tinted shadow vanishes on
+    // light themes (a near-white blur over a near-white page). We do NOT
+    // bake a `0 0 0 1px` ring in here: every consumer (the popovers and the
+    // annotation cards) already paints its own 1px CSS border, so the ring
+    // would render a second hairline just outside it and read as a doubled,
+    // too-thick border.
+    const popoverShadow =
+      '0 10px 30px rgb(0 0 0 / 0.18), 0 3px 8px rgb(0 0 0 / 0.12)';
     style['--diffshub-card-bg'] =
       `color-mix(in srgb, ${primaryFg} 6%, ${cardSurfaceBase})`;
     style['--diffshub-card-hover-bg'] =
@@ -462,8 +494,15 @@ export function buildThemeChromeStyle(
     style['--accent'] = popoverHoverBg;
     style['--color-accent-foreground'] = primaryFg;
     style['--accent-foreground'] = primaryFg;
-    style['--color-secondary'] = popoverBg;
-    style['--secondary'] = popoverBg;
+    // `secondary` is the segmented-control (ButtonGroup) track. It must sit
+    // visibly *behind* the buttons so the three Auto/Light/Dark options read
+    // as one connected control — but the popover surface it lives on is
+    // already `popoverBg`, so reusing that here made the track disappear
+    // into the menu. Use the slightly stronger hover mix so the track is a
+    // distinct inset band; the selected pill (which paints `background`)
+    // still pops above it.
+    style['--color-secondary'] = popoverHoverBg;
+    style['--secondary'] = popoverHoverBg;
     style['--color-secondary-foreground'] = primaryFg;
     style['--secondary-foreground'] = primaryFg;
     style['--color-input'] = popoverHoverBg;
@@ -486,6 +525,27 @@ export function buildThemeChromeStyle(
     const surfaceIsDark = isDarkSurface(bg, primaryFg);
     style['--diffshub-comment-add-fg'] = surfaceIsDark ? '#34d399' : '#047857';
     style['--diffshub-comment-del-fg'] = surfaceIsDark ? '#fb7185' : '#be123c';
+    // Hairline between diff files. The static global --color-border-opaque
+    // follows the app's light/dark palette, so it goes faint (or mismatched)
+    // once the diff renders on a Shiki theme that drifts from it.
+    //
+    // When the diff (editor) surface matches the sidebar surface — the
+    // common case — reuse the chrome border verbatim so the separator can
+    // never drift brighter or darker than it. This matters for themes like
+    // material-theme that share one bg (#263238) for editor and sidebar but
+    // pair it with a near-white editor fg (#EEFFFF) and a dim sidebar fg
+    // (#6c8692): deriving the separator from the editor fg would make it far
+    // brighter than the chrome border on the very same surface.
+    //
+    // Only when the palettes genuinely diverge (slack-ochin: dark navy
+    // sidebar, white editor) do we derive from the editor surface, so the
+    // hairline contrasts the diff body instead of going dark-on-light.
+    const editorBg = activeTheme.editorBg ?? bg;
+    const editorFg = activeTheme.editorFg ?? primaryFg;
+    style['--diffshub-diff-separator'] =
+      editorBg == null || surfacesMatch(editorBg, bg)
+        ? borderOpaque
+        : `color-mix(in srgb, ${editorFg} ${DIFF_BORDER_MIX}%, ${editorBg})`;
   }
   return style as CSSProperties;
 }
@@ -500,6 +560,21 @@ function isDarkSurface(bg: string | undefined, primaryFg: string): boolean {
   if (fromBg != null) return fromBg < 0.4;
   const fromFg = relativeLuminance(primaryFg);
   return fromFg != null ? fromFg > 0.6 : false;
+}
+
+// True when two surface colors read as the "same surface" — identical hex,
+// or close enough in luminance that a border tuned for one looks right on
+// the other. Used to decide whether the diff separator can reuse the chrome
+// border (shared surface) or must be re-derived from the editor surface
+// (divergent palettes like slack-ochin). Non-hex inputs we can't measure
+// are treated as non-matching so we fall back to per-surface derivation.
+function surfacesMatch(a: string | undefined, b: string | undefined): boolean {
+  if (a == null || b == null) return false;
+  if (a.trim().toLowerCase() === b.trim().toLowerCase()) return true;
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  if (la == null || lb == null) return false;
+  return Math.abs(la - lb) < 0.06;
 }
 
 // Parse the leading `#rrggbb` / `#rgb` of a color string and return its

--- a/apps/docs/app/(diffshub)/(view)/_components/useResolvedTreeThemeStyles.ts
+++ b/apps/docs/app/(diffshub)/(view)/_components/useResolvedTreeThemeStyles.ts
@@ -1,0 +1,540 @@
+'use client';
+
+import { type DiffsThemeNames, getResolvedOrResolveTheme } from '@pierre/diffs';
+import darkSoftTheme from '@pierre/theme/pierre-dark-soft';
+import lightSoftTheme from '@pierre/theme/pierre-light-soft';
+import { themeToTreeStyles, type TreeThemeStyles } from '@pierre/trees';
+import { type CSSProperties, useEffect, useMemo, useState } from 'react';
+
+import { useTheme } from '@/components/theme-provider';
+
+// Resolved Shiki/VS Code-style theme shape (the minimum bits diffshub
+// needs); kept loose so it accepts both the typed `@pierre/theme` bundles
+// and `getResolvedOrResolveTheme`'s `ThemeRegistrationResolved`.
+interface ResolvedShikiTheme {
+  type?: 'light' | 'dark';
+  bg?: string;
+  fg?: string;
+  colors?: Record<string, string>;
+}
+
+// Per-theme bundle: the tree styles for FileTree consumers, plus the raw
+// resolved colors that the sidebar chrome needs to mirror the theme
+// without going through TreeThemeStyles' tree-specific naming.
+export interface ResolvedTreeTheme {
+  treeStyles: TreeThemeStyles;
+  // The color the theme assigns to the sidebar surface
+  // (sideBar.foreground, falling back to editor.foreground then theme.fg).
+  // Use this for primary text and icon chrome so they stay legible
+  // against the tree's sideBar.background — picking editor.foreground
+  // first breaks on themes like slack-ochin where the editor and sidebar
+  // use opposite palettes (white editor, dark navy sidebar).
+  primaryFg?: string;
+  // descriptionForeground — VS Code's muted-text token. Many themes
+  // don't define it; when missing, callers should fade `primaryFg`
+  // themselves rather than reaching for another opaque token like
+  // sideBarSectionHeader.foreground, which on some themes is brighter
+  // than the primary text and inverts the muted/primary hierarchy.
+  mutedFg?: string;
+}
+
+// Defaults used while the user-selected Shiki theme is still resolving.
+function buildResolvedTheme(theme: ResolvedShikiTheme): ResolvedTreeTheme {
+  const c = theme.colors ?? {};
+  const sideBarBg =
+    c['sideBar.background'] ?? c['editor.background'] ?? theme.bg;
+  // Pick the foreground that's actually legible on the sidebar surface.
+  // Some themes (slack-ochin) want sideBar.foreground because their editor
+  // foreground is the opposite palette; others (material-theme-ocean) ship
+  // a deliberately dim sideBar.foreground — #525975 on #0F111A is ~2.6:1,
+  // well below WCAG AA — and the same theme's editor.foreground (#babed8
+  // ~10:1) is the brightness the chrome and tree are supposed to use.
+  // Probe candidates in design-intent order and keep the first one that
+  // clears AA; only fall through to "highest contrast wins" when no
+  // candidate is legible enough on its own.
+  //
+  // `theme.fg` is Shiki's normalized editor text color, populated through
+  // a fallback chain that covers `colors['editor.foreground']`, a
+  // tokenColor without scope, and finally Shiki's #bbbbbb default for
+  // dark themes / #333333 for light. Aurora-x has none of `sideBar`/
+  // `editor.foreground` set in its `colors` block, so the editor renders
+  // body text in that Shiki #bbbbbb fallback — using `theme.fg` here
+  // makes the chrome match. Notably absent from the list:
+  // - `list.activeSelectionForeground` — reserved for the *selected* item
+  //   highlight, often a saturated accent (aurora-x: `#86A5FF`); using it
+  //   as the default would tint every chrome label that accent color.
+  // - `colors.foreground` — VS Code's global UI text token. Aurora-x sets
+  //   it to `#576daf` (a deliberately dim blue-gray) intended for menus
+  //   and the like; preferring it over `theme.fg` swaps the chrome away
+  //   from the editor's body text color, which is exactly the mismatch
+  //   the user flagged.
+  const primaryFg = pickReadableForeground(sideBarBg, [
+    c['sideBar.foreground'],
+    c['editor.foreground'],
+    theme.fg,
+  ]);
+  const treeStyles = themeToTreeStyles(theme);
+  // themeToTreeStyles pulls its text color tokens straight from
+  // sideBar.foreground; when the contrast-based pick disagrees with that
+  // raw value, overwrite the tree's tokens so the file rows match the
+  // chrome instead of staying on the dim original. Tokens that the theme
+  // sets explicitly (sideBarSectionHeader.foreground,
+  // list.activeSelectionForeground) keep their intended values — we only
+  // upgrade the unconditional fallbacks.
+  if (
+    primaryFg != null &&
+    primaryFg !== c['sideBar.foreground'] &&
+    primaryFg !== ''
+  ) {
+    treeStyles.color = primaryFg;
+    treeStyles['--trees-theme-sidebar-fg'] = primaryFg;
+    if (c['sideBarSectionHeader.foreground'] == null) {
+      treeStyles['--trees-theme-sidebar-header-fg'] = primaryFg;
+    }
+    if (c['list.activeSelectionForeground'] == null) {
+      treeStyles['--trees-theme-list-active-selection-fg'] = primaryFg;
+    }
+    if (
+      c['list.focusOutline'] == null &&
+      c['focusBorder'] == null &&
+      c['sideBar.foreground'] == null
+    ) {
+      treeStyles['--trees-theme-focus-ring'] = primaryFg;
+    }
+  }
+  return {
+    treeStyles,
+    primaryFg,
+    mutedFg: c['descriptionForeground'],
+  };
+}
+
+// Walks `candidates` in priority order. Returns the first color whose
+// contrast against `bg` clears `MIN_READABLE_RATIO`. If nothing reaches
+// that bar, returns the candidate with the highest contrast — that keeps
+// weakly-typed themes (where everything is dim) on the brightest
+// available token rather than silently picking the first dim one. Non-hex
+// candidates (var(...), color-mix(...), named colors) can't be measured
+// here without rendering; they're treated as opaque misses and only
+// returned via the `firstDefined` fallback when nothing parses.
+//
+// The 3:1 threshold is WCAG AA's "large text" floor. We use it instead
+// of the 4.5:1 "normal text" cutoff because the theme designer's
+// `sideBar.foreground` is the design-intent value for sidebar chrome —
+// honoring it is preferable to forcing a stronger token whenever
+// possible. 3:1 still catches the egregious failures (material-theme-
+// ocean's #525975 on #0F111A at ~2.6:1) while leaving deliberately soft
+// palettes like pierre-light-soft (~4.4:1) untouched.
+const MIN_READABLE_RATIO = 3;
+
+// Muted chrome text ("Diff Stats", "System Monitor", "Comments", file
+// counts, empty-state copy) is normal-size body text, so we hold its
+// threshold at WCAG AA normal-text (4.5:1) rather than the large-text
+// floor used for the primary fg. Several VS Code themes set
+// `descriptionForeground` to a value that doubles as the editor comment
+// color and clears 3:1 but not 4.5:1 — ayu-dark's `#5a6378` on `#0d1017`
+// (~3.27:1) is the canonical case. We'd rather lose the muted/primary
+// hierarchy on those themes than ship sidebar text that fades into the
+// background.
+const MIN_MUTED_RATIO = 4.5;
+
+function pickReadableForeground(
+  bg: string | undefined,
+  candidates: ReadonlyArray<string | undefined>
+): string | undefined {
+  const bgL = relativeLuminance(bg);
+  const firstDefined = candidates.find(
+    (candidate) => candidate != null && candidate !== ''
+  );
+  if (bgL == null) return firstDefined;
+  let best: string | undefined;
+  let bestRatio = -1;
+  for (const candidate of candidates) {
+    if (candidate == null || candidate === '') continue;
+    const candidateL = relativeLuminance(candidate);
+    if (candidateL == null) continue;
+    const ratio = contrastRatio(bgL, candidateL);
+    if (ratio >= MIN_READABLE_RATIO) return candidate;
+    if (ratio > bestRatio) {
+      best = candidate;
+      bestRatio = ratio;
+    }
+  }
+  return best ?? firstDefined;
+}
+
+function contrastRatio(la: number, lb: number): number {
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+// Returns the theme's descriptionForeground when it's readable enough
+// (>= MIN_MUTED_RATIO against the chrome bg). Hex-with-alpha values like
+// aurora-x's `#576daf79` are composited over the bg first, since rgba
+// previews don't reach AA on their own. Returns undefined when the value
+// is missing, unparseable, or fails the contrast bar — letting the call
+// site fall back to a derived muted (or primaryFg when no bg is known).
+function pickReadableMuted(
+  bg: string | undefined,
+  mutedCandidate: string | undefined
+): string | undefined {
+  if (mutedCandidate == null || mutedCandidate === '') return undefined;
+  const composited = compositeOverBg(mutedCandidate, bg) ?? mutedCandidate;
+  const compositedL = relativeLuminance(composited);
+  const bgL = relativeLuminance(bg);
+  if (compositedL == null || bgL == null) {
+    // Can't measure — trust the designer's value rather than second-
+    // guess exotic non-hex formats (var(...), color-mix(...), named
+    // colors).
+    return mutedCandidate;
+  }
+  return contrastRatio(bgL, compositedL) >= MIN_MUTED_RATIO
+    ? mutedCandidate
+    : undefined;
+}
+
+// Mixes primaryFg toward bg until the result clears MIN_MUTED_RATIO,
+// stepping from a strong-hierarchy 60% blend up to 100% (== primaryFg).
+// Returning primaryFg as a final fallback flattens the muted/primary
+// hierarchy on extreme palettes, which is the correct tradeoff: dim but
+// legible chrome beats stylish but unreadable chrome. Falls back to a
+// CSS `color-mix` expression when either input isn't a parseable hex —
+// the browser can still composite, we just can't verify the contrast.
+function deriveMutedFg(primaryFg: string, bg: string | undefined): string {
+  if (bg == null) return primaryFg;
+  const fgParts = parseHexRgba(primaryFg);
+  const bgParts = parseHexRgba(bg);
+  const bgL = relativeLuminance(bg);
+  if (fgParts == null || bgParts == null || bgL == null) {
+    return `color-mix(in srgb, ${primaryFg} 70%, ${bg})`;
+  }
+  const [fr, fg2, fb] = fgParts;
+  const [br, bg3, bb] = bgParts;
+  for (const weight of [0.6, 0.7, 0.8, 0.9]) {
+    const r = Math.round(fr * weight + br * (1 - weight));
+    const g = Math.round(fg2 * weight + bg3 * (1 - weight));
+    const b = Math.round(fb * weight + bb * (1 - weight));
+    const hex =
+      '#' + [r, g, b].map((v) => v.toString(16).padStart(2, '0')).join('');
+    const L = relativeLuminance(hex);
+    if (L != null && contrastRatio(bgL, L) >= MIN_MUTED_RATIO) {
+      return hex;
+    }
+  }
+  return primaryFg;
+}
+
+// Composites a hex (`#rrggbb` or `#rrggbbaa`) candidate over a hex
+// background and returns the resulting opaque hex. Used so we can measure
+// the actual contrast of semi-transparent muted-fg tokens (#576daf79 etc.)
+// against the surface they'll render on, rather than the alpha-stripped
+// base color. Returns undefined for unparseable inputs.
+function compositeOverBg(
+  fg: string,
+  bg: string | undefined
+): string | undefined {
+  if (bg == null) return undefined;
+  const fgParts = parseHexRgba(fg);
+  const bgParts = parseHexRgba(bg);
+  if (fgParts == null || bgParts == null) return undefined;
+  const [fr, fg2, fb, fa] = fgParts;
+  const [br, bg3, bb] = bgParts;
+  const r = Math.round(fr * fa + br * (1 - fa));
+  const g = Math.round(fg2 * fa + bg3 * (1 - fa));
+  const b = Math.round(fb * fa + bb * (1 - fa));
+  return '#' + [r, g, b].map((v) => v.toString(16).padStart(2, '0')).join('');
+}
+
+// Parses `#rgb`, `#rrggbb`, or `#rrggbbaa` into [r, g, b, a] with channels
+// in [0, 255] and alpha in [0, 1]. Returns null for any other format.
+function parseHexRgba(
+  color: string
+): readonly [number, number, number, number] | null {
+  const match = /^#([0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})\b/i.exec(color.trim());
+  if (match == null) return null;
+  const hex = match[1];
+  let expanded: string;
+  let alpha = 1;
+  if (hex.length === 3) {
+    expanded = hex
+      .split('')
+      .map((c) => c + c)
+      .join('');
+  } else if (hex.length === 6) {
+    expanded = hex;
+  } else {
+    expanded = hex.slice(0, 6);
+    alpha = parseInt(hex.slice(6, 8), 16) / 255;
+  }
+  return [
+    parseInt(expanded.slice(0, 2), 16),
+    parseInt(expanded.slice(2, 4), 16),
+    parseInt(expanded.slice(4, 6), 16),
+    alpha,
+  ];
+}
+
+const LIGHT_SOFT_THEME = buildResolvedTheme(lightSoftTheme);
+const DARK_SOFT_THEME = buildResolvedTheme(darkSoftTheme);
+
+// Module-level cache so flipping back to a previously-selected Shiki theme
+// is synchronous and renders without flashing the default pierre-soft
+// palette in between.
+const RESOLVED_THEME_CACHE = new Map<string, ResolvedTreeTheme>();
+RESOLVED_THEME_CACHE.set('pierre-light-soft', LIGHT_SOFT_THEME);
+RESOLVED_THEME_CACHE.set('pierre-dark-soft', DARK_SOFT_THEME);
+
+function useResolvedThemeByName(
+  themeName: DiffsThemeNames,
+  fallback: ResolvedTreeTheme
+): ResolvedTreeTheme {
+  // Read the module cache on every render so a theme that's already
+  // resolved (the common case once the user has cycled through it
+  // once) applies in the same render as the prop change — no useState
+  // round-trip. Without this, the sidebar's comment cards and tab
+  // badge visibly lag one React commit behind the diff viewer's theme
+  // swap, because useState's initializer only runs on mount.
+  const cached = RESOLVED_THEME_CACHE.get(themeName);
+
+  // Track the most recently *resolved* theme so cold themes don't
+  // flash the pierre-soft fallback in between the prop change and the
+  // async load completing. The diff side keeps the previous theme
+  // visible during its own await inside `WorkerPoolManager.setRenderOptions`
+  // — matching that behaviour here means chrome and diff stay aligned
+  // through a swap: both show the prior theme until the new one is
+  // ready, then both flip together.
+  const [lastResolved, setLastResolved] = useState<ResolvedTreeTheme>(
+    cached ?? fallback
+  );
+
+  useEffect(() => {
+    const existing = RESOLVED_THEME_CACHE.get(themeName);
+    if (existing != null) {
+      // The render path already returned the cached value via `cached`
+      // above; update the fallback state too so it stays in step when
+      // the next swap hits a cold theme.
+      setLastResolved(existing);
+      return;
+    }
+    let cancelled = false;
+    async function load() {
+      try {
+        const theme = await getResolvedOrResolveTheme(themeName);
+        const next = buildResolvedTheme(theme);
+        RESOLVED_THEME_CACHE.set(themeName, next);
+        if (!cancelled) setLastResolved(next);
+      } catch {
+        // Resolution failures are surfaced by the diff side; keeping
+        // the previous theme keeps the sidebar usable in the meantime.
+      }
+    }
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [themeName]);
+
+  return cached ?? lastResolved;
+}
+
+// Returns the resolved Shiki theme bundle (tree styles + raw colors) for
+// whichever color mode is currently active in the global ThemeProvider.
+export function useResolvedTreeTheme(
+  lightTheme: DiffsThemeNames,
+  darkTheme: DiffsThemeNames
+): ResolvedTreeTheme {
+  const { resolvedTheme } = useTheme();
+  const light = useResolvedThemeByName(lightTheme, LIGHT_SOFT_THEME);
+  const dark = useResolvedThemeByName(darkTheme, DARK_SOFT_THEME);
+  return useMemo(
+    () => (resolvedTheme === 'dark' ? dark : light),
+    [resolvedTheme, dark, light]
+  );
+}
+
+// Back-compat alias returning just the TreeThemeStyles slice. Callers that
+// only need the file-tree CSS variables stay simple.
+export function useResolvedTreeThemeStyles(
+  lightTheme: DiffsThemeNames,
+  darkTheme: DiffsThemeNames
+): TreeThemeStyles {
+  return useResolvedTreeTheme(lightTheme, darkTheme).treeStyles;
+}
+
+// Builds the inline style we attach to any diffshub chrome surface (sidebar,
+// header) so it sits on the active Shiki theme's `sideBar.background` and its
+// text/icons/borders follow the same palette. We override the Tailwind v4
+// `--color-*` aliases as well as the legacy `--*` names because globals.css
+// bakes the aliases out to concrete values — overriding only `--foreground`
+// would leave `text-foreground` utilities pinned to the pre-theme color.
+//
+// Beyond the chrome colors, we also derive surface tokens for "cards" that
+// live on top of the sidebar bg (e.g. the comments list rows). Hardcoded
+// `bg-card` / `bg-neutral-800` collide with mixed-palette themes like
+// slack-ochin, which is classified `type: 'light'` but ships a dark navy
+// sidebar — light text from the sidebar override on a white `bg-card` is
+// unreadable. Mixing primaryFg into the sidebar bg keeps cards on-palette.
+export function buildThemeChromeStyle(
+  activeTheme: ResolvedTreeTheme
+): CSSProperties | undefined {
+  const bg =
+    typeof activeTheme.treeStyles.backgroundColor === 'string' &&
+    activeTheme.treeStyles.backgroundColor !== ''
+      ? activeTheme.treeStyles.backgroundColor
+      : undefined;
+  const primaryFg =
+    activeTheme.primaryFg ??
+    (typeof activeTheme.treeStyles.color === 'string'
+      ? activeTheme.treeStyles.color
+      : undefined);
+  if (bg == null && primaryFg == null) return undefined;
+  const style: CSSProperties & Record<string, string> = {};
+  if (bg != null) style.backgroundColor = bg;
+  if (primaryFg != null) {
+    style.color = primaryFg;
+    style['--color-foreground'] = primaryFg;
+    style['--foreground'] = primaryFg;
+    // The chrome (file tree, sidebar status panel, header, comments list)
+    // wants muted text that's softer than the primary fg for visual
+    // hierarchy, but still hits WCAG AA normal-text (~4.5:1) on the
+    // sidebar bg. We honour the theme's `descriptionForeground` when it
+    // clears that bar, fall back to a mix of primaryFg into bg when it
+    // doesn't, and only flatten down to primaryFg as a last resort. Two
+    // cautionary tales:
+    //   - Aurora-X sets descriptionForeground to `#576daf79` (~1.8:1
+    //     composited over the dark navy sidebar). Using it leaves
+    //     unselected tab icons and the empty-comments copy invisible.
+    //   - ayu-dark sets it to `#5a6378` (~3.27:1 on `#0d1017`) — clears
+    //     large-text 3:1 but fails normal-text 4.5:1, which is the bar
+    //     these chrome labels need to meet.
+    const muted =
+      pickReadableMuted(bg, activeTheme.mutedFg) ??
+      deriveMutedFg(primaryFg, bg);
+    style['--color-muted-foreground'] = muted;
+    style['--muted-foreground'] = muted;
+    const border = `color-mix(in srgb, ${primaryFg} 20%, transparent)`;
+    style['--color-border'] = border;
+    style['--border'] = border;
+    const borderOpaque = `color-mix(in srgb, ${primaryFg} 15%, ${bg ?? 'transparent'})`;
+    style['--color-border-opaque'] = borderOpaque;
+    style['--border-opaque'] = borderOpaque;
+    // Card surface tokens for chrome elements that sit on top of the
+    // sidebar bg (e.g. comment rows). We layer the theme's foreground onto
+    // its own background so cards remain legible regardless of whether the
+    // theme is "light" or "dark" — the cards always sit a touch above the
+    // surface they live on, and the same text color works on both.
+    const cardSurfaceBase = bg ?? 'transparent';
+    const popoverBg = `color-mix(in srgb, ${primaryFg} 7%, ${cardSurfaceBase})`;
+    const popoverHoverBg = `color-mix(in srgb, ${primaryFg} 14%, ${cardSurfaceBase})`;
+    const popoverSelectedBg = `color-mix(in srgb, ${primaryFg} 20%, ${cardSurfaceBase})`;
+    const popoverBorder = `color-mix(in srgb, ${primaryFg} 18%, ${cardSurfaceBase})`;
+    const popoverShadow = `0 18px 44px color-mix(in srgb, ${cardSurfaceBase} 72%, transparent), 0 0 0 1px ${popoverBorder}`;
+    style['--diffshub-card-bg'] =
+      `color-mix(in srgb, ${primaryFg} 6%, ${cardSurfaceBase})`;
+    style['--diffshub-card-hover-bg'] =
+      `color-mix(in srgb, ${primaryFg} 12%, ${cardSurfaceBase})`;
+    style['--diffshub-card-border'] =
+      `color-mix(in srgb, ${primaryFg} 12%, ${cardSurfaceBase})`;
+    style['--diffshub-popover-bg'] = popoverBg;
+    style['--diffshub-popover-fg'] = primaryFg;
+    style['--diffshub-popover-muted-fg'] = muted;
+    style['--diffshub-popover-hover-bg'] = popoverHoverBg;
+    style['--diffshub-popover-selected-bg'] = popoverSelectedBg;
+    style['--diffshub-popover-border'] = popoverBorder;
+    style['--diffshub-popover-shadow'] = popoverShadow;
+    style['--diffshub-annotation-bg'] = popoverBg;
+    style['--diffshub-annotation-fg'] = primaryFg;
+    style['--diffshub-annotation-border'] = popoverBorder;
+    style['--diffshub-annotation-hover-border'] =
+      `color-mix(in srgb, ${primaryFg} 28%, ${cardSurfaceBase})`;
+    style['--diffshub-annotation-shadow'] = popoverShadow;
+    style['--color-popover'] = popoverBg;
+    style['--popover'] = popoverBg;
+    style['--color-popover-foreground'] = primaryFg;
+    style['--popover-foreground'] = primaryFg;
+    style['--color-card'] = popoverBg;
+    style['--card'] = popoverBg;
+    style['--color-card-foreground'] = primaryFg;
+    style['--card-foreground'] = primaryFg;
+    style['--color-background'] = bg ?? popoverBg;
+    style['--background'] = bg ?? popoverBg;
+    style['--color-accent'] = popoverHoverBg;
+    style['--accent'] = popoverHoverBg;
+    style['--color-accent-foreground'] = primaryFg;
+    style['--accent-foreground'] = primaryFg;
+    style['--color-secondary'] = popoverBg;
+    style['--secondary'] = popoverBg;
+    style['--color-secondary-foreground'] = primaryFg;
+    style['--secondary-foreground'] = primaryFg;
+    style['--color-input'] = popoverHoverBg;
+    style['--input'] = popoverHoverBg;
+    style['--color-muted'] = popoverHoverBg;
+    style['--muted'] = popoverHoverBg;
+    style['--color-primary'] = primaryFg;
+    style['--primary'] = primaryFg;
+    style['--color-primary-foreground'] = bg ?? popoverBg;
+    style['--primary-foreground'] = bg ?? popoverBg;
+    style['--color-ring'] = primaryFg;
+    style['--ring'] = primaryFg;
+    // Addition / deletion tints for comment line labels switch between
+    // Tailwind's 700 and 400 shades based on whether the chrome surface is
+    // dark or light. The global `dark:` variant keys off the app's color
+    // mode, but mixed-palette themes like slack-ochin advertise as "light"
+    // while rendering a dark sidebar — so emerald-700/rose-700 end up on
+    // dark navy with poor contrast. Picking by perceived surface luminance
+    // instead keeps the tints legible across every theme.
+    const surfaceIsDark = isDarkSurface(bg, primaryFg);
+    style['--diffshub-comment-add-fg'] = surfaceIsDark ? '#34d399' : '#047857';
+    style['--diffshub-comment-del-fg'] = surfaceIsDark ? '#fb7185' : '#be123c';
+  }
+  return style as CSSProperties;
+}
+
+// Returns true when the chrome surface is perceptually dark. We prefer
+// reading the surface's own luminance, but some themes lean on the global
+// theme.bg fallback that doesn't survive into treeStyles — so when the bg
+// hex isn't parseable we use the primaryFg as a hint (light fg → dark
+// surface, the conventional pairing).
+function isDarkSurface(bg: string | undefined, primaryFg: string): boolean {
+  const fromBg = relativeLuminance(bg);
+  if (fromBg != null) return fromBg < 0.4;
+  const fromFg = relativeLuminance(primaryFg);
+  return fromFg != null ? fromFg > 0.6 : false;
+}
+
+// Parse the leading `#rrggbb` / `#rgb` of a color string and return its
+// WCAG-style relative luminance in [0, 1]. Returns null for non-hex inputs
+// like `var(...)`, `color-mix(...)`, named colors etc. — those can still
+// fall back through `isDarkSurface`'s primaryFg path.
+function relativeLuminance(color: string | undefined): number | null {
+  if (color == null) return null;
+  const match = /^#([0-9a-f]{3}|[0-9a-f]{6})\b/i.exec(color.trim());
+  if (match == null) return null;
+  const hex = match[1];
+  const expanded =
+    hex.length === 3
+      ? hex
+          .split('')
+          .map((c) => c + c)
+          .join('')
+      : hex;
+  const r = parseInt(expanded.slice(0, 2), 16) / 255;
+  const g = parseInt(expanded.slice(2, 4), 16) / 255;
+  const b = parseInt(expanded.slice(4, 6), 16) / 255;
+  const channel = (v: number) =>
+    v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+// Hook form: resolve the active theme and memoize the chrome style. Used by
+// both CodeViewSidebar and CodeViewHeader so the two surfaces stay in sync.
+// `activeTheme` is itself memoized inside `useResolvedTreeTheme` (and the
+// resolved-theme map caches entries by name), so a single dep is enough —
+// the reference only changes when the user actually picks a new theme.
+export function useThemeChromeStyle(
+  lightTheme: DiffsThemeNames,
+  darkTheme: DiffsThemeNames
+): CSSProperties | undefined {
+  const activeTheme = useResolvedTreeTheme(lightTheme, darkTheme);
+  return useMemo(() => buildThemeChromeStyle(activeTheme), [activeTheme]);
+}

--- a/apps/docs/app/(diffshub)/(view)/_components/useThemeCycle.ts
+++ b/apps/docs/app/(diffshub)/(view)/_components/useThemeCycle.ts
@@ -1,0 +1,133 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  type ColorMode,
+  DARK_THEMES,
+  type DarkTheme,
+  LIGHT_THEMES,
+  type LightTheme,
+} from './themes';
+
+// Step durations available on the System Monitor's theme-cycle button.
+// Plain-clicking the button advances through these in order; the
+// shift-click gesture starts/stops the actual rotation.
+export const THEME_CYCLE_DURATIONS_SECONDS = [3, 0.8, 0.4, 0.1] as const;
+
+export type ThemeCycleDurationSeconds =
+  (typeof THEME_CYCLE_DURATIONS_SECONDS)[number];
+
+export interface ThemeCycleControls {
+  cycling: boolean;
+  stepSeconds: ThemeCycleDurationSeconds;
+  bumpDuration(): void;
+  toggleCycle(): void;
+}
+
+interface UseThemeCycleArgs {
+  lightTheme: LightTheme;
+  darkTheme: DarkTheme;
+  // Resolved light/dark for the surrounding ThemeProvider — undefined while
+  // localStorage hydration is still pending. Cycling waits for a resolved
+  // value before starting so the first step doesn't anchor on the wrong
+  // phase.
+  resolvedThemeMode: 'light' | 'dark' | undefined;
+  setLightTheme: (theme: LightTheme) => void;
+  setDarkTheme: (theme: DarkTheme) => void;
+  setColorMode: (mode: ColorMode) => void;
+}
+
+// Drives a sweep through every available Shiki theme — all the light
+// themes, then all the dark themes, then back around — so users can
+// preview the full catalog without manually picking each one. The
+// rotation order is built once when cycling kicks off, anchored on
+// whichever theme is currently active so the visible state doesn't jump,
+// and the sweep walks the rest of that phase, the opposite phase, and
+// then loops back to where it started.
+export function useThemeCycle({
+  lightTheme,
+  darkTheme,
+  resolvedThemeMode,
+  setLightTheme,
+  setDarkTheme,
+  setColorMode,
+}: UseThemeCycleArgs): ThemeCycleControls {
+  const [stepSeconds, setStepSeconds] = useState<ThemeCycleDurationSeconds>(3);
+  const [cycling, setCycling] = useState(false);
+
+  // Capture the latest theme state in refs so the cycle effect doesn't
+  // restart its interval (and re-anchor the rotation order) every time
+  // the cycle advances. Each tick reads the same captured sequence.
+  const lightThemeRef = useRef(lightTheme);
+  const darkThemeRef = useRef(darkTheme);
+  const resolvedModeRef = useRef(resolvedThemeMode);
+  lightThemeRef.current = lightTheme;
+  darkThemeRef.current = darkTheme;
+  resolvedModeRef.current = resolvedThemeMode;
+
+  const bumpDuration = useCallback(() => {
+    setStepSeconds((prev) => {
+      const idx = THEME_CYCLE_DURATIONS_SECONDS.indexOf(prev);
+      return THEME_CYCLE_DURATIONS_SECONDS[
+        (idx + 1) % THEME_CYCLE_DURATIONS_SECONDS.length
+      ];
+    });
+  }, []);
+
+  const toggleCycle = useCallback(() => {
+    setCycling((c) => !c);
+  }, []);
+
+  useEffect(() => {
+    if (!cycling) return undefined;
+    const startMode = resolvedModeRef.current ?? 'light';
+    const lightStartIdx = Math.max(
+      0,
+      LIGHT_THEMES.indexOf(lightThemeRef.current)
+    );
+    const darkStartIdx = Math.max(0, DARK_THEMES.indexOf(darkThemeRef.current));
+    type Step =
+      | { mode: 'light'; theme: LightTheme }
+      | { mode: 'dark'; theme: DarkTheme };
+    const lightSequence: Step[] = LIGHT_THEMES.map((theme) => ({
+      mode: 'light',
+      theme,
+    }));
+    const darkSequence: Step[] = DARK_THEMES.map((theme) => ({
+      mode: 'dark',
+      theme,
+    }));
+    const order: Step[] =
+      startMode === 'dark'
+        ? [
+            ...darkSequence.slice(darkStartIdx),
+            ...lightSequence,
+            ...darkSequence.slice(0, darkStartIdx),
+          ]
+        : [
+            ...lightSequence.slice(lightStartIdx),
+            ...darkSequence,
+            ...lightSequence.slice(0, lightStartIdx),
+          ];
+    // Tick 0 is the already-active theme — start advancing from the next
+    // entry so the first interval fires onto something new.
+    let idx = 1;
+    const tick = () => {
+      const step = order[idx % order.length];
+      if (step.mode === 'light') {
+        setLightTheme(step.theme);
+        setColorMode('light');
+      } else {
+        setDarkTheme(step.theme);
+        setColorMode('dark');
+      }
+      idx++;
+    };
+    tick();
+    const intervalId = window.setInterval(tick, stepSeconds * 1000);
+    return () => window.clearInterval(intervalId);
+  }, [cycling, stepSeconds, setLightTheme, setDarkTheme, setColorMode]);
+
+  return { cycling, stepSeconds, bumpDuration, toggleCycle };
+}

--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -249,7 +249,7 @@
   }
 
   .inline-link {
-    @apply text-foreground hover:text-foreground decoration-muted-foreground hover:decoration-foreground underline decoration-[1px] underline-offset-3 transition-[color,text-decoration-color,text-underline-offset];
+    @apply text-foreground hover:text-foreground decoration-muted-foreground hover:decoration-foreground underline decoration-[1px] underline-offset-3 transition-[text-decoration-color,text-underline-offset];
   }
 
   .no-scrollbar::-webkit-scrollbar {

--- a/apps/docs/test/themeChromeStyle.test.ts
+++ b/apps/docs/test/themeChromeStyle.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'bun:test';
+import type { CSSProperties } from 'react';
+
+import { buildAnnotationThemeStyle } from '../app/(diffshub)/(view)/_components/CodeViewWrapper';
+import { buildThemeChromeStyle } from '../app/(diffshub)/(view)/_components/useResolvedTreeThemeStyles';
+
+describe('buildThemeChromeStyle', () => {
+  test('exports themed tokens for popovers, controls, and inline comments', () => {
+    const style = buildThemeChromeStyle({
+      mutedFg: '#b0c2c8',
+      primaryFg: '#d8eef4',
+      treeStyles: {
+        backgroundColor: '#20313a',
+        color: '#d8eef4',
+      },
+    });
+
+    // Snapshot raw token values before toMatchObject runs: it mutates the
+    // received object (swapping matched values for the matcher in its diff
+    // output), so reading style[...] afterwards would return the matcher,
+    // not the string.
+    const tokens = (style ?? {}) as Record<string, string>;
+    const separator = tokens['--diffshub-diff-separator'];
+    const borderOpaque = tokens['--color-border-opaque'];
+    const popoverShadow = tokens['--diffshub-popover-shadow'];
+    const annotationShadow = tokens['--diffshub-annotation-shadow'];
+
+    expect(style).toMatchObject({
+      '--color-accent': expect.stringContaining('#d8eef4'),
+      '--color-input': expect.stringContaining('#d8eef4'),
+      '--color-popover': expect.stringContaining('#d8eef4'),
+      '--color-popover-foreground': '#d8eef4',
+      '--diffshub-annotation-bg': expect.stringContaining('#d8eef4'),
+      '--diffshub-annotation-border': expect.stringContaining('#d8eef4'),
+      '--diffshub-annotation-fg': '#d8eef4',
+      '--diffshub-popover-bg': expect.stringContaining('#d8eef4'),
+      '--diffshub-popover-border': expect.stringContaining('#d8eef4'),
+      '--diffshub-popover-hover-bg': expect.stringContaining('#d8eef4'),
+      // Segmented-control track sits a step above the popover surface so it
+      // reads as a connected control rather than vanishing into the menu.
+      '--color-secondary': expect.stringContaining('#d8eef4'),
+      // Inter-file separator reuses the themed border-opaque value so it
+      // matches the surrounding chrome borders' weight on every theme.
+      '--diffshub-diff-separator': expect.stringContaining('#20313a'),
+    });
+
+    // On a shared editor/sidebar surface the file separator reuses the
+    // chrome border verbatim, so the two lines carry identical weight.
+    expect(separator).toBe(borderOpaque);
+
+    // The popover/annotation shadow is a real, surface-independent drop
+    // shadow (occlusion-black, visible on light themes too) and does NOT
+    // bake in a `0 0 0 1px` ring — every consumer already paints its own
+    // 1px border, so a ring would double it into a too-thick edge.
+    for (const shadow of [popoverShadow, annotationShadow]) {
+      expect(shadow).toContain('rgb(0 0 0');
+      expect(shadow).not.toContain('0 0 0 1px');
+    }
+  });
+
+  test('scopes inline comment theming without changing code-view chrome tokens', () => {
+    const themeChromeStyle = {
+      backgroundColor: '#101010',
+      color: '#f8fafc',
+      '--background': '#101010',
+      '--color-background': '#101010',
+      '--color-border': 'color-mix(in srgb, #f8fafc 20%, transparent)',
+      '--color-border-opaque': 'color-mix(in srgb, #f8fafc 15%, #101010)',
+      '--diffshub-annotation-bg': 'color-mix(in srgb, #f8fafc 7%, #101010)',
+      '--diffshub-annotation-border':
+        'color-mix(in srgb, #f8fafc 18%, #101010)',
+      '--diffshub-annotation-fg': '#f8fafc',
+      '--diffshub-annotation-hover-border':
+        'color-mix(in srgb, #f8fafc 28%, #101010)',
+      '--diffshub-annotation-shadow':
+        '0 18px 44px color-mix(in srgb, #101010 72%, transparent)',
+      '--diffshub-popover-muted-fg': '#cbd5e1',
+    } as CSSProperties & Record<string, string>;
+    const annotationStyle = buildAnnotationThemeStyle(themeChromeStyle);
+
+    expect(annotationStyle).toMatchObject({
+      '--diffshub-annotation-bg': 'color-mix(in srgb, #f8fafc 7%, #101010)',
+      '--diffshub-annotation-border':
+        'color-mix(in srgb, #f8fafc 18%, #101010)',
+      '--diffshub-annotation-fg': '#f8fafc',
+      '--diffshub-annotation-hover-border':
+        'color-mix(in srgb, #f8fafc 28%, #101010)',
+      '--diffshub-annotation-shadow':
+        '0 18px 44px color-mix(in srgb, #101010 72%, transparent)',
+      '--diffshub-popover-muted-fg': '#cbd5e1',
+    });
+    expect(annotationStyle).not.toHaveProperty('backgroundColor');
+    expect(annotationStyle).not.toHaveProperty('color');
+    expect(annotationStyle).not.toHaveProperty('--background');
+    expect(annotationStyle).not.toHaveProperty('--color-background');
+    expect(annotationStyle).not.toHaveProperty('--color-border');
+    expect(annotationStyle).not.toHaveProperty('--color-border-opaque');
+  });
+});

--- a/packages/trees/src/utils/themeToTreeStyles.ts
+++ b/packages/trees/src/utils/themeToTreeStyles.ts
@@ -79,6 +79,55 @@ function opaqueOrUndefined(color: string | undefined): string | undefined {
   return isFullyTransparent(color) ? undefined : color;
 }
 
+// Parses an opaque hex color (#rgb / #rrggbb / #rrggbbff) into 0..1 sRGB
+// components, ignoring the alpha byte when present. Returns undefined for
+// other color formats — callers should treat that as "unknown" and skip
+// any luminance-based heuristics rather than guessing.
+function parseHexRgb(color: string): [number, number, number] | undefined {
+  const m = /^#([0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i.exec(color.trim());
+  if (m == null) return undefined;
+  const hex = m[1];
+  const expand = (s: string) => parseInt(s.length === 1 ? s + s : s, 16) / 255;
+  if (hex.length === 3) {
+    return [expand(hex[0]), expand(hex[1]), expand(hex[2])];
+  }
+  return [
+    expand(hex.slice(0, 2)),
+    expand(hex.slice(2, 4)),
+    expand(hex.slice(4, 6)),
+  ];
+}
+
+// WCAG relative luminance: sRGB channel → linear → weighted sum. Used
+// only to compare two colors' lightness, not for absolute contrast
+// scoring, so the exact gamma curve is fine to keep inline.
+function relativeLuminance(rgb: [number, number, number]): number {
+  const linear = rgb.map((channel) =>
+    channel <= 0.03928 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4
+  );
+  return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2];
+}
+
+// True when `hover` is closer in luminance to `fg` than to `bg` — i.e.,
+// the hover surface would land on top of the row text rather than next
+// to it, erasing legibility. Returns false when any color can't be
+// parsed (unknown format → trust the theme designer's intent).
+function hoverWouldEraseText(
+  hover: string,
+  bg: string | undefined,
+  fg: string | undefined
+): boolean {
+  if (bg == null || fg == null) return false;
+  const hoverRgb = parseHexRgb(hover);
+  const bgRgb = parseHexRgb(bg);
+  const fgRgb = parseHexRgb(fg);
+  if (hoverRgb == null || bgRgb == null || fgRgb == null) return false;
+  const hoverL = relativeLuminance(hoverRgb);
+  const bgL = relativeLuminance(bgRgb);
+  const fgL = relativeLuminance(fgRgb);
+  return Math.abs(hoverL - fgL) < Math.abs(hoverL - bgL);
+}
+
 export function themeToTreeStyles(theme: TreeThemeInput): TreeThemeStyles {
   const c = theme.colors ?? {};
   const sideBarBg =
@@ -91,11 +140,19 @@ export function themeToTreeStyles(theme: TreeThemeInput): TreeThemeStyles {
 
   // Some themes (e.g. Material) set hover/selection bg to the same color as
   // the sidebar bg, making the state invisible. Detect this and fall through
-  // so the computed defaults provide visible feedback.
+  // so the computed defaults provide visible feedback. Additionally, some
+  // themes (e.g. slack-ochin) define list.hoverBackground for an editor
+  // surface whose palette is opposite the sidebar's — a near-white hover on
+  // a dark navy sidebar with light text. Reject those too so the hovered
+  // row's text doesn't disappear.
   const bgLower = sideBarBg?.toLowerCase();
   const rawHoverBg = c['list.hoverBackground'];
-  const listHoverBg =
-    rawHoverBg?.toLowerCase() === bgLower ? undefined : rawHoverBg;
+  let listHoverBg: string | undefined;
+  if (rawHoverBg != null && rawHoverBg.toLowerCase() !== bgLower) {
+    listHoverBg = hoverWouldEraseText(rawHoverBg, sideBarBg, sideBarFg)
+      ? undefined
+      : rawHoverBg;
+  }
   const rawSelectionBg = c['list.activeSelectionBackground'];
   const listSelectionBg =
     rawSelectionBg?.toLowerCase() === bgLower
@@ -127,6 +184,13 @@ export function themeToTreeStyles(theme: TreeThemeInput): TreeThemeStyles {
     c['editorGutter.deletedBackground'];
 
   const isDark = theme.type === 'dark';
+  // Pick the hover fallback based on the actual sidebar surface
+  // luminance, not theme.type — themes like slack-ochin are tagged
+  // `light` for the editor but ship a dark sidebar; a 6%-black overlay
+  // on dark navy is nearly invisible.
+  const sideBarBgRgb = sideBarBg != null ? parseHexRgb(sideBarBg) : undefined;
+  const sideBarIsDark =
+    sideBarBgRgb != null ? relativeLuminance(sideBarBgRgb) < 0.5 : isDark;
   const result: TreeThemeStyles = {
     colorScheme: isDark ? 'dark' : 'light',
     backgroundColor: sideBarBg ?? '',
@@ -139,7 +203,8 @@ export function themeToTreeStyles(theme: TreeThemeInput): TreeThemeStyles {
     '--trees-theme-list-active-selection-fg':
       listActiveSelectionFg ?? sideBarFg ?? '',
     '--trees-theme-list-hover-bg':
-      listHoverBg ?? (isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)'),
+      listHoverBg ??
+      (sideBarIsDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)'),
     '--trees-theme-list-active-selection-bg': listSelectionBg ?? 'transparent',
     '--trees-theme-focus-ring': focusRing ?? sideBarFg ?? '',
     '--trees-theme-input-bg': inputBg ?? '',

--- a/packages/trees/test/theme-to-tree-styles.test.ts
+++ b/packages/trees/test/theme-to-tree-styles.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'bun:test';
+
+import { themeToTreeStyles } from '../src/utils/themeToTreeStyles';
+
+const HOVER_KEY = '--trees-theme-list-hover-bg';
+
+describe('themeToTreeStyles list.hoverBackground heuristic', () => {
+  test('drops a near-foreground hover bg that would erase row text', () => {
+    // slack-ochin's actual values: list.hoverBackground is designed for
+    // the (white) editor surface, but the sidebar has a dark navy bg
+    // with light gray text. The hover ends up the same luminance as the
+    // text and would make hovered rows unreadable.
+    const styles = themeToTreeStyles({
+      type: 'light',
+      colors: {
+        'sideBar.background': '#2D3E4C',
+        'sideBar.foreground': '#DCDEDF',
+        'list.hoverBackground': '#d5e1ea',
+      },
+    });
+    // Falls back to the computed default. The fallback picks the dark
+    // variant because sideBar.background is dark, even though slack-ochin
+    // declares type: 'light' for its editor palette.
+    expect(styles[HOVER_KEY]).toBe('rgba(255,255,255,0.08)');
+  });
+
+  test('keeps a hover bg that sits between surface and text', () => {
+    // Typical case: hover is a small offset from sideBar.background and
+    // far from sideBar.foreground — should pass through unchanged.
+    const styles = themeToTreeStyles({
+      type: 'light',
+      colors: {
+        'sideBar.background': '#ffffff',
+        'sideBar.foreground': '#333333',
+        'list.hoverBackground': '#e8e8e8',
+      },
+    });
+    expect(styles[HOVER_KEY]).toBe('#e8e8e8');
+  });
+
+  test('picks the dark hover fallback when the sidebar bg is dark but theme.type is light', () => {
+    // slack-ochin pattern condensed: theme.type='light' but
+    // sideBar.background is dark navy. The fallback must read sidebar
+    // luminance instead of theme.type or a black-on-dark overlay
+    // becomes invisible.
+    const styles = themeToTreeStyles({
+      type: 'light',
+      colors: {
+        'sideBar.background': '#2D3E4C',
+        'sideBar.foreground': '#DCDEDF',
+      },
+    });
+    expect(styles[HOVER_KEY]).toBe('rgba(255,255,255,0.08)');
+  });
+
+  test('still drops hover bg that equals the surface', () => {
+    const styles = themeToTreeStyles({
+      type: 'dark',
+      colors: {
+        'sideBar.background': '#1e1e1e',
+        'sideBar.foreground': '#cccccc',
+        'list.hoverBackground': '#1E1E1E',
+      },
+    });
+    expect(styles[HOVER_KEY]).toBe('rgba(255,255,255,0.08)');
+  });
+
+  test('preserves non-hex hover bg (unknown format — trust the theme)', () => {
+    // The luminance check only runs on parseable hex; rgba/transparent/
+    // named colors pass through so we don't accidentally reject themes
+    // that use modern color syntax.
+    const styles = themeToTreeStyles({
+      type: 'dark',
+      colors: {
+        'sideBar.background': '#1e1e1e',
+        'sideBar.foreground': '#cccccc',
+        'list.hoverBackground': 'rgba(255, 255, 255, 0.1)',
+      },
+    });
+    expect(styles[HOVER_KEY]).toBe('rgba(255, 255, 255, 0.1)');
+  });
+});


### PR DESCRIPTION
Clean history version of #731

## Summary

Adds a theme switcher to the diffshub code view so reviewers can render diffs
and the surrounding chrome in any Shiki theme, independent of the app's
global light/dark palette.

- **Theme picker** in the header (next to the gear): a light-theme list, a
  dark-theme list, and an Auto/Light/Dark color-mode toggle, all in one
  in-place dropdown that fits narrow viewports. Picks persist across reloads.
- **Themed chrome**: the sidebar, file tree, header, comment cards, and inline
  annotations all source their colors from the resolved Shiki theme. Foreground
  and muted-foreground are chosen by contrast against the resolved surface
  (not the theme's declared values) so text stays legible on mixed-palette
  themes (e.g. slack-ochin, ayu-dark).
- **System Monitor theme-cycle button** sweeps through every theme for quick
  previewing.
- Diff and chrome repaints are kept in the same frame on a theme swap, gated on
  theme hydration so client-side navigation doesn't tokenize against the
  default palette.
- **[trees]** `themeToTreeStyles` now rejects a theme's `list.hoverBackground`
  when its luminance would erase the hovered row's text, and derives the rgba
  hover fallback from the sidebar's actual luminance rather than the declared
  theme type.

## Commits

Organized into 7 focused commits (foundations first, then UI):

1. `[trees]` Reject `list.hoverBackground` when it would erase row text
2. `[diffshub]` Add a localStorage-backed persisted state hook
3. `[diffshub]` Add the Shiki theme catalog
4. `[diffshub]` Resolve Shiki themes into themed chrome tokens
5. `[diffshub]` Add a theme switcher to the code view header
6. `[diffshub]` Apply the resolved theme across the chrome
7. `[diffshub]` Add a theme-cycle button to the System Monitor

## Test plan

- [x] Pick light/dark themes from the header; confirm diff + chrome update together
- [x] Reload and confirm picks persist; navigate away and back, confirm no
      wrong-palette flash
- [x] Try mixed-palette themes (slack-ochin, ayu-dark) and confirm sidebar
      labels / comment labels stay legible
- [x] Run the System Monitor theme-cycle button, scroll quickly up and down to ensure theme is correctly applied to collapsed and open files