### PR TITLE
[trees] Fix truncation markers showing on filename even when it fits horizontally

### DIFF
--- a/packages/trees/src/style.css
+++ b/packages/trees/src/style.css
@@ -1502,7 +1502,9 @@
       ease-in-out;
   }
 
-  @container measure (height > 1lh) {
+  /* Subpixel rendering can make a single-line filename slightly taller than
+   * 1lh, falsely showing its truncation marker when it fits horizontally. */
+  @container measure (height > calc(1lh + 1px)) {
     [data-truncate-marker] {
       opacity: 1;
       transition: opacity var(--truncate-internal-marker-fade-in-duration)


### PR DESCRIPTION
### Description

Fix https://github.com/pierrecomputer/pierre/issues/816, where the truncation markers may show up even when it can fit horizontally. Added a `1px` allowance for when the truncation markers will show up (not confident if this is the right fix for this)


### Motivation & Context

Reproduced the issues from https://github.com/pierrecomputer/pierre/issues/816 where on different zoom levels and browsers the truncation markers will show up even if there is enough space. 

On my display (with different monitor scaling) the truncation markers show up on the home page and at `trees-dev/density`, was able to reproduce it on Chrome, Edge, and Safari (except for Firefox where the issue is non-existent)


|  |  |
| :--- | :--- |
| **Chrome/Edge**; 200% scaling; 90% zoom | <img width="100%" alt="file-56a19214c7a433bf9f1ef721751ba170" src="https://github.com/user-attachments/assets/fb12e7e3-4a4d-4477-a864-18a2f991c5b5" /> |
| **Chrome/Edge** 175% scaling; 80%/110% zoom | <img width="100%" alt="image" src="https://github.com/user-attachments/assets/0cc3ef8a-262b-455b-b56c-a30f96c06f13" /> |

Unable to reproduce it on firefox.

https://chenhuijing.com/blog/about-subpixel-rendering-in-browsers/

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the contributing guidelines
- [x] My code follows the project style
- [x] My code is formatted properly
- [ ] I have added tests (not applicable; manually verified)
- [x] All relevant tests pass

### How was AI used in generating this PR

Had some help solving the issues with `moon` and `proto` on initial setup on Windows. Manually reproduced the issues across scalings, zoom, and browsers.

### Related issues

Fixes #816