### PR TITLE
[diffshub] Sync the iOS navbar tint to the theme

### DIFF
--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -174,6 +174,22 @@ const themeBootstrapScript = `(${String(function applyInitialTheme() {
     root.classList.remove('light', 'dark');
     root.classList.add(resolvedTheme);
     root.style.colorScheme = resolvedTheme;
+
+    // Set the iOS navbar tint before first paint so it matches the resolved
+    // mode immediately. The meta is created here (not authored in JSX, which
+    // React 19 would hoist into a duplicate) and owned by JS thereafter.
+    // Literals mirror MODE_THEME_COLOR in theme-provider.tsx (this stringified
+    // script can't import it); keep them in sync.
+    let themeColorMeta = document.querySelector('meta[name="theme-color"]');
+    if (themeColorMeta == null) {
+      themeColorMeta = document.createElement('meta');
+      themeColorMeta.setAttribute('name', 'theme-color');
+      document.head.appendChild(themeColorMeta);
+    }
+    themeColorMeta.setAttribute(
+      'content',
+      resolvedTheme === 'dark' ? '#0a0a0a' : '#ffffff'
+    );
   } catch {
     // Ignore storage/media failures and let CSS defaults apply.
   }
@@ -220,6 +236,10 @@ export default function RootLayout({
       className={`${berkeleyMono.variable} ${geistSans.variable} ${geistMono.variable} ${firaMono.variable} ${ibmPlexMono.variable} ${jetbrainsMono.variable} ${inter.variable}`}
     >
       <head>
+        {/* The iOS navbar tint <meta name="theme-color"> is created and
+            managed entirely by the bootstrap script below (and ThemeProvider),
+            not authored here — React 19 hoists head tags and would leave a
+            duplicate it manages alongside ours. */}
         <script
           id="docs-theme-bootstrap"
           dangerouslySetInnerHTML={{ __html: themeBootstrapScript }}

--- a/apps/docs/components/theme-provider.tsx
+++ b/apps/docs/components/theme-provider.tsx
@@ -39,6 +39,31 @@ const DEFAULT_STORAGE_KEY = 'theme';
 const DEFAULT_ATTRIBUTE = 'data-theme';
 const THEME_QUERY = '(prefers-color-scheme: dark)';
 
+// Navbar tint (iOS Safari's <meta name="theme-color">) for each resolved
+// color mode. These match the global body `--background` (oklch(1)/oklch(0.145))
+// that iOS samples at the top of the page, so the navbar blends with the page
+// instead of contrasting it. Kept in sync with the same literals hardcoded in
+// the layout's pre-paint bootstrap script (which can't import this module).
+const MODE_THEME_COLOR: Record<ResolvedTheme, string> = {
+  light: '#ffffff',
+  dark: '#0a0a0a',
+};
+
+// Points the document's theme-color meta at `color` (the iOS Safari navbar
+// tint), creating the meta if it isn't there yet. The meta is intentionally
+// not authored in JSX: React 19 hoists head tags and would leave a duplicate
+// next to the one it manages. Creating it imperatively keeps exactly one,
+// owned entirely by this code.
+function setThemeColorMeta(color: string) {
+  let meta = document.querySelector('meta[name="theme-color"]');
+  if (meta == null) {
+    meta = document.createElement('meta');
+    meta.setAttribute('name', 'theme-color');
+    document.head.appendChild(meta);
+  }
+  meta.setAttribute('content', color);
+}
+
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
 function getSystemTheme(): ResolvedTheme {
@@ -104,6 +129,9 @@ function applyTheme({
   if (enableColorScheme) {
     root.style.colorScheme = resolvedTheme;
   }
+
+  // Keep the iOS navbar tint in step with the resolved color mode.
+  setThemeColorMeta(MODE_THEME_COLOR[resolvedTheme]);
 }
 
 function isTheme(value: string | null, themes: Theme[]): value is Theme {


### PR DESCRIPTION
iOS Safari tints its toolbar from <meta name="theme-color">, which the app never set — so the navbar didn't track the selected theme. Add a JS-managed theme-color meta in two layers:

- Mode-level base, sitewide: the pre-paint bootstrap script and ThemeProvider.applyTheme set the meta to the resolved mode's background (#ffffff / #0a0a0a, matching the global body bg iOS samples). Correct on first paint, updates on mode change. Applies to all three sites (diffs/trees/diffshub) since it lives in shared layout/provider code.
- Shiki upgrade, diffshub viewer only: ReviewUI overwrites the meta with the resolved editor background (e.g. synthwave's #262335) so the navbar matches the diff surface, and restores the mode-level color on unmount so other pages don't inherit the viewer's tint.

The meta is created imperatively — by the bootstrap script, then ThemeProvider/the viewer — rather than authored in JSX, so a single element is owned end-to-end by the same code that updates it. Keeping creation and mutation in one place (instead of split between React-managed markup and DOM writes) makes the tag's value predictable across first paint, mode changes, and route transitions.
