### PR TITLE
fix(diffs): Disable caret blink under reduced motion

### DIFF
--- a/packages/diffs/src/editor/editor.css
+++ b/packages/diffs/src/editor/editor.css
@@ -81,6 +81,13 @@
   animation-delay: 0.8s;
   visibility: hidden;
 }
+/* Honor the OS reduced-motion setting: drop the blink so the caret renders as a
+   solid bar (opacity stays at its default of 1) instead of pulsing. */
+@media (prefers-reduced-motion: reduce) {
+  [data-caret] {
+    animation: none;
+  }
+}
 [data-selection-range] {
   z-index: -10;
   background-color: var(--diffs-editor-selection-bg);


### PR DESCRIPTION
The editor caret animated with `blinking 1.2s infinite` regardless of the user's OS reduced-motion preference, so the caret kept pulsing even when motion was meant to be suppressed.

Add a `@media (prefers-reduced-motion: reduce)` rule that sets `animation: none` on `[data-caret]`. With the animation removed, `opacity` falls back to its default of `1`, so the caret renders as a solid bar (still gated by the existing focus/visibility rules) instead of disappearing or pulsing.

A CSS media query is used rather than the existing `prefersReducedMotion()` helper because the caret is a purely declarative CSS animation; the media query reacts live to OS preference changes without any JS listener. The helper stays reserved for the JS-driven scroll-behavior decision.