### PR TITLE
[diffs] Removing BETA badge from Virtualization

### DIFF
--- a/apps/docs/lib/mdx.tsx
+++ b/apps/docs/lib/mdx.tsx
@@ -58,7 +58,7 @@ function MdxLink(props: ComponentPropsWithoutRef<'a'>) {
 // Section headings whose `## ` slug should render a "Beta" badge. The badge is
 // appended after the heading text (not part of the markdown) so the slug—and
 // therefore the anchor and any child heading ids—stays unchanged.
-const BETA_DOC_HEADING_IDS = new Set(['editor', 'virtualization']);
+const BETA_DOC_HEADING_IDS = new Set(['editor']);
 
 function MdxHeading2({
   id,


### PR DESCRIPTION
Noticed this branch added these new fancy beta tags, but I already moved the Virtualization component out of beta on `main` by removing the various beta/api notices, and needed to add an additional change here since the beta tags are new.