### PR TITLE
fix(diffs): Add accessible name to editor textbox host

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -548,6 +548,15 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       }
     }
 
+    // The contenteditable host advertises role="textbox", so without an
+    // accessible name screen readers announce an unlabeled text field. Label it
+    // with the file name. The same content element is reused across file
+    // switches (see File#applyFullRender), so refresh the label on every sync
+    // rather than only when the element is first initialized above.
+    if (contentEl.ariaLabel !== fileOrDiff.name) {
+      contentEl.ariaLabel = fileOrDiff.name;
+    }
+
     if (
       (lineAnnotations !== undefined && lineAnnotations.length > 0) ||
       (this.#fileInstance?.type === 'file-diff' &&


### PR DESCRIPTION
## Problem

The editor's `contenteditable` host in `packages/diffs/src/editor/editor.ts` sets `role="textbox"` and `aria-multiline="true"` but never sets an accessible name. Screen readers announce it as an unlabeled text field, so users have no way to tell which file the editing surface belongs to.

## Change

Set `aria-label` to the current file name in `__syncRenderView`.

The label is set outside the block that initializes the content element's static attributes. That block only runs when the content element node changes, but `File#applyFullRender` reuses the same content element node across file switches (it replaces the inner HTML rather than the element). Setting the label only on initialization would leave it pointing at the previous file after a switch, so the label is refreshed on every sync, guarded by a value check to avoid redundant DOM writes on the render path.

A `tabindex` was considered but not added: a `contenteditable="true"` element is already focusable with an implicit `tabindex=0`, and adding one could change focus behavior.

The fix lives in the editor's shared `__syncRenderView`, which both `File` and `FileDiff` route through, so file and diff views are both covered.

## Verification

- `moonx diffs:typecheck`
- `moonx diffs:test` (551 pass)
- `moon run root:format root:lint` (no new warnings)