### PR TITLE
fix(diffs): Guard gutter pointerdown to mouse only

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -820,6 +820,18 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     ];
   }
 
+  // Swaps in a new batch of transient "select" listeners — gutter drag
+  // tracking or the Safari annotation-hover workaround — disposing the
+  // previous batch first. Routing every reassignment through here keeps the
+  // dispose-before-replace invariant in one place: a stale set (e.g. from a
+  // pointerup that never fired after a canceled gesture, or a fresh
+  // pointerdown before the previous interaction tore down) can never be
+  // overwritten while its listeners are still attached to the document.
+  #replaceSelectEventListeners(disposes: (() => void)[]): void {
+    this.#selectEventDisposes?.forEach((dispose) => dispose());
+    this.#selectEventDisposes = disposes;
+  }
+
   #listenContentElement(contentEl: HTMLElement, gutterEl?: HTMLElement): void {
     const targetIsContentElement = (e: Event) => {
       const target = e.composedPath()[0] as HTMLElement | undefined;
@@ -848,7 +860,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
             this.#lineAnnotations !== undefined &&
             this.#lineAnnotations.length > 0
           ) {
-            this.#selectEventDisposes = [
+            const annotationDisposes = [
               ...contentEl.querySelectorAll<HTMLElement>(
                 '[data-line-annotation]'
               ),
@@ -862,6 +874,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
                 }),
               ])
               .flat();
+            this.#replaceSelectEventListeners(annotationDisposes);
           }
 
           this.#isContentMouseDown = true;
@@ -1070,6 +1083,15 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
           gutterEl,
           'pointerdown',
           (e) => {
+            // Gutter drag-selection is mouse-only: the global pointerup that
+            // clears #isGutterMouseDown and disposes the mousemove listener
+            // bails for non-mouse pointers, so reacting to a touch/pen tap
+            // here would strand that state and leak the listener. Mirror the
+            // content pointerdown guard.
+            if (e.pointerType !== 'mouse') {
+              return;
+            }
+
             const textDocument = this.#textDocument;
             const lineIndex = resolveEditableLine(
               resolveGutterTarget(
@@ -1093,7 +1115,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
             this.#selectionStart = selection;
             this.#updateSelections([selection]);
             this.#focus(selection.end);
-            this.#selectEventDisposes = [
+            this.#replaceSelectEventListeners([
               addEventListener(
                 document,
                 'mousemove',
@@ -1133,7 +1155,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
                 },
                 { passive: true }
               ),
-            ];
+            ]);
           },
           { passive: true }
         )


### PR DESCRIPTION
## Problem

A touch or pen tap on a line number ran the editor's gutter selection logic: it set `#isGutterMouseDown`, started a selection, and attached a `document` `mousemove` listener. The global `pointerup` that tears that state down bails for non-mouse pointers, so after a touch/pen tap:

- `#isGutterMouseDown` stayed stuck `true` (it also feeds `isMouseDown()`,  which the marker renderer reads), and
- the `mousemove` listener leaked on `document`, with a fresh one added on every subsequent gutter tap.

The content `pointerdown` handler already guards `if (e.pointerType !== 'mouse') return`; the gutter one did not.

## Fix

- Add the same pointer-type guard to the gutter `pointerdown` so non-mouse taps bail early, matching the content handler.
- Route both select-listener reassignment sites — the gutter drag tracker and the Safari annotation-hover workaround — through a new `#replaceSelectEventListeners` helper that disposes the prior batch before assigning. This keeps the dispose-before-replace invariant in one place so the two sites cannot drift out of sync. The teardown sites (`pointerup`, `cleanUp`) already dispose before clearing to `undefined` and are unchanged.

## Verification

- `moonx diffs:typecheck` — clean
- `moonx diffs:test` — 549 pass, 0 fail
- `moon run root:format root:lint` — 0 errors
