### PR TITLE
Fix shift selection column

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -1280,6 +1280,17 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         if (this.#selections !== undefined) {
           const edits: TextEdit[] = [];
           const nextSelections: EditorSelection[] = [];
+          // Single-line indent inserts text at each caret. When several carets
+          // share a line, indentation inserted by carets to their left shifts
+          // them right, so record each one here and offset its resulting
+          // position once every edit on the line is known. Without this, later
+          // same-line carets land before their own inserted indent.
+          const sameLineIndents: Array<{
+            line: number;
+            startCharacter: number;
+            addedLength: number;
+            selectionIndex: number;
+          }> = [];
           for (const selection of this.#selections) {
             const startLine = selection.start.line;
             const outdent = command === 'outdent';
@@ -1297,9 +1308,52 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
                 line: startLine,
                 character: 0,
               });
-              this.#replaceSelectionText(
-                lineChar0 === '\t' ? '\t' : ' '.repeat(this.#metrics.tabSize)
-              );
+              const text =
+                lineChar0 === '\t' ? '\t' : ' '.repeat(this.#metrics.tabSize);
+              edits.push({
+                range: selection,
+                newText: text,
+              });
+              sameLineIndents.push({
+                line: startLine,
+                startCharacter: selection.start.character,
+                addedLength:
+                  text.length -
+                  (selection.end.character - selection.start.character),
+                selectionIndex: nextSelections.length,
+              });
+              const nextPosition = {
+                line: selection.start.line,
+                character: selection.start.character + text.length,
+              };
+              nextSelections.push({
+                start: nextPosition,
+                end: nextPosition,
+                direction: DirectionNone,
+              });
+            }
+          }
+          for (const indent of sameLineIndents) {
+            let shift = 0;
+            for (const other of sameLineIndents) {
+              if (
+                other.line === indent.line &&
+                other.startCharacter < indent.startCharacter
+              ) {
+                shift += other.addedLength;
+              }
+            }
+            if (shift !== 0) {
+              const current = nextSelections[indent.selectionIndex];
+              const position = {
+                line: indent.line,
+                character: current.start.character + shift,
+              };
+              nextSelections[indent.selectionIndex] = {
+                start: position,
+                end: position,
+                direction: DirectionNone,
+              };
             }
           }
           const change = textDocument.applyEdits(

--- a/packages/diffs/src/editor/platform.ts
+++ b/packages/diffs/src/editor/platform.ts
@@ -2,6 +2,18 @@ let _isMacLike: boolean | undefined = undefined;
 let _isLinux: boolean | undefined = undefined;
 let _isSafari: boolean | undefined = undefined;
 
+/**
+ * Clears the cached platform/browser detection. Detection is memoized on first
+ * call, so a test process that swaps `navigator` (e.g. to exercise Linux or
+ * Safari behavior) must reset it; otherwise the value cached by an earlier test
+ * leaks across tests and no longer matches the active navigator.
+ */
+export function resetPlatformDetectionForTests(): void {
+  _isMacLike = undefined;
+  _isLinux = undefined;
+  _isSafari = undefined;
+}
+
 export function isMacLike(): boolean {
   return (_isMacLike ??= /macOS|MacIntel|iPhone|iPad|iPod/i.test(
     getPlatform()
@@ -37,7 +49,7 @@ export function isMoveCursorShortcut(
   | 'end'
   | undefined {
   // emacs key bindings
-  if ((isMacLike() || isLinux()) && e.ctrlKey && !e.altKey && !e.metaKey) {
+  if (isMacLike() && e.ctrlKey && !e.altKey && !e.metaKey) {
     switch (e.key) {
       case 'a':
         return 'start';

--- a/packages/diffs/src/editor/selection.ts
+++ b/packages/diffs/src/editor/selection.ts
@@ -189,11 +189,10 @@ export function mapSelectionShift(
   shortcut: 'textStart' | 'start' | 'end' | 'up' | 'down' | 'left' | 'right'
 ): EditorSelection[] {
   return selections.map((selection) => {
-    const [anchorOffset, focusOffset] = getSelectionAnchorAndFocusOffsets(
-      textDocument,
-      selection
-    );
-    const focusPosition = textDocument.positionAt(focusOffset);
+    const focusPosition =
+      selection.direction === DirectionBackward
+        ? selection.start
+        : selection.end;
     const [movedFocusSelection] = mapCursorMove(
       textDocument,
       [
@@ -205,12 +204,7 @@ export function mapSelectionShift(
       ],
       shortcut
     );
-    const movedFocusOffset = textDocument.offsetAt(movedFocusSelection.start);
-    return createSelectionFromAnchorAndFocusOffsets(
-      textDocument,
-      anchorOffset,
-      movedFocusOffset
-    );
+    return createSelectionFrom(selection, movedFocusSelection);
   });
 }
 

--- a/packages/diffs/src/editor/textDocument.ts
+++ b/packages/diffs/src/editor/textDocument.ts
@@ -173,7 +173,19 @@ export class TextDocument<LAnnotation> {
   }
 
   getText(range?: Range): string {
-    return this.#pieceTable.getText(range);
+    if (range === undefined) {
+      return this.#pieceTable.getText();
+    }
+    // Clamp the range to visible line content before extracting text. A
+    // preserved vertical-move "goal column" can leave a selection focus whose
+    // character overshoots a shorter line; without this, the piece table clamps
+    // to the line's offset span (which includes the trailing line break) and
+    // copy/cut would pull in that newline. Mirrors `offsetAt`, which normalizes
+    // positions the same way.
+    return this.#pieceTable.getText({
+      start: this.normalizePosition(range.start),
+      end: this.normalizePosition(range.end),
+    });
   }
 
   getLineText(line: number, includeLineBreak?: boolean): string {

--- a/packages/diffs/src/editor/textMeasure.ts
+++ b/packages/diffs/src/editor/textMeasure.ts
@@ -55,7 +55,10 @@ export class Metrics {
       this.#canvasCtx.font = font;
       this.ch = this.canvasMeasureTextWidth('0');
     }
-    this.tabSize = parseInt(tabSize, 10);
+    const nextTabSize = parseInt(tabSize, 10);
+    if (!Number.isNaN(nextTabSize)) {
+      this.tabSize = nextTabSize;
+    }
   }
 
   /** measure the width of the text */

--- a/packages/diffs/src/renderers/FileRenderer.ts
+++ b/packages/diffs/src/renderers/FileRenderer.ts
@@ -302,6 +302,7 @@ export class FileRenderer<LAnnotation = undefined> {
     }
     const { file, result } = this.renderCache;
     if (result != null && result.code.length !== textDocument.lineCount) {
+      result.code.length = Math.min(result.code.length, textDocument.lineCount);
       for (let i = result.code.length; i < textDocument.lineCount; i++) {
         // prefill lines with plain text content
         result.code.push({

--- a/packages/diffs/test/FileRenderer.test.ts
+++ b/packages/diffs/test/FileRenderer.test.ts
@@ -1,8 +1,18 @@
 import { afterAll, describe, expect, test } from 'bun:test';
 
+import { TextDocument } from '../src/editor/textDocument';
 import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
 import { FileRenderer } from '../src/renderers/FileRenderer';
+import type { FileContents } from '../src/types';
 import { mockFiles } from './mocks';
+
+type FileRendererCacheProbe = {
+  renderCache?: {
+    result?: {
+      code: unknown[];
+    };
+  };
+};
 
 afterAll(async () => {
   await disposeHighlighter();
@@ -19,5 +29,24 @@ describe('FileRenderer', () => {
     const instance = new FileRenderer();
     const result = await instance.asyncRender(mockFiles.file1);
     expect(instance.renderCodeAST(result)).toMatchSnapshot();
+  });
+
+  test('truncates cached code rows when document lines are deleted', async () => {
+    const instance = new FileRenderer();
+    const file: FileContents = {
+      cacheKey: 'editable-file',
+      contents: 'alpha\nbeta\ngamma',
+      name: 'editable.txt',
+    };
+
+    await instance.asyncRender(file);
+    expect(instance.renderFile(file)?.rowCount).toBe(3);
+
+    instance.applyDocumentChange(
+      new TextDocument('inmemory://editable-file', 'alpha\ngamma')
+    );
+
+    const cache = (instance as unknown as FileRendererCacheProbe).renderCache;
+    expect(cache?.result?.code).toHaveLength(2);
   });
 });

--- a/packages/diffs/test/domHarness.ts
+++ b/packages/diffs/test/domHarness.ts
@@ -1,6 +1,7 @@
 import { JSDOM } from 'jsdom';
 
 import type { CodeView } from '../src/components/CodeView';
+import { resetPlatformDetectionForTests } from '../src/editor/platform';
 import type { CodeViewItem, FileContents } from '../src/types';
 
 export interface InstallDomNavigatorOptions {
@@ -200,6 +201,10 @@ export function installDom(options: InstallDomOptions = {}): DomHandle {
     configurable: true,
     value: navigator,
   });
+  // Platform detection memoizes on first call; reset it so it re-runs against
+  // the navigator just installed above rather than a value an earlier test
+  // cached under a different platform.
+  resetPlatformDetectionForTests();
 
   return {
     window: dom.window,

--- a/packages/diffs/test/editorComposition.test.ts
+++ b/packages/diffs/test/editorComposition.test.ts
@@ -3,8 +3,9 @@ import { afterAll, describe, expect, spyOn, test } from 'bun:test';
 import { File } from '../src/components/File';
 import { DEFAULT_THEMES } from '../src/constants';
 import { Editor } from '../src/editor/editor';
+import { DirectionForward, DirectionNone } from '../src/editor/selection';
 import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
-import type { FileContents } from '../src/types';
+import type { DiffsEditorSelection, FileContents } from '../src/types';
 import { installDom, wait } from './domHarness';
 
 afterAll(async () => {
@@ -43,10 +44,22 @@ interface EditorTestWindow extends Window {
   InputEvent: {
     new (type: string, eventInitDict?: InputEventInit): InputEvent;
   };
+  KeyboardEvent: {
+    new (type: string, eventInitDict?: KeyboardEventInit): KeyboardEvent;
+  };
 }
 
-async function createEditorFixture(): Promise<EditorFixture> {
-  const dom = installDom();
+interface CreateEditorFixtureOptions {
+  contents?: string;
+  platform?: string;
+  selections?: DiffsEditorSelection[];
+}
+
+async function createEditorFixture(
+  options: CreateEditorFixtureOptions = {}
+): Promise<EditorFixture> {
+  const { contents = 'line 1', platform = 'MacIntel', selections } = options;
+  const dom = installDom({ navigator: { platform } });
   const fileContainer = document.createElement('div');
   document.body.appendChild(fileContainer);
 
@@ -56,8 +69,8 @@ async function createEditorFixture(): Promise<EditorFixture> {
   });
   const editor = new Editor<undefined>();
   const initialFile: FileContents = {
-    name: 'ime.ts',
-    contents: 'line 1',
+    name: 'editor.ts',
+    contents,
   };
 
   file.render({
@@ -68,13 +81,15 @@ async function createEditorFixture(): Promise<EditorFixture> {
   editor.edit(file);
 
   const content = await waitForEditableContent(fileContainer);
-  editor.setSelections([
-    {
-      start: { line: 0, character: initialFile.contents.length },
-      end: { line: 0, character: initialFile.contents.length },
-      direction: 'none',
-    },
-  ]);
+  editor.setSelections(
+    selections ?? [
+      {
+        start: { line: 0, character: initialFile.contents.length },
+        end: { line: 0, character: initialFile.contents.length },
+        direction: 'none',
+      },
+    ]
+  );
 
   return {
     cleanup() {
@@ -86,6 +101,21 @@ async function createEditorFixture(): Promise<EditorFixture> {
     editor,
     window: dom.window as unknown as EditorTestWindow,
   };
+}
+
+function dispatchKeydown(
+  window: EditorTestWindow,
+  target: HTMLElement,
+  init: KeyboardEventInit
+): KeyboardEvent {
+  const event = new window.KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    ...init,
+  });
+  target.dispatchEvent(event);
+  return event;
 }
 
 describe('Editor composition input', () => {
@@ -184,6 +214,138 @@ describe('Editor composition input', () => {
       expect(editor.getState().file.contents).toBe('line 1');
     } finally {
       consoleError.mockRestore();
+      cleanup();
+    }
+  });
+});
+
+describe('Editor keyboard editing', () => {
+  test('uses primary Linux Ctrl+A as select-all instead of cursor move', async () => {
+    const { cleanup, content, editor, window } = await createEditorFixture({
+      contents: 'alpha\nbeta',
+      platform: 'Linux x86_64',
+      selections: [
+        {
+          start: { line: 1, character: 2 },
+          end: { line: 1, character: 2 },
+          direction: 'none',
+        },
+      ],
+    });
+
+    try {
+      const event = dispatchKeydown(window, content, {
+        key: 'a',
+        ctrlKey: true,
+      });
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(editor.getState().selections).toEqual([
+        {
+          start: { line: 0, character: 0 },
+          end: { line: 1, character: 4 },
+          direction: DirectionForward,
+        },
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('uses primary Linux Ctrl+F as search instead of cursor move', async () => {
+    const { cleanup, content, window } = await createEditorFixture({
+      contents: 'alpha beta',
+      platform: 'Linux x86_64',
+      selections: [
+        {
+          start: { line: 0, character: 2 },
+          end: { line: 0, character: 2 },
+          direction: 'none',
+        },
+      ],
+    });
+
+    try {
+      const event = dispatchKeydown(window, content, {
+        key: 'f',
+        ctrlKey: true,
+      });
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(
+        (content.getRootNode() as ParentNode).querySelector(
+          '[data-search-panel]'
+        )
+      ).toBeInstanceOf(HTMLElement);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('applies single-line indent once per collapsed caret', async () => {
+    const { cleanup, content, editor, window } = await createEditorFixture({
+      contents: 'alpha\nbeta',
+      selections: [
+        {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 0 },
+          direction: 'none',
+        },
+        {
+          start: { line: 1, character: 0 },
+          end: { line: 1, character: 0 },
+          direction: 'none',
+        },
+      ],
+    });
+
+    try {
+      const event = dispatchKeydown(window, content, { key: 'Tab' });
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(editor.getState().file.contents).toBe('  alpha\n  beta');
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('shifts later same-line carets past earlier inserted indents', async () => {
+    const { cleanup, content, editor, window } = await createEditorFixture({
+      contents: 'abcdefgh',
+      selections: [
+        {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 0 },
+          direction: 'none',
+        },
+        {
+          start: { line: 0, character: 5 },
+          end: { line: 0, character: 5 },
+          direction: 'none',
+        },
+      ],
+    });
+
+    try {
+      const event = dispatchKeydown(window, content, { key: 'Tab' });
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(editor.getState().file.contents).toBe('  abcde  fgh');
+      // The second caret follows its own inserted indent (column 9), not the
+      // pre-shift column 7 that lands before it.
+      expect(editor.getState().selections).toEqual([
+        {
+          start: { line: 0, character: 2 },
+          end: { line: 0, character: 2 },
+          direction: DirectionNone,
+        },
+        {
+          start: { line: 0, character: 9 },
+          end: { line: 0, character: 9 },
+          direction: DirectionNone,
+        },
+      ]);
+    } finally {
       cleanup();
     }
   });

--- a/packages/diffs/test/editorSelection.test.ts
+++ b/packages/diffs/test/editorSelection.test.ts
@@ -18,6 +18,7 @@ import {
   getAutoSurroundReplacementTexts,
   getCaretPosition,
   getSelectionAnchor,
+  getSelectionText,
   mapCursorMove,
   mapSelectionShift,
   mergeOverlappingSelections,
@@ -1423,6 +1424,42 @@ describe('mapSelectionRangeMove', () => {
     expect(mapSelectionShift(textDocument, downSelections, 'down')).toEqual([
       createSelection(1, 3, 2, 1, DirectionForward),
     ]);
+  });
+
+  test('preserves goal column while extending down across a short line', () => {
+    const textDocument = new TextDocument(
+      'inmemory://1',
+      'this is a much longer line here\nshort\nanother much longer line here\n'
+    );
+    const onShortLine = mapSelectionShift(
+      textDocument,
+      [createSelection(0, 20, 0, 20)],
+      'down'
+    );
+    const onLongLine = mapSelectionShift(textDocument, onShortLine, 'down');
+
+    expect(onShortLine).toEqual([
+      createSelection(0, 20, 1, 20, DirectionForward),
+    ]);
+    expect(onLongLine).toEqual([
+      createSelection(0, 20, 2, 20, DirectionForward),
+    ]);
+  });
+
+  test('does not copy the trailing newline when the goal column overshoots', () => {
+    const textDocument = new TextDocument(
+      'inmemory://1',
+      'this is a much longer line here\nshort\nanother much longer line here\n'
+    );
+    const onShortLine = mapSelectionShift(
+      textDocument,
+      [createSelection(0, 20, 0, 20)],
+      'down'
+    );
+
+    expect(getSelectionText(textDocument, onShortLine)).toBe(
+      'r line here\nshort'
+    );
   });
 });
 


### PR DESCRIPTION
## Problem

The classic "selection collapses to the short line's width" bug. Caret at col 20, shift+Down over a 5-char line, shift+Down again, cursor lands at col 5, not 20.

## Fix

Carry Shift+Up/Down focus positions without converting through offsets so short intermediate lines do not clamp the preferred column. Add a regression covering Shift+Down from column 20 across a short line.