### PR TITLE
Harden CI for new workspace packages

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,39 @@
+name: Set up Bun and dependencies
+description: >-
+  Install the Bun version pinned in .prototools, restore the Bun install cache,
+  and install workspace dependencies with a frozen lockfile. Shared by every CI
+  job so the toolchain version and the dependency fast-path live in one place.
+
+runs:
+  using: composite
+  steps:
+    # Single source of truth for the Bun version: the same .prototools pin proto
+    # uses locally and assert-bun-version enforces on publish. Bump it there and
+    # every CI job follows automatically — there is no per-job version to sync.
+    - name: Resolve pinned Bun version
+      id: bun-version
+      shell: bash
+      run: |
+        version=$(awk -F'"' '/^bun[[:space:]]*=/ { print $2; exit }' .prototools)
+        if [ -z "$version" ]; then
+          echo "::error::Could not read the pinned Bun version from .prototools"
+          exit 1
+        fi
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: ${{ steps.bun-version.outputs.version }}
+
+    - name: Cache dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.bun/install/cache
+        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-bun-
+
+    - name: Install dependencies
+      shell: bash
+      run: bun install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,7 @@ jobs:
         with:
           name: build-output
           path: |
-            packages/diffs/dist/
-            packages/trees/dist/
-            packages/storage-elements/dist/
-            packages/storage-elements-next/dist/
+            packages/*/dist/
             apps/docs/.source/
             apps/docs/.next/
           retention-days: 1
@@ -167,14 +164,8 @@ jobs:
         with:
           name: build-output
 
-      - name: Run tests - precision-diffs
-        run: bun ws diffs test
-
-      - name: Run tests - trees
-        run: bun ws trees test
-
-      - name: Run tests - path-store
-        run: bun ws path-store test
+      - name: Run unit tests (all packages)
+        run: bun ws "packages/*" test --sequential
 
       - name: Mount Playwright browsers
         uses: useblacksmith/stickydisk@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,21 +14,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.12
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - name: Set up Bun and install dependencies
+        uses: ./.github/actions/setup
 
       - name: Build workspace packages
         run: bun ws "packages/*" build
@@ -57,21 +44,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.8
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - name: Set up Bun and install dependencies
+        uses: ./.github/actions/setup
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -89,21 +63,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.8
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - name: Set up Bun and install dependencies
+        uses: ./.github/actions/setup
 
       - name: Run Stylelint
         run: bun run lint:css
@@ -116,21 +77,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.8
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - name: Set up Bun and install dependencies
+        uses: ./.github/actions/setup
 
       - name: Run Format check
         run: bun run format:check
@@ -143,21 +91,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.8
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - name: Set up Bun and install dependencies
+        uses: ./.github/actions/setup
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -186,21 +121,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.8
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - name: Set up Bun and install dependencies
+        uses: ./.github/actions/setup
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4

--- a/packages/truncate/package.json
+++ b/packages/truncate/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "tsdown --clean",
     "dev": "echo 'Watching for changes…' && tsdown --watch --log-level error",
-    "test": "bun test",
+    "test": "bun test --pass-with-no-tests",
     "tsc": "tsgo --noEmit --pretty",
     "prepublishOnly": "bun run build"
   },

--- a/scripts/ws.ts
+++ b/scripts/ws.ts
@@ -301,6 +301,18 @@ if (verboseIndex !== -1) {
   args.splice(verboseIndex, 1);
 }
 
+// Pull `--parallel` / `--sequential` out of the args so they reach `bun run` as
+// run-mode options instead of being forwarded to the underlying script. They
+// switch bun's filtered output from the live (redrawn) tree to ordered
+// Foreman-style logs; `--sequential` runs one package at a time, which keeps
+// each package's output contiguous and readable instead of interleaved.
+const runModeFlag = ['--parallel', '--sequential'].find((flag) =>
+  args.includes(flag)
+);
+if (runModeFlag) {
+  args.splice(args.indexOf(runModeFlag), 1);
+}
+
 const [pkgArg, ...scriptArgs] = args;
 
 if (!pkgArg || scriptArgs.length === 0) {
@@ -313,6 +325,12 @@ if (!pkgArg || scriptArgs.length === 0) {
   console.log('');
   console.log('Options:');
   console.log('  -v, --verbose    Show full output (no line elision)');
+  console.log(
+    '  --parallel       Concurrent Foreman-style output (globs only)'
+  );
+  console.log(
+    '  --sequential     Run matched packages one at a time, in order'
+  );
   console.log('');
   console.log('Examples:');
   console.log('  bun ws diffs build');
@@ -352,9 +370,13 @@ if (pkgArg.includes('*')) {
     filter = `@pierre/${pkgArg}`;
   }
 
+  // With a run-mode flag, bun owns the output format (Foreman-style); otherwise
+  // fall back to the live tree with elision disabled so full output is shown.
+  const outputFlags = runModeFlag ? [runModeFlag] : ['--elide-lines=0'];
+
   const proc = spawn(
     'bun',
-    ['run', '-F', filter, '--elide-lines=0', ...scriptArgs],
+    ['run', '-F', filter, ...outputFlags, ...scriptArgs],
     {
       stdio: 'inherit',
       cwd,


### PR DESCRIPTION
Two CI fixes prompted by `@pierre/theme-kit` (a new workspace package) breaking lint, typecheck, and builds.

**Cover all packages in CI, not a hardcoded list.**

* Build artifact now uploads `packages/*/dist/` instead of an enumerated subset, so new packages' built types reach the lint/typecheck jobs (theme-kit was missing → types resolved to any).
* Test job runs every package via `bun ws "packages/*" test --sequential` instead of a hand-listed three, so new packages' tests actually run. `--sequential` keeps the log ordered and readable; `@pierre/truncate` (no test files yet) uses `--pass-with-no-tests`.

**Single source of truth for the Bun version**

* Extracted the repeated Setup Bun + cache + install steps into a local composite action (`.github/actions/setup`) that reads the version from `.prototools` — the same pin proto and assert-bun-version use. Per-job pins had already drifted (`1.3.12`/`1.3.8` vs. the pinned `1.3.14`).
* Every job now drops to checkout + `uses: ./.github/actions/setup`; new jobs get the same cached-deps fast path for free.