### PR TITLE
fix(diffs): Keep paste and cut as their own undo steps

### DIFF
--- a/packages/diffs/src/editor/editStack.ts
+++ b/packages/diffs/src/editor/editStack.ts
@@ -23,6 +23,12 @@ export interface EditStackEntry<LAnnotation> {
   lineAnnotationsBefore?: DiffLineAnnotation<LAnnotation>[];
   /** Line annotations after the transaction. */
   lineAnnotationsAfter?: DiffLineAnnotation<LAnnotation>[];
+  /**
+   * When `true`, this entry is its own undo step and never merges with the
+   * entry before or after it. Set for paste and cut, which otherwise look like
+   * typing and would merge into the previous keystroke.
+   */
+  undoBoundary?: boolean;
 }
 
 /** Options for the edit stack. */
@@ -176,6 +182,8 @@ export function shouldCoalesceEditStackEntry<LAnnotation>(
 ): boolean {
   if (
     previousEntry === undefined ||
+    previousEntry.undoBoundary === true ||
+    nextEntry.undoBoundary === true ||
     previousEntry.forwardEdits.length === 0 ||
     previousEntry.forwardEdits.length !== previousEntry.inverseEdits.length ||
     previousEntry.forwardEdits.length !== nextEntry.forwardEdits.length ||
@@ -201,6 +209,7 @@ export function shouldCoalesceEditStackEntry<LAnnotation>(
     const nextIsInsert =
       nextForward.start === nextForward.end &&
       nextForward.text.length > 0 &&
+      !nextForward.text.includes('\n') &&
       nextInverse.text.length === 0;
     if (previousWasInsert && nextIsInsert) {
       const expectedMappedNextStart = previousForward.end;

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -1053,7 +1053,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         if (text !== undefined) {
           // TODO(@ije): Add support of multiple selections copy&paste
           // TODO(@ije): normalize the pasted text with textDocument.EOF
-          this.#replaceSelectionText(text);
+          this.#replaceSelectionText(text, undefined, true);
         }
       }),
 
@@ -2578,7 +2578,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     }
 
     const text = getSelectionText(textDocument, selections);
-    this.#replaceSelectionText('');
+    this.#replaceSelectionText('', undefined, true);
     return text;
   }
 
@@ -2596,7 +2596,13 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       return;
     }
 
-    const change = textDocument.applyResolvedEdits(edits, true, selections);
+    const change = textDocument.applyResolvedEdits(
+      edits,
+      true,
+      selections,
+      undefined,
+      true
+    );
     if (change === undefined) {
       return;
     }
@@ -2622,7 +2628,8 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   // replace the selection text
   #replaceSelectionText(
     text: string | string[],
-    selections = this.#selections
+    selections = this.#selections,
+    undoBoundary = false
   ) {
     if (selections === undefined) {
       return;
@@ -2638,7 +2645,8 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
             textDocument,
             selections,
             text,
-            this.#lineAnnotations
+            this.#lineAnnotations,
+            undoBoundary
           )
         : applyTextChangeToSelections<LAnnotation>(
             textDocument,
@@ -2648,7 +2656,9 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
               end: textDocument.offsetAt(primarySelection.end),
               text: Array.isArray(text) ? text.join('\n') : text,
             },
-            this.#lineAnnotations
+            this.#lineAnnotations,
+            undefined,
+            undoBoundary
           );
 
     if (change !== undefined) {

--- a/packages/diffs/src/editor/selection.ts
+++ b/packages/diffs/src/editor/selection.ts
@@ -216,7 +216,8 @@ export function applyTextChangeToSelections<LAnnotation>(
   selections: EditorSelection[],
   edit: ResolvedTextEdit,
   lineAnnotations?: DiffLineAnnotation<LAnnotation>[],
-  tabSize = 2
+  tabSize = 2,
+  undoBoundary = false
 ): {
   nextSelections: EditorSelection[];
   change?: TextDocumentChange;
@@ -342,7 +343,13 @@ export function applyTextChangeToSelections<LAnnotation>(
   }
   finalizeMergedGroup();
 
-  const change = textDocument.applyResolvedEdits(edits, true, selections);
+  const change = textDocument.applyResolvedEdits(
+    edits,
+    true,
+    selections,
+    undefined,
+    undoBoundary
+  );
   const nextSelections = createSelectionsFromOffsetPairs(
     textDocument,
     nextSelectionOffsets.map((offsets) => {
@@ -404,7 +411,8 @@ export function applyTextReplaceToSelections<LAnnotation>(
   textDocument: TextDocument<LAnnotation>,
   selections: EditorSelection[],
   texts: string[],
-  lineAnnotations?: DiffLineAnnotation<LAnnotation>[]
+  lineAnnotations?: DiffLineAnnotation<LAnnotation>[],
+  undoBoundary = false
 ): {
   nextSelections: EditorSelection[];
   change?: TextDocumentChange;
@@ -537,7 +545,13 @@ export function applyTextReplaceToSelections<LAnnotation>(
     }
   }
 
-  const change = textDocument.applyResolvedEdits(edits, true, selections);
+  const change = textDocument.applyResolvedEdits(
+    edits,
+    true,
+    selections,
+    undefined,
+    undoBoundary
+  );
   const nextSelections = createSelectionsFromOffsetPairs(
     textDocument,
     nextSelectionOffsetPairs.map((offsets) => {

--- a/packages/diffs/src/editor/textDocument.ts
+++ b/packages/diffs/src/editor/textDocument.ts
@@ -224,7 +224,8 @@ export class TextDocument<LAnnotation> {
     edits: TextEdit[],
     updateHistory = false,
     selectionsBefore?: EditorSelection[],
-    selectionsAfter?: EditorSelection[]
+    selectionsAfter?: EditorSelection[],
+    undoBoundary = false
   ): TextDocumentChange | undefined {
     if (edits.length === 0) {
       return;
@@ -233,7 +234,8 @@ export class TextDocument<LAnnotation> {
       edits.map((edit) => this.#resolveEdit(edit)),
       updateHistory,
       selectionsBefore,
-      selectionsAfter
+      selectionsAfter,
+      undoBoundary
     );
   }
 
@@ -241,7 +243,8 @@ export class TextDocument<LAnnotation> {
     edits: ResolvedTextEdit[],
     updateHistory = false,
     selectionsBefore?: EditorSelection[],
-    selectionsAfter?: EditorSelection[]
+    selectionsAfter?: EditorSelection[],
+    undoBoundary = false
   ): TextDocumentChange | undefined {
     if (edits.length === 0) {
       return undefined;
@@ -256,6 +259,9 @@ export class TextDocument<LAnnotation> {
         selectionsBefore,
         selectionsAfter
       );
+      if (undoBoundary) {
+        entry.undoBoundary = true;
+      }
       const previousEntry = this.#editStack.peekUndo();
       const change = this.#applyResolvedEditsToBuffer(resolvedEdits);
       this.#version++;

--- a/packages/diffs/test/editorEditStack.test.ts
+++ b/packages/diffs/test/editorEditStack.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 
-import { createEditStackEntry, EditStack } from '../src/editor/editStack';
+import {
+  createEditStackEntry,
+  EditStack,
+  shouldCoalesceEditStackEntry,
+} from '../src/editor/editStack';
 import type { EditorSelection } from '../src/editor/selection';
 import {
   DirectionNone,
@@ -171,5 +175,36 @@ describe('EditHistory', () => {
     expect(editStack.canRedo).toBe(false);
     expect(editStack.popUndoToRedo()).toBeUndefined();
     expect(editStack.popRedoToUndo()).toBeUndefined();
+  });
+});
+
+describe('shouldCoalesceEditStackEntry', () => {
+  test('coalesces two consecutive single-character inserts', () => {
+    const previous = stackEntry('', [{ start: 0, end: 0, text: 'a' }], 0, 1);
+    const next = stackEntry('a', [{ start: 1, end: 1, text: 'b' }], 1, 2);
+    expect(shouldCoalesceEditStackEntry(previous, next)).toBe(true);
+  });
+
+  test('does not coalesce when the previous entry is an undo boundary', () => {
+    const previous = stackEntry('', [{ start: 0, end: 0, text: 'a' }], 0, 1);
+    previous.undoBoundary = true;
+    const next = stackEntry('a', [{ start: 1, end: 1, text: 'b' }], 1, 2);
+    expect(shouldCoalesceEditStackEntry(previous, next)).toBe(false);
+  });
+
+  test('does not coalesce when the next entry is an undo boundary', () => {
+    const previous = stackEntry('', [{ start: 0, end: 0, text: 'a' }], 0, 1);
+    const next = stackEntry('a', [{ start: 1, end: 1, text: 'b' }], 1, 2);
+    next.undoBoundary = true;
+    expect(shouldCoalesceEditStackEntry(previous, next)).toBe(false);
+  });
+
+  // A newline insert must never merge into the typing before it. The editor
+  // already prevents this with a separate `lineDelta === 0` check, so this test
+  // calls the helper directly to protect other callers.
+  test('does not coalesce a newline insert into preceding typing', () => {
+    const previous = stackEntry('', [{ start: 0, end: 0, text: 'a' }], 0, 1);
+    const next = stackEntry('a', [{ start: 1, end: 1, text: '\n' }], 1, 2);
+    expect(shouldCoalesceEditStackEntry(previous, next)).toBe(false);
   });
 });

--- a/packages/diffs/test/editorTextDocument.test.ts
+++ b/packages/diffs/test/editorTextDocument.test.ts
@@ -537,6 +537,92 @@ describe('TextDocument', () => {
     expect(d.getText()).toBe('hello');
   });
 
+  test('paste does not coalesce into the preceding typed character', () => {
+    const d = doc('');
+    // Type a single character (normal typing).
+    d.applyEdits(
+      [
+        {
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+          },
+          newText: 'a',
+        },
+      ],
+      true,
+      [caret(0, 0)]
+    );
+    // Paste a single-line string at the caret. The trailing `true` marks it as
+    // an undo boundary, like the editor's paste handler. Without it the paste
+    // looks just like typing and would merge into the previous step.
+    d.applyEdits(
+      [
+        {
+          range: {
+            start: { line: 0, character: 1 },
+            end: { line: 0, character: 1 },
+          },
+          newText: 'hello',
+        },
+      ],
+      true,
+      [caret(0, 1)],
+      undefined,
+      true
+    );
+
+    expect(d.getText()).toBe('ahello');
+
+    d.undo();
+    expect(d.getText()).toBe('a');
+
+    d.undo();
+    expect(d.getText()).toBe('');
+  });
+
+  test('typing after a paste does not coalesce into the pasted text', () => {
+    const d = doc('');
+    // Paste a single-line string (undo boundary).
+    d.applyEdits(
+      [
+        {
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+          },
+          newText: 'hello',
+        },
+      ],
+      true,
+      [caret(0, 0)],
+      undefined,
+      true
+    );
+    // Type a character immediately after the paste.
+    d.applyEdits(
+      [
+        {
+          range: {
+            start: { line: 0, character: 5 },
+            end: { line: 0, character: 5 },
+          },
+          newText: 'x',
+        },
+      ],
+      true,
+      [caret(0, 5)]
+    );
+
+    expect(d.getText()).toBe('hellox');
+
+    d.undo();
+    expect(d.getText()).toBe('hello');
+
+    d.undo();
+    expect(d.getText()).toBe('');
+  });
+
   test('contiguous forward deletes coalesce into one undo step', () => {
     const d = doc('abc');
     d.applyEdits(


### PR DESCRIPTION
Type a character, paste some text, then press undo. Both the paste
and the typed character disappear together, but undo should remove
only the paste.

Paste and cut go through the same path as typing, and the undo stack
only looks at the shape of an edit. A single-line paste looks just
like more typing, so it merged into the previous keystroke's undo
entry. (Multi-line pastes were kept separate only because they change
the line count.)

Mark paste and cut as undo boundaries so each stays its own step and
never merges with the edit before or after it. Typing still merges as
before.

Also stop the undo check from merging a newline insert into earlier
typing, so the shared helper is safe for any caller.
