### PR TITLE
 fix(diffs): Handle IME composition input

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -176,6 +176,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   #searchPanel?: SearchPanelWidget;
   #selectionAction?: SelectionActionWidget;
   #shouldIgnoreSelectionChange = false;
+  #isComposing = false;
   #isGutterMouseDown = false;
   #isContentMouseDown = false;
   #shiftKeyPressed = false;
@@ -680,7 +681,17 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
           }
 
           const selectionRaw = document.getSelection();
-          const composedRange = selectionRaw?.getComposedRanges({
+          // getComposedRanges is the only selection API that reads through the
+          // editor's shadow root, but it is newly available and missing on
+          // older browsers and embedded WebViews. Bail out instead of throwing
+          // out of this listener on every selectionchange when it is absent.
+          if (
+            selectionRaw == null ||
+            typeof selectionRaw.getComposedRanges !== 'function'
+          ) {
+            return;
+          }
+          const composedRange = selectionRaw.getComposedRanges({
             shadowRoots: [shadowRoot],
           })?.[0];
           if (
@@ -956,6 +967,9 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         if (!targetIsContentElement(e)) {
           return;
         }
+        if (e.inputType === 'insertCompositionText') {
+          return;
+        }
         e.preventDefault();
         this.#handleInput(e.inputType, e.data);
       }),
@@ -975,6 +989,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
           if (!targetIsContentElement(e)) {
             return;
           }
+          this.#isComposing = true;
           this.#shouldIgnoreSelectionChange = true;
         },
         { passive: true }
@@ -988,7 +1003,13 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
             return;
           }
           this.#shouldIgnoreSelectionChange = false;
-          this.#handleInput('insertText', e.data);
+          const wasComposing = this.#isComposing;
+          this.#isComposing = false;
+          // An empty compositionend during a tracked composition means the
+          // candidate was canceled (e.g. Esc), so there is nothing to commit.
+          if (e.data !== '' || !wasComposing) {
+            this.#handleInput('insertText', e.data);
+          }
         },
         { passive: true }
       ),
@@ -1455,6 +1476,8 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         this.#replaceSelectionText(autoSurroundTexts ?? text);
         break;
       }
+      case 'insertCompositionText':
+        break;
       case 'insertParagraph':
         // TODO(@ije): use document.EOF instead of '\n'
         this.#replaceSelectionText('\n');

--- a/packages/diffs/test/domHarness.ts
+++ b/packages/diffs/test/domHarness.ts
@@ -49,16 +49,21 @@ export function installDom(options: InstallDomOptions = {}): DomHandle {
     Element: Reflect.get(globalThis, 'Element'),
     Event: Reflect.get(globalThis, 'Event'),
     HTMLButtonElement: Reflect.get(globalThis, 'HTMLButtonElement'),
+    HTMLCanvasElement: Reflect.get(globalThis, 'HTMLCanvasElement'),
     HTMLDivElement: Reflect.get(globalThis, 'HTMLDivElement'),
     HTMLElement: Reflect.get(globalThis, 'HTMLElement'),
     HTMLPreElement: Reflect.get(globalThis, 'HTMLPreElement'),
     HTMLStyleElement: Reflect.get(globalThis, 'HTMLStyleElement'),
+    getComputedStyle: Reflect.get(globalThis, 'getComputedStyle'),
+    matchMedia: Reflect.get(globalThis, 'matchMedia'),
     MouseEvent: Reflect.get(globalThis, 'MouseEvent'),
+    MutationObserver: Reflect.get(globalThis, 'MutationObserver'),
     Node: Reflect.get(globalThis, 'Node'),
     PointerEvent: Reflect.get(globalThis, 'PointerEvent'),
     requestAnimationFrame: Reflect.get(globalThis, 'requestAnimationFrame'),
     ResizeObserver: Reflect.get(globalThis, 'ResizeObserver'),
     SVGElement: Reflect.get(globalThis, 'SVGElement'),
+    SVGSVGElement: Reflect.get(globalThis, 'SVGSVGElement'),
     window: Reflect.get(globalThis, 'window'),
   };
 
@@ -85,6 +90,19 @@ export function installDom(options: InstallDomOptions = {}): DomHandle {
     unobserve(_target: Element): void {}
     disconnect(): void {}
   }
+
+  const matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener(): void {},
+    removeEventListener(): void {},
+    addListener(): void {},
+    removeListener(): void {},
+    dispatchEvent(): boolean {
+      return true;
+    },
+  })) as typeof window.matchMedia;
 
   const {
     maxTouchPoints = 0,
@@ -115,6 +133,23 @@ export function installDom(options: InstallDomOptions = {}): DomHandle {
   let nextFrameId = 0;
   const frames = new Map<number, ReturnType<typeof setTimeout>>();
 
+  Object.defineProperty(dom.window.HTMLCanvasElement.prototype, 'getContext', {
+    configurable: true,
+    value: (contextId: string) => {
+      if (contextId !== '2d') {
+        return null;
+      }
+      return {
+        font: '',
+        measureText: (text: string) => ({ width: text.length * 8 }),
+      };
+    },
+  });
+  Object.defineProperty(dom.window.HTMLElement.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: () => {},
+  });
+
   const pointTargets = new Map<string, Element>();
   Object.defineProperty(dom.window.document, 'elementFromPoint', {
     configurable: true,
@@ -135,11 +170,15 @@ export function installDom(options: InstallDomOptions = {}): DomHandle {
     Element: dom.window.Element,
     Event: dom.window.Event,
     HTMLButtonElement: dom.window.HTMLButtonElement,
+    HTMLCanvasElement: dom.window.HTMLCanvasElement,
     HTMLDivElement: dom.window.HTMLDivElement,
     HTMLElement: dom.window.HTMLElement,
     HTMLPreElement: dom.window.HTMLPreElement,
     HTMLStyleElement: dom.window.HTMLStyleElement,
+    getComputedStyle: dom.window.getComputedStyle.bind(dom.window),
+    matchMedia,
     MouseEvent: dom.window.MouseEvent,
+    MutationObserver: dom.window.MutationObserver,
     Node: dom.window.Node,
     PointerEvent: MockPointerEvent,
     requestAnimationFrame: ((callback: FrameRequestCallback) => {
@@ -153,9 +192,10 @@ export function installDom(options: InstallDomOptions = {}): DomHandle {
     }) as typeof requestAnimationFrame,
     ResizeObserver: MockResizeObserver,
     SVGElement: dom.window.SVGElement,
+    SVGSVGElement: dom.window.SVGSVGElement,
     window: dom.window,
   });
-  Object.assign(dom.window, { PointerEvent: MockPointerEvent });
+  Object.assign(dom.window, { matchMedia, PointerEvent: MockPointerEvent });
   Object.defineProperty(globalThis, 'navigator', {
     configurable: true,
     value: navigator,

--- a/packages/diffs/test/editorComposition.test.ts
+++ b/packages/diffs/test/editorComposition.test.ts
@@ -1,0 +1,190 @@
+import { afterAll, describe, expect, spyOn, test } from 'bun:test';
+
+import { File } from '../src/components/File';
+import { DEFAULT_THEMES } from '../src/constants';
+import { Editor } from '../src/editor/editor';
+import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
+import type { FileContents } from '../src/types';
+import { installDom, wait } from './domHarness';
+
+afterAll(async () => {
+  await disposeHighlighter();
+});
+
+async function waitForEditableContent(
+  container: HTMLElement
+): Promise<HTMLElement> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const content = container.shadowRoot?.querySelector('[data-content]');
+    if (
+      content instanceof HTMLElement &&
+      (content.contentEditable === 'true' ||
+        content.getAttribute('contenteditable') === 'true')
+    ) {
+      return content;
+    }
+    await wait(0);
+  }
+
+  throw new Error('editor content did not become editable');
+}
+
+interface EditorFixture {
+  cleanup(): void;
+  content: HTMLElement;
+  editor: Editor<undefined>;
+  window: EditorTestWindow;
+}
+
+interface EditorTestWindow extends Window {
+  CompositionEvent: {
+    new (type: string, eventInitDict?: CompositionEventInit): CompositionEvent;
+  };
+  InputEvent: {
+    new (type: string, eventInitDict?: InputEventInit): InputEvent;
+  };
+}
+
+async function createEditorFixture(): Promise<EditorFixture> {
+  const dom = installDom();
+  const fileContainer = document.createElement('div');
+  document.body.appendChild(fileContainer);
+
+  const file = new File<undefined>({
+    disableFileHeader: true,
+    theme: DEFAULT_THEMES,
+  });
+  const editor = new Editor<undefined>();
+  const initialFile: FileContents = {
+    name: 'ime.ts',
+    contents: 'line 1',
+  };
+
+  file.render({
+    file: initialFile,
+    fileContainer,
+    forceRender: true,
+  });
+  editor.edit(file);
+
+  const content = await waitForEditableContent(fileContainer);
+  editor.setSelections([
+    {
+      start: { line: 0, character: initialFile.contents.length },
+      end: { line: 0, character: initialFile.contents.length },
+      direction: 'none',
+    },
+  ]);
+
+  return {
+    cleanup() {
+      editor.cleanUp();
+      file.cleanUp();
+      dom.cleanup();
+    },
+    content,
+    editor,
+    window: dom.window as unknown as EditorTestWindow,
+  };
+}
+
+describe('Editor composition input', () => {
+  test('lets the browser own IME preview before committing composition text', async () => {
+    const { cleanup, content, editor, window } = await createEditorFixture();
+    const consoleWarn = spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      content.dispatchEvent(
+        new window.CompositionEvent('compositionstart', {
+          bubbles: true,
+          composed: true,
+        })
+      );
+
+      const preview = new window.InputEvent('beforeinput', {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        data: 'あ',
+        inputType: 'insertCompositionText',
+      });
+      content.dispatchEvent(preview);
+
+      expect(preview.defaultPrevented).toBe(false);
+      expect(consoleWarn).not.toHaveBeenCalled();
+      expect(editor.getState().file.contents).toBe('line 1');
+
+      content.dispatchEvent(
+        new window.CompositionEvent('compositionend', {
+          bubbles: true,
+          composed: true,
+          data: 'あ',
+        })
+      );
+
+      expect(editor.getState().file.contents).toBe('line 1あ');
+    } finally {
+      consoleWarn.mockRestore();
+      cleanup();
+    }
+  });
+
+  test('does not commit canceled composition preview text', async () => {
+    const { cleanup, content, editor, window } = await createEditorFixture();
+
+    try {
+      content.dispatchEvent(
+        new window.CompositionEvent('compositionstart', {
+          bubbles: true,
+          composed: true,
+        })
+      );
+      content.dispatchEvent(
+        new window.CompositionEvent('compositionupdate', {
+          bubbles: true,
+          composed: true,
+          data: 'あ',
+        })
+      );
+      content.dispatchEvent(
+        new window.CompositionEvent('compositionend', {
+          bubbles: true,
+          composed: true,
+          data: '',
+        })
+      );
+
+      expect(editor.getState().file.contents).toBe('line 1');
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('survives selection changes when getComposedRanges is unavailable', async () => {
+    // The editor renders inside a shadow root and reads the selection via
+    // Selection.getComposedRanges, a newly available API. On browsers and
+    // embedded WebViews that lack it (as jsdom does here), a selectionchange
+    // must not throw out of the listener and leave the surface unusable.
+    const { cleanup, editor } = await createEditorFixture();
+    // jsdom forwards uncaught listener exceptions to console.error, so a throw
+    // inside the selectionchange handler surfaces here rather than propagating
+    // out of dispatchEvent.
+    const consoleError = spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      expect(document.getSelection()?.getComposedRanges).toBeUndefined();
+      // Drain any pending focus frames so the listener no longer ignores
+      // selection changes and actually reaches the composed-range read.
+      for (let i = 0; i < 5; i++) {
+        await wait(0);
+      }
+      document.dispatchEvent(new Event('selectionchange'));
+
+      expect(consoleError).not.toHaveBeenCalled();
+      expect(editor.getState().file.contents).toBe('line 1');
+    } finally {
+      consoleError.mockRestore();
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
Fixes the following issue:
1. Open an editable diffs editor and place the caret in content.
2. Start a CJK IME or accented/dead-key composition.
3. Type a preview candidate, then commit it or press Esc to cancel.

Previously, each preview beforeinput was prevented and warned as an unknown input type, so the browser could not show native preview text and canceled composition text could still be inserted on compositionend.

Let insertCompositionText beforeinput events stay with the browser. Track composition updates and only commit non-canceled compositionend data into the editor model. Add regression coverage for preview, commit, warning noise, and canceled composition text.