### PR TITLE
fix(diffs): re-measure character width after web font loads

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -192,6 +192,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   #scrollingToLineChar?: number;
   #scrollingToLineNoFocus = false;
   #retainSearchPanelFocus = false;
+  #fontRemeasureScheduled = false;
 
   #onDeferTokenize = (
     lines: Map<number, Array<HighlightedToken>>,
@@ -464,6 +465,9 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     this.#overlayElement = undefined;
     this.#resizeObserver?.disconnect();
     this.#resizeObserver = undefined;
+    // Let a reused instance schedule the font re-measure again on its next
+    // mount, where a different font-family string may not be loaded yet.
+    this.#fontRemeasureScheduled = false;
 
     this.#resetState();
   }
@@ -593,6 +597,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         contentEl.after(this.#overlayElement);
       }
       this.#metrics.init(contentEl);
+      this.#remeasureMetricsOnFontLoad();
       this.#listenContentElement(contentEl, gutterEl);
       if (
         this.#contentElement !== undefined &&
@@ -1450,6 +1455,43 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       }
     }
     this.#markerRenderer?.removePopup();
+  }
+
+  // A custom monospace web font can finish loading after the editor first
+  // renders. Until then Metrics measured the '0' width against the fallback
+  // font, so the gutter width and every caret/selection x-position (each
+  // offset by a whole number of `ch` units) are wrong. Re-measure once fonts
+  // settle and, when the width actually changed, drop the cached widths and
+  // offsets and repaint the overlays so they line up with the loaded glyphs.
+  // FontFaceSet is unavailable in non-browser hosts (e.g. jsdom in tests).
+  #remeasureMetricsOnFontLoad(): void {
+    if (this.#fontRemeasureScheduled) {
+      return;
+    }
+    const fonts = document.fonts as FontFaceSet | undefined;
+    if (fonts === undefined) {
+      return;
+    }
+    this.#fontRemeasureScheduled = true;
+    void fonts.ready.then(() => {
+      if (
+        this.#contentElement === undefined ||
+        !this.#metrics.remeasureCharacterWidth()
+      ) {
+        return;
+      }
+      this.#gutterWidthCache = undefined;
+      this.#contentWidthCache = undefined;
+      this.#resetCache();
+      if (
+        this.#selections !== undefined ||
+        this.#matches !== undefined ||
+        this.#markerRenderer !== undefined
+      ) {
+        this.#updateSelections(this.#selections ?? []);
+      }
+      this.#markerRenderer?.removePopup();
+    });
   }
 
   #rerender(

--- a/packages/diffs/src/editor/textMeasure.ts
+++ b/packages/diffs/src/editor/textMeasure.ts
@@ -61,6 +61,31 @@ export class Metrics {
     }
   }
 
+  /**
+   * Re-measure the '0' character width against the font that is loaded right
+   * now, returning true when it changed.
+   *
+   * A custom web font can finish loading after the editor first renders.
+   * Until then canvas measureText reports the fallback font's width, and
+   * getComputedStyle returns the same font-family string before and after the
+   * file arrives, so init()'s font guard never re-measures on its own. Call
+   * this once fonts have settled (e.g. on document.fonts.ready) to replace a
+   * width measured against the fallback font with the real glyph width. The
+   * boolean return lets the caller skip re-rendering when nothing changed.
+   */
+  remeasureCharacterWidth(): boolean {
+    if (this.#canvasCtx === undefined || this.#font === undefined) {
+      return false;
+    }
+    this.#canvasCtx.font = this.#font;
+    const ch = this.canvasMeasureTextWidth('0');
+    if (ch === this.ch) {
+      return false;
+    }
+    this.ch = ch;
+    return true;
+  }
+
   /** measure the width of the text */
   measureTextWidth(text: string): number {
     const textWithExpandedTabs = text.replaceAll(

--- a/packages/diffs/test/editorTextMeasure.test.ts
+++ b/packages/diffs/test/editorTextMeasure.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 
 import {
   getUnicodeMeasurementOffsets,
+  Metrics,
   needsDomTextMeasurement,
   snapTextOffsetToUnicodeBoundary,
 } from '../src/editor/textMeasure';
+import { type DomHandle, installDom } from './domHarness';
 
 describe('needsDomTextMeasurement', () => {
   test('returns false for empty and plain ASCII text', () => {
@@ -92,5 +94,59 @@ describe('getUnicodeMeasurementOffsets', () => {
   test('returns one offset per grapheme for ZWJ sequences', () => {
     const family = '👨‍👩‍👧‍👦';
     expect(getUnicodeMeasurementOffsets(family)).toEqual([0, family.length]);
+  });
+});
+
+describe('Metrics.remeasureCharacterWidth', () => {
+  let dom: DomHandle;
+  // Width the stubbed canvas reports for the '0' it measures. Tests change
+  // this between init() and remeasure to mimic a fallback font being replaced
+  // by a custom monospace web font that finishes loading after first render.
+  let glyphWidth: number;
+
+  beforeEach(() => {
+    dom = installDom();
+    glyphWidth = 8;
+    Object.defineProperty(window.HTMLCanvasElement.prototype, 'getContext', {
+      configurable: true,
+      value: (contextId: string) =>
+        contextId === '2d'
+          ? { font: '', measureText: () => ({ width: glyphWidth }) }
+          : null,
+    });
+  });
+
+  afterEach(() => {
+    dom.cleanup();
+  });
+
+  function initMetrics(): Metrics {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    const metrics = new Metrics();
+    metrics.init(root);
+    return metrics;
+  }
+
+  test('re-measures ch and reports the change after the font loads', () => {
+    const metrics = initMetrics();
+    expect(metrics.ch).toBe(8); // measured against the fallback font
+
+    // The custom web font loads and the same '0' now measures wider.
+    glyphWidth = 11;
+    expect(metrics.remeasureCharacterWidth()).toBe(true);
+    expect(metrics.ch).toBe(11);
+  });
+
+  test('reports no change when the measured width is stable', () => {
+    const metrics = initMetrics();
+    expect(metrics.remeasureCharacterWidth()).toBe(false);
+    expect(metrics.ch).toBe(8);
+  });
+
+  test('is a no-op before init has measured anything', () => {
+    const metrics = new Metrics();
+    expect(metrics.remeasureCharacterWidth()).toBe(false);
+    expect(metrics.ch).toBe(-1);
   });
 });


### PR DESCRIPTION
Steps to reproduce:
1. Open the editor on a page that uses a custom monospace web font.
2. Load it with a cold cache so the editor renders before the font file finishes downloading.
3. Click in the code to place a caret.

The caret and selection sit left of the real text and the gutter is too narrow. The editor measures the '0' character width on first render and uses it to size the gutter and place every caret. Before the web font loads, that width comes from the fallback font. getComputedStyle returns the same font-family string before and after the font arrives, so init() never re-measures and the wrong width sticks.

Re-measure the '0' width once document.fonts.ready resolves. If it changed, drop the cached widths and offsets and repaint the carets, selections, and markers so they match the loaded glyphs. Do nothing when the width is unchanged or the font was already loaded.

The re-measure is scheduled once per mount; cleanUp() clears the guard so a reused editor instance schedules it again for a font that may not be loaded yet.