### PR TITLE
[diffs/editor] Support unified diff

### DIFF
--- a/apps/docs/app/(diffs)/_examples/LiveEditor/LiveEditor.tsx
+++ b/apps/docs/app/(diffs)/_examples/LiveEditor/LiveEditor.tsx
@@ -78,7 +78,7 @@ export function LiveEditor({
           setHasEdits(file.contents !== LIVE_EDITOR_NEW_FILE.contents);
         },
       }),
-    []
+    [mode]
   );
 
   // Reset by remounting the editable surface. Bumping `resetKey` unmounts the

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -468,7 +468,7 @@ export class File<
     }
   }
 
-  private syncRenderView = () => {
+  private syncRenderViewToEditor = () => {
     const editor = this.editor;
     const fileContainer = this.fileContainer;
     const file = this.file;
@@ -488,7 +488,7 @@ export class File<
   public attachEditor(editor: DiffsEditor<LAnnotation>): () => void {
     this.editor?.cleanUp();
     this.editor = editor;
-    queueRender(this.syncRenderView);
+    queueRender(this.syncRenderViewToEditor);
     return () => {
       this.editor = undefined;
     };
@@ -663,7 +663,7 @@ export class File<
       this.renderAnnotations();
       this.renderGutterUtility();
       if (this.editor != null) {
-        queueRender(this.syncRenderView);
+        queueRender(this.syncRenderViewToEditor);
       }
     } catch (error: unknown) {
       if (disableErrorHandling) {

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -237,6 +237,7 @@ export class FileDiff<
   protected enabled = true;
 
   protected editor: DiffsEditor<LAnnotation> | undefined;
+  protected fastRefreshTimeout: ReturnType<typeof setTimeout> | undefined;
 
   constructor(
     public options: FileDiffOptions<LAnnotation> = { theme: DEFAULT_THEMES },
@@ -449,13 +450,8 @@ export class FileDiff<
   private canPartiallyRender(
     forceRender: boolean,
     annotationsChanged: boolean,
-    didContentChange: boolean,
-    didEdit: boolean
+    didContentChange: boolean
   ): boolean {
-    if (didEdit) {
-      // The editor is tokenizing the diff in background, so we can partially render
-      return true;
-    }
     if (
       forceRender ||
       annotationsChanged ||
@@ -555,6 +551,10 @@ export class FileDiff<
 
     this.editor?.cleanUp();
     this.editor = undefined;
+    if (this.fastRefreshTimeout != null) {
+      clearTimeout(this.fastRefreshTimeout);
+      this.fastRefreshTimeout = undefined;
+    }
   }
 
   public virtualizedSetup(): void {
@@ -746,7 +746,6 @@ export class FileDiff<
     newFile,
     fileDiff,
     deferManagers = false,
-    didEdit = false,
     forceRender = false,
     preventEmit = false,
     lineAnnotations,
@@ -784,7 +783,6 @@ export class FileDiff<
     if (
       !collapsed &&
       areRenderRangesEqual(nextRenderRange, this.renderRange) &&
-      !didEdit &&
       !forceRender &&
       !annotationsChanged &&
       !themeChanged &&
@@ -891,8 +889,7 @@ export class FileDiff<
         this.canPartiallyRender(
           forceRender,
           annotationsChanged,
-          filesDidChange || diffDidChange || themeChanged,
-          didEdit
+          filesDidChange || diffDidChange || themeChanged
         ) &&
         this.applyPartialRender({
           previousRenderRange,
@@ -935,10 +932,7 @@ export class FileDiff<
           this.pre = undefined;
         }
         this.renderSeparators(hunksResult.hunkData);
-      } else if (didEdit && nextRenderRange != null) {
-        this.updateLineType(nextRenderRange);
       }
-
       this.applyBuffers(pre, nextRenderRange);
       this.injectUnsafeCSS();
       this.renderAnnotations();
@@ -950,7 +944,7 @@ export class FileDiff<
       }
 
       if (this.editor != null) {
-        queueRender(this.syncRenderView);
+        queueRender(this.syncRenderViewToEditor);
       }
     } catch (error: unknown) {
       if (disableErrorHandling) {
@@ -994,16 +988,21 @@ export class FileDiff<
     onPostRender?.(fileContainer, this, phase);
   }
 
-  private syncRenderView = () => {
+  private syncRenderViewToEditor = () => {
     const editor = this.editor;
     const fileContainer = this.fileContainer;
-    const file = this.getAdditionFile();
-    if (editor != null && fileContainer != null && file != null) {
+    const fileDiff = this.fileDiff;
+    if (
+      editor != null &&
+      fileContainer != null &&
+      fileDiff != null &&
+      !fileDiff.isPartial
+    ) {
       void this.hunksRenderer.initializeHighlighter().then((highlighter) => {
         editor.__syncRenderView(
           highlighter,
           fileContainer,
-          file,
+          fileDiff,
           this.lineAnnotations,
           this.renderRange
         );
@@ -1014,7 +1013,7 @@ export class FileDiff<
   public attachEditor(editor: DiffsEditor<LAnnotation>): () => void {
     this.editor?.cleanUp();
     this.editor = editor;
-    queueRender(this.syncRenderView);
+    queueRender(this.syncRenderViewToEditor);
     return () => {
       this.editor = undefined;
     };
@@ -1046,33 +1045,22 @@ export class FileDiff<
   public updateRenderCache(
     dirtyLines: Map<number, Array<HighlightedToken>>,
     themeType: 'dark' | 'light',
-    shouldRerender?: boolean
+    shouldRefreshView?: boolean
   ): void {
     this.hunksRenderer.updateRenderCache(dirtyLines, themeType);
-    if (shouldRerender === true) {
-      this.render({ didEdit: true, renderRange: this.renderRange });
+    if (shouldRefreshView === true) {
+      if (this.options.diffStyle === 'split') {
+        if (this.fastRefreshTimeout != null) {
+          clearTimeout(this.fastRefreshTimeout);
+        }
+        this.fastRefreshTimeout = setTimeout(() => {
+          this.fastRefreshTimeout = undefined;
+          this.fastRefreshDiffView();
+        }, 100);
+      } else {
+        this.refreshDiffView();
+      }
     }
-  }
-
-  private getAdditionFile(): FileContents | undefined {
-    if (this.additionFile != null) {
-      return this.additionFile;
-    }
-    const fileDiff = this.fileDiff;
-    if (fileDiff != null && !fileDiff.isPartial) {
-      const { name, lang, cacheKey } = fileDiff;
-      const file = {
-        name,
-        lang,
-        cacheKey,
-      } as FileContents;
-      Object.defineProperty(file, 'contents', {
-        enumerable: true,
-        get: () => fileDiff.additionLines.join(''),
-      });
-      return file;
-    }
-    return undefined;
   }
 
   private removeRenderedCode(): void {
@@ -1901,15 +1889,16 @@ export class FileDiff<
     }
   }
 
-  // Update split-view `data-line-type` after an edit.
-  private updateLineType(renderRange: RenderRange): void {
-    if (this.options.diffStyle === 'unified') {
+  // fast refresh diff view via updating the `data-line-type` after an edit.
+  // only for split view.
+  private fastRefreshDiffView(): void {
+    if (this.options.diffStyle !== 'split') {
       return;
     }
 
     const hunksResult = this.hunksRenderer.renderDiff(
       this.fileDiff,
-      renderRange
+      this.renderRange
     );
     if (hunksResult == null) {
       return;
@@ -1921,7 +1910,7 @@ export class FileDiff<
       this.codeDeletions,
       this.codeAdditions
     );
-    if (columns == null || !Array.isArray(columns)) {
+    if (!Array.isArray(columns)) {
       return;
     }
 
@@ -1962,6 +1951,56 @@ export class FileDiff<
 
     applyLineType('deletions', columns[0]);
     applyLineType('additions', columns[1]);
+  }
+
+  // full diff view re-rendering
+  private refreshDiffView(): void {
+    const hunksResult = this.hunksRenderer.renderDiff(
+      this.fileDiff,
+      this.renderRange
+    );
+    if (hunksResult == null) {
+      return;
+    }
+
+    const columns = this.getCodeColumns(
+      this.options.diffStyle ?? 'split',
+      this.codeUnified,
+      this.codeDeletions,
+      this.codeAdditions
+    );
+    if (columns == null) {
+      return;
+    }
+
+    const render = (
+      type: 'deletions' | 'additions' | 'unified',
+      column: ColumnElements | undefined
+    ) => {
+      if (column == null) {
+        return;
+      }
+      const ast = this.hunksRenderer.renderCodeAST(type, hunksResult);
+      const gutterChildren = getElementChildren(ast?.[0]);
+      const contentChildren = getElementChildren(ast?.[1]);
+      for (const [el, astChildren] of [
+        [column.gutter, gutterChildren],
+        [column.content, contentChildren],
+      ] as const) {
+        if (astChildren != null) {
+          el.innerHTML = toHtml(astChildren);
+        }
+      }
+    };
+
+    if (Array.isArray(columns)) {
+      render('deletions', columns[0]);
+      render('additions', columns[1]);
+    } else {
+      render('unified', columns);
+    }
+
+    this.syncRenderViewToEditor();
   }
 
   private renderPartialColumn(

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -5,6 +5,7 @@ import type {
   DiffsEditorSelection,
   DiffsHighlighter,
   FileContents,
+  FileDiffMetadata,
   HighlightedToken,
   RenderRange,
 } from '../types';
@@ -168,7 +169,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
 
   // state
   #fileInstance?: DiffsEditableComponent<LAnnotation>;
-  #fileContents?: FileContents;
+  #fileInfo?: Omit<FileContents, 'contents'>;
   #lineAnnotations?: DiffLineAnnotation<LAnnotation>[];
   #textDocument?: TextDocument<LAnnotation>;
   #renderRange?: RenderRange;
@@ -227,7 +228,6 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       enableGutterUtility,
       enableLineSelection,
       expandUnchanged,
-      diffStyle,
       lineHoverHighlight,
       ...rest
     } = component.options;
@@ -236,18 +236,16 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       useTokenTransformer !== true ||
       enableGutterUtility === true ||
       enableLineSelection === true ||
-      lineHoverHighlight !== 'disabled' ||
       (expandUnchanged !== true && isDiff) ||
-      (diffStyle === 'unified' && isDiff)
+      lineHoverHighlight !== 'disabled'
     ) {
       component.setOptions({
         ...rest,
         useTokenTransformer: true,
         enableGutterUtility: false,
         enableLineSelection: false,
-        lineHoverHighlight: 'disabled',
         expandUnchanged: true,
-        diffStyle: 'split',
+        lineHoverHighlight: 'disabled',
       });
       component.rerender();
     }
@@ -431,7 +429,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   __syncRenderView: DiffsEditor<LAnnotation>['__syncRenderView'] = (
     highlighter: DiffsHighlighter,
     fileContainer: HTMLElement,
-    fileContents: FileContents,
+    fileOrDiff: FileContents | FileDiffMetadata,
     lineAnnotations: DiffLineAnnotation<LAnnotation>[] | undefined,
     renderRange: RenderRange | undefined
   ) => {
@@ -482,23 +480,29 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
 
     if (
       this.#textDocument === undefined ||
-      this.#fileContents === undefined ||
-      this.#fileContents.name !== fileContents.name ||
-      this.#fileContents.contents !== fileContents.contents ||
-      this.#fileContents.lang !== fileContents.lang ||
-      this.#fileContents.cacheKey !== fileContents.cacheKey
+      this.#fileInfo === undefined ||
+      this.#fileInfo.name !== fileOrDiff.name ||
+      this.#fileInfo.lang !== fileOrDiff.lang ||
+      this.#fileInfo.cacheKey !== fileOrDiff.cacheKey
     ) {
+      let contents = '';
+      if ('contents' in fileOrDiff) {
+        contents = fileOrDiff.contents;
+      } else {
+        contents = fileOrDiff.additionLines.join('');
+      }
       const editStack = new EditStack<LAnnotation>({
         maxEntries: this.#options.historyMaxEntries,
       });
       const textDocument = new TextDocument<LAnnotation>(
-        fileContents.name,
-        fileContents.contents,
-        fileContents.lang ?? getFiletypeFromFileName(fileContents.name),
+        fileOrDiff.name,
+        contents,
+        fileOrDiff.lang ?? getFiletypeFromFileName(fileOrDiff.name),
         0,
         editStack
       );
-      this.#fileContents = fileContents;
+      const { name, lang, cacheKey } = fileOrDiff;
+      this.#fileInfo = { name, lang, cacheKey };
       this.#textDocument = textDocument;
       this.#tokenizer?.cleanUp();
       this.#tokenizer = new EditorTokenizer({
@@ -541,6 +545,20 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         this.#options.__debug === true
       ) {
         console.log('[diffs/editor] full re-render triggered !!!');
+      }
+    }
+
+    if (
+      (lineAnnotations !== undefined && lineAnnotations.length > 0) ||
+      (this.#fileInstance?.type === 'file-diff' &&
+        this.#fileInstance.options.diffStyle === 'unified')
+    ) {
+      for (const child of this.#contentElement.children) {
+        const el = child as HTMLElement;
+        const { lineAnnotation, lineType } = el.dataset;
+        if (lineAnnotation !== undefined || lineType === 'change-deletion') {
+          el.setAttribute('contenteditable', 'false');
+        }
       }
     }
 
@@ -596,7 +614,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       const { startingLine, totalLines } = renderRange;
       console.log(
         '[diffs/editor] render file:',
-        fileContents.name,
+        fileOrDiff.name,
         'RenderRange:',
         startingLine + '-' + (startingLine + totalLines),
         'of',
@@ -1303,14 +1321,12 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   ) {
     const tokenizer = this.#tokenizer;
     const fileInstance = this.#fileInstance;
-    const fileContents = this.#fileContents;
     const textDocument = this.#textDocument;
     const gutterEl = this.#gutterElement;
     const contentEl = this.#contentElement;
     if (
       tokenizer === undefined ||
       fileInstance === undefined ||
-      fileContents === undefined ||
       textDocument === undefined ||
       contentEl === undefined
     ) {
@@ -1334,17 +1350,19 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         const child = children[i] as HTMLElement | undefined;
         if (child !== undefined) {
           const lineNumber = getLineNumberAttr(child);
-          if (lineNumber !== undefined) {
-            const lineIndex = lineNumber - 1;
-            if (dirtyLines.has(lineIndex)) {
-              const tokens = dirtyLines.get(lineIndex)!;
-              child.replaceChildren(
-                ...renderLineTokens(tokens, tokenizer.themeType)
-              );
-              dirtyLineIndexes.delete(lineIndex);
-              if (dirtyLineIndexes.size === 0) {
-                break;
-              }
+          const lineType = child.dataset.lineType;
+          if (lineNumber === undefined || lineType === 'change-deletion') {
+            continue;
+          }
+          const lineIndex = lineNumber - 1;
+          if (dirtyLines.has(lineIndex)) {
+            const tokens = dirtyLines.get(lineIndex)!;
+            child.replaceChildren(
+              ...renderLineTokens(tokens, tokenizer.themeType)
+            );
+            dirtyLineIndexes.delete(lineIndex);
+            if (dirtyLineIndexes.size === 0) {
+              break;
             }
           }
         }
@@ -1402,7 +1420,8 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
           const lineNumber =
             getLineNumberAttr(child) ??
             getLineNumberAttr(child, 'columnNumber');
-          if (lineNumber === undefined) {
+          const lineType = child.dataset.lineType;
+          if (lineNumber === undefined || lineType === 'change-deletion') {
             continue;
           }
           if (lineNumber - 1 < change.lineCount) {
@@ -1413,7 +1432,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       }
     }
 
-    const isDiff = Object.hasOwn(fileInstance, 'fileDiff');
+    const isDiff = this.#fileInstance?.type === 'file-diff';
     const didLineCountChange = change.lineDelta !== 0;
 
     // fix grid layout
@@ -1434,7 +1453,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     fileInstance.updateRenderCache(
       dirtyLines,
       tokenizer.themeType,
-      isDiff ? !didLineCountChange : undefined
+      isDiff && !didLineCountChange
     );
     if (didLineCountChange) {
       fileInstance.applyDocumentChange(
@@ -2592,12 +2611,12 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   }
 
   #getFileRef(): FileContents | undefined {
-    const fileContents = this.#fileContents;
+    const fileInfo = this.#fileInfo;
     const textDocument = this.#textDocument;
-    if (fileContents === undefined || textDocument === undefined) {
+    if (fileInfo === undefined || textDocument === undefined) {
       return undefined;
     }
-    const { contents: _, ...file } = fileContents;
+    const file = { ...fileInfo }; // copy
     Object.defineProperty(file, 'contents', {
       enumerable: true,
       get: () => textDocument.getText(),
@@ -2742,7 +2761,10 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
 
     // fallback to query selector
     lineElement ??= contentElement.querySelector<HTMLElement>(
-      `[data-line="${line + 1}"]`
+      `[data-line="${line + 1}"]` +
+        (this.#fileInstance?.options.diffStyle === 'unified'
+          ? ':not([data-line-type="change-deletion"])'
+          : '')
     );
 
     if (lineElement !== null) {

--- a/packages/diffs/src/editor/selection.ts
+++ b/packages/diffs/src/editor/selection.ts
@@ -1767,8 +1767,8 @@ function getLineChildEnd(
 }
 
 function getLineIndex(el: HTMLElement): number | undefined {
-  const { line } = el.dataset;
-  if (line !== undefined) {
+  const { line, lineType } = el.dataset;
+  if (line !== undefined && lineType !== 'change-deletion') {
     const lineNumber = parseInt(line, 10);
     if (!Number.isNaN(lineNumber)) {
       return lineNumber - 1;

--- a/packages/diffs/src/react/utils/useFileDiffInstance.ts
+++ b/packages/diffs/src/react/utils/useFileDiffInstance.ts
@@ -206,7 +206,6 @@ function mergeFileDiffOptions<LAnnotation>({
       enableGutterUtility: false,
       enableLineSelection: false,
       expandUnchanged: true,
-      diffStyle: 'split',
       lineHoverHighlight: 'disabled',
     };
   }

--- a/packages/diffs/src/types.ts
+++ b/packages/diffs/src/types.ts
@@ -931,7 +931,7 @@ export interface DiffsEditableComponent<
   updateRenderCache: (
     lines: Map<number, Array<HighlightedToken>>,
     themeType: 'dark' | 'light',
-    shouldRerender?: boolean
+    shouldRefreshView?: boolean
   ) => void;
 }
 
@@ -940,7 +940,7 @@ export interface DiffsEditor<LAnnotation> {
   __syncRenderView(
     highlighter: DiffsHighlighter,
     fileContainer: HTMLElement,
-    fileContents: FileContents,
+    fileOrDiff: FileContents | FileDiffMetadata,
     lineAnnotations:
       | LineAnnotation<LAnnotation>[]
       | DiffLineAnnotation<LAnnotation>[]


### PR DESCRIPTION
- [x] Allow 'unified' layout on an editor attach to the file diff component
- [x] Inline-edit doesn't trigger re-render now
- [x] refresh view when typing