### PR TITLE
[diffshub] Themify chrome: loading panel, scrollbar, and a reset link

### DIFF
--- a/apps/docs/app/(diffshub)/(view)/_components/CodeViewHeader.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/CodeViewHeader.tsx
@@ -34,6 +34,8 @@ import {
   type ColorMode,
   DARK_THEMES,
   type DarkTheme,
+  DEFAULT_DARK_THEME,
+  DEFAULT_LIGHT_THEME,
   LIGHT_THEMES,
   type LightTheme,
 } from './themes';
@@ -359,6 +361,10 @@ function ThemeDropdown({
 }: ThemeDropdownProps) {
   const TriggerIcon = colorModeIcon(colorMode);
   const [view, setView] = useState<'main' | 'light' | 'dark'>('main');
+  // Only offer a reset when at least one slot drifts from the default
+  // pierre-soft pair, so the link stays out of the way until it's useful.
+  const themesAreCustom =
+    lightTheme !== DEFAULT_LIGHT_THEME || darkTheme !== DEFAULT_DARK_THEME;
   return (
     // `modal={false}` lets the user scroll and click the code view while the
     // theme picker is open. The default Radix DropdownMenu blocks pointer
@@ -447,6 +453,18 @@ function ThemeDropdown({
                 className="text-muted-foreground -rotate-90"
               />
             </DropdownMenuItem>
+            {themesAreCustom && (
+              <DropdownMenuItem
+                className="text-muted-foreground hover:text-foreground mt-1 cursor-pointer justify-center text-xs focus:bg-transparent"
+                onSelect={(event) => {
+                  event.preventDefault();
+                  setLightTheme(DEFAULT_LIGHT_THEME);
+                  setDarkTheme(DEFAULT_DARK_THEME);
+                }}
+              >
+                Reset to default themes
+              </DropdownMenuItem>
+            )}
           </>
         ) : (
           <ThemeList

--- a/apps/docs/app/(diffshub)/(view)/_components/CodeViewStatusPanel.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/CodeViewStatusPanel.tsx
@@ -1,19 +1,31 @@
 import { IconCiWarningFill, IconRefresh } from '@pierre/icons';
 
 import type { ViewerLoadState } from './types';
+import { useThemeChromeStyle } from './useResolvedTreeThemeStyles';
 import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 
 interface CodeViewStatusPanelProps {
+  darkTheme: string;
   errorMessage: string | null;
+  lightTheme: string;
   onRetry(): void;
   state: ViewerLoadState;
 }
 
 export function CodeViewStatusPanel({
+  darkTheme,
   errorMessage,
+  lightTheme,
   onRetry,
   state,
 }: CodeViewStatusPanelProps) {
+  // Mirror the rest of the diffshub chrome so the loading screen sits on the
+  // active Shiki theme's surface instead of the global light/dark palette.
+  // Mounted before the viewer is available, so we lean on the same hook the
+  // header/sidebar use — the resolved-theme cache keeps subsequent renders
+  // synchronous.
+  const themeChromeStyle = useThemeChromeStyle(lightTheme, darkTheme);
   const isError = state === 'error';
   const title = isError
     ? 'Couldn’t load diff'
@@ -32,7 +44,13 @@ export function CodeViewStatusPanel({
         : 'Reading the patch and showing files as they arrive…';
 
   return (
-    <div className="col-span-full flex min-h-0 items-center justify-center p-6">
+    <div
+      className={cn(
+        'col-span-full flex min-h-0 items-center justify-center p-6',
+        themeChromeStyle == null && 'bg-background'
+      )}
+      style={themeChromeStyle}
+    >
       <section
         role={isError ? 'alert' : 'status'}
         aria-live="polite"

--- a/apps/docs/app/(diffshub)/(view)/_components/CodeViewWrapper.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/CodeViewWrapper.tsx
@@ -501,6 +501,9 @@ const ANNOTATION_THEME_STYLE_KEYS = [
   // (same weight as the header/sidebar chrome borders) so it stays visible
   // on any theme without reading darker than the surrounding chrome.
   '--diffshub-diff-separator',
+  // Main scrollbar thumb + gutter tint; this element is the cv-scrollbar host.
+  '--diffshub-scrollbar-thumb-bg',
+  '--diffshub-scrollbar-track-bg',
 ] as const;
 
 export function buildAnnotationThemeStyle(

--- a/apps/docs/app/(diffshub)/(view)/_components/ReviewUI.tsx
+++ b/apps/docs/app/(diffshub)/(view)/_components/ReviewUI.tsx
@@ -317,9 +317,11 @@ export function ReviewUI({ domain, initialUrl, path }: ReviewUIProps) {
         </>
       ) : (
         <CodeViewStatusPanel
-          state={loadState}
+          darkTheme={darkTheme}
           errorMessage={errorMessage}
+          lightTheme={lightTheme}
           onRetry={retryLoad}
+          state={loadState}
         />
       )}
     </ReviewGrid>

--- a/apps/docs/app/(diffshub)/(view)/_components/useResolvedTreeThemeStyles.ts
+++ b/apps/docs/app/(diffshub)/(view)/_components/useResolvedTreeThemeStyles.ts
@@ -546,6 +546,20 @@ export function buildThemeChromeStyle(
       editorBg == null || surfacesMatch(editorBg, bg)
         ? borderOpaque
         : `color-mix(in srgb, ${editorFg} ${DIFF_BORDER_MIX}%, ${editorBg})`;
+    // Theme the main scrollbar off the editor surface it overlays: thumb
+    // via the default rule's own formula (lighten dark surfaces, darken
+    // light ones) so it matches the dropdown mini-scrollbars, and track
+    // from the editor bg so the reserved gutter isn't a dark band beside
+    // the diff.
+    if (editorBg != null) {
+      style['--diffshub-scrollbar-thumb-bg'] = isDarkSurface(
+        editorBg,
+        editorFg ?? primaryFg
+      )
+        ? `color-mix(in lab, ${editorBg} 80%, white)`
+        : `color-mix(in lab, ${editorBg} 85%, black)`;
+      style['--diffshub-scrollbar-track-bg'] = editorBg;
+    }
   }
   return style as CSSProperties;
 }

--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -277,9 +277,14 @@
 }
 
 .cv-scrollbar {
-  --cv-scrollbar-thumb-bg: light-dark(
-    color-mix(in lab, var(--background) 85%, black),
-    color-mix(in lab, var(--background) 80%, white)
+  /* Themed thumb from useThemeChromeStyle; light-dark fallback for
+     non-themed contexts. */
+  --cv-scrollbar-thumb-bg: var(
+    --diffshub-scrollbar-thumb-bg,
+    light-dark(
+      color-mix(in lab, var(--background) 85%, black),
+      color-mix(in lab, var(--background) 80%, white)
+    )
   );
   scrollbar-gutter: stable;
 }
@@ -290,8 +295,13 @@
 }
 
 .cv-scrollbar::-webkit-scrollbar-track {
-  background: transparent;
-  border-left: 1px solid var(--color-border-opaque);
+  /* Themed editor surface so the gutter isn't a dark band beside the diff;
+     transparent fallback keeps default behavior. */
+  background: var(--diffshub-scrollbar-track-bg, transparent);
+  /* Reuse the inter-file separator so the gutter edge reads as one hairline
+     with the file boundaries. */
+  border-left: 1px solid
+    var(--diffshub-diff-separator, var(--color-border-opaque));
   margin-top: -1px;
 }
 
@@ -332,7 +342,8 @@
 
 @supports (-moz-appearance: none) {
   .cv-scrollbar {
-    scrollbar-color: var(--cv-scrollbar-thumb-bg) transparent;
+    scrollbar-color: var(--cv-scrollbar-thumb-bg)
+      var(--diffshub-scrollbar-track-bg, transparent);
   }
   .cv-mini-scrollbar {
     scrollbar-color: var(--cv-mini-scrollbar-thumb-bg) transparent;


### PR DESCRIPTION
Follows on from the recent theme-switcher work by extending the active Shiki theme to two surfaces that were still pinned to the global light/dark palette, and adds a quick way back to the defaults.

### Theme the loading status panel

The "Fetching diff" / "Preparing diff" / error panel rendered on the global background, so under any non-default theme the loading screen flashed a mismatched surface before the diff came up. It now applies `useThemeChromeStyle` so its background and text follow the active theme, exactly like the header and sidebar. The hook's module-level cache keeps the resolved theme available through the first render, so there's no one-frame flash.

### Theme the main code-view scrollbar

`cv-scrollbar` derived its thumb from `var(--background)` and left its track transparent, but the `CodeView` host never gets `--background` re-themed — so under a non-default theme you'd get a near-black thumb and a dark gutter band. (The dropdown mini-scrollbars avoid this for free because their surface re-themes `--background`.)

Two new chrome variables fix it:

* `--diffshub-scrollbar-thumb-bg` — uses the default rule's own lighten/darken formula on the editor surface, so the thumb matches the theme-list mini-scrollbars.
* `--diffshub-scrollbar-track-bg` — the editor surface, so the reserved gutter paints with the diff instead of the host background.

`globals.css` keeps the prior formulas as fallbacks, so default chrome and any non-themed `cv-scrollbar` consumer are unchanged. The track border also reuses the themed diff separator so the gutter edge reads as one hairline with the file boundaries.

### Add a "Reset to default themes" link

After wandering through the Shiki catalog there was no quick way back to the pierre-soft defaults short of hunting for them in the light and dark lists. A muted link at the bottom of the theme picker's main view restores both slots at once. It only appears when at least one slot has drifted from the default pair, so it stays out of the way until it's useful.