### PR TITLE
feat(diffs): Add programmatic undo and redo to the editor

### DIFF
--- a/apps/docs/app/(diffs)/_docs/DocsPage.tsx
+++ b/apps/docs/app/(diffs)/_docs/DocsPage.tsx
@@ -38,6 +38,7 @@ import {
   EDITOR_REACT_MULTI_FILE_DIFF_EXAMPLE,
   EDITOR_SELECTION_ACTION_CONTEXT_TYPE,
   EDITOR_SELECTION_ACTION_EXAMPLE,
+  EDITOR_UNDO_REDO_EXAMPLE,
   EDITOR_VANILLA_FILE_DIFF_EXAMPLE,
   EDITOR_VANILLA_FILE_EXAMPLE,
   EDITOR_WORKER_POOL_REACT_EXAMPLE,
@@ -412,6 +413,7 @@ async function EditorSection() {
     editorReactExample,
     editorReactFileDiffExample,
     editorReactMultiFileDiffExample,
+    editorUndoRedoExample,
     editorWorkerPoolReactExample,
     editorWorkerPoolVanillaExample,
   ] = await Promise.all([
@@ -428,6 +430,7 @@ async function EditorSection() {
     preloadFile(EDITOR_REACT_EXAMPLE),
     preloadFile(EDITOR_REACT_FILE_DIFF_EXAMPLE),
     preloadFile(EDITOR_REACT_MULTI_FILE_DIFF_EXAMPLE),
+    preloadFile(EDITOR_UNDO_REDO_EXAMPLE),
     preloadFile(EDITOR_WORKER_POOL_REACT_EXAMPLE),
     preloadFile(EDITOR_WORKER_POOL_VANILLA_EXAMPLE),
   ]);
@@ -447,6 +450,7 @@ async function EditorSection() {
       editorReactExample,
       editorReactFileDiffExample,
       editorReactMultiFileDiffExample,
+      editorUndoRedoExample,
       editorWorkerPoolReactExample,
       editorWorkerPoolVanillaExample,
     },

--- a/apps/docs/app/(diffs)/docs/Editor/constants.ts
+++ b/apps/docs/app/(diffs)/docs/Editor/constants.ts
@@ -264,6 +264,52 @@ editor.focus();`,
   options,
 };
 
+export const EDITOR_UNDO_REDO_EXAMPLE: PreloadFileOptions<undefined> = {
+  file: {
+    name: 'editor_undo_redo.tsx',
+    contents: `import { Editor } from '@pierre/diffs/editor';
+import { EditorProvider, File } from '@pierre/diffs/react';
+import { useMemo, useState } from 'react';
+
+export function EditorWithHistoryToolbar() {
+  const [canUndo, setCanUndo] = useState(false);
+  const [canRedo, setCanRedo] = useState(false);
+
+  const editor = useMemo(
+    () =>
+      new Editor({
+        onChange() {
+          // Undo and redo run through the same change path as edits, so refresh
+          // toolbar state from \`onChange\` rather than only after button clicks.
+          setCanUndo(editor.canUndo);
+          setCanRedo(editor.canRedo);
+        },
+      }),
+    []
+  );
+
+  return (
+    <EditorProvider editor={editor}>
+      <div className="toolbar">
+        <button type="button" disabled={!canUndo} onClick={() => editor.undo()}>
+          Undo
+        </button>
+        <button type="button" disabled={!canRedo} onClick={() => editor.redo()}>
+          Redo
+        </button>
+      </div>
+
+      <File
+        file={{ name: 'example.ts', contents: 'export const x = 1;' }}
+        contentEditable
+      />
+    </EditorProvider>
+  );
+}`,
+  },
+  options,
+};
+
 export const EDITOR_REACT_EXAMPLE: PreloadFileOptions<undefined> = {
   file: {
     name: 'editor_react.tsx',
@@ -558,6 +604,14 @@ editor.focus()
 
 // Blur the editor.
 editor.blur()
+
+// Whether there is an edit to undo or redo.
+editor.canUndo
+editor.canRedo
+
+// Undo the last edit or redo the last undone edit. No-ops when history is empty.
+editor.undo()
+editor.redo()
 `,
   },
   options,

--- a/apps/docs/app/(diffs)/docs/Editor/content.mdx
+++ b/apps/docs/app/(diffs)/docs/Editor/content.mdx
@@ -163,6 +163,23 @@ editor, placing the caret at the primary selection.
 
 <DocsCodeExample {...editorProgrammaticExample} />
 
+### History
+
+The editor keeps an undo stack for user edits and for programmatic edits applied
+with `applyEdits(..., true)`. Use `editor.canUndo` and `editor.canRedo` to
+enable or disable toolbar buttons, and call `editor.undo()` or `editor.redo()`
+to step through history from code. These methods share the same stack as the
+keyboard shortcuts (<kbd>Cmd/Ctrl-Z</kbd> and <kbd>Cmd/Ctrl-Shift-Z</kbd>).
+
+`undo()` and `redo()` are no-ops when there is nothing to undo or redo. Both run
+through the same change path as a normal edit, so your `onChange` handler fires
+and you can re-read `canUndo` / `canRedo` to keep UI state in sync.
+
+Limit the stack size with `historyMaxEntries` in
+[Editor Options](#editor-options) (default: 100).
+
+<DocsCodeExample {...editorUndoRedoExample} />
+
 ### Keyboard Shortcuts
 
 Shortcuts use <kbd>Cmd</kbd> on macOS and <kbd>Ctrl</kbd> on Windows and Linux.

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -331,6 +331,26 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     );
   }
 
+  /** Whether there is an edit to undo. */
+  get canUndo(): boolean {
+    return this.#textDocument?.canUndo ?? false;
+  }
+
+  /** Whether there is an undone edit to redo. */
+  get canRedo(): boolean {
+    return this.#textDocument?.canRedo ?? false;
+  }
+
+  /** Undo the last edit. Does nothing when there is nothing to undo. */
+  undo(): void {
+    this.#runCommand('undo');
+  }
+
+  /** Redo the last undone edit. Does nothing when there is nothing to redo. */
+  redo(): void {
+    this.#runCommand('redo');
+  }
+
   getState(): EditorState<LAnnotation> {
     const fileRef = this.#getFileRef();
     if (fileRef === undefined) {

--- a/packages/diffs/test/editorApplyEdits.test.ts
+++ b/packages/diffs/test/editorApplyEdits.test.ts
@@ -2,7 +2,7 @@ import { afterAll, describe, expect, test } from 'bun:test';
 
 import { File } from '../src/components/File';
 import { DEFAULT_THEMES } from '../src/constants';
-import { Editor } from '../src/editor/editor';
+import { Editor, type EditorOptions } from '../src/editor/editor';
 import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
 import type { FileContents } from '../src/types';
 import { installDom, wait } from './domHarness';
@@ -42,7 +42,10 @@ interface EditorFixture {
   window: EditorTestWindow;
 }
 
-async function createEditorFixture(contents: string): Promise<EditorFixture> {
+async function createEditorFixture(
+  contents: string,
+  editorOptions?: EditorOptions<undefined>
+): Promise<EditorFixture> {
   const dom = installDom();
   const fileContainer = document.createElement('div');
   document.body.appendChild(fileContainer);
@@ -51,7 +54,7 @@ async function createEditorFixture(contents: string): Promise<EditorFixture> {
     disableFileHeader: true,
     theme: DEFAULT_THEMES,
   });
-  const editor = new Editor<undefined>();
+  const editor = new Editor<undefined>(editorOptions);
   const initialFile: FileContents = { name: 'edits.ts', contents };
 
   file.render({ file: initialFile, fileContainer, forceRender: true });
@@ -294,6 +297,122 @@ describe('Editor.applyEdits selection sync', () => {
           direction: 0,
         },
       ]);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('Editor undo/redo API', () => {
+  const insertBang = [
+    {
+      range: {
+        start: { line: 0, character: 5 },
+        end: { line: 0, character: 5 },
+      },
+      newText: '!',
+    },
+  ];
+
+  test('canUndo and canRedo reflect the history state', async () => {
+    const { cleanup, editor } = await createEditorFixture('alpha');
+
+    try {
+      expect(editor.canUndo).toBe(false);
+      expect(editor.canRedo).toBe(false);
+
+      editor.applyEdits(insertBang, true);
+
+      expect(editor.getState().file.contents).toBe('alpha!');
+      expect(editor.canUndo).toBe(true);
+      expect(editor.canRedo).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('undo reverts the last edit and redo re-applies it', async () => {
+    const { cleanup, editor } = await createEditorFixture('alpha');
+
+    try {
+      editor.applyEdits(insertBang, true);
+      expect(editor.getState().file.contents).toBe('alpha!');
+
+      editor.undo();
+      expect(editor.getState().file.contents).toBe('alpha');
+      expect(editor.canUndo).toBe(false);
+      expect(editor.canRedo).toBe(true);
+
+      editor.redo();
+      expect(editor.getState().file.contents).toBe('alpha!');
+      expect(editor.canUndo).toBe(true);
+      expect(editor.canRedo).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('undo and redo do nothing when there is no history', async () => {
+    const { cleanup, editor } = await createEditorFixture('alpha');
+
+    try {
+      editor.undo();
+      editor.redo();
+
+      expect(editor.getState().file.contents).toBe('alpha');
+      expect(editor.canUndo).toBe(false);
+      expect(editor.canRedo).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('programmatic undo matches the keyboard undo result', async () => {
+    const { cleanup, content, editor, window } =
+      await createEditorFixture('alpha');
+
+    try {
+      const edit = [
+        {
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+          },
+          newText: 'X',
+        },
+      ];
+
+      editor.applyEdits(edit, true);
+      pressUndoRedo(window, content, false);
+      const keyboardResult = editor.getState().file.contents;
+
+      pressUndoRedo(window, content, true);
+      expect(editor.getState().file.contents).toBe('Xalpha');
+
+      editor.undo();
+      expect(editor.getState().file.contents).toBe(keyboardResult);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('undo notifies the onChange callback', async () => {
+    let changeCount = 0;
+    const { cleanup, editor } = await createEditorFixture('alpha', {
+      onChange() {
+        changeCount++;
+      },
+    });
+
+    try {
+      editor.applyEdits(insertBang, true);
+      const countAfterEdit = changeCount;
+
+      editor.undo();
+
+      // Undo runs through the same change path as an edit, so consumers are
+      // notified and can re-read canUndo/canRedo to update their UI.
+      expect(changeCount).toBe(countAfterEdit + 1);
     } finally {
       cleanup();
     }


### PR DESCRIPTION
The editor could only undo and redo through keyboard shortcuts. Apps that drive the editor (toolbar buttons, AI edits, custom shortcuts) had no way to trigger or check undo state.

Expose `undo()`, `redo()`, `canUndo`, and `canRedo` on the Editor class. The methods reuse the existing command path, so programmatic and keyboard undo behave the same and consumers still get the `onChange` callback after each one.
