### PR TITLE
perf(diffs): Reuse the compiled search regex across lines

### DIFF
--- a/packages/diffs/src/editor/pieceTable.ts
+++ b/packages/diffs/src/editor/pieceTable.ts
@@ -323,17 +323,19 @@ export class PieceTable {
     const docLength = this.#length;
     const charAt = (offset: number) => this.charAt(offset);
 
+    // Reuse the single compiled pattern across every line, resetting its
+    // lastIndex before each line, instead of allocating a fresh RegExp per
+    // line. The pattern is global, so lastIndex tracks progress within a line.
     for (let line = 0; line < this.#lineCount; line++) {
       const lineText = this.getLineText(line);
       const lineStart = this.offsetAt({ line, character: 0 });
-      const re = new RegExp(pattern.source, pattern.flags);
-      re.lastIndex = 0;
+      pattern.lastIndex = 0;
       let match: RegExpExecArray | null;
-      while ((match = re.exec(lineText)) !== null) {
+      while ((match = pattern.exec(lineText)) !== null) {
         const rel = match.index;
         const fragment = match[0];
         if (fragment.length === 0) {
-          re.lastIndex = advancePastEmptyMatch(lineText, rel);
+          pattern.lastIndex = advancePastEmptyMatch(lineText, rel);
           continue;
         }
         const docStart = lineStart + rel;
@@ -346,8 +348,8 @@ export class PieceTable {
             return out;
           }
         }
-        if (rel === re.lastIndex) {
-          re.lastIndex = advancePastEmptyMatch(lineText, rel);
+        if (rel === pattern.lastIndex) {
+          pattern.lastIndex = advancePastEmptyMatch(lineText, rel);
         }
       }
     }

--- a/packages/diffs/test/editorPieceTable.test.ts
+++ b/packages/diffs/test/editorPieceTable.test.ts
@@ -294,6 +294,28 @@ describe('PieceTable', () => {
     ).toBeUndefined();
   });
 
+  test('search returns every match across lines with one reused pattern', () => {
+    // Two matches share line 1 (offsets advance within the line) while lines 0
+    // and 2 match from their start (the pattern resets between lines). This is
+    // the behavior that must hold when the compiled regex is reused per line
+    // instead of recompiled.
+    const table = new PieceTable('foo\nfoofoo\nbar foo');
+    const searchParams = {
+      text: 'foo',
+      replaceText: '',
+      caseSensitive: false,
+      wholeWord: false,
+      regex: false,
+    };
+
+    expect(table.search(searchParams)).toEqual([
+      [0, 3],
+      [4, 7],
+      [7, 10],
+      [15, 18],
+    ]);
+  });
+
   test('search does not match newline-spanning plain queries', () => {
     const table = new PieceTable('foo\nbar\nfoo');
     const searchParams = {


### PR DESCRIPTION
Line-by-line search compiled a new RegExp from the pattern's source
and flags on every line, so a search over an N-line document built N
identical regexes for no benefit. Reuse the single compiled pattern
and reset its lastIndex before each line instead.

Add a regression test for matches within and across lines, which had
no happy-path coverage before.