### PR TITLE
tool(wt): Add reusable worktree setup command

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -97,6 +97,7 @@ tool didn't create (e.g. agent-spawned ones under `.omx/worktrees/` or
 
 ```bash
 bun run wt new <slug> [--branch <name>] [--base <ref>]
+bun run wt setup [<slug>]
 bun run wt rm  <slug> [--keep-branch] [--force]
 bun run wt clean [<slug>|--all]
 bun run wt ps
@@ -124,6 +125,9 @@ By default:
 - `bun install` runs automatically so husky hooks regenerate and the worktree's
   `node_modules` is ready.
 - A summary of the worktree's URLs and the `cd` command is printed.
+
+Internally, `wt new` creates the git worktree and then runs the same post-add
+setup as `wt setup`.
 
 Flags:
 
@@ -154,6 +158,43 @@ copy-paste it. If you want true auto-cd, wrap `wt new` in a shell function of
 your own (out of scope for this repo, deliberately — we don't force anyone to
 install anything).
 
+### `wt setup [<slug>]` — initialize an existing worktree
+
+Runs the post-add setup that `wt new` runs automatically:
+
+- Resolves the target worktree.
+- Writes or reuses `.env.worktree` with `PIERRE_WORKTREE_SLUG` and
+  `PIERRE_PORT_OFFSET`.
+- Runs `bun install` in the target worktree.
+- Prints the worktree's URLs and `cd` command.
+
+With a slug, `wt setup` targets the managed worktree path:
+
+```bash
+bun run wt setup drag-drop-fix
+# → initializes ~/pierre/pierre-worktrees/drag-drop-fix/
+```
+
+Without a slug, it targets the current linked worktree. This is intended for
+scripts that create or enter a worktree themselves before running setup:
+
+```bash
+git worktree add ~/pierre/pierre-worktrees/manual-branch manual-branch
+cd ~/pierre/pierre-worktrees/manual-branch
+bun run wt setup
+```
+
+`wt setup` refuses to initialize the main clone, because the main clone should
+not have a `.env.worktree` and should keep offset 0.
+
+Other TypeScript scripts can call the path-first setup function directly:
+
+```ts
+import { setupWorktree } from './wt.ts';
+
+await setupWorktree({ path: process.cwd(), slug: 'manual-branch' });
+```
+
 ### `wt rm <slug>` — tear down a worktree
 
 Runs `wt clean <slug>` first (kills any processes bound to the worktree's
@@ -178,8 +219,7 @@ launch a duplicate. `wt clean` fixes this on demand.
   `.env.worktree` are skipped — `wt` doesn't know their ports.)
 - `bun run wt clean <slug>` — same, but only for that worktree.
 
-Agents in particular should run `bun run wt clean` before ending their turn
-(this is documented in `AGENTS.md`).
+Agents in particular should run `bun run wt clean` before ending their turn.
 
 ### `wt ps` — see what's listening
 
@@ -215,16 +255,18 @@ Every worktree owns a **port offset** (0, 10, 20, 30, …). Its actual ports are
 
 ### How the offset is chosen
 
-`wt new` picks an offset deterministically from the slug's hash (so recreating a
-worktree with the same slug tends to give you the same ports and preserve your
-browser bookmarks). If that candidate collides with another live worktree's
-offset, it bumps by 10 until it finds a free slot. Discovery of live offsets is
-stateless — `git worktree list` + each worktree's `.env.worktree` is the source
-of truth. There is no central registry file.
+`wt setup` picks an offset deterministically from the slug's hash (so recreating
+a worktree with the same slug tends to give you the same ports and preserve your
+browser bookmarks). `wt new` runs `wt setup` after adding the worktree. If that
+candidate collides with another live worktree's offset, it bumps by 10 until it
+finds a free slot. Discovery of live offsets is stateless: `git worktree list`
+combined with each worktree's `.env.worktree` is the source of truth. There is
+no central registry file.
 
 ### How the offset reaches your dev scripts
 
-1. `wt new` writes `.env.worktree` at the worktree root:
+1. `wt setup` writes `.env.worktree` at the worktree root. `wt new` runs setup
+   automatically after adding the worktree:
    ```
    PIERRE_WORKTREE_SLUG=drag-drop-fix
    PIERRE_PORT_OFFSET=30
@@ -335,7 +377,13 @@ bun run wt rm drag-drop-fix --force
 git fetch
 bun run wt new review-mdos-pr --branch mdo/new-feature
 cd ~/pierre/pierre-worktrees/review-mdos-pr
-bun install
+```
+
+### Need to initialize a worktree another script already created
+
+```bash
+cd ~/pierre/pierre-worktrees/generated-by-script
+bun run wt setup
 ```
 
 ---
@@ -355,18 +403,18 @@ bun install
   dev server binds the main clone's port. Configs that run _after_ the shell
   (Next's `next.config.mjs`, Playwright configs) will still pick up
   `.env.worktree` on their own — but `PORT` arithmetic in a package.json script
-  is resolved by the shell, so always prefer `bun ws …` from the worktree root
-  (this is already the convention in `AGENTS.md`).
+  is resolved by the shell, so always prefer `bun ws …` from the worktree root.
 - **Port offsets can't be manually re-used between worktrees.** If you want two
-  worktrees on deterministic sibling ports, just let `wt new` pick — the hash is
-  stable per slug.
+  worktrees on deterministic sibling ports, let `wt setup` pick — `wt new` runs
+  setup automatically, and the hash is stable per slug.
 - **Unmanaged worktrees are visible but ignored for offset accounting.** Agent
   worktrees under `.omx/worktrees/` or `/private/tmp/pierre-*` show up in
   `wt list` and `wt ps`, but they don't claim offsets and `wt clean --all`
   doesn't try to guess their ports.
 - **Hooks / generated files.** Fresh worktrees don't have `.husky/_/` (it's
-  regenerated by husky's `prepare` script on install). `wt new` runs
-  `bun install` automatically so this is usually invisible.
+  regenerated by husky's `prepare` script on install). `wt setup` runs
+  `bun install` automatically, and `wt new` runs setup after creating the
+  worktree, so this is usually invisible.
 
 ---
 

--- a/scripts/wt.ts
+++ b/scripts/wt.ts
@@ -3,6 +3,7 @@
 // Worktree command suite for this monorepo.
 //
 //   bun run wt new <slug> [--branch <name>] [--base <ref>]
+//   bun run wt setup [<slug>]
 //   bun run wt rm <slug> [--keep-branch] [--force]
 //   bun run wt clean [<slug>|--all]
 //   bun run wt ps
@@ -25,7 +26,7 @@
 import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir, userInfo } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 
 const WORKTREES_HOME = join(homedir(), 'pierre', 'pierre-worktrees');
 
@@ -54,15 +55,30 @@ interface Worktree {
   isMain: boolean;
 }
 
+export interface SetupWorktreeOptions {
+  /** Directory inside the worktree to initialize. Defaults to the current working directory. */
+  path?: string;
+  /** Slug to write into `.env.worktree`. Defaults to the existing env slug or worktree directory name. */
+  slug?: string;
+  /** Run `bun install` in the worktree after writing `.env.worktree`. Defaults to true. */
+  install?: boolean;
+  /** Print the port summary and cd command after setup. Defaults to true. */
+  printSummary?: boolean;
+}
+
+export interface SetupWorktreeResult {
+  path: string;
+  slug: string;
+  offset: number;
+}
+
 // -----------------------------------------------------------------------------
 // Entry point
 // -----------------------------------------------------------------------------
 
-const args = process.argv.slice(2);
-const sub = args[0];
-
 const commands: Record<string, (rest: string[]) => Promise<number> | number> = {
   new: cmdNew,
+  setup: cmdSetup,
   rm: cmdRm,
   clean: cmdClean,
   ps: cmdPs,
@@ -72,18 +88,23 @@ const commands: Record<string, (rest: string[]) => Promise<number> | number> = {
   '-h': cmdHelp,
 };
 
-if (!sub || !(sub in commands)) {
-  cmdHelp();
-  process.exit(sub ? 1 : 0);
-}
+if (import.meta.main) {
+  const args = process.argv.slice(2);
+  const sub = args[0];
 
-Promise.resolve(commands[sub](args.slice(1))).then(
-  (code) => process.exit(code ?? 0),
-  (err) => {
-    console.error(err instanceof Error ? err.message : String(err));
-    process.exit(1);
+  if (!sub || !(sub in commands)) {
+    cmdHelp();
+    process.exit(sub ? 1 : 0);
   }
-);
+
+  Promise.resolve(commands[sub](args.slice(1))).then(
+    (code) => process.exit(code ?? 0),
+    (err) => {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+  );
+}
 
 function cmdHelp(): number {
   console.log(`Usage: bun run wt <subcommand> [args]
@@ -93,6 +114,12 @@ Subcommands:
       Create a new worktree at ~/pierre/pierre-worktrees/<slug>.
       Branch defaults to "$USER/<slug>". --branch attaches an existing branch.
       --base selects the starting ref (default: main).
+
+  setup [<slug>]
+      Run post-add setup for an existing worktree: write .env.worktree,
+      run bun install, and print the worktree's ports. With <slug>, targets
+      ~/pierre/pierre-worktrees/<slug>. Without <slug>, targets the current
+      linked worktree.
 
   rm <slug> [--keep-branch] [--force]
       Kill any processes bound to the worktree's ports, then remove it.
@@ -141,11 +168,6 @@ async function cmdNew(rest: string[]): Promise<number> {
 
   mkdirSync(WORKTREES_HOME, { recursive: true });
 
-  const offset = allocateOffset(
-    slug,
-    worktrees.map((w) => w.offset).filter((o): o is number => o !== null)
-  );
-
   // Decide how to invoke `git worktree add`:
   //   - If --branch was passed, the branch may already exist locally: use
   //     `git worktree add <path> <branch>` (no -b).
@@ -160,25 +182,7 @@ async function cmdNew(rest: string[]): Promise<number> {
     return gitResult.status ?? 1;
   }
 
-  writeFileSync(
-    join(worktreePath, '.env.worktree'),
-    `PIERRE_WORKTREE_SLUG=${slug}\nPIERRE_PORT_OFFSET=${offset}\n`,
-    'utf8'
-  );
-
-  console.log(`\nInstalling dependencies in ${worktreePath}...`);
-  const bunInstall = spawnSync('bun', ['install'], {
-    cwd: worktreePath,
-    stdio: 'inherit',
-  });
-  if (bunInstall.status !== 0) {
-    console.error(
-      'wt new: bun install failed; the worktree was created but may be incomplete'
-    );
-    return bunInstall.status ?? 1;
-  }
-
-  printPortMap(slug, offset, worktreePath);
+  await setupWorktree({ path: worktreePath, slug });
   return 0;
 }
 
@@ -201,6 +205,74 @@ function parseNewArgs(rest: string[]): {
     }
   }
   return { slug, branch, base };
+}
+
+// -----------------------------------------------------------------------------
+// wt setup
+// -----------------------------------------------------------------------------
+
+async function cmdSetup(rest: string[]): Promise<number> {
+  const slug = rest.find((a) => !a.startsWith('--'));
+  const path = slug ? join(WORKTREES_HOME, slugify(slug)) : process.cwd();
+  await setupWorktree({ path, slug });
+  return 0;
+}
+
+// Initialize the generated worktree metadata and dependencies for a linked
+// worktree. The path-first shape lets other scripts call this after they have
+// already changed into the worktree they created.
+export async function setupWorktree(
+  options: SetupWorktreeOptions = {}
+): Promise<SetupWorktreeResult> {
+  const inputPath = resolve(options.path ?? process.cwd());
+  const worktreeRoot = resolveGitWorktreeRoot(inputPath);
+  const worktrees = enumerateWorktrees(worktreeRoot);
+  const worktree = findWorktreeByPath(worktrees, worktreeRoot);
+
+  if (!worktree) {
+    throw new Error(
+      `wt setup: ${worktreeRoot} is not listed as a git worktree`
+    );
+  }
+  if (worktree.isMain) {
+    throw new Error('wt setup: refusing to initialize the main clone');
+  }
+
+  const envPath = join(worktreeRoot, '.env.worktree');
+  const existingEnv = existsSync(envPath) ? parseEnvFile(envPath) : {};
+  const slug =
+    options.slug ?? existingEnv.PIERRE_WORKTREE_SLUG ?? basename(worktreeRoot);
+  const existingOffset = parseOffset(existingEnv.PIERRE_PORT_OFFSET);
+  const offset =
+    existingOffset ??
+    allocateOffset(
+      slug,
+      worktrees.map((w) => w.offset).filter((o): o is number => o !== null)
+    );
+
+  const envText = `PIERRE_WORKTREE_SLUG=${slug}\nPIERRE_PORT_OFFSET=${offset}\n`;
+  if (!existsSync(envPath) || readFileSync(envPath, 'utf8') !== envText) {
+    writeFileSync(envPath, envText, 'utf8');
+  }
+
+  if (options.install ?? true) {
+    console.log(`\nInstalling dependencies in ${worktreeRoot}...`);
+    const bunInstall = spawnSync('bun', ['install'], {
+      cwd: worktreeRoot,
+      stdio: 'inherit',
+    });
+    if (bunInstall.status !== 0) {
+      throw new Error(
+        'wt setup: bun install failed; the worktree may be incomplete'
+      );
+    }
+  }
+
+  if (options.printSummary ?? true) {
+    printPortMap(slug, offset, worktreeRoot);
+  }
+
+  return { path: worktreeRoot, slug, offset };
 }
 
 // -----------------------------------------------------------------------------
@@ -349,10 +421,14 @@ function cmdList(): number {
 // Parse `git worktree list --porcelain`. Each record is terminated by a blank
 // line. Fields we care about: `worktree <path>`, `HEAD <sha>`, `branch
 // refs/heads/<name>` (or `detached`).
-function enumerateWorktrees(): Worktree[] {
-  const result = spawnSync('git', ['worktree', 'list', '--porcelain'], {
-    encoding: 'utf8',
-  });
+function enumerateWorktrees(cwd = process.cwd()): Worktree[] {
+  const result = spawnSync(
+    'git',
+    ['-C', cwd, 'worktree', 'list', '--porcelain'],
+    {
+      encoding: 'utf8',
+    }
+  );
   if (result.status !== 0) {
     throw new Error(`git worktree list failed:\n${result.stderr}`);
   }
@@ -413,6 +489,34 @@ function enumerateWorktrees(): Worktree[] {
 
 function findWorktreeBySlug(slug: string): Worktree | undefined {
   return enumerateWorktrees().find((w) => w.slug === slug);
+}
+
+function findWorktreeByPath(
+  worktrees: Worktree[],
+  path: string
+): Worktree | undefined {
+  const targetPath = resolve(path);
+  return worktrees.find((w) => resolve(w.path) === targetPath);
+}
+
+function resolveGitWorktreeRoot(path: string): string {
+  const result = spawnSync(
+    'git',
+    ['-C', path, 'rev-parse', '--show-toplevel'],
+    {
+      encoding: 'utf8',
+    }
+  );
+  if (result.status !== 0) {
+    throw new Error(`wt setup: ${path} is not inside a git worktree`);
+  }
+  return resolve(result.stdout.trim());
+}
+
+function parseOffset(value: string | undefined): number | null {
+  if (value === undefined) return null;
+  const offset = Number(value);
+  return Number.isFinite(offset) ? offset : null;
 }
 
 // Stable, deterministic offset candidate from slug. Steps by 10 so ports in


### PR DESCRIPTION
Extract post-add worktree initialization into an exported path-first setupWorktree helper, then have wt new delegate to it after creating the git worktree.

Add wt setup for initializing an existing linked worktree from the current directory or from a managed slug path. Document the new command and update the worktree setup flow in scripts/README.md.

Guard the CLI entrypoint so scripts can import the helper safely, and refuse setup on the main clone to preserve default ports.

@SlexAxton this was mostly in regards to our chat from the other day around wanting the ability to run a command that does your worktree stuff without creating the worktree