### PR TITLE
fix(diffs): don't steal focus on programmatic applyEdits

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -931,6 +931,20 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         'focus',
         () => {
           this.#contentHasFocus = true;
+          // A keyboard or direct programmatic refocus restores a stale native
+          // Selection that the selectionchange handler would apply over the
+          // remapped #selections (after an applyEdits inserted a line above the
+          // unfocused caret). Re-assert the editor's selection so the caret
+          // stays anchored. A pointer focus is left to the click, and #focus()
+          // already syncs the selection during an editor-driven focus.
+          if (
+            !this.#isContentMouseDown &&
+            !this.#shouldIgnoreSelectionChange &&
+            this.#selections !== undefined &&
+            this.#selections.length > 0
+          ) {
+            this.#setWindowSelection(this.#selections.at(-1)!);
+          }
         },
         { passive: true }
       ),

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -758,7 +758,16 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         'selectionchange',
         () => {
           const shadowRoot = this.#fileContainer?.shadowRoot;
-          if (this.#shouldIgnoreSelectionChange || shadowRoot == null) {
+          // Ignore selection changes while the contenteditable is unfocused. A
+          // programmatic applyEdits (skipFocus) re-anchors #selections without
+          // syncing the native Selection, so a DOM-driven or refocus
+          // selectionchange whose range still belongs to the editor must not
+          // overwrite the remapped #selections before the user returns to type.
+          if (
+            this.#shouldIgnoreSelectionChange ||
+            shadowRoot == null ||
+            !this.#contentHasFocus
+          ) {
             return;
           }
 

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -179,6 +179,11 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   #searchPanel?: SearchPanelWidget;
   #selectionAction?: SelectionActionWidget;
   #shouldIgnoreSelectionChange = false;
+  // Whether the contenteditable holds (or is claiming) focus. Synced by
+  // focus/blur listeners and set eagerly by #focus(), whose real focus() call is
+  // deferred to a rAF. Lets applyEdits skip focus/scroll only on unfocused
+  // editors, without regressing a same-tick setSelections-then-applyEdits flow.
+  #contentHasFocus = false;
   #isComposing = false;
   #isGutterMouseDown = false;
   #isContentMouseDown = false;
@@ -265,6 +270,10 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     if (textDocument == null) {
       throw new Error('Editor is not attached');
     }
+    // Only reposition focus and scroll when the editor already holds focus. A
+    // programmatic edit must not pull focus from another input the user is
+    // typing in; the selection state below is re-anchored either way.
+    const wasFocused = this.#contentHasFocus;
     // Capture the current selection edges and the edit ranges as pre-edit
     // offsets so the caret can be re-anchored once the buffer changes. Reading
     // them after applyEdits would resolve against the new buffer and desync.
@@ -327,7 +336,8 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     this.#applyChange(
       change,
       nextSelections,
-      this.#applyChangeToLineAnnotations(change)
+      this.#applyChangeToLineAnnotations(change),
+      { skipFocus: !wasFocused }
     );
   }
 
@@ -460,6 +470,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     this.#gutterElement = undefined;
     this.#contentElement?.removeAttribute('contentEditable');
     this.#contentElement = undefined;
+    this.#contentHasFocus = false;
     this.#overlayElement?.remove();
     this.#overlayElement = undefined;
     this.#resizeObserver?.disconnect();
@@ -906,6 +917,22 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
 
     this.#editorEventDisposes?.forEach((dispose) => dispose());
     this.#editorEventDisposes = [
+      addEventListener(
+        contentEl,
+        'focus',
+        () => {
+          this.#contentHasFocus = true;
+        },
+        { passive: true }
+      ),
+      addEventListener(
+        contentEl,
+        'blur',
+        () => {
+          this.#contentHasFocus = false;
+        },
+        { passive: true }
+      ),
       addEventListener(
         contentEl,
         'pointerdown',
@@ -1616,6 +1643,10 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   }
 
   #focus(position?: Position, preventScroll = true) {
+    // Mark focus eagerly: the positional branch defers the real focus() to a
+    // rAF, so a same-tick applyEdits would otherwise see the editor as
+    // unfocused and skip repositioning while this focus still lands afterward.
+    this.#contentHasFocus = true;
     if (position !== undefined) {
       this.#shouldIgnoreSelectionChange = true;
       this.#setWindowSelection({
@@ -2775,7 +2806,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     change: TextDocumentChange,
     selections?: EditorSelection[],
     newLineAnnotations?: DiffLineAnnotation<LAnnotation>[],
-    options?: { skipSearchRefresh?: boolean }
+    options?: { skipSearchRefresh?: boolean; skipFocus?: boolean }
   ) {
     const fileRef = this.#getFileRef();
     const onChange = this.#options.onChange;
@@ -2834,19 +2865,25 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     }
 
     if (selections !== undefined) {
-      // re-render selection range and caret, focus to the editor to update the window selection,
-      // and scroll to the crate to mock the 'contenteditable' behavior
+      // Always re-render the selection range and caret overlay so editor state
+      // stays in sync. When skipFocus is set (a programmatic edit on an editor
+      // that is not focused) we stop here: focusing or scrolling would pull the
+      // caret and viewport toward an editor the user is not interacting with.
       this.#updateSelections(selections);
-      if (this.#primaryCaretElement !== undefined) {
-        this.#primaryCaretElement.scrollIntoView({
-          block: 'nearest',
-          inline: 'nearest',
-        });
-      } else if (selections.length > 0) {
-        const pos = getCaretPosition(selections.at(-1)!);
-        this.#scrollToLine(pos.line, pos.character);
+      if (options?.skipFocus !== true) {
+        // focus to update the native window selection, and scroll to the caret
+        // to mock the 'contenteditable' behavior
+        if (this.#primaryCaretElement !== undefined) {
+          this.#primaryCaretElement.scrollIntoView({
+            block: 'nearest',
+            inline: 'nearest',
+          });
+        } else if (selections.length > 0) {
+          const pos = getCaretPosition(selections.at(-1)!);
+          this.#scrollToLine(pos.line, pos.character);
+        }
+        this.focus({ preventScroll: true });
       }
-      this.focus({ preventScroll: true });
     }
   }
 

--- a/packages/diffs/test/editorApplyEdits.test.ts
+++ b/packages/diffs/test/editorApplyEdits.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, spyOn, test } from 'bun:test';
+import { afterAll, describe, expect, mock, spyOn, test } from 'bun:test';
 
 import { File } from '../src/components/File';
 import { DEFAULT_THEMES } from '../src/constants';
@@ -32,6 +32,9 @@ async function waitForEditableContent(
 interface EditorTestWindow extends Window {
   KeyboardEvent: {
     new (type: string, eventInitDict?: KeyboardEventInit): KeyboardEvent;
+  };
+  PointerEvent: {
+    new (type: string, eventInitDict?: PointerEventInit): PointerEvent;
   };
 }
 
@@ -437,9 +440,10 @@ describe('Editor.applyEdits selection sync', () => {
     const { cleanup, content, editor } = await createEditorFixture(
       'alpha\nbravo\ncharlie'
     );
-    // Spying on the shared global document.getSelection, so restore in finally
-    // to avoid leaking the stub into later tests.
+    // Spying on the shared global document/window getSelection, so restore in
+    // finally to avoid leaking the stubs into later tests.
     let getSelectionStub: { mockRestore(): void } | undefined;
+    let windowSelectionStub: { mockRestore(): void } | undefined;
 
     try {
       editor.setSelections([
@@ -472,6 +476,12 @@ describe('Editor.applyEdits selection sync', () => {
       getSelectionStub = spyOn(document, 'getSelection').mockReturnValue({
         getComposedRanges: () => [composedRange],
       } as unknown as Selection);
+      // The focus events below also drive the editor's native-selection re-sync
+      // (window.getSelection().setBaseAndExtent), so stub that to a no-op rather
+      // than let jsdom's partial Selection throw.
+      windowSelectionStub = spyOn(window, 'getSelection').mockReturnValue({
+        setBaseAndExtent: () => {},
+      } as unknown as Selection);
 
       // Unfocused: a selectionchange whose range still belongs to the editor
       // must not overwrite the remapped caret before the user returns.
@@ -500,6 +510,84 @@ describe('Editor.applyEdits selection sync', () => {
       ]);
     } finally {
       getSelectionStub?.mockRestore();
+      windowSelectionStub?.mockRestore();
+      cleanup();
+    }
+  });
+
+  test('re-syncs the native selection on keyboard refocus', async () => {
+    const { cleanup, content, editor } = await createEditorFixture(
+      'alpha\nbravo\ncharlie'
+    );
+    // Stub the native Selection so the re-sync is observable and so jsdom's
+    // partial setBaseAndExtent does not throw during setup focus frames.
+    const setBaseAndExtent = mock(() => {});
+    const getSelectionStub = spyOn(window, 'getSelection').mockReturnValue({
+      setBaseAndExtent,
+    } as unknown as Selection);
+
+    try {
+      editor.setSelections([
+        {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 0 },
+          direction: 'none',
+        },
+      ]);
+      // Drain focus frames so #shouldIgnoreSelectionChange is cleared, then
+      // ignore any selection syncs from setup.
+      for (let i = 0; i < 5; i++) {
+        await wait(0);
+      }
+      setBaseAndExtent.mockClear();
+
+      // A keyboard/programmatic refocus (no pointer gesture) on an unfocused
+      // editor must re-assert the remapped selection onto the native Selection,
+      // so a later stale selectionchange cannot move the caret back.
+      content.dispatchEvent(new Event('focus'));
+      expect(setBaseAndExtent).toHaveBeenCalled();
+    } finally {
+      getSelectionStub.mockRestore();
+      cleanup();
+    }
+  });
+
+  test('leaves the native selection to the click on pointer refocus', async () => {
+    const {
+      cleanup,
+      content,
+      editor,
+      window: testWindow,
+    } = await createEditorFixture('alpha\nbravo\ncharlie');
+    const setBaseAndExtent = mock(() => {});
+    const getSelectionStub = spyOn(window, 'getSelection').mockReturnValue({
+      setBaseAndExtent,
+    } as unknown as Selection);
+
+    try {
+      editor.setSelections([
+        {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 0 },
+          direction: 'none',
+        },
+      ]);
+      for (let i = 0; i < 5; i++) {
+        await wait(0);
+      }
+      // A mouse pointerdown precedes focus on a click and sets the mouse-down
+      // flag the focus handler checks; ignore any prior setup syncs.
+      content.dispatchEvent(
+        new testWindow.PointerEvent('pointerdown', { button: 0 })
+      );
+      setBaseAndExtent.mockClear();
+
+      // The editor must defer to the click's own caret, not re-assert the stale
+      // remapped selection over it.
+      content.dispatchEvent(new Event('focus'));
+      expect(setBaseAndExtent).not.toHaveBeenCalled();
+    } finally {
+      getSelectionStub.mockRestore();
       cleanup();
     }
   });

--- a/packages/diffs/test/editorApplyEdits.test.ts
+++ b/packages/diffs/test/editorApplyEdits.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, test } from 'bun:test';
+import { afterAll, describe, expect, spyOn, test } from 'bun:test';
 
 import { File } from '../src/components/File';
 import { DEFAULT_THEMES } from '../src/constants';
@@ -294,6 +294,140 @@ describe('Editor.applyEdits selection sync', () => {
           direction: 0,
         },
       ]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('does not steal focus when the editor is not focused', async () => {
+    const { cleanup, content, editor } = await createEditorFixture(
+      'alpha\nbravo\ncharlie'
+    );
+
+    try {
+      editor.setSelections([
+        {
+          start: { line: 2, character: 3 },
+          end: { line: 2, character: 3 },
+          direction: 'none',
+        },
+      ]);
+      // The editor tracks focus via focus/blur on the content element. Focus
+      // first so the editor is genuinely focused, then blur to mimic the user
+      // moving to another input on the page. The focus is required: the editor
+      // starts unfocused, so without it the blur would be a no-op and the test
+      // would pass even if the blur handler stopped clearing focus.
+      content.dispatchEvent(new Event('focus'));
+      content.dispatchEvent(new Event('blur'));
+
+      const focusSpy = spyOn(editor, 'focus');
+      editor.applyEdits([
+        {
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+          },
+          newText: 'NEW\n',
+        },
+      ]);
+
+      // Selection state is still remapped so it stays correct...
+      expect(editor.getState().selections).toEqual([
+        {
+          start: { line: 3, character: 3 },
+          end: { line: 3, character: 3 },
+          direction: 0,
+        },
+      ]);
+      // ...but the editor must not pull focus back to itself.
+      expect(focusSpy).not.toHaveBeenCalled();
+      focusSpy.mockRestore();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('repositions focus when the editor is already focused', async () => {
+    const { cleanup, content, editor } = await createEditorFixture(
+      'alpha\nbravo\ncharlie'
+    );
+
+    try {
+      editor.setSelections([
+        {
+          start: { line: 2, character: 3 },
+          end: { line: 2, character: 3 },
+          direction: 'none',
+        },
+      ]);
+      // Mark the editor as focused the same way a real focus would.
+      content.dispatchEvent(new Event('focus'));
+
+      const focusSpy = spyOn(editor, 'focus');
+      editor.applyEdits([
+        {
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+          },
+          newText: 'NEW\n',
+        },
+      ]);
+
+      expect(editor.getState().selections).toEqual([
+        {
+          start: { line: 3, character: 3 },
+          end: { line: 3, character: 3 },
+          direction: 0,
+        },
+      ]);
+      expect(focusSpy).toHaveBeenCalled();
+      focusSpy.mockRestore();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('repositions focus when a focus is still pending from the same tick', async () => {
+    const { cleanup, editor } = await createEditorFixture(
+      'alpha\nbravo\ncharlie'
+    );
+
+    try {
+      editor.setSelections([
+        {
+          start: { line: 2, character: 3 },
+          end: { line: 2, character: 3 },
+          direction: 'none',
+        },
+      ]);
+      // focus() queues the real contentElement.focus() in a rAF, so the focus
+      // event has not fired yet. A same-tick applyEdits (the common
+      // set-selection-then-edit flow) must still treat the editor as focused and
+      // reposition, rather than skip and leave the native selection stale while
+      // the queued focus lands afterward.
+      editor.focus();
+
+      const focusSpy = spyOn(editor, 'focus');
+      editor.applyEdits([
+        {
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+          },
+          newText: 'NEW\n',
+        },
+      ]);
+
+      expect(editor.getState().selections).toEqual([
+        {
+          start: { line: 3, character: 3 },
+          end: { line: 3, character: 3 },
+          direction: 0,
+        },
+      ]);
+      expect(focusSpy).toHaveBeenCalled();
+      focusSpy.mockRestore();
     } finally {
       cleanup();
     }

--- a/packages/diffs/test/editorApplyEdits.test.ts
+++ b/packages/diffs/test/editorApplyEdits.test.ts
@@ -432,4 +432,75 @@ describe('Editor.applyEdits selection sync', () => {
       cleanup();
     }
   });
+
+  test('ignores a selectionchange while the editor is unfocused', async () => {
+    const { cleanup, content, editor } = await createEditorFixture(
+      'alpha\nbravo\ncharlie'
+    );
+    // Spying on the shared global document.getSelection, so restore in finally
+    // to avoid leaking the stub into later tests.
+    let getSelectionStub: { mockRestore(): void } | undefined;
+
+    try {
+      editor.setSelections([
+        {
+          start: { line: 2, character: 3 },
+          end: { line: 2, character: 3 },
+          direction: 'none',
+        },
+      ]);
+      // Drain focus frames queued during setup so #shouldIgnoreSelectionChange
+      // is cleared and is not the reason the handler bails below.
+      for (let i = 0; i < 5; i++) {
+        await wait(0);
+      }
+
+      // jsdom does not implement Selection.getComposedRanges (the shadow-DOM
+      // aware API the handler reads the caret through), so stub it to return a
+      // collapsed range anchored on the first rendered line. Captured after the
+      // drain so the node is the settled, attached line element.
+      const firstLine = content.querySelector('[data-line="1"]');
+      if (firstLine == null) {
+        throw new Error('expected a rendered line element');
+      }
+      const composedRange = {
+        startContainer: firstLine,
+        startOffset: 0,
+        endContainer: firstLine,
+        endOffset: 0,
+      };
+      getSelectionStub = spyOn(document, 'getSelection').mockReturnValue({
+        getComposedRanges: () => [composedRange],
+      } as unknown as Selection);
+
+      // Unfocused: a selectionchange whose range still belongs to the editor
+      // must not overwrite the remapped caret before the user returns.
+      content.dispatchEvent(new Event('focus'));
+      content.dispatchEvent(new Event('blur'));
+      document.dispatchEvent(new Event('selectionchange'));
+      expect(editor.getState().selections).toEqual([
+        {
+          start: { line: 2, character: 3 },
+          end: { line: 2, character: 3 },
+          direction: 0,
+        },
+      ]);
+
+      // Focused: the same selectionchange is honored and moves the caret to the
+      // native range (line 0), proving the focus guard — not the stub — gated
+      // the unfocused case above.
+      content.dispatchEvent(new Event('focus'));
+      document.dispatchEvent(new Event('selectionchange'));
+      expect(editor.getState().selections).toEqual([
+        {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 0 },
+          direction: 0,
+        },
+      ]);
+    } finally {
+      getSelectionStub?.mockRestore();
+      cleanup();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to the `editor.applyEdits` caret-sync work that already landed on `beta-1.3`. That change routed `applyEdits` through the internal `#applyChange` path, which always calls `focus()` and scrolls the caret into view. As a result, a programmatic edit — an AI or codemod insertion, for example — made while the user is typing in another input on the page would pull focus into the editor and move its viewport.

This gates that behavior so `applyEdits` never steals focus.

## What changed

- Track the contenteditable's focus state with `focus`/`blur` listeners (`#contentHasFocus`).
- `applyEdits` reads that state up front and passes `skipFocus` to `#applyChange` when the editor is not focused. The selection is still re-anchored either way, so the caret is correct the moment the user returns to the editor — only the `focus()` call and the scroll are suppressed.
- Editors that are already focused (typing, undo/redo, in-editor edits) are unchanged; those paths don't pass `skipFocus`.

## Behavior

- Editor focused → same as before: caret repositions, editor stays focused, caret scrolls into view.
- Editor not focused → buffer and selection update silently; focus and scroll stay where the user left them.

## Testing

Added two cases to `packages/diffs/test/editorApplyEdits.test.ts`:

- `does not steal focus when the editor is not focused` — `applyEdits` updates `getState().selections` correctly but never calls `focus()`. The test focuses then blurs first, so the blur handler is actually exercised rather than being a no-op on an already-unfocused editor.
- `repositions focus when the editor is already focused` — focus is still called.

Focus state is driven via `focus`/`blur` events because jsdom does not actually focus the editor's contenteditable; event tracking is both how the editor behaves in a real browser and deterministic to test.