### PR TITLE
fix(diffs): Measure tabs against tab stops, not a flat width

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -2152,23 +2152,13 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         continue;
       }
 
-      let segmentLeft: number;
-      let segmentWidth: number;
+      const segmentStartWidth = this.#segmentTextWidth(
+        lineText,
+        segmentStart,
+        wrapStartChar
+      );
+      const segmentLeft = offsetLeft + segmentStartWidth;
       let paddingEnd = 0;
-      if (wrapStartChar === 0) {
-        segmentLeft = offsetLeft;
-      } else {
-        const prefixInSegment = lineText.slice(segmentStart, wrapStartChar);
-        const prefixAsciiColumns = getExpandedAsciiTextColumns(
-          prefixInSegment,
-          this.#metrics.tabSize
-        );
-        segmentLeft =
-          offsetLeft +
-          (prefixAsciiColumns !== -1
-            ? prefixAsciiColumns * this.#metrics.ch
-            : this.#metrics.measureTextWidth(prefixInSegment));
-      }
       if (
         !isLastLine &&
         wrapLine === segmentCount - 1 &&
@@ -2176,20 +2166,15 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       ) {
         paddingEnd = this.#metrics.ch;
       }
-      if (wrapStartChar === wrapEndChar) {
-        segmentWidth = paddingEnd;
-      } else {
-        const selectionInSegment = lineText.slice(wrapStartChar, wrapEndChar);
-        const selectionAsciiWidth = getExpandedAsciiTextColumns(
-          selectionInSegment,
-          this.#metrics.tabSize
-        );
-        segmentWidth =
-          selectionAsciiWidth !== -1
-            ? selectionAsciiWidth * this.#metrics.ch
-            : this.#metrics.measureTextWidth(selectionInSegment);
-        segmentWidth += paddingEnd;
-      }
+      // Measure the selection width as the gap between two segment-relative
+      // offsets so a tab inside the selection advances from its real column,
+      // not from the start of the sliced selection text.
+      const segmentWidth =
+        wrapStartChar === wrapEndChar
+          ? paddingEnd
+          : this.#segmentTextWidth(lineText, segmentStart, wrapEndChar) -
+            segmentStartWidth +
+            paddingEnd;
 
       this.#renderSelectionBlock(
         renderCtx,
@@ -2201,6 +2186,27 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         extraDataset
       );
     }
+  }
+
+  // Pixel width of the text from a wrapped segment's start up to a character,
+  // relative to the segment's left edge. Tabs advance from the segment start,
+  // which sits on a tab stop, so tab stops line up with the rendered text.
+  #segmentTextWidth(
+    lineText: string,
+    segmentStart: number,
+    character: number
+  ): number {
+    if (character <= segmentStart) {
+      return 0;
+    }
+    const segmentText = lineText.slice(segmentStart, character);
+    const asciiColumns = getExpandedAsciiTextColumns(
+      segmentText,
+      this.#metrics.tabSize
+    );
+    return asciiColumns !== -1
+      ? asciiColumns * this.#metrics.ch
+      : this.#metrics.measureTextWidth(segmentText);
   }
 
   // Render one selection block for a single visual line.

--- a/packages/diffs/src/editor/textMeasure.ts
+++ b/packages/diffs/src/editor/textMeasure.ts
@@ -88,10 +88,7 @@ export class Metrics {
 
   /** measure the width of the text */
   measureTextWidth(text: string): number {
-    const textWithExpandedTabs = text.replaceAll(
-      '\t',
-      ' '.repeat(this.tabSize)
-    );
+    const textWithExpandedTabs = expandTabsToSpaces(text, this.tabSize);
     if (needsDomTextMeasurement(textWithExpandedTabs)) {
       return this.domMeasureTextWidth(textWithExpandedTabs);
     }
@@ -204,17 +201,48 @@ export function getUnicodeMeasurementOffsets(
   return offsets;
 }
 
-/** get the number of columns of the ASCII text */
+/**
+ * Expand tab characters to spaces using fixed tab stops: each tab advances to
+ * the next multiple of tabSize from its running column, matching how the
+ * rendered text expands tabs via CSS `tab-size`. Expanding every tab to a flat
+ * tabSize would mis-measure tabs that follow other characters on the same line
+ * (e.g. an alignment tab in `foo\tbar`).
+ */
+export function expandTabsToSpaces(text: string, tabSize: number): string {
+  if (!text.includes('\t')) {
+    return text;
+  }
+  let result = '';
+  let column = 0;
+  for (let i = 0; i < text.length; i++) {
+    if (text.charCodeAt(i) === /* '\t' */ 9) {
+      const advance = tabSize - (column % tabSize);
+      result += ' '.repeat(advance);
+      column += advance;
+    } else {
+      result += text[i];
+      column += 1;
+    }
+  }
+  return result;
+}
+
+/**
+ * Count the rendered columns of ASCII text, advancing each tab to the next
+ * fixed tab stop (a multiple of tabSize) to match CSS `tab-size`. Returns -1
+ * for non-ASCII text, which must be measured glyph-by-glyph instead.
+ */
 export function getExpandedAsciiTextColumns(
   text: string,
   tabSize: number
 ): number {
   let columns = 0;
   for (let i = 0; i < text.length; i++) {
-    if (text.charCodeAt(i) > 127) {
+    const code = text.charCodeAt(i);
+    if (code > 127) {
       return -1;
     }
-    columns += text.charCodeAt(i) === /* '\t' */ 9 ? tabSize : 1;
+    columns += code === /* '\t' */ 9 ? tabSize - (columns % tabSize) : 1;
   }
   return columns;
 }

--- a/packages/diffs/test/editorTextMeasure.test.ts
+++ b/packages/diffs/test/editorTextMeasure.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 
 import {
+  expandTabsToSpaces,
+  getExpandedAsciiTextColumns,
   getUnicodeMeasurementOffsets,
   Metrics,
   needsDomTextMeasurement,
@@ -94,6 +96,80 @@ describe('getUnicodeMeasurementOffsets', () => {
   test('returns one offset per grapheme for ZWJ sequences', () => {
     const family = '👨‍👩‍👧‍👦';
     expect(getUnicodeMeasurementOffsets(family)).toEqual([0, family.length]);
+  });
+});
+
+describe('getExpandedAsciiTextColumns', () => {
+  test('counts plain ASCII as one column per character', () => {
+    expect(getExpandedAsciiTextColumns('', 4)).toBe(0);
+    expect(getExpandedAsciiTextColumns('hello', 4)).toBe(5);
+  });
+
+  test('returns -1 for non-ASCII text', () => {
+    expect(getExpandedAsciiTextColumns('café', 4)).toBe(-1);
+    expect(getExpandedAsciiTextColumns('a😀', 4)).toBe(-1);
+  });
+
+  test('leading tabs advance one full tab stop each', () => {
+    expect(getExpandedAsciiTextColumns('\t', 4)).toBe(4);
+    expect(getExpandedAsciiTextColumns('\t\t', 4)).toBe(8);
+    expect(getExpandedAsciiTextColumns('\t', 2)).toBe(2);
+  });
+
+  // Regression: a tab is a tab stop, not a fixed tabSize-wide character. A tab
+  // preceded by other characters advances only to the next multiple of tabSize,
+  // matching CSS `tab-size`. The previous implementation added a flat tabSize.
+  test('mid-line tabs advance to the next tab stop, not a flat tabSize', () => {
+    // 'foo' fills cols 0-3; tab at col 3 advances to col 4 (not 3 + 4 = 7).
+    expect(getExpandedAsciiTextColumns('foo\t', 4)).toBe(4);
+    expect(getExpandedAsciiTextColumns('foo\tbar', 4)).toBe(7);
+    // tabSize 2: 'foo' (col 3) -> tab to col 4 (not 3 + 2 = 5).
+    expect(getExpandedAsciiTextColumns('foo\t', 2)).toBe(4);
+    // A tab landing exactly on a tab stop still advances a full tabSize.
+    expect(getExpandedAsciiTextColumns('ab\t', 2)).toBe(4);
+    // Multiple alignment tabs each snap to their own next tab stop.
+    expect(getExpandedAsciiTextColumns('a\tb\tc', 4)).toBe(9);
+  });
+
+  // The width of a slice that starts off a tab stop (e.g. a selection on a
+  // wrapped line) must be taken as the gap between two offsets measured from
+  // the segment start, not by measuring the bare slice. Measuring the slice
+  // alone restarts the tab at column 0 and reports the wrong width.
+  test('a tabbed slice is measured as the gap between segment offsets', () => {
+    const tabSize = 4;
+    // Segment "abcx\t": selecting "x\t" starts at column 3; x fills col 3-4
+    // and the tab advances from column 4 to column 8, a 5-column selection.
+    const startOffset = getExpandedAsciiTextColumns('abc', tabSize);
+    const endOffset = getExpandedAsciiTextColumns('abcx\t', tabSize);
+    expect(endOffset - startOffset).toBe(5);
+    // Measuring the bare slice "x\t" instead reports only 4 columns.
+    expect(getExpandedAsciiTextColumns('x\t', tabSize)).toBe(4);
+  });
+});
+
+describe('expandTabsToSpaces', () => {
+  test('returns the input unchanged when there are no tabs', () => {
+    const text = 'no tabs here';
+    expect(expandTabsToSpaces(text, 4)).toBe(text);
+  });
+
+  test('expands leading tabs to a full tab stop', () => {
+    expect(expandTabsToSpaces('\t', 4)).toBe('    ');
+    expect(expandTabsToSpaces('\t\t', 4)).toBe('        ');
+  });
+
+  // Regression: the space count for a mid-line tab depends on its column.
+  test('expands mid-line tabs to the next tab stop', () => {
+    // 'foo' (col 3) -> 1 space to reach col 4.
+    expect(expandTabsToSpaces('foo\t', 4)).toBe('foo ');
+    expect(expandTabsToSpaces('foo\tbar', 4)).toBe('foo bar');
+    // tabSize 2: 'a' (col 1) -> 1 space to reach col 2.
+    expect(expandTabsToSpaces('a\tb', 2)).toBe('a b');
+  });
+
+  test('preserves non-ASCII characters while expanding tabs by column', () => {
+    // 'é' occupies one column; the tab then fills cols 1-4.
+    expect(expandTabsToSpaces('é\t', 4)).toBe('é   ');
   });
 });
 


### PR DESCRIPTION
Put a tab after other text on a line, like `foo<tab>bar`, then place the caret right after the tab. The caret and selection box landed a column past the real glyph.

The editor renders tabs with CSS tab-size, so a tab advances to the next tab stop (the next multiple of the tab size). The measurement code instead added a full tab size for every tab, which is too wide for any tab that follows other characters. Leading indentation still lined up because each tab there already starts on a tab stop.

Advance each tab to the next tab stop from its running column, both in the ASCII column count and in the tab-to-space expansion used for canvas and DOM measurement. Add regression tests for mid-line tabs.
