### PR TITLE
[diffs] Improve `onPostRender` API

### DIFF
--- a/apps/docs/app/(diffs)/_docs/DocsPage.tsx
+++ b/apps/docs/app/(diffs)/_docs/DocsPage.tsx
@@ -21,6 +21,7 @@ import {
   FILE_DIFF_METADATA_TYPE,
   PARSE_DIFF_FROM_FILE_EXAMPLE,
   PARSE_PATCH_FILES_EXAMPLE,
+  POST_RENDER_PHASE_TYPE,
 } from '../docs/CoreTypes/constants';
 import {
   CUSTOM_HUNK_SEPARATORS_EXAMPLE,
@@ -43,6 +44,7 @@ import {
   REACT_API_FILE_DIFF,
   REACT_API_MULTI_FILE_DIFF,
   REACT_API_PATCH_DIFF,
+  REACT_API_POST_RENDER_LIFECYCLE,
   REACT_API_SHARED_DIFF_OPTIONS,
   REACT_API_SHARED_DIFF_RENDER_PROPS,
   REACT_API_SHARED_FILE_OPTIONS,
@@ -92,6 +94,7 @@ import {
   VANILLA_API_FILE_RENDERER,
   VANILLA_API_HUNKS_RENDERER_FILE,
   VANILLA_API_HUNKS_RENDERER_PATCH_FILE,
+  VANILLA_API_POST_RENDER_LIFECYCLE,
   VANILLA_API_UNRESOLVED_FILE_EXAMPLE,
 } from '../docs/VanillaAPI/constants';
 import {
@@ -210,11 +213,13 @@ async function CoreTypesSection() {
   const [
     fileContentsType,
     fileDiffMetadataType,
+    postRenderPhaseType,
     parseDiffFromFileExample,
     parsePatchFilesExample,
   ] = await Promise.all([
     preloadFile(FILE_CONTENTS_TYPE),
     preloadFile(FILE_DIFF_METADATA_TYPE),
+    preloadFile(POST_RENDER_PHASE_TYPE),
     preloadFile(PARSE_DIFF_FROM_FILE_EXAMPLE),
     preloadFile(PARSE_PATCH_FILES_EXAMPLE),
   ]);
@@ -223,6 +228,7 @@ async function CoreTypesSection() {
     scope: {
       fileContentsType,
       fileDiffMetadataType,
+      postRenderPhaseType,
       parseDiffFromFileExample,
       parsePatchFilesExample,
     },
@@ -265,6 +271,7 @@ async function ReactAPISection() {
     reactAPIPatch,
     reactAPIFileDiff,
     reactAPIUnresolvedFile,
+    postRenderLifecycleExample,
     sharedDiffOptions,
     sharedDiffRenderProps,
     sharedFileOptions,
@@ -276,6 +283,7 @@ async function ReactAPISection() {
     preloadFile(REACT_API_PATCH_DIFF),
     preloadFile(REACT_API_FILE_DIFF),
     preloadFile(REACT_API_UNRESOLVED_FILE),
+    preloadFile(REACT_API_POST_RENDER_LIFECYCLE),
     preloadFile(REACT_API_SHARED_DIFF_OPTIONS),
     preloadFile(REACT_API_SHARED_DIFF_RENDER_PROPS),
     preloadFile(REACT_API_SHARED_FILE_OPTIONS),
@@ -290,6 +298,7 @@ async function ReactAPISection() {
       reactAPIFileDiff,
       reactAPIFile,
       reactAPIUnresolvedFile,
+      postRenderLifecycleExample,
       sharedDiffOptions,
       sharedDiffRenderProps,
       sharedFileOptions,
@@ -307,6 +316,7 @@ async function VanillaAPISection() {
     fileDiffProps,
     fileProps,
     unresolvedFileExample,
+    postRenderLifecycleExample,
     customHunk,
     diffHunksRenderer,
     diffHunksRendererPatch,
@@ -318,6 +328,7 @@ async function VanillaAPISection() {
     preloadFile(VANILLA_API_FILE_DIFF_PROPS),
     preloadFile(VANILLA_API_FILE_PROPS),
     preloadFile(VANILLA_API_UNRESOLVED_FILE_EXAMPLE),
+    preloadFile(VANILLA_API_POST_RENDER_LIFECYCLE),
     preloadFile(VANILLA_API_CUSTOM_HUNK_FILE),
     preloadFile(VANILLA_API_HUNKS_RENDERER_FILE),
     preloadFile(VANILLA_API_HUNKS_RENDERER_PATCH_FILE),
@@ -332,6 +343,7 @@ async function VanillaAPISection() {
       fileDiffProps,
       fileProps,
       unresolvedFileExample,
+      postRenderLifecycleExample,
       customHunk,
       diffHunksRenderer,
       diffHunksRendererPatch,

--- a/apps/docs/app/(diffs)/docs/CodeView/content.mdx
+++ b/apps/docs/app/(diffs)/docs/CodeView/content.mdx
@@ -113,6 +113,9 @@ items or update existing ones.
   viewer, and `getItem` / `updateItem` for item-level imperative changes.
 - Shared callbacks receive the normal file/diff payload plus a `context`
   argument containing the current viewer item and instance.
+- `onPostRender` receives `(node, instance, phase, context)`. Its `unmount`
+  phase will fire when an item scrolls out of the rendered window and CodeView
+  recycles that item's DOM shell.
 - By default, `CodeView` temporarily disables pointer events on rendered content
   while scrolling for smoother scroll performance. Set
   `pointerEventsOnScroll: true` only when pointer interactions must remain

--- a/apps/docs/app/(diffs)/docs/CoreTypes/constants.ts
+++ b/apps/docs/app/(diffs)/docs/CoreTypes/constants.ts
@@ -138,6 +138,20 @@ interface ChangeContent {
   options,
 };
 
+export const POST_RENDER_PHASE_TYPE: PreloadFileOptions<undefined> = {
+  file: {
+    name: 'PostRenderPhase.ts',
+    contents: `// Exported from @pierre/diffs.
+// Lifecycle phase passed as the third argument to onPostRender.
+type PostRenderPhase = 'mount' | 'update' | 'unmount';
+
+// mount: first committed render or hydration for a container node
+// update: later committed render for the same mounted container node
+// unmount: before a mounted container node is removed, replaced, or recycled`,
+  },
+  options,
+};
+
 export const PARSE_DIFF_FROM_FILE_EXAMPLE: PreloadFileOptions<undefined> = {
   file: {
     name: 'parseDiffFromFile.ts',

--- a/apps/docs/app/(diffs)/docs/CoreTypes/content.mdx
+++ b/apps/docs/app/(diffs)/docs/CoreTypes/content.mdx
@@ -23,6 +23,13 @@ expansion.
 
 <DocsCodeExample {...fileDiffMetadataType} />
 
+### PostRenderPhase
+
+`PostRenderPhase` is passed to `onPostRender` callbacks so integrations can
+separate setup, update, and teardown work for the rendered DOM node.
+
+<DocsCodeExample {...postRenderPhaseType} />
+
 ### Creating Diffs
 
 There are two ways to create a `FileDiffMetadata`.

--- a/apps/docs/app/(diffs)/docs/ReactAPI/constants.ts
+++ b/apps/docs/app/(diffs)/docs/ReactAPI/constants.ts
@@ -8,6 +8,37 @@ const options = {
   unsafeCSS: CustomScrollbarCSS,
 } as const;
 
+export const REACT_API_POST_RENDER_LIFECYCLE: PreloadFileOptions<undefined> = {
+  file: {
+    name: 'post_render_lifecycle.tsx',
+    contents: `import { FileDiff } from '@pierre/diffs/react';
+
+const cleanupByNode = new WeakMap<HTMLElement, () => void>();
+
+<FileDiff
+  fileDiff={fileDiff}
+  options={{
+    onPostRender(node, _instance, phase) {
+      if (phase === 'mount') {
+        const observer = new ResizeObserver(() => {
+          console.log(node.getBoundingClientRect().height);
+        });
+        observer.observe(node);
+        cleanupByNode.set(node, () => observer.disconnect());
+        return;
+      }
+
+      if (phase === 'unmount') {
+        cleanupByNode.get(node)?.();
+        cleanupByNode.delete(node);
+      }
+    },
+  }}
+/>`,
+  },
+  options,
+};
+
 export const REACT_API_SHARED_DIFF_OPTIONS: PreloadFileOptions<undefined> = {
   file: {
     name: 'shared_diff_options.tsx',
@@ -20,6 +51,7 @@ export const REACT_API_SHARED_DIFF_OPTIONS: PreloadFileOptions<undefined> = {
 import type {
   DiffTokenEventBaseProps,
   FileDiff as FileDiffClass,
+  PostRenderPhase,
 } from '@pierre/diffs';
 import { MultiFileDiff } from '@pierre/diffs/react';
 
@@ -139,12 +171,20 @@ interface DiffOptions {
   // Skip syntax highlighting for lines exceeding this length
   tokenizeMaxLineLength: 1000,
 
-  // Fires after hydration, and after render passes that commit DOM updates.
-  // Those DOM updates may be a full replacement or a partial update.
+  // Fires after hydration, after DOM-committing render updates, and before
+  // mounted DOM is removed. Phase is 'mount' | 'update' | 'unmount'.
   // Receives the outer diffs container element.
-  // Useful when you want to do your own post-render DOM manipulation.
+  // Useful when you want to measure, observe, or clean up DOM-node state.
   // You can access the shadow DOM from here if you need to inspect lines.
-  onPostRender(node: HTMLElement, instance: FileDiffClass) {
+  onPostRender(
+    node: HTMLElement,
+    instance: FileDiffClass,
+    phase: PostRenderPhase
+  ) {
+    if (phase === 'unmount') {
+      return;
+    }
+
     const codeLines = node.shadowRoot?.querySelectorAll('[data-line]');
     console.log('rendered line count', codeLines?.length ?? 0);
   },
@@ -568,7 +608,10 @@ export function CodeFile() {
 export const REACT_API_UNRESOLVED_FILE: PreloadFileOptions<undefined> = {
   file: {
     name: 'unresolved_file.tsx',
-    contents: `import type { UnresolvedFile as UnresolvedFileClass } from '@pierre/diffs';
+    contents: `import type {
+  PostRenderPhase,
+  UnresolvedFile as UnresolvedFileClass,
+} from '@pierre/diffs';
 import { UnresolvedFile, type FileContents } from '@pierre/diffs/react';
 import { useState } from 'react';
 
@@ -601,7 +644,15 @@ export function MergeConflictPreview() {
         options={{
           theme: { dark: 'pierre-dark', light: 'pierre-light' },
           diffIndicators: 'none',
-          onPostRender(node: HTMLElement, instance: UnresolvedFileClass) {
+          onPostRender(
+            node: HTMLElement,
+            instance: UnresolvedFileClass,
+            phase: PostRenderPhase
+          ) {
+            if (phase === 'unmount') {
+              return;
+            }
+
             const codeLines = node.shadowRoot?.querySelectorAll(
               '[data-line]'
             );
@@ -687,7 +738,11 @@ export const REACT_API_SHARED_FILE_OPTIONS: PreloadFileOptions<undefined> = {
 // ============================================================
 // Pass these via the \`options\` prop on the File component.
 
-import type { File as FileClass, TokenEventBase } from '@pierre/diffs';
+import type {
+  File as FileClass,
+  PostRenderPhase,
+  TokenEventBase,
+} from '@pierre/diffs';
 import { File } from '@pierre/diffs/react';
 
 <File
@@ -740,12 +795,20 @@ interface FileOptions {
   // Skip syntax highlighting for lines exceeding this length
   tokenizeMaxLineLength: 1000,
 
-  // Fires after hydration, and after render passes that commit DOM updates.
-  // Those DOM updates may be a full replacement or a partial update.
+  // Fires after hydration, after DOM-committing render updates, and before
+  // mounted DOM is removed. Phase is 'mount' | 'update' | 'unmount'.
   // Receives the outer diffs container element.
-  // Useful when you want to do your own post-render DOM manipulation.
+  // Useful when you want to measure, observe, or clean up DOM-node state.
   // You can access the shadow DOM from here if you need to inspect lines.
-  onPostRender(node: HTMLElement, instance: FileClass) {
+  onPostRender(
+    node: HTMLElement,
+    instance: FileClass,
+    phase: PostRenderPhase
+  ) {
+    if (phase === 'unmount') {
+      return;
+    }
+
     const codeLines = node.shadowRoot?.querySelectorAll('[data-line]');
     console.log('rendered line count', codeLines?.length ?? 0);
   },

--- a/apps/docs/app/(diffs)/docs/ReactAPI/content.mdx
+++ b/apps/docs/app/(diffs)/docs/ReactAPI/content.mdx
@@ -64,6 +64,21 @@ Header customization and collapsing behavior:
 - Use `options.collapsed` to hide file body content while keeping the file
   header visible.
 
+#### Post Render Lifecycle
+
+`options.onPostRender(node, instance, phase)` is a DOM-node lifecycle callback.
+It fires with `phase: 'mount'` after the first committed render or hydration for
+a container node, `phase: 'update'` after later DOM-committing renders, and
+`phase: 'unmount'` before a mounted container node is removed, replaced, cleaned
+up, or recycled.
+
+Use this callback for DOM-node-associated work such as observers, measurements,
+or imperative integrations. Treat `unmount` as node-centric: if you need
+teardown state, capture it by `node` when the node mounts instead of depending
+on mutable instance fields.
+
+<DocsCodeExample {...postRenderLifecycleExample} />
+
 <SharedPropTabs
   sharedDiffOptions={sharedDiffOptions}
   sharedDiffRenderProps={sharedDiffRenderProps}

--- a/apps/docs/app/(diffs)/docs/SSR/content.mdx
+++ b/apps/docs/app/(diffs)/docs/SSR/content.mdx
@@ -8,10 +8,12 @@ The SSR API allows you to pre-render file diffs on the server with syntax
 highlighting, then hydrate them on the client for full interactivity.
 
 If you pass `prerenderedHTML`, `onPostRender` still fires on the client after
-hydration. On later renders, it also fires after DOM-committing updates, whether
-those updates are a full replacement or a partial update. This is useful for
-measuring, observing, or otherwise manipulating the mounted diff container or
-content of the diffs itself.
+hydration with `phase: 'mount'`. On later renders, it also fires after
+DOM-committing updates with `phase: 'update'`, whether those updates are a full
+replacement or a partial update. Before a mounted container is removed,
+replaced, or recycled, it fires with `phase: 'unmount'`. This is useful for
+measuring, observing, cleaning up, or otherwise manipulating the mounted diff
+container or content of the diffs itself.
 
 ### Usage
 

--- a/apps/docs/app/(diffs)/docs/VanillaAPI/constants.ts
+++ b/apps/docs/app/(diffs)/docs/VanillaAPI/constants.ts
@@ -8,6 +8,35 @@ const options = {
   unsafeCSS: CustomScrollbarCSS,
 } as const;
 
+export const VANILLA_API_POST_RENDER_LIFECYCLE: PreloadFileOptions<undefined> =
+  {
+    file: {
+      name: 'post_render_lifecycle.ts',
+      contents: `import { FileDiff } from '@pierre/diffs';
+
+const cleanupByNode = new WeakMap<HTMLElement, () => void>();
+
+const instance = new FileDiff({
+  onPostRender(node, _instance, phase) {
+    if (phase === 'mount') {
+      const observer = new ResizeObserver(() => {
+        console.log(node.getBoundingClientRect().height);
+      });
+      observer.observe(node);
+      cleanupByNode.set(node, () => observer.disconnect());
+      return;
+    }
+
+    if (phase === 'unmount') {
+      cleanupByNode.get(node)?.();
+      cleanupByNode.delete(node);
+    }
+  },
+});`,
+    },
+    options,
+  };
+
 // =============================================================================
 // COMPONENT EXAMPLES (short, focused on usage)
 // =============================================================================
@@ -331,12 +360,16 @@ const instance = new FileDiff({
   // Skip syntax highlighting for lines exceeding this length
   tokenizeMaxLineLength: 1000,
 
-  // Fires after hydration, and after render passes that commit DOM updates.
-  // Those DOM updates may be a full replacement or a partial update.
+  // Fires after hydration, after DOM-committing render updates, and before
+  // mounted DOM is removed. Phase is 'mount' | 'update' | 'unmount'.
   // Receives the outer diffs container element.
-  // Useful when you want to do your own post-render DOM manipulation.
+  // Useful when you want to measure, observe, or clean up DOM-node state.
   // You can access the shadow DOM from here if you need to inspect lines.
-  onPostRender(node, fileDiffInstance) {
+  onPostRender(node, fileDiffInstance, phase) {
+    if (phase === 'unmount') {
+      return;
+    }
+
     const codeLines = node.shadowRoot?.querySelectorAll('[data-line]');
     console.log('rendered line count', codeLines?.length ?? 0);
   },
@@ -583,12 +616,16 @@ const instance = new File({
   // Skip syntax highlighting for lines exceeding this length
   tokenizeMaxLineLength: 1000,
 
-  // Fires after hydration, and after render passes that commit DOM updates.
-  // Those DOM updates may be a full replacement or a partial update.
+  // Fires after hydration, after DOM-committing render updates, and before
+  // mounted DOM is removed. Phase is 'mount' | 'update' | 'unmount'.
   // Receives the outer diffs container element.
-  // Useful when you want to do your own post-render DOM manipulation.
+  // Useful when you want to measure, observe, or clean up DOM-node state.
   // You can access the shadow DOM from here if you need to inspect lines.
-  onPostRender(node, fileInstance) {
+  onPostRender(node, fileInstance, phase) {
+    if (phase === 'unmount') {
+      return;
+    }
+
     const codeLines = node.shadowRoot?.querySelectorAll('[data-line]');
     console.log('rendered line count', codeLines?.length ?? 0);
   },

--- a/apps/docs/app/(diffs)/docs/VanillaAPI/content.mdx
+++ b/apps/docs/app/(diffs)/docs/VanillaAPI/content.mdx
@@ -58,6 +58,21 @@ Header customization and collapsing behavior:
 - Use `collapsed` in constructor options to hide file body content while keeping
   the file header visible.
 
+#### Post Render Lifecycle
+
+`onPostRender(node, instance, phase)` is a DOM-node lifecycle callback. It fires
+with `phase: 'mount'` after the first committed render or hydration for a
+container node, `phase: 'update'` after later DOM-committing renders, and
+`phase: 'unmount'` before a mounted container node is removed, replaced, cleaned
+up, or recycled.
+
+Use this callback for DOM-node-associated work such as observers, measurements,
+or imperative integrations. Treat `unmount` as node-centric: if you need
+teardown state, capture it by `node` when the node mounts instead of depending
+on mutable instance fields.
+
+<DocsCodeExample {...postRenderLifecycleExample} />
+
 <VanillaPropTabs fileDiffProps={fileDiffProps} fileProps={fileProps} />
 
 Token callbacks (`onTokenClick`, `onTokenEnter`, `onTokenLeave`) and

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -287,6 +287,7 @@ export class File<LAnnotation = undefined> {
   }
 
   public cleanUp(recycle = false): void {
+    this.emitPostRender(true);
     this.resizeManager.cleanUp();
     this.interactionManager.cleanUp();
     this.managersDirty = false;
@@ -371,6 +372,9 @@ export class File<LAnnotation = undefined> {
     fileContainer: HTMLElement,
     prerenderedHTML: string | undefined
   ): void {
+    if (this.fileContainer !== fileContainer) {
+      this.emitPostRender(true);
+    }
     prerenderHTMLIfNecessary(fileContainer, prerenderedHTML);
     for (const element of Array.from(
       fileContainer.shadowRoot?.children ?? []
@@ -411,9 +415,6 @@ export class File<LAnnotation = undefined> {
     if (this.pre != null) {
       this.syncCodeNodeFromPre(this.pre);
       this.pre.removeAttribute('data-dehydrated');
-    }
-    if (this.fileContainer !== fileContainer) {
-      this.mounted = false;
     }
     this.fileContainer = fileContainer;
     this.hydrateMeasuredScrollbar();
@@ -600,11 +601,24 @@ export class File<LAnnotation = undefined> {
     return true;
   }
 
-  private emitPostRender() {
+  private emitPostRender(unmount = false) {
     const {
       fileContainer,
       options: { onPostRender },
     } = this;
+
+    if (unmount) {
+      if (!this.mounted) {
+        return;
+      }
+      this.mounted = false;
+      if (fileContainer == null) {
+        return;
+      }
+      onPostRender?.(fileContainer, this, 'unmount');
+      return;
+    }
+
     if (fileContainer == null) {
       return;
     }
@@ -658,6 +672,7 @@ export class File<LAnnotation = undefined> {
     if (this.fileContainer == null) {
       return false;
     }
+    this.emitPostRender(true);
     this.cleanChildNodes();
 
     if (this.placeHolder == null) {

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -27,6 +27,7 @@ import type {
   BaseCodeOptions,
   FileContents,
   LineAnnotation,
+  PostRenderPhase,
   PrePropertiesConfig,
   RenderFileMetadata,
   RenderRange,
@@ -98,7 +99,11 @@ export interface FileOptions<LAnnotation>
     getHoveredRow: () => GetHoveredLineResult<'file'> | undefined
   ): HTMLElement | null | undefined;
 
-  onPostRender?(node: HTMLElement, instance: File<LAnnotation>): unknown;
+  onPostRender?(
+    node: HTMLElement,
+    instance: File<LAnnotation>,
+    phase: PostRenderPhase
+  ): unknown;
 }
 
 interface AnnotationElementCache<LAnnotation> {
@@ -122,6 +127,7 @@ export class File<LAnnotation = undefined> {
   static LoadedCustomComponent: boolean = DiffsContainerLoaded;
 
   readonly __id: string = `file:${++instanceId}`;
+  readonly type = 'file';
 
   protected fileContainer: HTMLElement | undefined;
   protected spriteSVG: SVGElement | undefined;
@@ -141,6 +147,7 @@ export class File<LAnnotation = undefined> {
   protected cachedHeaderHTML: string | undefined;
   protected appliedPreAttributes: PrePropertiesConfig | undefined;
   protected lastRowCount: number | undefined;
+  private mounted = false;
 
   protected headerElement: HTMLElement | undefined;
   protected headerCustom: HTMLElement | undefined;
@@ -156,7 +163,7 @@ export class File<LAnnotation = undefined> {
   protected lineAnnotations: LineAnnotation<LAnnotation>[] = [];
   protected managersDirty = false;
 
-  protected file: FileContents | undefined;
+  public file: FileContents | undefined;
   protected renderRange: RenderRange | undefined;
   protected enabled = true;
 
@@ -291,6 +298,7 @@ export class File<LAnnotation = undefined> {
       this.fileContainer?.remove();
     }
     this.fileContainer = undefined;
+    this.mounted = false;
     this.lineAnnotations = [];
     this.annotationCache.clear();
     this.pre = undefined;
@@ -403,6 +411,9 @@ export class File<LAnnotation = undefined> {
     if (this.pre != null) {
       this.syncCodeNodeFromPre(this.pre);
       this.pre.removeAttribute('data-dehydrated');
+    }
+    if (this.fileContainer !== fileContainer) {
+      this.mounted = false;
     }
     this.fileContainer = fileContainer;
     this.hydrateMeasuredScrollbar();
@@ -590,9 +601,17 @@ export class File<LAnnotation = undefined> {
   }
 
   private emitPostRender() {
-    if (this.fileContainer != null) {
-      this.options.onPostRender?.(this.fileContainer, this);
+    const {
+      fileContainer,
+      options: { onPostRender },
+    } = this;
+    if (fileContainer == null) {
+      return;
     }
+
+    const phase: PostRenderPhase = this.mounted ? 'update' : 'mount';
+    this.mounted = true;
+    onPostRender?.(fileContainer, this, phase);
   }
 
   private removeRenderedCode(): void {
@@ -710,6 +729,8 @@ export class File<LAnnotation = undefined> {
 
     this.lastRenderedHeaderHTML = undefined;
     this.lastRowCount = undefined;
+
+    this.mounted = false;
   }
 
   private renderAnnotations(): void {
@@ -1256,6 +1277,9 @@ export class File<LAnnotation = undefined> {
       this.fileContainer ??
       document.createElement(DIFFS_TAG_NAME);
     const containerChanged = previousContainer !== this.fileContainer;
+    if (containerChanged) {
+      this.mounted = false;
+    }
     if (previousContainer != null && containerChanged) {
       this.lastRenderedHeaderHTML = undefined;
       this.headerElement = undefined;

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -1286,15 +1286,16 @@ export class File<LAnnotation = undefined> {
     fileContainer?: HTMLElement,
     parentNode?: HTMLElement
   ): HTMLElement {
-    const previousContainer = this.fileContainer;
-    this.fileContainer =
+    const { fileContainer: previousContainer } = this;
+    const nextContainer =
       fileContainer ??
-      this.fileContainer ??
+      previousContainer ??
       document.createElement(DIFFS_TAG_NAME);
-    const containerChanged = previousContainer !== this.fileContainer;
+    const containerChanged = previousContainer !== nextContainer;
     if (containerChanged) {
-      this.mounted = false;
+      this.emitPostRender(true);
     }
+    this.fileContainer = nextContainer;
     if (previousContainer != null && containerChanged) {
       this.lastRenderedHeaderHTML = undefined;
       this.headerElement = undefined;

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -478,6 +478,7 @@ export class FileDiff<LAnnotation = undefined> {
   }
 
   public cleanUp(recycle: boolean = false): void {
+    this.emitPostRender(true);
     this.resizeManager.cleanUp();
     this.interactionManager.cleanUp();
     this.scrollSyncManager.cleanUp();
@@ -581,6 +582,9 @@ export class FileDiff<LAnnotation = undefined> {
     fileContainer: HTMLElement,
     prerenderedHTML: string | undefined
   ): void {
+    if (this.fileContainer !== fileContainer) {
+      this.emitPostRender(true);
+    }
     prerenderHTMLIfNecessary(fileContainer, prerenderedHTML);
     for (const element of fileContainer.shadowRoot?.children ?? []) {
       if (element instanceof SVGElement) {
@@ -634,9 +638,6 @@ export class FileDiff<LAnnotation = undefined> {
     if (this.pre != null) {
       this.syncCodeNodesFromPre(this.pre);
       this.pre.removeAttribute('data-dehydrated');
-    }
-    if (this.fileContainer !== fileContainer) {
-      this.mounted = false;
     }
     this.fileContainer = fileContainer;
     this.hydrateMeasuredScrollbar();
@@ -929,15 +930,31 @@ export class FileDiff<LAnnotation = undefined> {
     return true;
   }
 
-  protected emitPostRender(): void {
-    const { fileContainer } = this;
+  protected emitPostRender(unmount = false): void {
+    const {
+      fileContainer,
+      options: { onPostRender },
+    } = this;
+
+    if (unmount) {
+      if (!this.mounted) {
+        return;
+      }
+      this.mounted = false;
+      if (fileContainer == null) {
+        return;
+      }
+      this.options.onPostRender?.(fileContainer, this, 'unmount');
+      return;
+    }
+
     if (fileContainer == null) {
       return;
     }
 
     const phase: PostRenderPhase = this.mounted ? 'update' : 'mount';
     this.mounted = true;
-    this.options.onPostRender?.(fileContainer, this, phase);
+    onPostRender?.(fileContainer, this, phase);
   }
 
   private removeRenderedCode(): void {
@@ -983,6 +1000,7 @@ export class FileDiff<LAnnotation = undefined> {
     if (this.fileContainer == null) {
       return false;
     }
+    this.emitPostRender(true);
     this.cleanChildNodes();
 
     if (this.placeHolder == null) {

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -1186,15 +1186,16 @@ export class FileDiff<LAnnotation = undefined> {
     fileContainer?: HTMLElement,
     parentNode?: HTMLElement
   ): HTMLElement {
-    const previousContainer = this.fileContainer;
-    this.fileContainer =
+    const { fileContainer: previousContainer } = this;
+    const nextContainer =
       fileContainer ??
-      this.fileContainer ??
+      previousContainer ??
       document.createElement(DIFFS_TAG_NAME);
-    const containerChanged = previousContainer !== this.fileContainer;
+    const containerChanged = previousContainer !== nextContainer;
     if (containerChanged) {
-      this.mounted = false;
+      this.emitPostRender(true);
     }
+    this.fileContainer = nextContainer;
     if (previousContainer != null && containerChanged) {
       this.lastRenderedHeaderHTML = undefined;
       this.headerElement = undefined;

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -38,6 +38,7 @@ import type {
   FileDiffMetadata,
   HunkData,
   HunkSeparators,
+  PostRenderPhase,
   PrePropertiesConfig,
   RenderHeaderMetadataCallback,
   RenderHeaderPrefixCallback,
@@ -94,6 +95,8 @@ export interface FileDiffHydrationProps<LAnnotation> extends Omit<
   prerenderedHTML?: string;
 }
 
+export type FileDiffType = 'file-diff' | 'unresolved-file';
+
 export interface FileDiffOptions<LAnnotation>
   extends
     Omit<BaseDiffOptions, 'hunkSeparators'>,
@@ -124,7 +127,11 @@ export interface FileDiffOptions<LAnnotation>
     getHoveredRow: () => GetHoveredLineResult<'diff'> | undefined
   ): HTMLElement | null | undefined;
 
-  onPostRender?(node: HTMLElement, instance: FileDiff<LAnnotation>): unknown;
+  onPostRender?(
+    node: HTMLElement,
+    instance: FileDiff<LAnnotation>,
+    phase: PostRenderPhase
+  ): unknown;
 }
 
 interface AnnotationElementCache<LAnnotation> {
@@ -174,6 +181,7 @@ export class FileDiff<LAnnotation = undefined> {
   static LoadedCustomComponent: boolean = DiffsContainerLoaded;
 
   readonly __id: string = `file-diff:${++instanceId}`;
+  readonly type: FileDiffType = 'file-diff';
 
   protected fileContainer: HTMLElement | undefined;
   protected spriteSVG: SVGElement | undefined;
@@ -210,12 +218,13 @@ export class FileDiff<LAnnotation = undefined> {
 
   protected deletionFile: FileContents | undefined;
   protected additionFile: FileContents | undefined;
-  protected fileDiff: FileDiffMetadata | undefined;
+  public fileDiff: FileDiffMetadata | undefined;
   protected renderRange: RenderRange | undefined;
   protected appliedPreAttributes: PrePropertiesConfig | undefined;
   protected lastRenderedHeaderHTML: string | undefined;
   protected cachedHeaderHTML: string | undefined;
   protected lastRowCount: number | undefined;
+  private mounted = false;
 
   protected enabled = true;
 
@@ -481,6 +490,7 @@ export class FileDiff<LAnnotation = undefined> {
       this.fileContainer?.remove();
     }
     this.fileContainer = undefined;
+    this.mounted = false;
     this.lineAnnotations = [];
     this.clearAuxiliaryNodes();
     this.annotationCache.clear();
@@ -624,6 +634,9 @@ export class FileDiff<LAnnotation = undefined> {
     if (this.pre != null) {
       this.syncCodeNodesFromPre(this.pre);
       this.pre.removeAttribute('data-dehydrated');
+    }
+    if (this.fileContainer !== fileContainer) {
+      this.mounted = false;
     }
     this.fileContainer = fileContainer;
     this.hydrateMeasuredScrollbar();
@@ -917,9 +930,14 @@ export class FileDiff<LAnnotation = undefined> {
   }
 
   protected emitPostRender(): void {
-    if (this.fileContainer != null) {
-      this.options.onPostRender?.(this.fileContainer, this);
+    const { fileContainer } = this;
+    if (fileContainer == null) {
+      return;
     }
+
+    const phase: PostRenderPhase = this.mounted ? 'update' : 'mount';
+    this.mounted = true;
+    this.options.onPostRender?.(fileContainer, this, phase);
   }
 
   private removeRenderedCode(): void {
@@ -1040,6 +1058,7 @@ export class FileDiff<LAnnotation = undefined> {
 
     this.lastRenderedHeaderHTML = undefined;
     this.lastRowCount = undefined;
+    this.mounted = false;
   }
 
   private renderSeparators(hunkData: HunkData[]): void {
@@ -1155,6 +1174,9 @@ export class FileDiff<LAnnotation = undefined> {
       this.fileContainer ??
       document.createElement(DIFFS_TAG_NAME);
     const containerChanged = previousContainer !== this.fileContainer;
+    if (containerChanged) {
+      this.mounted = false;
+    }
     if (previousContainer != null && containerChanged) {
       this.lastRenderedHeaderHTML = undefined;
       this.headerElement = undefined;

--- a/packages/diffs/src/components/UnresolvedFile.ts
+++ b/packages/diffs/src/components/UnresolvedFile.ts
@@ -201,6 +201,7 @@ export class UnresolvedFile<
   }
 
   override cleanUp(): void {
+    this.emitPostRender(true);
     this.clearMergeConflictActionCache();
     this.computedCache = {
       file: undefined,

--- a/packages/diffs/src/components/UnresolvedFile.ts
+++ b/packages/diffs/src/components/UnresolvedFile.ts
@@ -13,6 +13,7 @@ import type {
   MergeConflictMarkerRow,
   MergeConflictRegion,
   MergeConflictResolution,
+  PostRenderPhase,
 } from '../types';
 import { areFilesEqual } from '../utils/areFilesEqual';
 import { areMergeConflictActionsEqual } from '../utils/areMergeConflictActionsEqual';
@@ -45,11 +46,12 @@ export type MergeConflictActionsTypeOption<LAnnotation> =
 
 export interface UnresolvedFileOptions<LAnnotation> extends Omit<
   FileDiffOptions<LAnnotation>,
-  'diffStyle'
+  'diffStyle' | 'onPostRender'
 > {
   onPostRender?(
     node: HTMLElement,
-    instance: UnresolvedFile<LAnnotation>
+    instance: UnresolvedFile<LAnnotation>,
+    phase: PostRenderPhase
   ): unknown;
   mergeConflictActionsType?: MergeConflictActionsTypeOption<LAnnotation>;
   onMergeConflictAction?(
@@ -114,6 +116,8 @@ export class UnresolvedFile<
   LAnnotation = undefined,
 > extends FileDiff<LAnnotation> {
   override readonly __id: string = `unresolved-file:${++instanceId}`;
+  override readonly type = 'unresolved-file';
+
   protected computedCache: UnresolvedFileDataCache = {
     file: undefined,
     fileDiff: undefined,

--- a/packages/diffs/src/react/UnresolvedFile.tsx
+++ b/packages/diffs/src/react/UnresolvedFile.tsx
@@ -10,6 +10,7 @@ import type {
   FileContents,
   HunkSeparators,
   MergeConflictResolution,
+  PostRenderPhase,
 } from '../types';
 import { type MergeConflictDiffAction } from '../utils/parseMergeConflictDiffFromFile';
 import type { FileDiffProps } from './FileDiff';
@@ -41,7 +42,8 @@ export interface UnresolvedFileReactOptions<LAnnotation>
   hunkSeparators?: HunkSeparators;
   onPostRender?(
     node: HTMLElement,
-    instance: UnresolvedFileClass<LAnnotation>
+    instance: UnresolvedFileClass<LAnnotation>,
+    phase: PostRenderPhase
   ): unknown;
   maxContextLines?: number;
 }

--- a/packages/diffs/src/types.ts
+++ b/packages/diffs/src/types.ts
@@ -355,7 +355,7 @@ export type HunkLineType =
 
 export type ThemeTypes = 'system' | 'light' | 'dark';
 
-export type PostRenderPhase = 'mount' | 'update';
+export type PostRenderPhase = 'mount' | 'update' | 'unmount';
 
 /**
  * The `'custom'` variant is deprecated and will be removed in a future version.

--- a/packages/diffs/src/types.ts
+++ b/packages/diffs/src/types.ts
@@ -355,6 +355,8 @@ export type HunkLineType =
 
 export type ThemeTypes = 'system' | 'light' | 'dark';
 
+export type PostRenderPhase = 'mount' | 'update';
+
 /**
  * The `'custom'` variant is deprecated and will be removed in a future version.
  */

--- a/packages/diffs/test/onPostRenderPhase.test.ts
+++ b/packages/diffs/test/onPostRenderPhase.test.ts
@@ -256,6 +256,38 @@ describe('onPostRender phases', () => {
     }
   });
 
+  test('FileDiff emits unmount for the previous container when render swaps containers', () => {
+    const { cleanup } = installDom();
+    const firstContainer = createHydrationContainer();
+    const secondContainer = createHydrationContainer();
+    const phases: { container: 'first' | 'second'; phase: PostRenderPhase }[] =
+      [];
+    const instance = new FileDiff({
+      collapsed: true,
+      disableFileHeader: true,
+      onPostRender(node, _instance, phase) {
+        phases.push({
+          container: node === firstContainer ? 'first' : 'second',
+          phase,
+        });
+      },
+    });
+
+    try {
+      instance.render({ fileDiff, fileContainer: firstContainer });
+      instance.render({ fileDiff, fileContainer: secondContainer });
+
+      expect(phases).toEqual([
+        { container: 'first', phase: 'mount' },
+        { container: 'first', phase: 'unmount' },
+        { container: 'second', phase: 'mount' },
+      ]);
+    } finally {
+      instance.cleanUp();
+      cleanup();
+    }
+  });
+
   test('UnresolvedFile emits mount, update, and unmount around cleanup', () => {
     const { cleanup } = installDom();
     const phases: PostRenderPhase[] = [];

--- a/packages/diffs/test/onPostRenderPhase.test.ts
+++ b/packages/diffs/test/onPostRenderPhase.test.ts
@@ -1,0 +1,394 @@
+import { describe, expect, test } from 'bun:test';
+import { JSDOM } from 'jsdom';
+
+import { CodeView } from '../src/components/CodeView';
+import { File } from '../src/components/File';
+import { FileDiff } from '../src/components/FileDiff';
+import { UnresolvedFile } from '../src/components/UnresolvedFile';
+import { DEFAULT_THEMES } from '../src/constants';
+import type {
+  CodeViewItem,
+  FileContents,
+  FileDiffMetadata,
+  PostRenderPhase,
+} from '../src/types';
+
+function installDom() {
+  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+    url: 'http://localhost',
+  });
+  const originalValues = {
+    cancelAnimationFrame: Reflect.get(globalThis, 'cancelAnimationFrame'),
+    document: Reflect.get(globalThis, 'document'),
+    DocumentFragment: Reflect.get(globalThis, 'DocumentFragment'),
+    Element: Reflect.get(globalThis, 'Element'),
+    HTMLDivElement: Reflect.get(globalThis, 'HTMLDivElement'),
+    HTMLElement: Reflect.get(globalThis, 'HTMLElement'),
+    HTMLPreElement: Reflect.get(globalThis, 'HTMLPreElement'),
+    HTMLStyleElement: Reflect.get(globalThis, 'HTMLStyleElement'),
+    Node: Reflect.get(globalThis, 'Node'),
+    requestAnimationFrame: Reflect.get(globalThis, 'requestAnimationFrame'),
+    ResizeObserver: Reflect.get(globalThis, 'ResizeObserver'),
+    SVGElement: Reflect.get(globalThis, 'SVGElement'),
+    window: Reflect.get(globalThis, 'window'),
+  };
+
+  class MockResizeObserver {
+    observe(_target: Element): void {}
+    unobserve(_target: Element): void {}
+    disconnect(): void {}
+  }
+
+  let nextFrameId = 0;
+  const frames = new Map<number, ReturnType<typeof setTimeout>>();
+
+  Object.assign(globalThis, {
+    cancelAnimationFrame: ((id: number) => {
+      const timeout = frames.get(id);
+      if (timeout != null) {
+        clearTimeout(timeout);
+        frames.delete(id);
+      }
+    }) as typeof cancelAnimationFrame,
+    document: dom.window.document,
+    DocumentFragment: dom.window.DocumentFragment,
+    Element: dom.window.Element,
+    HTMLDivElement: dom.window.HTMLDivElement,
+    HTMLElement: dom.window.HTMLElement,
+    HTMLPreElement: dom.window.HTMLPreElement,
+    HTMLStyleElement: dom.window.HTMLStyleElement,
+    Node: dom.window.Node,
+    requestAnimationFrame: ((callback: FrameRequestCallback) => {
+      const id = ++nextFrameId;
+      const timeout = setTimeout(() => {
+        frames.delete(id);
+        callback(performance.now());
+      }, 0);
+      frames.set(id, timeout);
+      return id;
+    }) as typeof requestAnimationFrame,
+    ResizeObserver: MockResizeObserver,
+    SVGElement: dom.window.SVGElement,
+    window: dom.window,
+  });
+
+  return {
+    cleanup() {
+      for (const timeout of frames.values()) {
+        clearTimeout(timeout);
+      }
+      frames.clear();
+
+      for (const [key, value] of Object.entries(originalValues)) {
+        if (value === undefined) {
+          Reflect.deleteProperty(globalThis, key);
+        } else {
+          Object.assign(globalThis, { [key]: value });
+        }
+      }
+      dom.window.close();
+    },
+  };
+}
+
+function createHydrationContainer(): HTMLElement {
+  const container = document.createElement('div');
+  container.attachShadow({ mode: 'open' });
+  return container;
+}
+
+function createRoot(height: number): HTMLDivElement {
+  const root = document.createElement('div');
+  root.scrollTo = (options?: ScrollToOptions | number, y?: number) => {
+    root.scrollTop =
+      typeof options === 'number' ? (y ?? 0) : (options?.top ?? root.scrollTop);
+  };
+  Object.defineProperty(root, 'getBoundingClientRect', {
+    value: () => ({
+      bottom: height,
+      height,
+      left: 0,
+      right: 1000,
+      top: 0,
+      width: 1000,
+      x: 0,
+      y: 0,
+      toJSON() {
+        return {};
+      },
+    }),
+  });
+  document.body.appendChild(root);
+  return root;
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function dispatchScroll(root: HTMLElement): void {
+  root.dispatchEvent(new window.Event('scroll'));
+}
+
+function makeFile(
+  name: string,
+  label: string,
+  lineCount: number
+): FileContents {
+  return {
+    name,
+    contents: Array.from(
+      { length: lineCount },
+      (_, index) => `${label} line ${index + 1}`
+    ).join('\n'),
+  };
+}
+
+function makeFileItem(
+  id: string,
+  label: string,
+  lineCount: number
+): CodeViewItem<undefined> {
+  return {
+    id,
+    type: 'file',
+    file: makeFile(`${id}.ts`, label, lineCount),
+  };
+}
+
+async function renderItems(
+  viewer: CodeView,
+  items: readonly CodeViewItem[]
+): Promise<void> {
+  viewer.setItems(items);
+  viewer.render(true);
+  await wait(0);
+}
+
+async function waitForPhases(
+  phases: readonly { id: string; phase: PostRenderPhase }[],
+  expected: readonly { id: string; phase: PostRenderPhase }[]
+): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    try {
+      expect(phases).toEqual(expected);
+      return;
+    } catch {
+      await wait(10);
+    }
+  }
+  expect(phases).toEqual(expected);
+}
+
+const file: FileContents = {
+  name: 'file.ts',
+  contents: 'const value = 1;\n',
+};
+
+const unresolvedFile: FileContents = {
+  name: 'file.ts',
+  contents: `const value = 1;
+<<<<<<< HEAD
+const conflict = 'current';
+=======
+const conflict = 'incoming';
+>>>>>>> branch
+`,
+};
+
+const fileDiff: FileDiffMetadata = {
+  name: 'file.ts',
+  type: 'change',
+  hunks: [],
+  splitLineCount: 0,
+  unifiedLineCount: 0,
+  isPartial: false,
+  deletionLines: [],
+  additionLines: [],
+};
+
+describe('onPostRender phases', () => {
+  test('File emits mount, update, and unmount around cleanup', () => {
+    const { cleanup } = installDom();
+    const phases: PostRenderPhase[] = [];
+    const instance = new File({
+      collapsed: true,
+      disableFileHeader: true,
+      onPostRender(_node, _instance, phase) {
+        phases.push(phase);
+      },
+    });
+    const fileContainer = createHydrationContainer();
+
+    try {
+      instance.hydrate({ file, fileContainer });
+      instance.hydrate({ file, fileContainer });
+      instance.cleanUp();
+      instance.cleanUp();
+
+      expect(phases).toEqual(['mount', 'update', 'unmount']);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('FileDiff emits mount, update, and unmount around cleanup', () => {
+    const { cleanup } = installDom();
+    const phases: PostRenderPhase[] = [];
+    const instance = new FileDiff({
+      collapsed: true,
+      disableFileHeader: true,
+      onPostRender(_node, _instance, phase) {
+        phases.push(phase);
+      },
+    });
+    const fileContainer = createHydrationContainer();
+
+    try {
+      instance.hydrate({ fileDiff, fileContainer });
+      instance.hydrate({ fileDiff, fileContainer });
+      instance.cleanUp();
+      instance.cleanUp();
+
+      expect(phases).toEqual(['mount', 'update', 'unmount']);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('UnresolvedFile emits mount, update, and unmount around cleanup', () => {
+    const { cleanup } = installDom();
+    const phases: PostRenderPhase[] = [];
+    const instance = new UnresolvedFile({
+      collapsed: true,
+      disableFileHeader: true,
+      onPostRender(_node, _instance, phase) {
+        phases.push(phase);
+      },
+    });
+    const fileContainer = createHydrationContainer();
+
+    try {
+      instance.hydrate({ file: unresolvedFile, fileContainer });
+      instance.hydrate({ file: unresolvedFile, fileContainer });
+      instance.cleanUp();
+      instance.cleanUp();
+
+      expect(phases).toEqual(['mount', 'update', 'unmount']);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('File placeholder rendering unmounts once and allows remount', () => {
+    const { cleanup } = installDom();
+    const phases: PostRenderPhase[] = [];
+    const instance = new File({
+      collapsed: true,
+      disableFileHeader: true,
+      onPostRender(_node, _instance, phase) {
+        phases.push(phase);
+      },
+    });
+    const fileContainer = createHydrationContainer();
+
+    try {
+      instance.hydrate({ file, fileContainer });
+      instance.renderPlaceholder(24);
+      instance.renderPlaceholder(48);
+      instance.hydrate({ file, fileContainer });
+
+      expect(phases).toEqual(['mount', 'unmount', 'mount']);
+    } finally {
+      instance.cleanUp();
+      cleanup();
+    }
+  });
+
+  test('FileDiff placeholder rendering unmounts once and allows remount', () => {
+    const { cleanup } = installDom();
+    const phases: PostRenderPhase[] = [];
+    const instance = new FileDiff({
+      collapsed: true,
+      disableFileHeader: true,
+      onPostRender(_node, _instance, phase) {
+        phases.push(phase);
+      },
+    });
+    const fileContainer = createHydrationContainer();
+
+    try {
+      instance.hydrate({ fileDiff, fileContainer });
+      instance.renderPlaceholder(24);
+      instance.renderPlaceholder(48);
+      instance.hydrate({ fileDiff, fileContainer });
+
+      expect(phases).toEqual(['mount', 'unmount', 'mount']);
+    } finally {
+      instance.cleanUp();
+      cleanup();
+    }
+  });
+
+  test('cleanup propagates File unmount callback errors', () => {
+    const { cleanup } = installDom();
+    const instance = new File({
+      collapsed: true,
+      disableFileHeader: true,
+      onPostRender(_node, _instance, phase) {
+        if (phase === 'unmount') {
+          throw new Error('unmount failed');
+        }
+      },
+    });
+    const fileContainer = createHydrationContainer();
+
+    try {
+      instance.hydrate({ file, fileContainer });
+
+      expect(() => instance.cleanUp()).toThrow('unmount failed');
+      instance.cleanUp();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('CodeView forwards unmount when a rendered item scrolls out', async () => {
+    const { cleanup } = installDom();
+    const phases: { id: string; phase: PostRenderPhase }[] = [];
+    const viewer = new CodeView({
+      disableFileHeader: true,
+      theme: DEFAULT_THEMES,
+      onPostRender(_node, _instance, phase, context) {
+        phases.push({ id: context.item.id, phase });
+      },
+    });
+    const root = createRoot(120);
+    const items = [
+      makeFileItem('file:first', 'first content', 100),
+      makeFileItem('file:second', 'second content', 100),
+    ];
+
+    try {
+      viewer.setup(root);
+      await renderItems(viewer, items);
+
+      await waitForPhases(phases, [{ id: 'file:first', phase: 'mount' }]);
+
+      root.scrollTop = 2_400;
+      dispatchScroll(root);
+      viewer.render(true);
+      await wait(0);
+
+      await waitForPhases(phases, [
+        { id: 'file:first', phase: 'mount' },
+        { id: 'file:first', phase: 'unmount' },
+        { id: 'file:second', phase: 'mount' },
+      ]);
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
Some improvements to the `onPostRender` API. `onPostRender` now receives a new prop called `phase`. The possible values for this phase are: `'mount'`, `'update'`, and `'unmount'`. This can allow a lot more power around orchestrating third party DOM updates if necessary.