### PR TITLE
[diffs] Fix CodeView Hunk Expansion Bugs

### DIFF
--- a/apps/demo/src/main.ts
+++ b/apps/demo/src/main.ts
@@ -56,6 +56,7 @@ const WORKER_POOL = true;
 const VIRTUALIZE = true;
 const CRAZY_FILE = false;
 const LARGE_CONFLICT_FILE = false;
+const CODE_VIEW_OLD_NEW_FILE = true;
 
 const FileStreamCodeConfigs: FileStreamCodeConfigsItem[] = [
   {
@@ -175,6 +176,41 @@ function startStreaming() {
 }
 
 let parsedPatches: ParsedPatch[] | undefined;
+let parsedCodeViewFilePatches: ParsedPatch[] | undefined;
+
+function createCodeViewFilePatches(): ParsedPatch[] {
+  const oldFile: FileContents = {
+    name: 'file_old.ts',
+    contents: FILE_OLD,
+    cacheKey: 'code-view-file-old',
+  };
+  const newFile: FileContents = {
+    name: 'file_new.ts',
+    contents: FILE_NEW,
+    cacheKey: 'code-view-file-new',
+  };
+
+  return [{ files: [parseDiffFromFile(oldFile, newFile)] }];
+}
+
+async function loadCodeViewPatches(): Promise<ParsedPatch[]> {
+  if (CODE_VIEW_OLD_NEW_FILE) {
+    return (parsedCodeViewFilePatches ??= createCodeViewFilePatches());
+  }
+  return (parsedPatches ??= parsePatchFiles(
+    await loadPatchContent(),
+    'parsed-patch'
+  ));
+}
+
+function handlePreloadCodeViewDiff() {
+  if (CODE_VIEW_OLD_NEW_FILE) {
+    parsedCodeViewFilePatches ??= createCodeViewFilePatches();
+    return;
+  }
+  void handlePreloadDiff();
+}
+
 async function handlePreloadDiff() {
   if (parsedPatches != null) return;
   const content = await loadPatchContent();
@@ -512,16 +548,12 @@ const renderCodeViewButton = document.getElementById('render-code-view');
 if (renderCodeViewButton != null) {
   renderCodeViewButton.addEventListener('click', () => {
     void (async () => {
-      parsedPatches ??= parsePatchFiles(
-        await loadPatchContent(),
-        'parsed-patch'
-      );
-      renderCodeView(parsedPatches);
+      renderCodeView(await loadCodeViewPatches());
     })();
   });
   renderCodeViewButton.addEventListener(
     'pointerenter',
-    () => void handlePreloadDiff()
+    handlePreloadCodeViewDiff
   );
 }
 

--- a/packages/diffs/src/components/VirtualizedFileDiff.ts
+++ b/packages/diffs/src/components/VirtualizedFileDiff.ts
@@ -644,8 +644,11 @@ export class VirtualizedFileDiff<
       direction,
       expansionLineCountOverride
     );
+    this.forceRenderOverride = true;
     this.resetLayoutCache({ includeEstimatedHeights: true });
-    this.computeApproximateSize();
+    if (this.isSimpleMode()) {
+      this.computeApproximateSize();
+    }
     this.virtualizer.instanceChanged(this, true);
   };
 

--- a/packages/diffs/src/components/VirtualizedFileDiff.ts
+++ b/packages/diffs/src/components/VirtualizedFileDiff.ts
@@ -25,9 +25,9 @@ import {
 import { iterateOverDiff } from '../utils/iterateOverDiff';
 import { parseDiffFromFile } from '../utils/parseDiffFromFile';
 import {
-  type ExpandedRegionResult,
   getExpandedRegion,
   getLeadingHunkSeparatorLayout,
+  getTrailingExpandedRegion,
   getTrailingHunkSeparatorLayout,
 } from '../utils/virtualDiffLayout';
 import type { WorkerPoolManager } from '../worker';
@@ -918,6 +918,7 @@ export class VirtualizedFileDiff<
       expandUnchanged = false,
       collapsedContextThreshold = DEFAULT_COLLAPSED_CONTEXT_THRESHOLD,
     } = this.options;
+    const finalHunkIndex = this.fileDiff.hunks.length - 1;
     const diffStyle = this.getDiffStyle();
     const hunkSeparators = this.getHunkSeparatorType();
     const expandedHunks = expandUnchanged
@@ -1031,13 +1032,16 @@ export class VirtualizedFileDiff<
         pendingLeadingSeparatorHeight = 0;
       }
 
-      const trailingRegion = getTrailingExpandedRegion({
-        fileDiff: this.fileDiff,
-        hunk,
-        hunkIndex,
-        expandedHunks,
-        collapsedContextThreshold,
-      });
+      const trailingRegion =
+        hunkIndex === finalHunkIndex
+          ? getTrailingExpandedRegion({
+              fileDiff: this.fileDiff,
+              hunkIndex,
+              expandedHunks,
+              collapsedContextThreshold,
+              errorPrefix: 'VirtualizedFileDiff',
+            })
+          : undefined;
       const trailingSeparatorHeight =
         trailingRegion != null && trailingRegion.collapsedLines > 0
           ? (getTrailingHunkSeparatorLayout({
@@ -1194,30 +1198,15 @@ export class VirtualizedFileDiff<
       }
     }
 
-    const lastHunk = fileDiff.hunks.at(-1);
-    if (lastHunk != null && hasFinalHunk(fileDiff)) {
-      const additionRemaining =
-        fileDiff.additionLines.length -
-        (lastHunk.additionLineIndex + lastHunk.additionCount);
-      const deletionRemaining =
-        fileDiff.deletionLines.length -
-        (lastHunk.deletionLineIndex + lastHunk.deletionCount);
-      if (lastHunk != null && additionRemaining !== deletionRemaining) {
-        throw new Error(
-          `VirtualizedFileDiff: trailing context mismatch (additions=${additionRemaining}, deletions=${deletionRemaining}) for ${fileDiff.name}`
-        );
-      }
-      const trailingRangeSize = Math.min(additionRemaining, deletionRemaining);
-      if (lastHunk != null && trailingRangeSize > 0) {
-        const { fromStart, renderAll } = getExpandedRegion({
-          isPartial: fileDiff.isPartial,
-          rangeSize: trailingRangeSize,
-          expandedHunks,
-          hunkIndex: fileDiff.hunks.length,
-          collapsedContextThreshold,
-        });
-        count += renderAll ? trailingRangeSize : fromStart;
-      }
+    const trailingRegion = getTrailingExpandedRegion({
+      fileDiff,
+      hunkIndex: fileDiff.hunks.length - 1,
+      expandedHunks,
+      collapsedContextThreshold,
+      errorPrefix: 'VirtualizedFileDiff',
+    });
+    if (trailingRegion != null) {
+      count += trailingRegion.fromStart + trailingRegion.fromEnd;
     }
 
     return count;
@@ -1565,45 +1554,6 @@ function getHunkMetadataOffsets({
   return offsets;
 }
 
-function getTrailingExpandedRegion({
-  fileDiff,
-  hunk,
-  hunkIndex,
-  expandedHunks,
-  collapsedContextThreshold,
-}: {
-  fileDiff: FileDiffMetadata;
-  hunk: Hunk;
-  hunkIndex: number;
-  expandedHunks: Parameters<typeof getExpandedRegion>[0]['expandedHunks'];
-  collapsedContextThreshold: number;
-}): ExpandedRegionResult | undefined {
-  if (hunkIndex !== fileDiff.hunks.length - 1 || !hasFinalHunk(fileDiff)) {
-    return undefined;
-  }
-
-  const additionRemaining =
-    fileDiff.additionLines.length -
-    (hunk.additionLineIndex + hunk.additionCount);
-  const deletionRemaining =
-    fileDiff.deletionLines.length -
-    (hunk.deletionLineIndex + hunk.deletionCount);
-
-  if (additionRemaining !== deletionRemaining) {
-    throw new Error(
-      `VirtualizedFileDiff: trailing context mismatch (additions=${additionRemaining}, deletions=${deletionRemaining}) for ${fileDiff.name}`
-    );
-  }
-
-  return getExpandedRegion({
-    isPartial: fileDiff.isPartial,
-    rangeSize: Math.min(additionRemaining, deletionRemaining),
-    expandedHunks,
-    hunkIndex: fileDiff.hunks.length,
-    collapsedContextThreshold,
-  });
-}
-
 function hasDiffLayoutOptionChanged<LAnnotation>(
   previousOptions: FileDiffOptions<LAnnotation>,
   nextOptions: FileDiffOptions<LAnnotation>
@@ -1656,25 +1606,6 @@ function getOptionHunkSeparatorType<LAnnotation>(
   return typeof hunkSeparators === 'function'
     ? 'custom'
     : (hunkSeparators ?? 'line-info');
-}
-
-function hasFinalHunk(fileDiff: FileDiffMetadata): boolean {
-  const lastHunk = fileDiff.hunks.at(-1);
-  if (
-    lastHunk == null ||
-    fileDiff.isPartial ||
-    fileDiff.additionLines.length === 0 ||
-    fileDiff.deletionLines.length === 0
-  ) {
-    return false;
-  }
-
-  return (
-    lastHunk.additionLineIndex + lastHunk.additionCount <
-      fileDiff.additionLines.length ||
-    lastHunk.deletionLineIndex + lastHunk.deletionCount <
-      fileDiff.deletionLines.length
-  );
 }
 
 // Extracts the view-specific line index from the data-line-index attribute.

--- a/packages/diffs/src/components/Virtualizer.ts
+++ b/packages/diffs/src/components/Virtualizer.ts
@@ -325,6 +325,7 @@ export class Virtualizer {
       // NOTE(amadeus): Is this a safe assumption/optimization?
       return;
     }
+    let instancesHaveChanged = this.instancesChanged.size > 0;
 
     // If we got an emitted update from a bunch of instances, we should skip
     // the window check first and attempt to render with existing logic first
@@ -337,10 +338,10 @@ export class Virtualizer {
         overscrollSize: this.config.overscrollSize,
       });
       if (
+        !wrapperDirty &&
         areVirtualWindowSpecsEqual(this.windowSpecs, windowSpecs) &&
         this.renderedObservers === this.observers.size &&
-        !this.visibleInstancesDirty &&
-        this.instancesChanged.size === 0
+        !this.visibleInstancesDirty
       ) {
         return;
       }
@@ -367,17 +368,19 @@ export class Virtualizer {
     }
 
     this.scrollFix(anchor);
-    // Scroll fix may have marked the dom as dirty, but if there instance
-    // changes, we should definitely mark as dirty
-    if (this.instancesChanged.size > 0) {
-      this.markDOMDirty();
-    }
 
     for (const instance of updatedInstances) {
       instance.reconcileHeights();
     }
+    instancesHaveChanged ||= this.instancesChanged.size > 0;
 
-    if (this.instancesChanged.size > 0 || wrapperDirty) {
+    // Reconciliation reads virtualized offsets and can consume dirty geometry
+    // flags, so mark after it when an instance update needs a corrected pass.
+    if (instancesHaveChanged) {
+      this.markDOMDirty();
+    }
+
+    if (instancesHaveChanged || wrapperDirty) {
       queueRender(this.computeRenderRangeAndEmit);
     }
     updatedInstances.clear();

--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -64,6 +64,7 @@ import type { DiffLineMetadata } from '../utils/iterateOverDiff';
 import { iterateOverDiff } from '../utils/iterateOverDiff';
 import { renderDiffWithHighlighter } from '../utils/renderDiffWithHighlighter';
 import { shouldUseTokenTransformer } from '../utils/shouldUseTokenTransformer';
+import { getTrailingContextRangeSize } from '../utils/virtualDiffLayout';
 import type { WorkerPoolManager } from '../worker';
 
 interface PushLineWithAnnotation {
@@ -774,7 +775,10 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
         }
       },
     };
-    const trailingRangeSize = calculateTrailingRangeSize(fileDiff);
+    const trailingRangeSize = getTrailingContextRangeSize({
+      fileDiff,
+      errorPrefix: 'DiffHunksRenderer.processDiffResult',
+    });
     const pendingSplitContext: PendingSplitContext = {
       size: 0,
       side: undefined,
@@ -1672,28 +1676,4 @@ function isDiffMassive(
     Math.max(diff.additionLines.length, diff.deletionLines.length) >
     tokenizeMaxLength
   );
-}
-
-function calculateTrailingRangeSize(fileDiff: FileDiffMetadata): number {
-  const lastHunk = fileDiff.hunks.at(-1);
-  if (
-    lastHunk == null ||
-    fileDiff.isPartial ||
-    fileDiff.additionLines.length === 0 ||
-    fileDiff.deletionLines.length === 0
-  ) {
-    return 0;
-  }
-  const additionRemaining =
-    fileDiff.additionLines.length -
-    (lastHunk.additionLineIndex + lastHunk.additionCount);
-  const deletionRemaining =
-    fileDiff.deletionLines.length -
-    (lastHunk.deletionLineIndex + lastHunk.deletionCount);
-  if (additionRemaining !== deletionRemaining) {
-    throw new Error(
-      `DiffHunksRenderer.processDiffResult: trailing context mismatch (additions=${additionRemaining}, deletions=${deletionRemaining}) for ${fileDiff.name}`
-    );
-  }
-  return Math.min(additionRemaining, deletionRemaining);
 }

--- a/packages/diffs/src/utils/computeEstimatedDiffHeights.ts
+++ b/packages/diffs/src/utils/computeEstimatedDiffHeights.ts
@@ -13,6 +13,7 @@ import {
 import {
   getExpandedRegion,
   getLeadingHunkSeparatorLayout,
+  getTrailingExpandedRegion,
   getTrailingHunkSeparatorLayout,
 } from './virtualDiffLayout';
 
@@ -84,14 +85,17 @@ export function computeEstimatedDiffHeights({
     splitHeight += metadataLineCounts.split * metrics.lineHeight;
     unifiedHeight += metadataLineCounts.unified * metrics.lineHeight;
 
-    if (hunkIndex === finalHunkIndex && hasFinalCollapsedHunk(fileDiff)) {
-      const trailingRegion = getExpandedRegion({
-        isPartial: fileDiff.isPartial,
-        rangeSize: getTrailingRangeSize(fileDiff, hunk),
-        expandedHunks,
-        hunkIndex: fileDiff.hunks.length,
-        collapsedContextThreshold,
-      });
+    const trailingRegion =
+      hunkIndex === finalHunkIndex
+        ? getTrailingExpandedRegion({
+            fileDiff,
+            hunkIndex,
+            expandedHunks,
+            collapsedContextThreshold,
+            errorPrefix: 'computeEstimatedDiffHeights',
+          })
+        : undefined;
+    if (trailingRegion != null) {
       const trailingExpandedHeight =
         (trailingRegion.fromStart + trailingRegion.fromEnd) *
         metrics.lineHeight;
@@ -139,7 +143,6 @@ function getNoNewlineMetadataLineCounts(hunk: Hunk): {
 
   return getChangeNoNewlineMetadataLineCounts(hunk, lastContent);
 }
-
 function getChangeNoNewlineMetadataLineCounts(
   hunk: Hunk,
   content: ChangeContent
@@ -154,39 +157,4 @@ function getChangeNoNewlineMetadataLineCounts(
   const split = splitDeletionHasMetadata || splitAdditionHasMetadata ? 1 : 0;
 
   return { split, unified };
-}
-
-function hasFinalCollapsedHunk(fileDiff: FileDiffMetadata): boolean {
-  const lastHunk = fileDiff.hunks.at(-1);
-  if (
-    lastHunk == null ||
-    fileDiff.isPartial ||
-    fileDiff.additionLines.length === 0 ||
-    fileDiff.deletionLines.length === 0
-  ) {
-    return false;
-  }
-
-  return (
-    lastHunk.additionLineIndex + lastHunk.additionCount <
-      fileDiff.additionLines.length ||
-    lastHunk.deletionLineIndex + lastHunk.deletionCount <
-      fileDiff.deletionLines.length
-  );
-}
-
-function getTrailingRangeSize(fileDiff: FileDiffMetadata, hunk: Hunk): number {
-  const additionRemaining =
-    fileDiff.additionLines.length -
-    (hunk.additionLineIndex + hunk.additionCount);
-  const deletionRemaining =
-    fileDiff.deletionLines.length -
-    (hunk.deletionLineIndex + hunk.deletionCount);
-
-  if (additionRemaining !== deletionRemaining) {
-    throw new Error(
-      `computeEstimatedDiffHeights: trailing context mismatch (additions=${additionRemaining}, deletions=${deletionRemaining}) for ${fileDiff.name}`
-    );
-  }
-  return Math.min(additionRemaining, deletionRemaining);
 }

--- a/packages/diffs/src/utils/iterateOverDiff.ts
+++ b/packages/diffs/src/utils/iterateOverDiff.ts
@@ -50,9 +50,11 @@ export type DiffLineCallbackProps =
 
 type DiffStyle = 'unified' | 'split' | 'both';
 
-type EqualLineIterationRange = [startIndex: number, endIndex: number];
+type LineIterationBounds = [startIndex: number, endIndex: number];
 
 type ChangeContentSide = 'deletions' | 'additions';
+
+type ContextLineCallback = (index: number) => boolean | void;
 
 interface IterationState {
   isWindowedHighlight: boolean;
@@ -291,60 +293,39 @@ export function iterateOverDiff({
       let deletionLineNumber = hunk.deletionStart - leadingRegion.rangeSize;
       let additionLineNumber = hunk.additionStart - leadingRegion.rangeSize;
 
-      const [startIndex, endIndex] = getEqualLineIterationRange(
-        state,
-        leadingRegion.fromStart,
-        diffStyle
-      );
-      if (startIndex > 0) {
-        state.incrementCounts(startIndex, startIndex);
-      }
-      let index = startIndex;
-      while (index < leadingRegion.fromStart) {
-        if (index >= endIndex) {
-          state.incrementCounts(
-            leadingRegion.fromStart - index,
-            leadingRegion.fromStart - index
-          );
-          break;
-        }
-        if (state.isInWindow(0, 0)) {
-          if (
-            state.emit({
-              hunkIndex,
-              hunk: hunk,
-              collapsedBefore: 0,
-              collapsedAfter: 0,
-              // NOTE(amadeus): Pretty sure this is would never return a value,
-              // so lets not call it, but if i notice a bug, i may need to
-              // bring this back.
-              // collapsedAfter: getTrailingCollapsedAfter(
-              //   unifiedRowIndex,
-              //   splitRowIndex
-              // ),
-              type: 'context-expanded',
-              deletionLine: {
-                lineNumber: deletionLineNumber + index,
-                lineIndex: deletionLineIndex + index,
-                noEOFCR: false,
-                unifiedLineIndex: unifiedLineIndex + index,
-                splitLineIndex: splitLineIndex + index,
-              },
-              additionLine: {
-                unifiedLineIndex: unifiedLineIndex + index,
-                splitLineIndex: splitLineIndex + index,
-                lineIndex: additionLineIndex + index,
-                lineNumber: additionLineNumber + index,
-                noEOFCR: false,
-              },
-            })
-          ) {
-            break hunkIterator;
-          }
-        } else {
-          state.incrementCounts(1, 1);
-        }
-        index++;
+      if (
+        walkContextLines(state, leadingRegion.fromStart, diffStyle, (index) => {
+          return state.emit({
+            hunkIndex,
+            hunk: hunk,
+            collapsedBefore: 0,
+            collapsedAfter: 0,
+            // NOTE(amadeus): Pretty sure this is would never return a value,
+            // so lets not call it, but if i notice a bug, i may need to
+            // bring this back.
+            // collapsedAfter: getTrailingCollapsedAfter(
+            //   unifiedRowIndex,
+            //   splitRowIndex
+            // ),
+            type: 'context-expanded',
+            deletionLine: {
+              lineNumber: deletionLineNumber + index,
+              lineIndex: deletionLineIndex + index,
+              noEOFCR: false,
+              unifiedLineIndex: unifiedLineIndex + index,
+              splitLineIndex: splitLineIndex + index,
+            },
+            additionLine: {
+              unifiedLineIndex: unifiedLineIndex + index,
+              splitLineIndex: splitLineIndex + index,
+              lineIndex: additionLineIndex + index,
+              lineNumber: additionLineNumber + index,
+              noEOFCR: false,
+            },
+          });
+        })
+      ) {
+        break hunkIterator;
       }
 
       unifiedLineIndex = hunk.unifiedLineStart - leadingRegion.fromEnd;
@@ -354,31 +335,13 @@ export function iterateOverDiff({
       additionLineIndex = hunk.additionLineIndex - leadingRegion.fromEnd;
       deletionLineNumber = hunk.deletionStart - leadingRegion.fromEnd;
       additionLineNumber = hunk.additionStart - leadingRegion.fromEnd;
-      const [fromEndStartIndex, fromEndEndIndex] = getEqualLineIterationRange(
-        state,
-        leadingRegion.fromEnd,
-        diffStyle
-      );
-      if (fromEndStartIndex > 0) {
-        state.incrementCounts(fromEndStartIndex, fromEndStartIndex);
-        // The collapsed separator belongs before this fromEnd slice. If the
-        // render window starts inside the slice, consume it with the skipped
-        // rows so it is not attached to the first emitted row.
-        consumePendingCollapsed();
-      }
-      index = fromEndStartIndex;
-
-      while (index < leadingRegion.fromEnd) {
-        if (index >= fromEndEndIndex) {
-          state.incrementCounts(
-            leadingRegion.fromEnd - index,
-            leadingRegion.fromEnd - index
-          );
-          break;
-        }
-        if (state.isInWindow(0, 0)) {
-          if (
-            state.emit({
+      if (
+        walkContextLines(
+          state,
+          leadingRegion.fromEnd,
+          diffStyle,
+          (index) => {
+            return state.emit({
               hunkIndex,
               hunk,
               collapsedBefore: consumePendingCollapsed(),
@@ -405,14 +368,17 @@ export function iterateOverDiff({
                 lineNumber: additionLineNumber + index,
                 noEOFCR: false,
               },
-            })
-          ) {
-            break hunkIterator;
+            });
+          },
+          () => {
+            // The collapsed separator belongs before this fromEnd slice. If the
+            // render window starts inside the slice, consume it with the skipped
+            // rows so it is not attached to the first emitted row.
+            consumePendingCollapsed();
           }
-        } else {
-          state.incrementCounts(1, 1);
-        }
-        index++;
+        )
+      ) {
+        break hunkIterator;
       }
     } else {
       state.incrementCounts(expandedLineCount, expandedLineCount);
@@ -438,33 +404,16 @@ export function iterateOverDiff({
       // Hunk Context Content
       if (content.type === 'context') {
         if (!state.shouldSkip(content.lines, content.lines)) {
-          const [startIndex, endIndex] = getEqualLineIterationRange(
-            state,
-            content.lines,
-            diffStyle
-          );
-          if (startIndex > 0) {
-            state.incrementCounts(startIndex, startIndex);
-            // When windowing starts inside context content, the leading
-            // separator was above the visible range and should not be emitted
-            // on the first rendered context line.
-            consumePendingCollapsed();
-          }
-          let index = startIndex;
-          while (index < content.lines) {
-            if (index >= endIndex) {
-              state.incrementCounts(
-                content.lines - index,
-                content.lines - index
-              );
-              break;
-            }
-            if (state.isInWindow(0, 0)) {
-              const isLastLine = isLastContent && index === content.lines - 1;
-              const unifiedRowIndex = unifiedLineIndex + index;
-              const splitRowIndex = splitLineIndex + index;
-              if (
-                state.emit({
+          if (
+            walkContextLines(
+              state,
+              content.lines,
+              diffStyle,
+              (index) => {
+                const isLastLine = isLastContent && index === content.lines - 1;
+                const unifiedRowIndex = unifiedLineIndex + index;
+                const splitRowIndex = splitLineIndex + index;
+                return state.emit({
                   hunkIndex,
                   hunk,
                   collapsedBefore: consumePendingCollapsed(),
@@ -487,14 +436,17 @@ export function iterateOverDiff({
                     lineNumber: additionLineNumber + index,
                     noEOFCR: isLastLine && hunk.noEOFCRAdditions,
                   },
-                })
-              ) {
-                break hunkIterator;
+                });
+              },
+              () => {
+                // When windowing starts inside context content, the leading
+                // separator was above the visible range and should not be
+                // emitted on the first rendered context line.
+                consumePendingCollapsed();
               }
-            } else {
-              state.incrementCounts(1, 1);
-            }
-            index++;
+            )
+          ) {
+            break hunkIterator;
           }
         } else {
           state.incrementCounts(content.lines, content.lines);
@@ -585,27 +537,14 @@ export function iterateOverDiff({
     if (trailingRegion != null) {
       const { collapsedLines, fromStart, fromEnd } = trailingRegion;
       const len = fromStart + fromEnd;
-      const [startIndex, endIndex] = getEqualLineIterationRange(
-        state,
-        len,
-        diffStyle
-      );
-      if (startIndex > 0) {
-        state.incrementCounts(startIndex, startIndex);
-      }
-      let index = startIndex;
-      while (index < len) {
-        if (state.shouldBreak()) {
-          break hunkIterator;
-        }
-        if (index >= endIndex) {
-          state.incrementCounts(len - index, len - index);
-          break;
-        }
-        if (state.isInWindow(0, 0)) {
-          const isLastLine = index === len - 1;
-          if (
-            state.emit({
+      if (
+        walkContextLines(
+          state,
+          len,
+          diffStyle,
+          (index) => {
+            const isLastLine = index === len - 1;
+            return state.emit({
               hunkIndex: diff.hunks.length,
               hunk: undefined,
               collapsedBefore: 0,
@@ -627,14 +566,13 @@ export function iterateOverDiff({
                 lineNumber: additionLineNumber + index,
                 noEOFCR: false,
               },
-            })
-          ) {
-            break hunkIterator;
-          }
-        } else {
-          state.incrementCounts(1, 1);
-        }
-        index++;
+            });
+          },
+          undefined,
+          () => state.shouldBreak()
+        )
+      ) {
+        break hunkIterator;
       }
     }
   }
@@ -767,20 +705,20 @@ function getHunkPrefixCounts({
   return prefixCounts;
 }
 
-// Clip a run of unchanged rows to the active rendered window. Equal rows advance
-// split and unified counters together, but `diffStyle: both` needs the union of
-// the split and unified visible ranges because either view can make the row
-// worth emitting.
-function getEqualLineIterationRange(
+// Clip a run of context rows to a single bounded hull around the active rendered
+// window. `diffStyle: both` can make split and unified rows visible in disjoint
+// ranges, so these bounds may include interior gaps that still need per-row
+// filtering before emitting.
+function getContextLineIterationBounds(
   state: IterationState,
   count: number,
   diffStyle: DiffStyle
-): EqualLineIterationRange {
+): LineIterationBounds {
   if (!state.isWindowedHighlight || count <= 0) {
     return [0, count];
   }
 
-  const ranges: EqualLineIterationRange[] = [];
+  const ranges: LineIterationBounds[] = [];
   function pushRange(currentCount: number): void {
     const start = Math.max(0, state.viewportStart - currentCount);
     const end = Math.min(count, state.viewportEnd - currentCount);
@@ -809,6 +747,50 @@ function getEqualLineIterationRange(
   }
   return [start, end];
 }
+
+// Walk context rows through the active window while keeping split and
+// unified counters aligned. The callback only runs after the final per-row
+// window check, which keeps `diffStyle: both` gap rows from being emitted.
+function walkContextLines(
+  state: IterationState,
+  count: number,
+  diffStyle: DiffStyle,
+  callback: ContextLineCallback,
+  onSkippedStart?: () => void,
+  shouldBreak?: () => boolean
+): boolean {
+  const [startIndex, endIndex] = getContextLineIterationBounds(
+    state,
+    count,
+    diffStyle
+  );
+  if (startIndex > 0) {
+    state.incrementCounts(startIndex, startIndex);
+    onSkippedStart?.();
+  }
+
+  let index = startIndex;
+  while (index < count) {
+    if (shouldBreak?.() === true) {
+      return true;
+    }
+    if (index >= endIndex) {
+      state.incrementCounts(count - index, count - index);
+      break;
+    }
+    if (state.isInWindow(0, 0)) {
+      if (callback(index) === true) {
+        return true;
+      }
+    } else {
+      state.incrementCounts(1, 1);
+    }
+    index++;
+  }
+
+  return false;
+}
+
 // The intention of this function is to grab the appropriate windowed ranges of
 // the change content.  If diffStyle is both, we will iterate AS split, however
 // we will encompass all needed lines to allow us to render split or unified
@@ -816,7 +798,7 @@ function getChangeIterationRanges(
   state: IterationState,
   content: ChangeContent,
   diffStyle: DiffStyle
-): EqualLineIterationRange[] {
+): LineIterationBounds[] {
   // If not a window highlight, then we should just render the entire range
   if (!state.isWindowedHighlight) {
     return [
@@ -831,11 +813,11 @@ function getChangeIterationRanges(
   const useUnified = diffStyle !== 'split';
   const useSplit = diffStyle !== 'unified';
   const iterationSpace = diffStyle === 'unified' ? 'unified' : 'split';
-  const iterationRanges: EqualLineIterationRange[] = [];
+  const iterationRanges: LineIterationBounds[] = [];
   function getVisibleRange(
     start: number,
     count: number
-  ): EqualLineIterationRange | undefined {
+  ): LineIterationBounds | undefined {
     const end = start + count;
     if (end <= state.viewportStart || start >= state.viewportEnd) {
       return undefined;
@@ -845,9 +827,9 @@ function getChangeIterationRanges(
     return visibleEnd > visibleStart ? [visibleStart, visibleEnd] : undefined;
   }
   function mapRangeToIteration(
-    range: EqualLineIterationRange,
+    range: LineIterationBounds,
     kind: ChangeContentSide
-  ): EqualLineIterationRange {
+  ): LineIterationBounds {
     if (iterationSpace === 'split') {
       // For split iteration, additions/deletions are already in split row space.
       return range;
@@ -857,7 +839,7 @@ function getChangeIterationRanges(
       : range;
   }
   function pushRange(
-    range: EqualLineIterationRange | undefined,
+    range: LineIterationBounds | undefined,
     kind: ChangeContentSide
   ) {
     if (range == null) {
@@ -899,7 +881,7 @@ function getChangeIterationRanges(
   }
 
   iterationRanges.sort((a, b) => a[0] - b[0]);
-  const merged: EqualLineIterationRange[] = [iterationRanges[0]];
+  const merged: LineIterationBounds[] = [iterationRanges[0]];
   for (const [start, end] of iterationRanges.slice(1)) {
     const last = merged[merged.length - 1];
     if (start <= last[1]) {

--- a/packages/diffs/src/utils/iterateOverDiff.ts
+++ b/packages/diffs/src/utils/iterateOverDiff.ts
@@ -5,7 +5,10 @@ import type {
   Hunk,
   HunkExpansionRegion,
 } from '../types';
-import { getExpandedRegion } from './virtualDiffLayout';
+import {
+  getExpandedRegion,
+  getTrailingExpandedRegion,
+} from './virtualDiffLayout';
 
 export interface DiffLineMetadata {
   unifiedLineIndex: number;
@@ -52,12 +55,12 @@ type EqualLineIterationRange = [startIndex: number, endIndex: number];
 type ChangeContentSide = 'deletions' | 'additions';
 
 interface IterationState {
-  finalHunk: Hunk | undefined;
   isWindowedHighlight: boolean;
   viewportStart: number;
   viewportEnd: number;
   splitCount: number;
   unifiedCount: number;
+  finalHunkIndex: number;
   shouldBreak(): boolean;
   shouldSkip(unifiedHeight: number, splitHeight: number): boolean;
   incrementCounts(unifiedValue: number, splitValue: number): void;
@@ -120,12 +123,12 @@ export function iterateOverDiff({
     collapsedContextThreshold,
   });
   const state: IterationState = {
-    finalHunk: diff.hunks.at(-1),
     viewportStart: startingLine,
     viewportEnd: startingLine + totalLines,
     isWindowedHighlight: startingLine > 0 || totalLines < Infinity,
     splitCount: iterationStart.splitCount,
     unifiedCount: iterationStart.unifiedCount,
+    finalHunkIndex: diff.hunks.length - 1,
     shouldBreak() {
       if (!state.isWindowedHighlight) {
         return false;
@@ -235,33 +238,16 @@ export function iterateOverDiff({
       hunkIndex,
       collapsedContextThreshold,
     });
-    // We only create a trailing region if it's the last hunk
-    const trailingRegion = (() => {
-      if (hunk !== state.finalHunk || !hasFinalCollapsedHunk(diff)) {
-        return undefined;
-      }
-      const additionRemaining =
-        diff.additionLines.length -
-        (hunk.additionLineIndex + hunk.additionCount);
-      const deletionRemaining =
-        diff.deletionLines.length -
-        (hunk.deletionLineIndex + hunk.deletionCount);
-
-      if (additionRemaining !== deletionRemaining) {
-        throw new Error(
-          `iterateOverDiff: trailing context mismatch (additions=${additionRemaining}, deletions=${deletionRemaining}) for ${diff.name}`
-        );
-      }
-      const trailingRangeSize = Math.min(additionRemaining, deletionRemaining);
-      return getExpandedRegion({
-        isPartial: diff.isPartial,
-        rangeSize: trailingRangeSize,
-        expandedHunks,
-        // hunkIndex for trailing region
-        hunkIndex: diff.hunks.length,
-        collapsedContextThreshold,
-      });
-    })();
+    const trailingRegion =
+      hunkIndex === state.finalHunkIndex
+        ? getTrailingExpandedRegion({
+            fileDiff: diff,
+            hunkIndex,
+            expandedHunks,
+            collapsedContextThreshold,
+            errorPrefix: 'iterateOverDiff',
+          })
+        : undefined;
     const expandedLineCount = leadingRegion.fromStart + leadingRegion.fromEnd;
 
     function getTrailingCollapsedAfter(
@@ -758,15 +744,17 @@ function getHunkPrefixCounts({
     splitCount += leadingCount + hunk.splitLineCount;
     unifiedCount += leadingCount + hunk.unifiedLineCount;
 
-    if (index === finalHunkIndex && hasFinalCollapsedHunk(diff)) {
-      const trailingRangeSize = getTrailingRangeSize(diff, hunk);
-      const trailingRegion = getExpandedRegion({
-        isPartial: diff.isPartial,
-        rangeSize: trailingRangeSize,
-        expandedHunks,
-        hunkIndex: diff.hunks.length,
-        collapsedContextThreshold,
-      });
+    const trailingRegion =
+      index === finalHunkIndex
+        ? getTrailingExpandedRegion({
+            fileDiff: diff,
+            hunkIndex: index,
+            expandedHunks,
+            collapsedContextThreshold,
+            errorPrefix: 'iterateOverDiff',
+          })
+        : undefined;
+    if (trailingRegion != null) {
       const trailingCount = trailingRegion.fromStart + trailingRegion.fromEnd;
       splitCount += trailingCount;
       unifiedCount += trailingCount;
@@ -820,42 +808,6 @@ function getEqualLineIterationRange(
   }
   return [start, end];
 }
-
-// Measure the unchanged tail after the final hunk so it can be collapsed or
-// expanded like leading hunk context. Both sides must have the same remaining
-// length because trailing context represents paired unchanged lines.
-function getTrailingRangeSize(diff: FileDiffMetadata, hunk: Hunk): number {
-  const additionRemaining =
-    diff.additionLines.length - (hunk.additionLineIndex + hunk.additionCount);
-  const deletionRemaining =
-    diff.deletionLines.length - (hunk.deletionLineIndex + hunk.deletionCount);
-
-  if (additionRemaining !== deletionRemaining) {
-    throw new Error(
-      `iterateOverDiff: trailing context mismatch (additions=${additionRemaining}, deletions=${deletionRemaining}) for ${diff.name}`
-    );
-  }
-  return Math.min(additionRemaining, deletionRemaining);
-}
-
-function hasFinalCollapsedHunk(diff: FileDiffMetadata): boolean {
-  const lastHunk = diff.hunks.at(-1);
-  if (
-    lastHunk == null ||
-    diff.isPartial ||
-    diff.additionLines.length === 0 ||
-    diff.deletionLines.length === 0
-  ) {
-    return false;
-  }
-  return (
-    lastHunk.additionLineIndex + lastHunk.additionCount <
-      diff.additionLines.length ||
-    lastHunk.deletionLineIndex + lastHunk.deletionCount <
-      diff.deletionLines.length
-  );
-}
-
 // The intention of this function is to grab the appropriate windowed ranges of
 // the change content.  If diffStyle is both, we will iterate AS split, however
 // we will encompass all needed lines to allow us to render split or unified

--- a/packages/diffs/src/utils/iterateOverDiff.ts
+++ b/packages/diffs/src/utils/iterateOverDiff.ts
@@ -374,6 +374,10 @@ export function iterateOverDiff({
       );
       if (fromEndStartIndex > 0) {
         state.incrementCounts(fromEndStartIndex, fromEndStartIndex);
+        // The collapsed separator belongs before this fromEnd slice. If the
+        // render window starts inside the slice, consume it with the skipped
+        // rows so it is not attached to the first emitted row.
+        getPendingCollapsed();
       }
       index = fromEndStartIndex;
 
@@ -454,6 +458,10 @@ export function iterateOverDiff({
           );
           if (startIndex > 0) {
             state.incrementCounts(startIndex, startIndex);
+            // When windowing starts inside context content, the leading
+            // separator was above the visible range and should not be emitted
+            // on the first rendered context line.
+            getPendingCollapsed();
           }
           let index = startIndex;
           while (index < content.lines) {
@@ -524,6 +532,13 @@ export function iterateOverDiff({
             content,
             diffStyle
           );
+          const firstRangeStart = iterationRanges[0]?.[0] ?? 0;
+          if (firstRangeStart > 0) {
+            // Change rows can be windowed from the middle of the block too. In
+            // that case the leading separator belongs to skipped rows, not to
+            // the first visible deletion/addition row.
+            getPendingCollapsed();
+          }
 
           // No need for any skipping because the render ranges skip for us
           for (const [rangeStart, rangeEnd] of iterationRanges) {

--- a/packages/diffs/src/utils/iterateOverDiff.ts
+++ b/packages/diffs/src/utils/iterateOverDiff.ts
@@ -271,13 +271,14 @@ export function iterateOverDiff({
         ? trailingRegion.collapsedLines
         : 0;
     }
-    function getPendingCollapsed() {
-      if (leadingRegion.collapsedLines === 0) {
+
+    let consumedCollapsed = leadingRegion.collapsedLines === 0;
+    function consumePendingCollapsed() {
+      if (consumedCollapsed) {
         return 0;
       }
-      const value = leadingRegion.collapsedLines;
-      leadingRegion.collapsedLines = 0;
-      return value;
+      consumedCollapsed = true;
+      return leadingRegion.collapsedLines;
     }
 
     // Emit for expanded lines
@@ -363,7 +364,7 @@ export function iterateOverDiff({
         // The collapsed separator belongs before this fromEnd slice. If the
         // render window starts inside the slice, consume it with the skipped
         // rows so it is not attached to the first emitted row.
-        getPendingCollapsed();
+        consumePendingCollapsed();
       }
       index = fromEndStartIndex;
 
@@ -380,7 +381,7 @@ export function iterateOverDiff({
             state.emit({
               hunkIndex,
               hunk,
-              collapsedBefore: getPendingCollapsed(),
+              collapsedBefore: consumePendingCollapsed(),
               collapsedAfter: 0,
               // NOTE(amadeus): Pretty sure this is would never return a value,
               // so lets not call it, but if i notice a bug, i may need to
@@ -415,7 +416,7 @@ export function iterateOverDiff({
       }
     } else {
       state.incrementCounts(expandedLineCount, expandedLineCount);
-      getPendingCollapsed();
+      consumePendingCollapsed();
     }
 
     let unifiedLineIndex = hunk.unifiedLineStart;
@@ -447,7 +448,7 @@ export function iterateOverDiff({
             // When windowing starts inside context content, the leading
             // separator was above the visible range and should not be emitted
             // on the first rendered context line.
-            getPendingCollapsed();
+            consumePendingCollapsed();
           }
           let index = startIndex;
           while (index < content.lines) {
@@ -466,7 +467,7 @@ export function iterateOverDiff({
                 state.emit({
                   hunkIndex,
                   hunk,
-                  collapsedBefore: getPendingCollapsed(),
+                  collapsedBefore: consumePendingCollapsed(),
                   collapsedAfter: getTrailingCollapsedAfter(
                     unifiedRowIndex,
                     splitRowIndex
@@ -497,7 +498,7 @@ export function iterateOverDiff({
           }
         } else {
           state.incrementCounts(content.lines, content.lines);
-          getPendingCollapsed();
+          consumePendingCollapsed();
         }
         unifiedLineIndex += content.lines;
         splitLineIndex += content.lines;
@@ -523,7 +524,7 @@ export function iterateOverDiff({
             // Change rows can be windowed from the middle of the block too. In
             // that case the leading separator belongs to skipped rows, not to
             // the first visible deletion/addition row.
-            getPendingCollapsed();
+            consumePendingCollapsed();
           }
 
           // No need for any skipping because the render ranges skip for us
@@ -546,7 +547,7 @@ export function iterateOverDiff({
                   getChangeLineData({
                     hunkIndex,
                     hunk,
-                    collapsedBefore: getPendingCollapsed(),
+                    collapsedBefore: consumePendingCollapsed(),
                     collapsedAfter,
                     diffStyle,
                     index,
@@ -570,7 +571,7 @@ export function iterateOverDiff({
           }
         }
 
-        getPendingCollapsed();
+        consumePendingCollapsed();
         state.incrementCounts(unifiedCount, splitCount);
         unifiedLineIndex += unifiedCount;
         splitLineIndex += splitCount;

--- a/packages/diffs/src/utils/iterateOverDiff.ts
+++ b/packages/diffs/src/utils/iterateOverDiff.ts
@@ -209,11 +209,6 @@ export function iterateOverDiff({
           state.incrementCounts(0, 1);
         } else {
           state.incrementCounts(1, 1);
-          // FIXME MAYBE
-          // state.incrementCounts(
-          //   state.isInUnifiedWindow(0) ? 1 : 0,
-          //   state.isInSplitWindow(0) ? 1 : 0
-          // );
         }
       }
       return callback(props) ?? false;
@@ -300,13 +295,6 @@ export function iterateOverDiff({
             hunk: hunk,
             collapsedBefore: 0,
             collapsedAfter: 0,
-            // NOTE(amadeus): Pretty sure this is would never return a value,
-            // so lets not call it, but if i notice a bug, i may need to
-            // bring this back.
-            // collapsedAfter: getTrailingCollapsedAfter(
-            //   unifiedRowIndex,
-            //   splitRowIndex
-            // ),
             type: 'context-expanded',
             deletionLine: {
               lineNumber: deletionLineNumber + index,
@@ -346,13 +334,6 @@ export function iterateOverDiff({
               hunk,
               collapsedBefore: consumePendingCollapsed(),
               collapsedAfter: 0,
-              // NOTE(amadeus): Pretty sure this is would never return a value,
-              // so lets not call it, but if i notice a bug, i may need to
-              // bring this back.
-              // collapsedAfter: getTrailingCollapsedAfter(
-              //   unifiedRowIndex,
-              //   splitRowIndex
-              // ),
               type: 'context-expanded',
               deletionLine: {
                 lineNumber: deletionLineNumber + index,
@@ -478,8 +459,8 @@ export function iterateOverDiff({
             // the first visible deletion/addition row.
             consumePendingCollapsed();
           }
-
-          // No need for any skipping because the render ranges skip for us
+          // Change ranges are already clipped to the active window. Counts move
+          // once for the whole change block after the selected rows emit.
           for (const [rangeStart, rangeEnd] of iterationRanges) {
             for (let index = rangeStart; index < rangeEnd; index++) {
               const unifiedRowIndex = unifiedLineIndex + index;
@@ -550,8 +531,6 @@ export function iterateOverDiff({
               collapsedBefore: 0,
               collapsedAfter: isLastLine ? collapsedLines : 0,
               type: 'context-expanded',
-              // NOTE(amadeus): Maybe create an object cache for this to reduce
-              // garbage collection?
               deletionLine: {
                 lineNumber: deletionLineNumber + index,
                 lineIndex: deletionLineIndex + index,
@@ -791,9 +770,9 @@ function walkContextLines(
   return false;
 }
 
-// The intention of this function is to grab the appropriate windowed ranges of
-// the change content.  If diffStyle is both, we will iterate AS split, however
-// we will encompass all needed lines to allow us to render split or unified
+// Clip a change block to the rows that can be visible in the active coordinate
+// space. `diffStyle: both` iterates in split row space, but includes the unified
+// ranges too so either view can render the visible change rows it needs.
 function getChangeIterationRanges(
   state: IterationState,
   content: ChangeContent,
@@ -913,9 +892,8 @@ interface GetChangeLineDataProps {
   splitCount: number;
 }
 
-// NOTE(amadeus): It's quite tedious to grab the appropriate line info and
-// related props for change content regions, so I made it a specialized
-// function to help make the main hunkIterator easy to reason about
+// Build the callback payload for one change row, mapping the selected row index
+// into split/unified coordinates and addition/deletion line metadata.
 function getChangeLineData({
   hunkIndex,
   hunk,
@@ -987,9 +965,7 @@ function getChangeLineData({
     deletionLineIndexValue != null &&
     deletionLineNumberValue != null &&
     unifiedDeletionLineIndex != null
-      ? // NOTE(amadeus): Maybe create an object cache for this to reduce
-        // garbage collection?
-        {
+      ? {
           lineNumber: deletionLineNumberValue,
           lineIndex: deletionLineIndexValue,
           noEOFCR: noEOFCRDeletion,
@@ -1001,9 +977,7 @@ function getChangeLineData({
     additionLineIndexValue != null &&
     additionLineNumberValue != null &&
     unifiedAdditionLineIndex != null
-      ? // NOTE(amadeus): Maybe create an object cache for this to reduce
-        // garbage collection?
-        {
+      ? {
           unifiedLineIndex: unifiedAdditionLineIndex,
           splitLineIndex: resolvedSplitLineIndex,
           lineIndex: additionLineIndexValue,

--- a/packages/diffs/src/utils/virtualDiffLayout.ts
+++ b/packages/diffs/src/utils/virtualDiffLayout.ts
@@ -178,13 +178,33 @@ export function getTrailingExpandedRegion({
     return undefined;
   }
 
-  return getExpandedRegion({
-    isPartial: fileDiff.isPartial,
+  if (
+    expandedHunks === true ||
+    trailingRangeSize <= collapsedContextThreshold
+  ) {
+    return {
+      fromStart: trailingRangeSize,
+      fromEnd: 0,
+      rangeSize: trailingRangeSize,
+      collapsedLines: 0,
+      renderAll: true,
+    };
+  }
+
+  // The final trailing separator only exposes upward partial expansion. Treat it
+  // as a bottom-only pseudo-hunk and ignore unsupported downward expansion.
+  const region = expandedHunks?.get(fileDiff.hunks.length);
+  const fromStart = Math.min(
+    Math.max(region?.fromStart ?? 0, 0),
+    trailingRangeSize
+  );
+  return {
+    fromStart,
+    fromEnd: 0,
     rangeSize: trailingRangeSize,
-    expandedHunks,
-    hunkIndex: fileDiff.hunks.length,
-    collapsedContextThreshold,
-  });
+    collapsedLines: trailingRangeSize - fromStart,
+    renderAll: fromStart >= trailingRangeSize,
+  };
 }
 
 export function getHunkSeparatorHeight({

--- a/packages/diffs/src/utils/virtualDiffLayout.ts
+++ b/packages/diffs/src/utils/virtualDiffLayout.ts
@@ -1,4 +1,5 @@
 import type {
+  FileDiffMetadata,
   HunkExpansionRegion,
   HunkSeparators,
   VirtualFileMetrics,
@@ -18,6 +19,17 @@ export interface GetExpandedRegionProps {
   rangeSize: number;
   expandedHunks: Map<number, HunkExpansionRegion> | true | undefined;
   hunkIndex: number;
+  collapsedContextThreshold: number;
+}
+
+export interface GetTrailingContextRangeSizeProps {
+  fileDiff: FileDiffMetadata;
+  errorPrefix: string;
+}
+
+export interface GetTrailingExpandedRegionProps extends GetTrailingContextRangeSizeProps {
+  hunkIndex: number;
+  expandedHunks: GetExpandedRegionProps['expandedHunks'];
   collapsedContextThreshold: number;
 }
 
@@ -89,6 +101,90 @@ export function getExpandedRegion({
     collapsedLines: Math.max(normalizedRangeSize - expandedCount, 0),
     renderAll,
   };
+}
+
+export function hasTrailingContext(fileDiff: FileDiffMetadata): boolean {
+  const lastHunk = fileDiff.hunks[fileDiff.hunks.length - 1];
+  if (
+    lastHunk == null ||
+    fileDiff.isPartial ||
+    fileDiff.additionLines.length === 0 ||
+    fileDiff.deletionLines.length === 0
+  ) {
+    return false;
+  }
+
+  const additionRemaining =
+    fileDiff.additionLines.length -
+    (lastHunk.additionLineIndex + lastHunk.additionCount);
+  const deletionRemaining =
+    fileDiff.deletionLines.length -
+    (lastHunk.deletionLineIndex + lastHunk.deletionCount);
+
+  return additionRemaining > 0 || deletionRemaining > 0;
+}
+
+// Measures the unchanged tail after the final hunk. Both sides must have the
+// same remaining length because trailing context represents paired lines.
+export function getTrailingContextRangeSize({
+  fileDiff,
+  errorPrefix,
+}: GetTrailingContextRangeSizeProps): number {
+  const lastHunk = fileDiff.hunks[fileDiff.hunks.length - 1];
+  if (
+    lastHunk == null ||
+    fileDiff.isPartial ||
+    fileDiff.additionLines.length === 0 ||
+    fileDiff.deletionLines.length === 0
+  ) {
+    return 0;
+  }
+
+  const additionRemaining =
+    fileDiff.additionLines.length -
+    (lastHunk.additionLineIndex + lastHunk.additionCount);
+  const deletionRemaining =
+    fileDiff.deletionLines.length -
+    (lastHunk.deletionLineIndex + lastHunk.deletionCount);
+
+  if (additionRemaining <= 0 && deletionRemaining <= 0) {
+    return 0;
+  }
+
+  if (additionRemaining !== deletionRemaining) {
+    throw new Error(
+      `${errorPrefix}: trailing context mismatch (additions=${additionRemaining}, deletions=${deletionRemaining}) for ${fileDiff.name}`
+    );
+  }
+  return Math.min(additionRemaining, deletionRemaining);
+}
+
+export function getTrailingExpandedRegion({
+  fileDiff,
+  hunkIndex,
+  expandedHunks,
+  collapsedContextThreshold,
+  errorPrefix,
+}: GetTrailingExpandedRegionProps): ExpandedRegionResult | undefined {
+  if (hunkIndex !== fileDiff.hunks.length - 1) {
+    return undefined;
+  }
+
+  const trailingRangeSize = getTrailingContextRangeSize({
+    fileDiff,
+    errorPrefix,
+  });
+  if (trailingRangeSize <= 0) {
+    return undefined;
+  }
+
+  return getExpandedRegion({
+    isPartial: fileDiff.isPartial,
+    rangeSize: trailingRangeSize,
+    expandedHunks,
+    hunkIndex: fileDiff.hunks.length,
+    collapsedContextThreshold,
+  });
 }
 
 export function getHunkSeparatorHeight({

--- a/packages/diffs/test/computeEstimatedDiffHeights.test.ts
+++ b/packages/diffs/test/computeEstimatedDiffHeights.test.ts
@@ -138,15 +138,15 @@ describe('computeEstimatedDiffHeights', () => {
     });
   });
 
-  test('accounts for partially expanded trailing context', () => {
+  test('accounts for partially expanded trailing context from the start only', () => {
     const fileDiff = createTwoHunkDiff();
     const expandedHunks = new Map([
       [fileDiff.hunks.length, { fromStart: 2, fromEnd: 3 }],
     ]);
 
     expect(compute(fileDiff, { expandedHunks })).toEqual({
-      splitHeight: 376,
-      unifiedHeight: 396,
+      splitHeight: 346,
+      unifiedHeight: 366,
     });
   });
 

--- a/packages/diffs/test/computeEstimatedDiffHeights.test.ts
+++ b/packages/diffs/test/computeEstimatedDiffHeights.test.ts
@@ -138,6 +138,18 @@ describe('computeEstimatedDiffHeights', () => {
     });
   });
 
+  test('accounts for partially expanded trailing context', () => {
+    const fileDiff = createTwoHunkDiff();
+    const expandedHunks = new Map([
+      [fileDiff.hunks.length, { fromStart: 2, fromEnd: 3 }],
+    ]);
+
+    expect(compute(fileDiff, { expandedHunks })).toEqual({
+      splitHeight: 376,
+      unifiedHeight: 396,
+    });
+  });
+
   test('does not estimate trailing collapsed context for partial diffs', () => {
     const fileDiff = { ...createTwoHunkDiff(), isPartial: true };
 

--- a/packages/diffs/test/iterateOverDiff.test.ts
+++ b/packages/diffs/test/iterateOverDiff.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import { parseDiffFromFile } from '../src';
+import type { FileDiffMetadata, Hunk } from '../src/types';
 import { iterateOverDiff } from '../src/utils/iterateOverDiff';
 import { fileNew, fileOld } from './mocks';
 
@@ -167,4 +168,147 @@ describe('iterateOverDiff', () => {
       expect(results[i]).toBe(results[i - 1] + 1);
     }
   });
+
+  test('windowed expansion does not attach skipped collapsed separators to visible rows', () => {
+    const cases: Array<{
+      name: string;
+      diff: FileDiffMetadata;
+      expandedHunks: Map<number, { fromStart: number; fromEnd: number }>;
+      startingLine: number;
+      expectedType: string;
+    }> = [
+      {
+        name: 'expanded fromEnd context',
+        diff: createWindowedSeparatorDiff([
+          {
+            type: 'context',
+            lines: 1,
+            deletionLineIndex: COLLAPSED_BEFORE,
+            additionLineIndex: COLLAPSED_BEFORE,
+          },
+        ]),
+        expandedHunks: new Map([[0, { fromStart: 2, fromEnd: 3 }]]),
+        startingLine: 3,
+        expectedType: 'context-expanded',
+      },
+      {
+        name: 'hunk context content',
+        diff: createWindowedSeparatorDiff([
+          {
+            type: 'context',
+            lines: 3,
+            deletionLineIndex: COLLAPSED_BEFORE,
+            additionLineIndex: COLLAPSED_BEFORE,
+          },
+        ]),
+        expandedHunks: new Map([[0, { fromStart: 2, fromEnd: 0 }]]),
+        startingLine: 3,
+        expectedType: 'context',
+      },
+      {
+        name: 'hunk change content',
+        diff: createWindowedSeparatorDiff([
+          {
+            type: 'change',
+            deletions: 3,
+            deletionLineIndex: COLLAPSED_BEFORE,
+            additions: 3,
+            additionLineIndex: COLLAPSED_BEFORE,
+          },
+        ]),
+        expandedHunks: new Map([[0, { fromStart: 2, fromEnd: 0 }]]),
+        startingLine: 3,
+        expectedType: 'change',
+      },
+    ];
+
+    for (const testCase of cases) {
+      const rows: Array<{ type: string; collapsedBefore: number }> = [];
+
+      iterateOverDiff({
+        diff: testCase.diff,
+        diffStyle: 'unified',
+        expandedHunks: testCase.expandedHunks,
+        startingLine: testCase.startingLine,
+        totalLines: 1,
+        callback: (props) => {
+          rows.push({
+            type: props.type,
+            collapsedBefore: props.collapsedBefore,
+          });
+        },
+      });
+
+      expect({ name: testCase.name, rows }).toEqual({
+        name: testCase.name,
+        rows: [{ type: testCase.expectedType, collapsedBefore: 0 }],
+      });
+    }
+  });
 });
+
+const COLLAPSED_BEFORE = 10;
+
+// Build a minimal full-file diff where a collapsed leading gap can be partially
+// expanded, letting windowed iteration start after the separator boundary.
+function createWindowedSeparatorDiff(
+  hunkContent: Hunk['hunkContent']
+): FileDiffMetadata {
+  let additionCount = 0;
+  let deletionCount = 0;
+  let additionLines = 0;
+  let deletionLines = 0;
+  let splitLineCount = 0;
+  let unifiedLineCount = 0;
+
+  for (const content of hunkContent) {
+    if (content.type === 'context') {
+      additionCount += content.lines;
+      deletionCount += content.lines;
+      splitLineCount += content.lines;
+      unifiedLineCount += content.lines;
+    } else {
+      additionCount += content.additions;
+      deletionCount += content.deletions;
+      additionLines += content.additions;
+      deletionLines += content.deletions;
+      splitLineCount += Math.max(content.additions, content.deletions);
+      unifiedLineCount += content.additions + content.deletions;
+    }
+  }
+
+  const hunk: Hunk = {
+    collapsedBefore: COLLAPSED_BEFORE,
+    additionStart: COLLAPSED_BEFORE + 1,
+    additionCount,
+    additionLines,
+    additionLineIndex: COLLAPSED_BEFORE,
+    deletionStart: COLLAPSED_BEFORE + 1,
+    deletionCount,
+    deletionLines,
+    deletionLineIndex: COLLAPSED_BEFORE,
+    hunkContent,
+    hunkSpecs: `@@ -${COLLAPSED_BEFORE + 1},${deletionCount} +${COLLAPSED_BEFORE + 1},${additionCount} @@`,
+    splitLineStart: COLLAPSED_BEFORE,
+    splitLineCount,
+    unifiedLineStart: COLLAPSED_BEFORE,
+    unifiedLineCount,
+    noEOFCRDeletions: false,
+    noEOFCRAdditions: false,
+  };
+
+  return {
+    name: 'windowed-separator.ts',
+    type: 'change',
+    hunks: [hunk],
+    splitLineCount: COLLAPSED_BEFORE + splitLineCount,
+    unifiedLineCount: COLLAPSED_BEFORE + unifiedLineCount,
+    isPartial: false,
+    deletionLines: createLines(COLLAPSED_BEFORE + deletionCount),
+    additionLines: createLines(COLLAPSED_BEFORE + additionCount),
+  };
+}
+
+function createLines(count: number): string[] {
+  return Array.from({ length: count }, (_, index) => `line ${index}\n`);
+}

--- a/packages/diffs/test/iterateOverDiff.test.ts
+++ b/packages/diffs/test/iterateOverDiff.test.ts
@@ -407,15 +407,9 @@ describe('iterateOverDiff', () => {
       },
       {
         type: 'context-expanded',
-        collapsedAfter: 0,
+        collapsedAfter: 3,
         deletionLineIndex: 3,
         additionLineIndex: 3,
-      },
-      {
-        type: 'context-expanded',
-        collapsedAfter: 2,
-        deletionLineIndex: 4,
-        additionLineIndex: 4,
       },
     ]);
   });

--- a/packages/diffs/test/iterateOverDiff.test.ts
+++ b/packages/diffs/test/iterateOverDiff.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test } from 'bun:test';
 
 import { parseDiffFromFile } from '../src';
 import type { FileDiffMetadata, Hunk } from '../src/types';
-import { iterateOverDiff } from '../src/utils/iterateOverDiff';
+import {
+  type DiffLineCallbackProps,
+  type DiffLineMetadata,
+  iterateOverDiff,
+} from '../src/utils/iterateOverDiff';
 import { fileNew, fileOld } from './mocks';
 
 // NOTE(amadeus): These tests were written by an AI and they are probably
@@ -169,6 +173,311 @@ describe('iterateOverDiff', () => {
     }
   });
 
+  test('windowed iteration matches full iteration slices for unified and split styles', () => {
+    const cases: Array<{
+      diffStyle: 'unified' | 'split';
+      startingLine: number;
+      totalLines: number;
+    }> = [
+      { diffStyle: 'unified', startingLine: 0, totalLines: 8 },
+      { diffStyle: 'unified', startingLine: 10, totalLines: 5 },
+      { diffStyle: 'unified', startingLine: 150, totalLines: 13 },
+      { diffStyle: 'split', startingLine: 0, totalLines: 8 },
+      { diffStyle: 'split', startingLine: 10, totalLines: 5 },
+      { diffStyle: 'split', startingLine: 120, totalLines: 17 },
+    ];
+
+    for (const testCase of cases) {
+      const fullRows = collectRows({ diff, diffStyle: testCase.diffStyle });
+      const windowedRows = collectRows({
+        diff,
+        diffStyle: testCase.diffStyle,
+        startingLine: testCase.startingLine,
+        totalLines: testCase.totalLines,
+      });
+
+      expect({ name: testCase, rows: windowedRows }).toEqual({
+        name: testCase,
+        rows: fullRows.slice(
+          testCase.startingLine,
+          testCase.startingLine + testCase.totalLines
+        ),
+      });
+    }
+  });
+
+  test('both style includes rows visible in either split or unified coordinates for uneven changes', () => {
+    const unevenDiff = createSingleHunkDiff({
+      hunkContent: [
+        {
+          type: 'context',
+          lines: 2,
+          deletionLineIndex: 0,
+          additionLineIndex: 0,
+        },
+        {
+          type: 'change',
+          deletions: 4,
+          deletionLineIndex: 2,
+          additions: 1,
+          additionLineIndex: 2,
+        },
+      ],
+    });
+
+    const rows = collectRows({
+      diff: unevenDiff,
+      diffStyle: 'both',
+      startingLine: 6,
+      totalLines: 1,
+    });
+
+    expect(rows).toEqual([
+      {
+        type: 'change',
+        hunkIndex: 0,
+        collapsedBefore: 0,
+        collapsedAfter: 0,
+        deletionLine: {
+          unifiedLineIndex: 2,
+          splitLineIndex: 2,
+          lineIndex: 2,
+          lineNumber: 3,
+          noEOFCR: false,
+        },
+        additionLine: {
+          unifiedLineIndex: 6,
+          splitLineIndex: 2,
+          lineIndex: 2,
+          lineNumber: 3,
+          noEOFCR: false,
+        },
+      },
+    ]);
+  });
+
+  test('both style skips gap rows between disjoint split and unified equal-row windows', () => {
+    const gapDiff = createSingleHunkDiff({
+      hunkContent: [
+        {
+          type: 'change',
+          deletions: 5,
+          deletionLineIndex: 0,
+          additions: 5,
+          additionLineIndex: 0,
+        },
+        {
+          type: 'context',
+          lines: 10,
+          deletionLineIndex: 5,
+          additionLineIndex: 5,
+        },
+      ],
+    });
+
+    const rows = collectRows({
+      diff: gapDiff,
+      diffStyle: 'both',
+      startingLine: 12,
+      totalLines: 1,
+    });
+
+    expect(
+      rows.map((row) => ({
+        type: row.type,
+        unifiedLineIndex: row.deletionLine?.unifiedLineIndex,
+        splitLineIndex: row.deletionLine?.splitLineIndex,
+        lineIndex: row.deletionLine?.lineIndex,
+      }))
+    ).toEqual([
+      {
+        type: 'context',
+        unifiedLineIndex: 12,
+        splitLineIndex: 7,
+        lineIndex: 7,
+      },
+      {
+        type: 'context',
+        unifiedLineIndex: 17,
+        splitLineIndex: 12,
+        lineIndex: 12,
+      },
+    ]);
+  });
+
+  test('expanded leading context preserves fromStart and fromEnd placement', () => {
+    const leadingDiff = createSingleHunkDiff({
+      collapsedBefore: 6,
+      hunkContent: [
+        {
+          type: 'change',
+          deletions: 1,
+          deletionLineIndex: 6,
+          additions: 1,
+          additionLineIndex: 6,
+        },
+      ],
+    });
+    const rows = collectRows({
+      diff: leadingDiff,
+      diffStyle: 'unified',
+      expandedHunks: new Map([[0, { fromStart: 2, fromEnd: 2 }]]),
+    });
+
+    expect(
+      rows.slice(0, 5).map((row) => ({
+        type: row.type,
+        collapsedBefore: row.collapsedBefore,
+        deletionLineIndex: row.deletionLine?.lineIndex,
+        additionLineIndex: row.additionLine?.lineIndex,
+      }))
+    ).toEqual([
+      {
+        type: 'context-expanded',
+        collapsedBefore: 0,
+        deletionLineIndex: 0,
+        additionLineIndex: 0,
+      },
+      {
+        type: 'context-expanded',
+        collapsedBefore: 0,
+        deletionLineIndex: 1,
+        additionLineIndex: 1,
+      },
+      {
+        type: 'context-expanded',
+        collapsedBefore: 2,
+        deletionLineIndex: 4,
+        additionLineIndex: 4,
+      },
+      {
+        type: 'context-expanded',
+        collapsedBefore: 0,
+        deletionLineIndex: 5,
+        additionLineIndex: 5,
+      },
+      {
+        type: 'change',
+        collapsedBefore: 0,
+        deletionLineIndex: 6,
+        additionLineIndex: undefined,
+      },
+    ]);
+  });
+
+  test('trailing context is collapsed after hunk content or emitted when expanded', () => {
+    const trailingDiff = createSingleHunkDiff({
+      hunkContent: [
+        {
+          type: 'context',
+          lines: 2,
+          deletionLineIndex: 0,
+          additionLineIndex: 0,
+        },
+      ],
+      trailingLineCount: 5,
+    });
+
+    const collapsedRows = collectRows({
+      diff: trailingDiff,
+      diffStyle: 'unified',
+    });
+    expect(collapsedRows).toHaveLength(2);
+    expect(collapsedRows.at(-1)?.collapsedAfter).toBe(5);
+
+    const expandedRows = collectRows({
+      diff: trailingDiff,
+      diffStyle: 'unified',
+      expandedHunks: new Map([[1, { fromStart: 2, fromEnd: 1 }]]),
+    });
+
+    expect(
+      expandedRows.slice(2).map((row) => ({
+        type: row.type,
+        collapsedAfter: row.collapsedAfter,
+        deletionLineIndex: row.deletionLine?.lineIndex,
+        additionLineIndex: row.additionLine?.lineIndex,
+      }))
+    ).toEqual([
+      {
+        type: 'context-expanded',
+        collapsedAfter: 0,
+        deletionLineIndex: 2,
+        additionLineIndex: 2,
+      },
+      {
+        type: 'context-expanded',
+        collapsedAfter: 0,
+        deletionLineIndex: 3,
+        additionLineIndex: 3,
+      },
+      {
+        type: 'context-expanded',
+        collapsedAfter: 2,
+        deletionLineIndex: 4,
+        additionLineIndex: 4,
+      },
+    ]);
+  });
+
+  test('windowed iteration preserves collapsedBefore and collapsedAfter separator placement', () => {
+    const leadingRows = collectRows({
+      diff: createWindowedSeparatorDiff([
+        {
+          type: 'context',
+          lines: 3,
+          deletionLineIndex: COLLAPSED_BEFORE,
+          additionLineIndex: COLLAPSED_BEFORE,
+        },
+      ]),
+      diffStyle: 'unified',
+      expandedHunks: new Map([[0, { fromStart: 2, fromEnd: 0 }]]),
+      startingLine: 3,
+      totalLines: 1,
+    });
+    expect(leadingRows).toEqual([
+      expect.objectContaining({ type: 'context', collapsedBefore: 0 }),
+    ]);
+
+    const trailingRows = collectRows({
+      diff: createSingleHunkDiff({
+        hunkContent: [
+          {
+            type: 'context',
+            lines: 3,
+            deletionLineIndex: 0,
+            additionLineIndex: 0,
+          },
+        ],
+        trailingLineCount: 4,
+      }),
+      diffStyle: 'unified',
+      startingLine: 2,
+      totalLines: 1,
+    });
+    expect(trailingRows).toEqual([
+      expect.objectContaining({ type: 'context', collapsedAfter: 4 }),
+    ]);
+  });
+
+  test('callback can stop iteration early', () => {
+    const rows: RowSnapshot[] = [];
+
+    iterateOverDiff({
+      diff,
+      diffStyle: 'unified',
+      callback: (props) => {
+        rows.push(serializeRow(props));
+        return rows.length === 3;
+      },
+    });
+
+    expect(rows).toEqual(
+      collectRows({ diff, diffStyle: 'unified' }).slice(0, rows.length)
+    );
+    expect(rows).toHaveLength(3);
+  });
+
   test('windowed expansion does not attach skipped collapsed separators to visible rows', () => {
     const cases: Array<{
       name: string;
@@ -249,11 +558,159 @@ describe('iterateOverDiff', () => {
 
 const COLLAPSED_BEFORE = 10;
 
+type IterateOptions = Omit<Parameters<typeof iterateOverDiff>[0], 'callback'>;
+
+interface LineSnapshot {
+  unifiedLineIndex: number;
+  splitLineIndex: number;
+  lineIndex: number;
+  lineNumber: number;
+  noEOFCR: boolean;
+}
+
+interface RowSnapshot {
+  type: DiffLineCallbackProps['type'];
+  hunkIndex: number;
+  collapsedBefore: number;
+  collapsedAfter: number;
+  deletionLine: LineSnapshot | undefined;
+  additionLine: LineSnapshot | undefined;
+}
+
+function collectRows(options: IterateOptions): RowSnapshot[] {
+  const rows: RowSnapshot[] = [];
+
+  iterateOverDiff({
+    ...options,
+    callback: (props) => {
+      rows.push(serializeRow(props));
+    },
+  });
+
+  return rows;
+}
+
+function serializeRow(props: DiffLineCallbackProps): RowSnapshot {
+  return {
+    type: props.type,
+    hunkIndex: props.hunkIndex,
+    collapsedBefore: props.collapsedBefore,
+    collapsedAfter: props.collapsedAfter,
+    deletionLine: serializeLine(props.deletionLine),
+    additionLine: serializeLine(props.additionLine),
+  };
+}
+
+function serializeLine(
+  line: DiffLineMetadata | undefined
+): LineSnapshot | undefined {
+  if (line == null) {
+    return undefined;
+  }
+  return {
+    unifiedLineIndex: line.unifiedLineIndex,
+    splitLineIndex: line.splitLineIndex,
+    lineIndex: line.lineIndex,
+    lineNumber: line.lineNumber,
+    noEOFCR: line.noEOFCR,
+  };
+}
+
+function createSingleHunkDiff({
+  collapsedBefore = 0,
+  hunkContent,
+  trailingLineCount = 0,
+}: {
+  collapsedBefore?: number;
+  hunkContent: Hunk['hunkContent'];
+  trailingLineCount?: number;
+}): FileDiffMetadata {
+  const counts = getHunkContentCounts(hunkContent);
+
+  const hunk: Hunk = {
+    collapsedBefore,
+    additionStart: collapsedBefore + 1,
+    additionCount: counts.additionCount,
+    additionLines: counts.additionLines,
+    additionLineIndex: collapsedBefore,
+    deletionStart: collapsedBefore + 1,
+    deletionCount: counts.deletionCount,
+    deletionLines: counts.deletionLines,
+    deletionLineIndex: collapsedBefore,
+    hunkContent,
+    hunkSpecs: `@@ -${collapsedBefore + 1},${counts.deletionCount} +${collapsedBefore + 1},${counts.additionCount} @@`,
+    splitLineStart: collapsedBefore,
+    splitLineCount: counts.splitLineCount,
+    unifiedLineStart: collapsedBefore,
+    unifiedLineCount: counts.unifiedLineCount,
+    noEOFCRDeletions: false,
+    noEOFCRAdditions: false,
+  };
+
+  return {
+    name: 'single-hunk.ts',
+    type: 'change',
+    hunks: [hunk],
+    splitLineCount: collapsedBefore + counts.splitLineCount + trailingLineCount,
+    unifiedLineCount:
+      collapsedBefore + counts.unifiedLineCount + trailingLineCount,
+    isPartial: false,
+    deletionLines: createLines(
+      collapsedBefore + counts.deletionCount + trailingLineCount
+    ),
+    additionLines: createLines(
+      collapsedBefore + counts.additionCount + trailingLineCount
+    ),
+  };
+}
+
 // Build a minimal full-file diff where a collapsed leading gap can be partially
 // expanded, letting windowed iteration start after the separator boundary.
 function createWindowedSeparatorDiff(
   hunkContent: Hunk['hunkContent']
 ): FileDiffMetadata {
+  const counts = getHunkContentCounts(hunkContent);
+
+  const hunk: Hunk = {
+    collapsedBefore: COLLAPSED_BEFORE,
+    additionStart: COLLAPSED_BEFORE + 1,
+    additionCount: counts.additionCount,
+    additionLines: counts.additionLines,
+    additionLineIndex: COLLAPSED_BEFORE,
+    deletionStart: COLLAPSED_BEFORE + 1,
+    deletionCount: counts.deletionCount,
+    deletionLines: counts.deletionLines,
+    deletionLineIndex: COLLAPSED_BEFORE,
+    hunkContent,
+    hunkSpecs: `@@ -${COLLAPSED_BEFORE + 1},${counts.deletionCount} +${COLLAPSED_BEFORE + 1},${counts.additionCount} @@`,
+    splitLineStart: COLLAPSED_BEFORE,
+    splitLineCount: counts.splitLineCount,
+    unifiedLineStart: COLLAPSED_BEFORE,
+    unifiedLineCount: counts.unifiedLineCount,
+    noEOFCRDeletions: false,
+    noEOFCRAdditions: false,
+  };
+
+  return {
+    name: 'windowed-separator.ts',
+    type: 'change',
+    hunks: [hunk],
+    splitLineCount: COLLAPSED_BEFORE + counts.splitLineCount,
+    unifiedLineCount: COLLAPSED_BEFORE + counts.unifiedLineCount,
+    isPartial: false,
+    deletionLines: createLines(COLLAPSED_BEFORE + counts.deletionCount),
+    additionLines: createLines(COLLAPSED_BEFORE + counts.additionCount),
+  };
+}
+
+function getHunkContentCounts(hunkContent: Hunk['hunkContent']): {
+  additionCount: number;
+  deletionCount: number;
+  additionLines: number;
+  deletionLines: number;
+  splitLineCount: number;
+  unifiedLineCount: number;
+} {
   let additionCount = 0;
   let deletionCount = 0;
   let additionLines = 0;
@@ -277,35 +734,13 @@ function createWindowedSeparatorDiff(
     }
   }
 
-  const hunk: Hunk = {
-    collapsedBefore: COLLAPSED_BEFORE,
-    additionStart: COLLAPSED_BEFORE + 1,
-    additionCount,
-    additionLines,
-    additionLineIndex: COLLAPSED_BEFORE,
-    deletionStart: COLLAPSED_BEFORE + 1,
-    deletionCount,
-    deletionLines,
-    deletionLineIndex: COLLAPSED_BEFORE,
-    hunkContent,
-    hunkSpecs: `@@ -${COLLAPSED_BEFORE + 1},${deletionCount} +${COLLAPSED_BEFORE + 1},${additionCount} @@`,
-    splitLineStart: COLLAPSED_BEFORE,
-    splitLineCount,
-    unifiedLineStart: COLLAPSED_BEFORE,
-    unifiedLineCount,
-    noEOFCRDeletions: false,
-    noEOFCRAdditions: false,
-  };
-
   return {
-    name: 'windowed-separator.ts',
-    type: 'change',
-    hunks: [hunk],
-    splitLineCount: COLLAPSED_BEFORE + splitLineCount,
-    unifiedLineCount: COLLAPSED_BEFORE + unifiedLineCount,
-    isPartial: false,
-    deletionLines: createLines(COLLAPSED_BEFORE + deletionCount),
-    additionLines: createLines(COLLAPSED_BEFORE + additionCount),
+    additionCount,
+    deletionCount,
+    additionLines,
+    deletionLines,
+    splitLineCount,
+    unifiedLineCount,
   };
 }
 

--- a/packages/diffs/test/virtualDiffLayout.test.ts
+++ b/packages/diffs/test/virtualDiffLayout.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, test } from 'bun:test';
 
-import type { HunkSeparators, VirtualFileMetrics } from '../src/types';
+import type {
+  FileDiffMetadata,
+  Hunk,
+  HunkSeparators,
+  VirtualFileMetrics,
+} from '../src/types';
 import {
   getExpandedRegion,
   getLeadingHunkSeparatorLayout,
+  getTrailingExpandedRegion,
   getTrailingHunkSeparatorLayout,
 } from '../src/utils/virtualDiffLayout';
 
@@ -107,6 +113,72 @@ describe('virtual diff layout helpers', () => {
     });
   });
 
+  describe('getTrailingExpandedRegion', () => {
+    test('ignores unsupported final trailing fromEnd expansion', () => {
+      const fileDiff = createTrailingDiff(5);
+
+      expect(
+        getTrailingExpandedRegion({
+          fileDiff,
+          hunkIndex: 0,
+          expandedHunks: new Map([[1, { fromStart: 2, fromEnd: 3 }]]),
+          collapsedContextThreshold: 0,
+          errorPrefix: 'virtualDiffLayout.test',
+        })
+      ).toEqual({
+        fromStart: 2,
+        fromEnd: 0,
+        rangeSize: 5,
+        collapsedLines: 3,
+        renderAll: false,
+      });
+    });
+
+    test('expands all final trailing context from the start', () => {
+      const fileDiff = createTrailingDiff(5);
+
+      expect(
+        getTrailingExpandedRegion({
+          fileDiff,
+          hunkIndex: 0,
+          expandedHunks: true,
+          collapsedContextThreshold: 0,
+          errorPrefix: 'virtualDiffLayout.test',
+        })
+      ).toEqual({
+        fromStart: 5,
+        fromEnd: 0,
+        rangeSize: 5,
+        collapsedLines: 0,
+        renderAll: true,
+      });
+
+      expect(
+        getTrailingExpandedRegion({
+          fileDiff,
+          hunkIndex: 0,
+          expandedHunks: new Map([
+            [
+              1,
+              {
+                fromStart: Number.POSITIVE_INFINITY,
+                fromEnd: Number.POSITIVE_INFINITY,
+              },
+            ],
+          ]),
+          collapsedContextThreshold: 0,
+          errorPrefix: 'virtualDiffLayout.test',
+        })
+      ).toEqual({
+        fromStart: 5,
+        fromEnd: 0,
+        rangeSize: 5,
+        collapsedLines: 0,
+        renderAll: true,
+      });
+    });
+  });
+
   describe('separator layouts', () => {
     test('preserves current leading separator rules', () => {
       const cases: [
@@ -166,3 +238,47 @@ describe('virtual diff layout helpers', () => {
     });
   });
 });
+
+function createTrailingDiff(trailingLineCount: number): FileDiffMetadata {
+  const hunk: Hunk = {
+    collapsedBefore: 0,
+    additionStart: 1,
+    additionCount: 2,
+    additionLines: 0,
+    additionLineIndex: 0,
+    deletionStart: 1,
+    deletionCount: 2,
+    deletionLines: 0,
+    deletionLineIndex: 0,
+    hunkContent: [
+      {
+        type: 'context',
+        lines: 2,
+        deletionLineIndex: 0,
+        additionLineIndex: 0,
+      },
+    ],
+    hunkSpecs: '@@ -1,2 +1,2 @@',
+    splitLineStart: 0,
+    splitLineCount: 2,
+    unifiedLineStart: 0,
+    unifiedLineCount: 2,
+    noEOFCRDeletions: false,
+    noEOFCRAdditions: false,
+  };
+
+  return {
+    name: 'trailing.ts',
+    type: 'change',
+    hunks: [hunk],
+    splitLineCount: 2 + trailingLineCount,
+    unifiedLineCount: 2 + trailingLineCount,
+    isPartial: false,
+    deletionLines: createLines(2 + trailingLineCount),
+    additionLines: createLines(2 + trailingLineCount),
+  };
+}
+
+function createLines(count: number): string[] {
+  return Array.from({ length: count }, (_, index) => `line ${index}\n`);
+}

--- a/packages/diffs/test/virtualizedFileDiffEstimatedHeights.test.ts
+++ b/packages/diffs/test/virtualizedFileDiffEstimatedHeights.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, test } from 'bun:test';
 
 import { VirtualizedFileDiff } from '../src/components/VirtualizedFileDiff';
 import { DEFAULT_CODE_VIEW_FILE_METRICS } from '../src/constants';
-import type { FileDiffMetadata, VirtualFileMetrics } from '../src/types';
+import type {
+  FileDiffMetadata,
+  HunkExpansionRegion,
+  VirtualFileMetrics,
+} from '../src/types';
+import { iterateOverDiff } from '../src/utils/iterateOverDiff';
 import { parseDiffFromFile } from '../src/utils/parseDiffFromFile';
 
 const metrics: VirtualFileMetrics = {
@@ -39,6 +44,10 @@ interface InspectableVirtualizedFileDiff {
     checkpoints: unknown[];
     totalLines: number;
   };
+  getExpandedLineCount(
+    fileDiff: FileDiffMetadata,
+    diffStyle: 'split' | 'unified'
+  ): number;
   fileContainer: HTMLElement | undefined;
   codeAdditions: HTMLElement | undefined;
 }
@@ -172,6 +181,23 @@ function createMeasuredCodeGroup(
   content.append(line);
   group.append(gutter, content);
   return group as unknown as HTMLElement;
+}
+
+function countIteratedRows(
+  fileDiff: FileDiffMetadata,
+  diffStyle: 'split' | 'unified',
+  expandedHunks: Map<number, HunkExpansionRegion>
+): number {
+  let count = 0;
+  iterateOverDiff({
+    diff: fileDiff,
+    diffStyle,
+    expandedHunks,
+    callback: () => {
+      count++;
+    },
+  });
+  return count;
 }
 
 describe('VirtualizedFileDiff estimated height cache', () => {
@@ -372,6 +398,25 @@ describe('VirtualizedFileDiff estimated height cache', () => {
     expect(instance.getVirtualizedHeight()).toBe(estimatedHeight);
     expect(inspect(instance).cache.totalLines).toBeGreaterThan(10_000);
     expect(inspect(instance).cache.checkpoints.length).toBeGreaterThan(1);
+  });
+
+  test('counts trailing fromEnd expansion in render range line totals', () => {
+    const fileDiff = createTwoHunkDiff();
+    const trailingHunkIndex = fileDiff.hunks.length;
+    const expandedHunks = new Map<number, HunkExpansionRegion>([
+      [trailingHunkIndex, { fromStart: 2, fromEnd: 3 }],
+    ]);
+    const instance = new VirtualizedFileDiff({}, virtualizer, metrics);
+
+    instance.expandHunk(trailingHunkIndex, 'up', 2);
+    instance.expandHunk(trailingHunkIndex, 'down', 3);
+
+    expect(inspect(instance).getExpandedLineCount(fileDiff, 'split')).toBe(
+      countIteratedRows(fileDiff, 'split', expandedHunks)
+    );
+    expect(inspect(instance).getExpandedLineCount(fileDiff, 'unified')).toBe(
+      countIteratedRows(fileDiff, 'unified', expandedHunks)
+    );
   });
 
   test('checkpoint generation jumps through large uniform blocks', () => {

--- a/packages/diffs/test/virtualizedFileDiffEstimatedHeights.test.ts
+++ b/packages/diffs/test/virtualizedFileDiffEstimatedHeights.test.ts
@@ -400,11 +400,11 @@ describe('VirtualizedFileDiff estimated height cache', () => {
     expect(inspect(instance).cache.checkpoints.length).toBeGreaterThan(1);
   });
 
-  test('counts trailing fromEnd expansion in render range line totals', () => {
+  test('ignores trailing fromEnd expansion in render range line totals', () => {
     const fileDiff = createTwoHunkDiff();
     const trailingHunkIndex = fileDiff.hunks.length;
-    const expandedHunks = new Map<number, HunkExpansionRegion>([
-      [trailingHunkIndex, { fromStart: 2, fromEnd: 3 }],
+    const fromStartOnly = new Map<number, HunkExpansionRegion>([
+      [trailingHunkIndex, { fromStart: 2, fromEnd: 0 }],
     ]);
     const instance = new VirtualizedFileDiff({}, virtualizer, metrics);
 
@@ -412,10 +412,10 @@ describe('VirtualizedFileDiff estimated height cache', () => {
     instance.expandHunk(trailingHunkIndex, 'down', 3);
 
     expect(inspect(instance).getExpandedLineCount(fileDiff, 'split')).toBe(
-      countIteratedRows(fileDiff, 'split', expandedHunks)
+      countIteratedRows(fileDiff, 'split', fromStartOnly)
     );
     expect(inspect(instance).getExpandedLineCount(fileDiff, 'unified')).toBe(
-      countIteratedRows(fileDiff, 'unified', expandedHunks)
+      countIteratedRows(fileDiff, 'unified', fromStartOnly)
     );
   });
 


### PR DESCRIPTION
Initially i setup to fix the bug in: #756, which you can see in the work in 0450e8ccc23acf3df7601aabe243c4f05123ab62, 1a8d2121c3fbfbe2ba0e5b922ffebc60343ab4d6.

However, as I was working through that, I felt like the entire iterateOverDiffs needed a bit if a cleanup/refactor, so appended that onto the general fix. This involved adding a few more tests to ensure we maintain backwards compatibility with everything.

Somehow we also improved performance a bit of iterateOverDiff function.