### PR TITLE
fix(docs): Gate DiffsHub routes by site

### DIFF
--- a/apps/docs/app/(diffshub)/(view)/[...path]/page.tsx
+++ b/apps/docs/app/(diffshub)/(view)/[...path]/page.tsx
@@ -1,7 +1,9 @@
-import { redirect } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 
 import { ReviewUI } from '../_components/ReviewUI';
 import { resolveDiffshubViewerRoute } from '../_components/utils';
+
+const SITE = process.env.NEXT_PUBLIC_SITE;
 
 // Viewer route that mirrors the upstream path. GitHub is the public default,
 // while hidden alternate domains can opt in through the `domain` query param.
@@ -15,7 +17,11 @@ export default async function DiffshubViewByPathPage({
   const { path } = await params;
   const { domain } = await searchParams;
   const requestedDomain = Array.isArray(domain) ? domain[0] : domain;
-  const route = resolveDiffshubViewerRoute(path, requestedDomain);
+  const route = resolveDiffshubViewerRoute(path, requestedDomain, SITE);
+  if (route.kind === 'notFound') {
+    notFound();
+  }
+
   if (route.kind === 'redirect') {
     redirect(route.target);
   }

--- a/apps/docs/app/(diffshub)/(view)/_components/utils.ts
+++ b/apps/docs/app/(diffshub)/(view)/_components/utils.ts
@@ -131,6 +131,7 @@ export function getPatchViewerHref(input: string): string | undefined {
 }
 
 export type DiffshubViewerRoute =
+  | { kind: 'notFound' }
   | { kind: 'redirect'; target: string }
   | {
       kind: 'render';
@@ -147,8 +148,13 @@ export type DiffshubViewerRoute =
 // hosts are passed through unchanged because their canonical form is unknown.
 export function resolveDiffshubViewerRoute(
   pathSegments: readonly string[],
-  requestedDomainInput: string | undefined
+  requestedDomainInput: string | undefined,
+  site: string | undefined = 'diffshub'
 ): DiffshubViewerRoute {
+  if (site !== 'diffshub') {
+    return { kind: 'notFound' };
+  }
+
   if (pathSegments.length === 0) {
     return { kind: 'redirect', target: '/' };
   }

--- a/apps/docs/test/resolveDiffshubViewerRoute.test.ts
+++ b/apps/docs/test/resolveDiffshubViewerRoute.test.ts
@@ -3,6 +3,20 @@ import { describe, expect, test } from 'bun:test';
 import { resolveDiffshubViewerRoute } from '../app/(diffshub)/(view)/_components/utils';
 
 describe('resolveDiffshubViewerRoute', () => {
+  describe('site gating', () => {
+    test('returns notFound outside the diffshub site', () => {
+      expect(
+        resolveDiffshubViewerRoute(
+          ['owner', 'repo', 'pull', '123'],
+          undefined,
+          'diffs'
+        )
+      ).toEqual({
+        kind: 'notFound',
+      });
+    });
+  });
+
   describe('empty path', () => {
     test('redirects to home', () => {
       expect(resolveDiffshubViewerRoute([], undefined)).toEqual({


### PR DESCRIPTION
Adds site gating so the DiffsHub catch-all viewer route returns 404s outside diffshub builds, while preserving the legacy `/gh` redirect to diffshub.com.

This prevents diffs.com missing paths from rendering the DiffsHub viewer without breaking the existing `/gh` redirect.