### PR TITLE
[diffs] Potential Sticky Layout Bugfix

### DIFF
--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -700,6 +700,53 @@ export class CodeView<LAnnotation = undefined> {
     );
   }
 
+  // Dev-only invariant check: the sticky container only holds the currently
+  // rendered item content, so its measured block-size must equal the
+  // `stickyHeight` we derived from the first/last item sticky specs. Individual
+  // item heights can all be correct while this aggregate is still wrong (for
+  // example when an edge item reports a logical-bottom offset while it only
+  // rendered its header), and that mismatch is what drives the sticky container
+  // to position against the wrong bounds.
+  private validateStickyContainerHeight(): void {
+    if (!this.shouldValidateItemHeights()) {
+      return;
+    }
+
+    const { firstIndex, lastIndex, stickyHeight, stickyTop, stickyBottom } =
+      this.renderState;
+    if (firstIndex === -1 || lastIndex === -1) {
+      return;
+    }
+
+    const actualHeight = this.stickyContainer.getBoundingClientRect().height;
+    // Tolerate sub-pixel rounding from summing many flex children; real
+    // discrepancies are whole rows (or larger) tall.
+    if (Math.abs(actualHeight - stickyHeight) < 1) {
+      return;
+    }
+
+    console.error(
+      'CodeView: sticky container height does not match computed layout',
+      {
+        computedStickyHeight: stickyHeight,
+        actualStickyHeight: actualHeight,
+        delta: actualHeight - stickyHeight,
+        stickyTop,
+        stickyBottom,
+        firstIndex,
+        lastIndex,
+        firstStickySpecs:
+          this.items[firstIndex]?.instance.getAdvancedStickySpecs(),
+        lastStickySpecs:
+          this.items[lastIndex]?.instance.getAdvancedStickySpecs(),
+        scrollTop: this.getScrollTop(),
+        scrollPageOffset: this.scrollPageOffset,
+        windowSpecs: { ...this.windowSpecs },
+        stickyContainer: this.stickyContainer,
+      }
+    );
+  }
+
   private clearScrollInteractionTimer(): void {
     if (this.scrollInteractionFixTimer != null) {
       clearTimeout(this.scrollInteractionFixTimer);
@@ -2671,6 +2718,8 @@ export class CodeView<LAnnotation = undefined> {
     this.renderState.scrollTop = roundToDevicePixel(syncedScrollTop);
 
     this.flushManagers(updatedItems);
+
+    this.validateStickyContainerHeight();
 
     // If we are hitting a fitPerfectly heuristic, we should queue up another
     // render to fill out content. If we are performing a scroll animation we'll

--- a/packages/diffs/src/components/VirtualizedFile.ts
+++ b/packages/diffs/src/components/VirtualizedFile.ts
@@ -424,8 +424,27 @@ export class VirtualizedFile<
       return undefined;
     }
     const { bufferBefore, bufferAfter, totalLines } = renderRange;
+    // Rendered items flow contiguously in the sticky container with no buffer
+    // spacers, so a header-only item (totalLines === 0, none of its rows fall
+    // inside the window) must report where its header actually sits in that
+    // flow, which depends on which side of the window its content is on:
+    //  - content ABOVE the window (item starts above window.top): the header
+    //    sits at the item's bottom so the following item connects, so offset by
+    //    bufferAfter.
+    //  - content BELOW the window (item starts at/after window.top, e.g. a
+    //    trailing header peeking in at the bottom): the header renders at the
+    //    item's top with nothing after it, so no offset. Always adding
+    //    bufferAfter here made getStickyBounds over-measure the sticky
+    //    container for that trailing case.
+    let headerOnlyOffset = 0;
+    if (totalLines === 0) {
+      const activeWindow = windowSpecs ?? this.virtualizer.getWindowSpecs();
+      if (this.top < activeWindow.top) {
+        headerOnlyOffset = bufferAfter;
+      }
+    }
     return {
-      topOffset: this.top + bufferBefore + (totalLines === 0 ? bufferAfter : 0),
+      topOffset: this.top + bufferBefore + headerOnlyOffset,
       height: this.height - (bufferBefore + bufferAfter),
     };
   }

--- a/packages/diffs/src/components/VirtualizedFileDiff.ts
+++ b/packages/diffs/src/components/VirtualizedFileDiff.ts
@@ -598,8 +598,27 @@ export class VirtualizedFileDiff<
       return undefined;
     }
     const { bufferBefore, bufferAfter, totalLines } = renderRange;
+    // Rendered items flow contiguously in the sticky container with no buffer
+    // spacers, so a header-only item (totalLines === 0, none of its rows fall
+    // inside the window) must report where its header actually sits in that
+    // flow, which depends on which side of the window its content is on:
+    //  - content ABOVE the window (item starts above window.top): the header
+    //    sits at the item's bottom so the following item connects, so offset by
+    //    bufferAfter.
+    //  - content BELOW the window (item starts at/after window.top, e.g. a
+    //    trailing header peeking in at the bottom): the header renders at the
+    //    item's top with nothing after it, so no offset. Always adding
+    //    bufferAfter here made getStickyBounds over-measure the sticky
+    //    container for that trailing case.
+    let headerOnlyOffset = 0;
+    if (totalLines === 0) {
+      const activeWindow = windowSpecs ?? this.virtualizer.getWindowSpecs();
+      if (this.top < activeWindow.top) {
+        headerOnlyOffset = bufferAfter;
+      }
+    }
     return {
-      topOffset: this.top + bufferBefore + (totalLines === 0 ? bufferAfter : 0),
+      topOffset: this.top + bufferBefore + headerOnlyOffset,
       height: this.height - (bufferBefore + bufferAfter),
     };
   }

--- a/packages/diffs/test/advancedStickySpecs.test.ts
+++ b/packages/diffs/test/advancedStickySpecs.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, test } from 'bun:test';
+
+import { VirtualizedFile } from '../src/components/VirtualizedFile';
+import { VirtualizedFileDiff } from '../src/components/VirtualizedFileDiff';
+import type { FileContents, VirtualFileMetrics } from '../src/types';
+import {
+  getVirtualFileHeaderRegion,
+  getVirtualFilePaddingBottom,
+} from '../src/utils/computeVirtualFileMetrics';
+import { parseDiffFromFile } from '../src/utils/parseDiffFromFile';
+
+// getAdvancedStickySpecs reports where an item's rendered content actually
+// lives inside the sticky container so CodeView can size/position that
+// container. The subtle case is a "header-only" item: when none of its rows
+// fall inside the render window (totalLines === 0) the element still renders
+// just its header, and where that header sits in the contiguous (buffer-less)
+// flow depends on which side of the window the item's content is on:
+//   - content BELOW the window (item starts at/after window.top, e.g. a
+//     trailing header peeking in at the bottom): header renders at the item's
+//     top, so topOffset === top.
+//   - content ABOVE the window (item starts before window.top): the header
+//     sits at the item's bottom so the following item connects, so
+//     topOffset === top + bufferAfter.
+// Getting this wrong makes CodeView over/under-measure the sticky container,
+// which is the regression these tests guard.
+
+const metrics: VirtualFileMetrics = {
+  hunkLineCount: 50,
+  lineHeight: 20,
+  diffHeaderHeight: 44,
+  spacing: 8,
+};
+
+// A header-only item reports a height of just its header region plus the
+// trailing padding, regardless of how much (collapsed) content it has.
+const HEADER_ONLY_HEIGHT =
+  getVirtualFileHeaderRegion(metrics, false) +
+  getVirtualFilePaddingBottom(metrics);
+
+const ITEM_TOP = 1000;
+
+// Minimal stand-in for the owning virtualizer. getAdvancedStickySpecs is pure
+// layout math over the cached diff/file + metrics, so no DOM is required.
+const virtualizer = {
+  type: 'simple',
+  config: {},
+  connect() {},
+  disconnect() {},
+  getWindowSpecs() {
+    return { top: 0, bottom: 0 };
+  },
+  getOffsetInScrollContainer() {
+    return 0;
+  },
+  instanceChanged() {},
+  isInstanceVisible() {
+    return true;
+  },
+} as never;
+
+function makeDiff(): ReturnType<typeof parseDiffFromFile> {
+  return parseDiffFromFile(
+    { name: 'example.ts', contents: 'one\ntwo\nthree\n' },
+    { name: 'example.ts', contents: 'one\ntwo changed\nthree\n' }
+  );
+}
+
+function makeFile(lineCount = 10): FileContents {
+  return {
+    name: 'example.ts',
+    contents: Array.from(
+      { length: lineCount },
+      (_, index) => `line ${index + 1}`
+    ).join('\n'),
+  };
+}
+
+// A window entirely below the item: its content is below, so the header
+// renders at the item's top.
+function trailingWindow() {
+  return { top: 0, bottom: ITEM_TOP - 1 };
+}
+
+// A window entirely above the item: its content is above, so the header must
+// sit at the item's bottom so the next item connects.
+function leadingWindow(height: number) {
+  return { top: ITEM_TOP + height + 1, bottom: ITEM_TOP + height + 100 };
+}
+
+describe('VirtualizedFileDiff.getAdvancedStickySpecs', () => {
+  test('reports a fully rendered item at its top with its full height', () => {
+    const instance = new VirtualizedFileDiff({}, virtualizer, metrics);
+    instance.prepareCodeViewItem(makeDiff(), ITEM_TOP);
+    const height = instance.getVirtualizedHeight();
+
+    expect(
+      instance.getAdvancedStickySpecs({
+        top: ITEM_TOP,
+        bottom: ITEM_TOP + height,
+      })
+    ).toEqual({ topOffset: ITEM_TOP, height });
+  });
+
+  test('anchors a trailing header-only item at its top (no bufferAfter)', () => {
+    const instance = new VirtualizedFileDiff({}, virtualizer, metrics);
+    instance.prepareCodeViewItem(makeDiff(), ITEM_TOP);
+
+    expect(instance.getAdvancedStickySpecs(trailingWindow())).toEqual({
+      topOffset: ITEM_TOP,
+      height: HEADER_ONLY_HEIGHT,
+    });
+  });
+
+  test('anchors a leading header-only item at its bottom (offset by bufferAfter)', () => {
+    const instance = new VirtualizedFileDiff({}, virtualizer, metrics);
+    instance.prepareCodeViewItem(makeDiff(), ITEM_TOP);
+    const height = instance.getVirtualizedHeight();
+    const bufferAfter = height - HEADER_ONLY_HEIGHT;
+
+    const specs = instance.getAdvancedStickySpecs(leadingWindow(height));
+    expect(specs).toEqual({
+      topOffset: ITEM_TOP + bufferAfter,
+      height: HEADER_ONLY_HEIGHT,
+    });
+    // The region ends exactly at the item's logical bottom so the next item
+    // connects contiguously.
+    expect(specs!.topOffset + specs!.height).toBe(ITEM_TOP + height);
+  });
+
+  test('reports a collapsed item as its full (header) height at its top', () => {
+    const instance = new VirtualizedFileDiff(
+      { collapsed: true },
+      virtualizer,
+      metrics
+    );
+    instance.prepareCodeViewItem(makeDiff(), ITEM_TOP);
+    const height = instance.getVirtualizedHeight();
+
+    expect(instance.getAdvancedStickySpecs(trailingWindow())).toEqual({
+      topOffset: ITEM_TOP,
+      height,
+    });
+  });
+});
+
+describe('VirtualizedFile.getAdvancedStickySpecs', () => {
+  test('reports a fully rendered item at its top with its full height', () => {
+    const instance = new VirtualizedFile({}, virtualizer, metrics);
+    instance.prepareCodeViewItem(makeFile(), ITEM_TOP);
+    const height = instance.getVirtualizedHeight();
+
+    expect(
+      instance.getAdvancedStickySpecs({
+        top: ITEM_TOP,
+        bottom: ITEM_TOP + height,
+      })
+    ).toEqual({ topOffset: ITEM_TOP, height });
+  });
+
+  test('anchors a trailing header-only item at its top (no bufferAfter)', () => {
+    const instance = new VirtualizedFile({}, virtualizer, metrics);
+    instance.prepareCodeViewItem(makeFile(), ITEM_TOP);
+
+    expect(instance.getAdvancedStickySpecs(trailingWindow())).toEqual({
+      topOffset: ITEM_TOP,
+      height: HEADER_ONLY_HEIGHT,
+    });
+  });
+
+  test('anchors a leading header-only item at its bottom (offset by bufferAfter)', () => {
+    const instance = new VirtualizedFile({}, virtualizer, metrics);
+    instance.prepareCodeViewItem(makeFile(), ITEM_TOP);
+    const height = instance.getVirtualizedHeight();
+    const bufferAfter = height - HEADER_ONLY_HEIGHT;
+
+    const specs = instance.getAdvancedStickySpecs(leadingWindow(height));
+    expect(specs).toEqual({
+      topOffset: ITEM_TOP + bufferAfter,
+      height: HEADER_ONLY_HEIGHT,
+    });
+    expect(specs!.topOffset + specs!.height).toBe(ITEM_TOP + height);
+  });
+
+  test('reports a collapsed item as its full (header) height at its top', () => {
+    const instance = new VirtualizedFile(
+      { collapsed: true },
+      virtualizer,
+      metrics
+    );
+    instance.prepareCodeViewItem(makeFile(), ITEM_TOP);
+    const height = instance.getVirtualizedHeight();
+
+    expect(instance.getAdvancedStickySpecs(trailingWindow())).toEqual({
+      topOffset: ITEM_TOP,
+      height,
+    });
+  });
+});


### PR DESCRIPTION
In certain cases when dealing with collapsed files or files that need to be rendered without any lines, could often trigger funky scroll jumps in very specific and hard to reproduce situations.