### PR TITLE
[editor/diff] Update toggle icon size in search panel

### DIFF
--- a/packages/diffs/src/editor/editor.css
+++ b/packages/diffs/src/editor/editor.css
@@ -319,6 +319,9 @@
     background-color 0.1s ease-in-out,
     color 0.1s ease-in-out;
 }
+[data-input-box] [data-icon] {
+  width: 20px;
+}
 [data-search-panel] [data-icon][data-disabled='true'] {
   opacity: 0.25;
   pointer-events: none;

--- a/packages/diffs/src/editor/searchPanel.ts
+++ b/packages/diffs/src/editor/searchPanel.ts
@@ -226,7 +226,7 @@ export class SearchPanelWidget {
       const button = h('div', {
         dataset: { icon, active: String(searchParams[key]) },
         title,
-        innerHTML: getEditorIconSvg(icon),
+        innerHTML: getEditorIconSvg(icon, 14),
         onclick: () => {
           const next = !searchParams[key];
           button.dataset.active = String(next);


### PR DESCRIPTION
- Reduce the icon size from 16 -> 14
- Reduce the width from 24 -> 20

<img width="395" height="67" alt="Screenshot 2026-06-17 at 15 19 54" src="https://github.com/user-attachments/assets/180ef3ff-dd57-4c40-8970-091198462b49" />

↓

<img width="394" height="67" alt="Screenshot 2026-06-17 at 15 22 53" src="https://github.com/user-attachments/assets/48549c17-247b-4151-9980-eb9ca9e519dd" />
