### PR TITLE
fix(diffs): count CR line breaks in edit change ranges

### DIFF
--- a/packages/diffs/src/editor/textDocument.ts
+++ b/packages/diffs/src/editor/textDocument.ts
@@ -1,4 +1,5 @@
 import type { DiffLineAnnotation } from '../types';
+import { countLineBreaks } from '../utils/computeFileOffsets';
 import {
   coalesceEditStackEntries,
   createEditStackEntry,
@@ -408,7 +409,7 @@ export class TextDocument<LAnnotation> {
       const edit = edits[i];
       const editStartLine = editPositions[i * 2].line;
       const editEndLine = editPositions[i * 2 + 1].line;
-      const insertedLineSpan = lineFeedCount(edit.text);
+      const insertedLineSpan = countLineBreaks(edit.text);
       const changedStartLine = editStartLine + lineDeltaBeforeEdit;
       const changedEndLine = changedStartLine + insertedLineSpan;
       startLine = Math.min(startLine, editStartLine);
@@ -433,14 +434,4 @@ export class TextDocument<LAnnotation> {
     }
     return { startLine, endLine, ranges };
   }
-}
-
-function lineFeedCount(text: string): number {
-  let count = 0;
-  for (let i = 0; i < text.length; i++) {
-    if (text.charCodeAt(i) === /* \n */ 10) {
-      count++;
-    }
-  }
-  return count;
 }

--- a/packages/diffs/src/utils/computeFileOffsets.ts
+++ b/packages/diffs/src/utils/computeFileOffsets.ts
@@ -23,6 +23,32 @@ export function computeLineOffsets(contents: string): number[] {
 }
 
 /**
+ * Counts line breaks in a string, treating `\n`, `\r`, and `\r\n` the same way
+ * {@link computeLineOffsets} does (a `\r\n` pair is one break). Mirrors that
+ * scan but counts in a single pass instead of building and discarding an
+ * offsets array, so sizing the changed-line range for large edits stays cheap.
+ * A unit test asserts it stays in lockstep with `computeLineOffsets`.
+ */
+export function countLineBreaks(contents: string): number {
+  let count = 0;
+  for (let i = 0; i < contents.length; i++) {
+    const char = contents.charCodeAt(i);
+    if (char === LINE_FEED || char === CARRIAGE_RETURN) {
+      // Skip the `\n` of a `\r\n` pair so it counts as one break, not two.
+      if (
+        char === CARRIAGE_RETURN &&
+        i + 1 < contents.length &&
+        contents.charCodeAt(i + 1) === LINE_FEED
+      ) {
+        i++;
+      }
+      count++;
+    }
+  }
+  return count;
+}
+
+/**
  * Splits file contents into lines aligned with {@link computeLineOffsets}.
  * Unlike splitFileContents, a trailing newline produces a final empty line.
  */

--- a/packages/diffs/test/computeLineOffsets.test.ts
+++ b/packages/diffs/test/computeLineOffsets.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import {
   computeLineOffsets,
+  countLineBreaks,
   linesFromFileContents,
 } from '../src/utils/computeFileOffsets';
 
@@ -45,6 +46,37 @@ describe('computeLineOffsets', () => {
 
     expect([...lines]).toEqual([0, 1]);
     expect(lines.length).toBe(2);
+  });
+});
+
+describe('countLineBreaks', () => {
+  test('stays consistent with computeLineOffsets across line endings', () => {
+    const cases = [
+      '',
+      'hello',
+      'a\nb',
+      'a\nb\n',
+      'a\r\nb\r\n',
+      '\rworld\rfoo',
+      'a\rb\r\nc\n',
+      '\n',
+      '\r',
+    ];
+
+    for (const contents of cases) {
+      expect(countLineBreaks(contents)).toBe(
+        computeLineOffsets(contents).length - 1
+      );
+    }
+  });
+
+  test('counts a lone CR as one break and CRLF as one break', () => {
+    expect(countLineBreaks('')).toBe(0);
+    expect(countLineBreaks('no breaks')).toBe(0);
+    expect(countLineBreaks('\r')).toBe(1);
+    expect(countLineBreaks('a\rb\rc')).toBe(2);
+    expect(countLineBreaks('a\r\nb')).toBe(1);
+    expect(countLineBreaks('a\nb\nc')).toBe(2);
   });
 });
 

--- a/packages/diffs/test/editorTextDocument.test.ts
+++ b/packages/diffs/test/editorTextDocument.test.ts
@@ -281,6 +281,54 @@ describe('TextDocument', () => {
     expect(d.getText()).toBe('a\r\nB\r\nc');
   });
 
+  test('applyEdits reports inserted lines for a lone CR line ending', () => {
+    const d = doc('a');
+    const change = d.applyEdits([
+      {
+        range: {
+          start: { line: 0, character: 1 },
+          end: { line: 0, character: 1 },
+        },
+        newText: '\rb',
+      },
+    ]);
+    expect(d.getText()).toBe('a\rb');
+    expect(d.lineCount).toBe(2);
+    expect(change).toEqual({
+      startLine: 0,
+      startCharacter: 1,
+      endLine: 1,
+      previousLineCount: 1,
+      lineCount: 2,
+      lineDelta: 1,
+      changedLineRanges: [[0, 1]],
+    });
+  });
+
+  test('applyEdits reports inserted lines for multiple lone CR line endings', () => {
+    const d = doc('hello');
+    const change = d.applyEdits([
+      {
+        range: {
+          start: { line: 0, character: 5 },
+          end: { line: 0, character: 5 },
+        },
+        newText: '\rworld\rfoo',
+      },
+    ]);
+    expect(d.getText()).toBe('hello\rworld\rfoo');
+    expect(d.lineCount).toBe(3);
+    expect(change).toEqual({
+      startLine: 0,
+      startCharacter: 5,
+      endLine: 2,
+      previousLineCount: 1,
+      lineCount: 3,
+      lineDelta: 2,
+      changedLineRanges: [[0, 2]],
+    });
+  });
+
   test('getText(range) spans multiple lines correctly after edits', () => {
     const d = doc('foo\nbar\nbaz');
     d.applyEdits([


### PR DESCRIPTION
`#computeChangedLineRange` counted only `\n` when sizing the inserted line span, but the piece table (and `lineCount`/`lineDelta`) count `\n`, `\r`, and `\r\n` via `computeLineOffsets`. Inserting lone-`\r` (classic Mac) text therefore under-scoped `changedLineRanges` and `endLine`, leaving the tokenizer to skip re-highlighting new lines.

Add a shared `countLineBreaks` helper that delegates to `computeLineOffsets` so the two stay in lockstep, and use it for the inserted line span. Cover the fix with lone-`\r` change-range tests and `countLineBreaks` unit tests.