### PR TITLE
More edit CSS fixes

### DIFF
--- a/apps/docs/app/(diffs)/_examples/LiveEditing/LiveEditing.tsx
+++ b/apps/docs/app/(diffs)/_examples/LiveEditing/LiveEditing.tsx
@@ -6,7 +6,7 @@ import type {
   PreloadedFileResult,
   PreloadFileDiffResult,
 } from '@pierre/diffs/ssr';
-import { IconRefresh } from '@pierre/icons';
+import { IconDiffSplit, IconDiffUnified, IconRefresh } from '@pierre/icons';
 import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { LIVE_EDITOR_NEW_FILE } from '../LiveEditor/constants';
@@ -181,16 +181,17 @@ export function LiveEditing({
           value={diffLayout}
           onValueChange={(value) => handleDiffLayoutChange(value as DiffLayout)}
           aria-label="Diff layout"
+          size="icon"
         >
           {(['unified', 'split'] as const).map((value) => (
             <ButtonGroupItem
               key={value}
               value={value}
-              className="capitalize"
+              aria-label={value}
               // Layout only applies to the diff surface; disable it for files.
               disabled={surface === 'file'}
             >
-              {value}
+              {value === 'split' ? <IconDiffSplit /> : <IconDiffUnified />}
             </ButtonGroupItem>
           ))}
         </ButtonGroup>

--- a/apps/docs/app/(diffs)/playground/PlaygroundClient.tsx
+++ b/apps/docs/app/(diffs)/playground/PlaygroundClient.tsx
@@ -149,6 +149,9 @@ interface PlaygroundControlsContentProps {
   setSelectedRange: (v: SelectedLineRange | null) => void;
   handleCopyLink: () => void;
   hideShare?: boolean;
+  // In the mobile drawer the dropdowns portal to <body> beneath the drawer
+  // (z-60), so callers pass a higher z-index class to lift menus above it.
+  dropdownContentClassName?: string;
 }
 
 function PlaygroundControlsContent({
@@ -186,6 +189,7 @@ function PlaygroundControlsContent({
   setSelectedRange,
   handleCopyLink,
   hideShare = false,
+  dropdownContentClassName,
 }: PlaygroundControlsContentProps) {
   const interactionMode: 'select' | 'comment' | 'none' = enableGutterUtility
     ? 'comment'
@@ -255,7 +259,11 @@ function PlaygroundControlsContent({
               <IconChevronSm className="text-muted-foreground ml-auto" />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" scrollSelectedIntoView>
+          <DropdownMenuContent
+            align="start"
+            scrollSelectedIntoView
+            className={dropdownContentClassName}
+          >
             {LIGHT_THEMES.map((theme) => (
               <DropdownMenuItem
                 key={theme}
@@ -282,7 +290,11 @@ function PlaygroundControlsContent({
               <IconChevronSm className="text-muted-foreground ml-auto" />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" scrollSelectedIntoView>
+          <DropdownMenuContent
+            align="start"
+            scrollSelectedIntoView
+            className={dropdownContentClassName}
+          >
             {DARK_THEMES.map((theme) => (
               <DropdownMenuItem
                 key={theme}
@@ -348,7 +360,11 @@ function PlaygroundControlsContent({
               <IconChevronSm className="text-muted-foreground ml-auto" />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" scrollSelectedIntoView>
+          <DropdownMenuContent
+            align="start"
+            scrollSelectedIntoView
+            className={dropdownContentClassName}
+          >
             {LINE_DIFF_OPTIONS.map((option) => (
               <DropdownMenuItem
                 key={option.value}
@@ -432,7 +448,11 @@ function PlaygroundControlsContent({
               <IconChevronSm className="text-muted-foreground ml-auto" />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" scrollSelectedIntoView>
+          <DropdownMenuContent
+            align="start"
+            scrollSelectedIntoView
+            className={dropdownContentClassName}
+          >
             {HUNK_SEPARATOR_OPTIONS.map((option) => (
               <DropdownMenuItem
                 key={option.value}
@@ -460,7 +480,11 @@ function PlaygroundControlsContent({
               <IconChevronSm className="text-muted-foreground ml-auto" />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" scrollSelectedIntoView>
+          <DropdownMenuContent
+            align="start"
+            scrollSelectedIntoView
+            className={dropdownContentClassName}
+          >
             {interactionModeOptions.map((option) => (
               <DropdownMenuItem
                 key={option.value}
@@ -940,7 +964,11 @@ export function PlaygroundClient({ prerenderedDiff }: PlaygroundClientProps) {
                 Close
               </Button>
             </div>
-            <PlaygroundControlsContent {...controlsContentProps} hideShare />
+            <PlaygroundControlsContent
+              {...controlsContentProps}
+              hideShare
+              dropdownContentClassName="z-[70]"
+            />
           </div>
         </div>
       </div>

--- a/apps/docs/app/(diffs)/playground/PlaygroundClient.tsx
+++ b/apps/docs/app/(diffs)/playground/PlaygroundClient.tsx
@@ -6,11 +6,13 @@ import type {
   DiffLineAnnotation,
   SelectedLineRange,
 } from '@pierre/diffs';
-import { FileDiff } from '@pierre/diffs/react';
+import { Editor } from '@pierre/diffs/editor';
+import { EditorProvider, FileDiff } from '@pierre/diffs/react';
 import type { PreloadFileDiffResult } from '@pierre/diffs/ssr';
 import {
   IconCheck,
   IconChevronSm,
+  IconCiWarning,
   IconCodeStyleBars,
   IconCodeStyleBg,
   IconCodeStyleInline,
@@ -20,20 +22,23 @@ import {
   IconCursor,
   IconDiffSplit,
   IconDiffUnified,
+  IconEye,
   IconHunkDivider,
   IconInReview,
   IconLink,
   IconListOrdered,
   IconParagraph,
+  IconPencil,
   IconSymbolDiffstat,
   IconWordWrap,
   IconXSquircle,
 } from '@pierre/icons';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 import type { PlaygroundAnnotationMetadata } from './constants';
+import { PLAYGROUND_MARKERS } from './constants';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { ButtonGroup, ButtonGroupItem } from '@/components/ui/button-group';
@@ -81,6 +86,10 @@ const HUNK_SEPARATOR_OPTIONS = [
 
 type HunkSeparatorValue = (typeof HUNK_SEPARATOR_OPTIONS)[number]['value'];
 
+// The editable surface is rendered read-only (Review) or attached to a live
+// editor (Edit). Markers are diagnostics shown only while editing.
+type EditorMode = 'review' | 'edit';
+
 // Default values for URL param comparison
 const DEFAULTS = {
   diffStyle: 'split',
@@ -97,6 +106,8 @@ const DEFAULTS = {
   gutterButton: true,
   interactionMode: 'comment' as const,
   annotations: true,
+  editorMode: 'review' as EditorMode,
+  markers: false,
 } as const;
 
 interface PlaygroundClientProps {
@@ -130,6 +141,10 @@ interface PlaygroundControlsContentProps {
   setEnableGutterUtility: (v: boolean) => void;
   showAnnotations: boolean;
   setShowAnnotations: (v: boolean) => void;
+  editorMode: EditorMode;
+  setEditorMode: (v: EditorMode) => void;
+  showMarkers: boolean;
+  setShowMarkers: (v: boolean) => void;
   selectedRange: SelectedLineRange | null;
   setSelectedRange: (v: SelectedLineRange | null) => void;
   handleCopyLink: () => void;
@@ -163,6 +178,10 @@ function PlaygroundControlsContent({
   setEnableGutterUtility,
   showAnnotations,
   setShowAnnotations,
+  editorMode,
+  setEditorMode,
+  showMarkers,
+  setShowMarkers,
   selectedRange,
   setSelectedRange,
   handleCopyLink,
@@ -200,12 +219,29 @@ function PlaygroundControlsContent({
         <ButtonGroup
           value={diffStyle}
           onValueChange={(value) => setDiffStyle(value as 'split' | 'unified')}
+          size="icon"
         >
           <ButtonGroupItem value="split">
             <IconDiffSplit />
           </ButtonGroupItem>
           <ButtonGroupItem value="unified">
             <IconDiffUnified />
+          </ButtonGroupItem>
+        </ButtonGroup>
+
+        <div className="bg-border h-6 w-px" />
+
+        <ButtonGroup
+          value={editorMode}
+          onValueChange={(value) => setEditorMode(value as EditorMode)}
+          aria-label="Editor mode"
+          size="icon"
+        >
+          <ButtonGroupItem value="review">
+            <IconEye />
+          </ButtonGroupItem>
+          <ButtonGroupItem value="edit">
+            <IconPencil />
           </ButtonGroupItem>
         </ButtonGroup>
 
@@ -270,6 +306,7 @@ function PlaygroundControlsContent({
           onValueChange={(value) =>
             setThemeType(value as 'system' | 'light' | 'dark')
           }
+          size="icon"
         >
           <ButtonGroupItem value="system">
             <IconColorAuto />
@@ -287,6 +324,7 @@ function PlaygroundControlsContent({
         <ButtonGroup
           value={diffIndicators}
           onValueChange={(value) => setDiffIndicators(value as DiffIndicators)}
+          size="icon"
         >
           <ButtonGroupItem value="bars">
             <IconCodeStyleBars />
@@ -368,6 +406,20 @@ function PlaygroundControlsContent({
           label="Annotations"
           checked={showAnnotations}
           onCheckedChange={setShowAnnotations}
+        />
+
+        <ToggleButton
+          icon={<IconCiWarning />}
+          label="Markers"
+          checked={showMarkers}
+          onCheckedChange={setShowMarkers}
+          // Markers come from an attached editor, so they only render in Edit.
+          disabled={editorMode !== 'edit'}
+          title={
+            editorMode !== 'edit'
+              ? 'Switch to Edit mode to show lint markers'
+              : undefined
+          }
         />
 
         <DropdownMenu>
@@ -546,6 +598,12 @@ export function PlaygroundClient({ prerenderedDiff }: PlaygroundClientProps) {
   const [showAnnotations, setShowAnnotations] = useState(
     getBoolParam('annot', DEFAULTS.annotations)
   );
+  const [editorMode, setEditorMode] = useState<EditorMode>(
+    getParam('edit', DEFAULTS.editorMode) === 'edit' ? 'edit' : 'review'
+  );
+  const [showMarkers, setShowMarkers] = useState(
+    getBoolParam('markers', DEFAULTS.markers)
+  );
 
   // Parse selected line range from URL
   // Format: L15a (line 15 additions), L28-35a (lines 28-35 additions), L10d (line 10 deletions)
@@ -576,6 +634,34 @@ export function PlaygroundClient({ prerenderedDiff }: PlaygroundClientProps) {
     : enableLineSelection
       ? 'select'
       : 'none';
+
+  const contentEditable = editorMode === 'edit';
+
+  // The editor attaches to the diff's editable (new-file) side. Recreate it
+  // when the diff layout or edit mode changes so it re-attaches to the freshly
+  // relaid-out surface with a clean document instead of reusing a torn-down
+  // instance (mirrors LiveEditing's editor lifecycle).
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- deps intentionally force a fresh editor; the factory takes no inputs
+  const editor = useMemo(() => new Editor({}), [diffStyle, editorMode]);
+
+  // Apply (or clear) the demo markers whenever the editor, mode, or toggle
+  // changes. `setMarkers` throws until the editor attaches to its surface
+  // (async), so retry each frame until the call sticks (mirrors MarkerDemo).
+  useEffect(() => {
+    if (!contentEditable) {
+      return;
+    }
+    let frame = 0;
+    const apply = () => {
+      try {
+        editor.setMarkers(showMarkers ? PLAYGROUND_MARKERS : []);
+      } catch {
+        frame = requestAnimationFrame(apply);
+      }
+    };
+    apply();
+    return () => cancelAnimationFrame(frame);
+  }, [editor, contentEditable, showMarkers]);
 
   // Build URL with current config
   const buildUrl = useCallback(() => {
@@ -608,6 +694,9 @@ export function PlaygroundClient({ prerenderedDiff }: PlaygroundClientProps) {
       params.set('gutter', enableGutterUtility ? '1' : '0');
     if (showAnnotations !== DEFAULTS.annotations)
       params.set('annot', showAnnotations ? '1' : '0');
+    if (editorMode !== DEFAULTS.editorMode) params.set('edit', editorMode);
+    if (showMarkers !== DEFAULTS.markers)
+      params.set('markers', showMarkers ? '1' : '0');
 
     if (selectedRange != null) {
       const sideChar = selectedRange.side === 'deletions' ? 'd' : 'a';
@@ -637,6 +726,8 @@ export function PlaygroundClient({ prerenderedDiff }: PlaygroundClientProps) {
     enableLineSelection,
     enableGutterUtility,
     showAnnotations,
+    editorMode,
+    showMarkers,
     selectedRange,
   ]);
 
@@ -744,10 +835,63 @@ export function PlaygroundClient({ prerenderedDiff }: PlaygroundClientProps) {
     setEnableGutterUtility,
     showAnnotations,
     setShowAnnotations,
+    editorMode,
+    setEditorMode,
+    showMarkers,
+    setShowMarkers,
     selectedRange,
     setSelectedRange,
     handleCopyLink,
   };
+
+  // Editing takes over click targets, so line selection and gutter comments are
+  // disabled while in Edit mode (they only make sense in read-only Review).
+  const fileDiff = (
+    <FileDiff
+      {...prerenderedDiff}
+      className="border-border overflow-hidden rounded-lg border"
+      contentEditable={contentEditable}
+      selectedLines={contentEditable ? null : selectedRange}
+      lineAnnotations={showAnnotations ? annotations : []}
+      options={{
+        ...prerenderedDiff.options,
+        diffStyle,
+        diffIndicators,
+        lineDiffType,
+        hunkSeparators,
+        disableBackground,
+        disableLineNumbers,
+        overflow,
+        themeType,
+        theme: { dark: selectedDarkTheme, light: selectedLightTheme },
+        enableLineSelection: contentEditable ? false : canSelectLines,
+        enableGutterUtility: contentEditable ? false : canUseGutterComments,
+        onLineSelectionEnd: handleLineSelectionEnd,
+        onGutterUtilityClick:
+          !contentEditable && canUseGutterComments
+            ? (range) => {
+                if (range.side != null) {
+                  addCommentAtLine(range.side, range.start);
+                }
+              }
+            : undefined,
+      }}
+      renderAnnotation={
+        showAnnotations
+          ? (annotation) =>
+              annotation.metadata.isThread === true ? (
+                <ExampleThread />
+              ) : (
+                <CommentForm
+                  side={annotation.side}
+                  lineNumber={annotation.lineNumber}
+                  onCancel={handleCancelComment}
+                />
+              )
+          : undefined
+      }
+    />
+  );
 
   return (
     <div className="space-y-6">
@@ -801,48 +945,11 @@ export function PlaygroundClient({ prerenderedDiff }: PlaygroundClientProps) {
         </div>
       </div>
 
-      <FileDiff
-        {...prerenderedDiff}
-        className="border-border overflow-hidden rounded-lg border"
-        selectedLines={selectedRange}
-        lineAnnotations={showAnnotations ? annotations : []}
-        options={{
-          ...prerenderedDiff.options,
-          diffStyle,
-          diffIndicators,
-          lineDiffType,
-          hunkSeparators,
-          disableBackground,
-          disableLineNumbers,
-          overflow,
-          themeType,
-          theme: { dark: selectedDarkTheme, light: selectedLightTheme },
-          enableLineSelection: canSelectLines,
-          enableGutterUtility: canUseGutterComments,
-          onLineSelectionEnd: handleLineSelectionEnd,
-          onGutterUtilityClick: canUseGutterComments
-            ? (range) => {
-                if (range.side != null) {
-                  addCommentAtLine(range.side, range.start);
-                }
-              }
-            : undefined,
-        }}
-        renderAnnotation={
-          showAnnotations
-            ? (annotation) =>
-                annotation.metadata.isThread === true ? (
-                  <ExampleThread />
-                ) : (
-                  <CommentForm
-                    side={annotation.side}
-                    lineNumber={annotation.lineNumber}
-                    onCancel={handleCancelComment}
-                  />
-                )
-            : undefined
-        }
-      />
+      {contentEditable ? (
+        <EditorProvider editor={editor}>{fileDiff}</EditorProvider>
+      ) : (
+        fileDiff
+      )}
     </div>
   );
 }
@@ -852,17 +959,22 @@ function ToggleButton({
   label,
   checked,
   onCheckedChange,
+  disabled = false,
+  title,
 }: {
   icon?: React.ReactNode;
   label: string;
   checked: boolean;
   onCheckedChange: (checked: boolean) => void;
+  disabled?: boolean;
+  title?: string;
 }) {
   return (
-    <div className="gridstack">
+    <div className="gridstack" title={title}>
       <Button
         variant="outline"
         className="justify-between gap-3 pr-11 pl-3"
+        disabled={disabled}
         onClick={() => onCheckedChange(!checked)}
       >
         <div className="flex items-center gap-2">
@@ -873,6 +985,7 @@ function ToggleButton({
       <Switch
         checked={checked}
         onCheckedChange={onCheckedChange}
+        disabled={disabled}
         onClick={(e) => e.stopPropagation()}
         className="pointer-events-none mr-3 place-self-center justify-self-end"
       />

--- a/apps/docs/app/(diffs)/playground/constants.ts
+++ b/apps/docs/app/(diffs)/playground/constants.ts
@@ -107,6 +107,43 @@ export async function deleteUser(id: string): Promise<void> {
 
 `;
 
+// Diagnostics for the playground's edit-mode marker toggle. Positions are
+// zero-based line/character ranges into NEW_USERS_CONTENT (the diff's editable
+// new-file side), so keep them in sync if that content changes. Severities are
+// `as const` so the literals satisfy the editor's MarkerSeverity union without
+// importing the Marker type (mirrors _edit/constants.ts MARKER_DEMO_MARKERS).
+// Covers all four severities so the toggle exercises every marker color.
+export const PLAYGROUND_MARKERS = [
+  {
+    severity: 'error' as const,
+    source: 'ts',
+    message: "Module './utils' has no exported member 'hashPassword'.",
+    start: { line: 8, character: 24 },
+    end: { line: 8, character: 36 },
+  },
+  {
+    severity: 'info' as const,
+    source: 'ts',
+    message: "'user' is declared here; consider narrowing before use.",
+    start: { line: 18, character: 8 },
+    end: { line: 18, character: 12 },
+  },
+  {
+    severity: 'warning' as const,
+    source: 'eslint',
+    message: 'Prefer a custom error subclass over the generic Error.',
+    start: { line: 22, character: 14 },
+    end: { line: 22, character: 19 },
+  },
+  {
+    severity: 'hint' as const,
+    source: 'eslint',
+    message: 'Redundant comment; the guard above already documents this.',
+    start: { line: 24, character: 2 },
+    end: { line: 24, character: 14 },
+  },
+];
+
 export const PLAYGROUND_DIFF: PreloadFileDiffOptions<PlaygroundAnnotationMetadata> =
   {
     fileDiff: parseDiffFromFile(

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -20,7 +20,6 @@ import {
   type SelectionWriteOptions,
 } from '../managers/InteractionManager';
 import { ResizeManager } from '../managers/ResizeManager';
-import { queueRender } from '../managers/UniversalRenderingManager';
 import { FileRenderer, type FileRenderResult } from '../renderers/FileRenderer';
 import { SVGSpriteSheet } from '../sprite';
 import type {
@@ -468,7 +467,7 @@ export class File<
     }
   }
 
-  private syncRenderViewToEditor = () => {
+  private syncRenderViewToEditor(): void {
     const editor = this.editor;
     const fileContainer = this.fileContainer;
     const file = this.file;
@@ -483,12 +482,12 @@ export class File<
         );
       });
     }
-  };
+  }
 
   public attachEditor(editor: DiffsEditor<LAnnotation>): () => void {
     this.editor?.cleanUp();
     this.editor = editor;
-    queueRender(this.syncRenderViewToEditor);
+    this.syncRenderViewToEditor();
     return () => {
       this.editor = undefined;
     };
@@ -663,7 +662,7 @@ export class File<
       this.renderAnnotations();
       this.renderGutterUtility();
       if (this.editor != null) {
-        queueRender(this.syncRenderViewToEditor);
+        this.syncRenderViewToEditor();
       }
     } catch (error: unknown) {
       if (disableErrorHandling) {

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -22,7 +22,6 @@ import {
 } from '../managers/InteractionManager';
 import { ResizeManager } from '../managers/ResizeManager';
 import { ScrollSyncManager } from '../managers/ScrollSyncManager';
-import { queueRender } from '../managers/UniversalRenderingManager';
 import {
   DiffHunksRenderer,
   type DiffHunksRendererOptions,
@@ -944,7 +943,7 @@ export class FileDiff<
       }
 
       if (this.editor != null) {
-        queueRender(this.syncRenderViewToEditor);
+        this.syncRenderViewToEditor();
       }
     } catch (error: unknown) {
       if (disableErrorHandling) {
@@ -988,7 +987,7 @@ export class FileDiff<
     onPostRender?.(fileContainer, this, phase);
   }
 
-  private syncRenderViewToEditor = () => {
+  private syncRenderViewToEditor(): void {
     const editor = this.editor;
     const fileContainer = this.fileContainer;
     const fileDiff = this.fileDiff;
@@ -1008,12 +1007,12 @@ export class FileDiff<
         );
       });
     }
-  };
+  }
 
   public attachEditor(editor: DiffsEditor<LAnnotation>): () => void {
     this.editor?.cleanUp();
     this.editor = editor;
-    queueRender(this.syncRenderViewToEditor);
+    this.syncRenderViewToEditor();
     return () => {
       this.editor = undefined;
     };

--- a/packages/diffs/src/editor/editor.css
+++ b/packages/diffs/src/editor/editor.css
@@ -20,6 +20,7 @@
   position: relative;
 }
 [data-content] {
+  cursor: text;
   background-color: transparent;
   caret-color: var(--diffs-bg-caret);
   outline: none;
@@ -29,16 +30,6 @@
 [data-line]:not([data-selected-line]) span,
 [data-line-annotation] {
   background-color: transparent;
-}
-[data-column-number] {
-  color: var(--diffs-editor-line-number-fg);
-}
-[data-column-number]:is([data-selected-line]) {
-  background-color: var(--diffs-editor-line-number-active-bg);
-  color: var(--diffs-editor-line-number-active-fg);
-}
-[data-column-number]:is([data-active]) {
-  color: var(--diffs-editor-line-number-active-fg);
 }
 [data-line] {
   cursor: text;
@@ -77,15 +68,13 @@
       )
     )
   );
-  animation: blinking 1.2s infinite;
-  animation-delay: 0.8s;
   visibility: hidden;
 }
-/* Honor the OS reduced-motion setting: drop the blink so the caret renders as a
-   solid bar (opacity stays at its default of 1) instead of pulsing. */
-@media (prefers-reduced-motion: reduce) {
+/* Reduce motion only if user has set a preference */
+@media (prefers-reduced-motion: no-preference) {
   [data-caret] {
-    animation: none;
+    animation: blinking 1.2s infinite;
+    animation-delay: 0.8s;
   }
 }
 [data-selection-range] {
@@ -112,27 +101,36 @@
 }
 [data-marker-range] {
   z-index: 1;
-  /* White stroke: luminance masks treat black as transparent. */
-  -webkit-mask-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2IiBoZWlnaHQ9IjMiPjxwYXRoIGQ9Im0wIDIuNSBsMiAtMS41IGwxIDAgbDIgMS41IGwxIDAiIHN0cm9rZT0iI2ZmZiIgZmlsbD0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIi8+PC9zdmc+');
+  background-color: var(--diffs-marker-fg);
   mask-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2IiBoZWlnaHQ9IjMiPjxwYXRoIGQ9Im0wIDIuNSBsMiAtMS41IGwxIDAgbDIgMS41IGwxIDAiIHN0cm9rZT0iI2ZmZiIgZmlsbD0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIi8+PC9zdmc+');
-  -webkit-mask-position: left bottom;
   mask-position: left bottom;
-  -webkit-mask-repeat: repeat-x;
   mask-repeat: repeat-x;
-  -webkit-mask-size: 6px 3px;
   mask-size: 6px 3px;
 }
-[data-marker-error] {
-  background-color: var(--diffs-editor-error-fg, red);
+/* Marker severity palette, shared by the squiggle underline
+   ([data-marker-range]) and the hover popover ([data-marker-popup]). Each
+   severity resolves a single --diffs-marker-fg token that both consumers read,
+   so the colors live in one place. The range element carries
+   data-marker-<severity>; the popup carries data-marker-severity="<severity>". */
+[data-marker-error],
+[data-marker-popup][data-marker-severity='error'] {
+  --diffs-marker-fg: var(--diffs-editor-error-fg, var(--diffs-deletion-base));
 }
-[data-marker-warning] {
-  background-color: var(--diffs-editor-warning-fg, #cca700);
+[data-marker-warning],
+[data-marker-popup][data-marker-severity='warning'] {
+  --diffs-widget-fg: #000;
+  --diffs-marker-fg: var(
+    --diffs-editor-warning-fg,
+    light-dark(var(--diffs-warning-light), var(--diffs-warning-dark))
+  );
 }
-[data-marker-info] {
-  background-color: var(--diffs-editor-info-fg, #3794ff);
+[data-marker-info],
+[data-marker-popup][data-marker-severity='info'] {
+  --diffs-marker-fg: var(--diffs-editor-info-fg, var(--diffs-modified-base));
 }
-[data-marker-hint] {
-  background-color: var(--diffs-editor-hint-fg, #6a6a6a);
+[data-marker-hint],
+[data-marker-popup][data-marker-severity='hint'] {
+  --diffs-marker-fg: var(--diffs-editor-hint-fg, var(--diffs-fg-number));
 }
 [data-rtl] {
   border-top-left-radius: 3px;
@@ -192,25 +190,14 @@
    white text, mirroring the underline. The inset 1px ring (normally painted in
    the surface background) is dropped so the fill reads as one solid chip. */
 [data-marker-popup][data-marker-severity] {
-  color: #fff;
+  color: var(--diffs-widget-fg, #fff);
   border-color: transparent;
+  --diffs-widget-bg: var(--diffs-marker-fg);
   --diffs-widget-shadow:
     0 4px 8px rgb(0 0 0 / 0.15), 0 6px 18px rgb(0 0 0 / 0.15);
 }
 [data-marker-popup][data-marker-severity] code {
   color: inherit;
-}
-[data-marker-popup][data-marker-severity='error'] {
-  --diffs-widget-bg: var(--diffs-editor-error-fg, #e5484d);
-}
-[data-marker-popup][data-marker-severity='warning'] {
-  --diffs-widget-bg: var(--diffs-editor-warning-fg, #cca700);
-}
-[data-marker-popup][data-marker-severity='info'] {
-  --diffs-widget-bg: var(--diffs-editor-info-fg, #3794ff);
-}
-[data-marker-popup][data-marker-severity='hint'] {
-  --diffs-widget-bg: var(--diffs-editor-hint-fg, #6a6a6a);
 }
 
 /* Selection Action Widget */

--- a/packages/diffs/src/editor/editor.css
+++ b/packages/diffs/src/editor/editor.css
@@ -41,9 +41,22 @@
   background-color: var(--diffs-line-bg);
 }
 
-/* Editor Overlay */
+/* Editor Overlay
+   Holds the absolutely-positioned caret, selection, match, and marker layers.
+   It is a positioned box (not `display: contents`) so its children resolve their
+   containing block to it instead of bubbling up to the diff container. The editor
+   sets its left/top/width to the editable column's origin and width (see
+   Editor#syncOverlayOrigin) so the layers line up — and overlay widgets like the
+   marker popup size correctly — in single-file, unified, split-scroll, and
+   split-wrap layouts alike. `[data-code]` is `display: contents` in split-wrap,
+   so without this the overlay would fall back to the diff container and render
+   over the wrong (deletions) column. */
 [data-editor-overlay] {
-  display: contents;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
 }
 [data-caret],
 [data-selection-range],

--- a/packages/diffs/src/editor/editor.css
+++ b/packages/diffs/src/editor/editor.css
@@ -16,7 +16,8 @@
 
 :host, /* for scroll anchor */
 [data-code], /* for editor overlay */
-[data-content] /* for wrap line measurement */ {
+[data-content] /* for wrap line measurement */,
+[data-diff-type='split'][data-overflow='wrap'] {
   position: relative;
 }
 [data-content] {
@@ -41,22 +42,8 @@
   background-color: var(--diffs-line-bg);
 }
 
-/* Editor Overlay
-   Holds the absolutely-positioned caret, selection, match, and marker layers.
-   It is a positioned box (not `display: contents`) so its children resolve their
-   containing block to it instead of bubbling up to the diff container. The editor
-   sets its left/top/width to the editable column's origin and width (see
-   Editor#syncOverlayOrigin) so the layers line up — and overlay widgets like the
-   marker popup size correctly — in single-file, unified, split-scroll, and
-   split-wrap layouts alike. `[data-code]` is `display: contents` in split-wrap,
-   so without this the overlay would fall back to the diff container and render
-   over the wrong (deletions) column. */
 [data-editor-overlay] {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 0;
-  height: 0;
+  display: contents;
 }
 [data-caret],
 [data-selection-range],

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -2292,8 +2292,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
 
     const { ch, lineHeight } = this.#metrics;
     const y = this.#getLineY(line) + wrapLine * lineHeight;
-    const css = `width:${width}px;transform:translateX(${left}px) translateY(${y}px);`;
-    const cacheKey = `${type}-${line}/${wrapLine}-${left}-${width}${extraDataset ?? ''}`;
+    const cacheKey = `${type}-${line}/${wrapLine}-${left}-${width} ${extraDataset ?? ''}`;
     const overlayEls = this.#overlayElements;
     const rounded =
       (this.#options.roundedSelection ?? true) && type === 'selection';
@@ -2411,8 +2410,6 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
 
     if (overlayEls?.has(cacheKey) === true) {
       rangeEl = overlayEls.get(cacheKey)!;
-      rangeEl.style.cssText = css;
-      console.log('[diffs/editor] rangeEl', rangeEl);
       overlayEls.delete(cacheKey);
     } else {
       rangeEl = h(
@@ -2421,12 +2418,13 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
           dataset: extraDataset
             ? [type + 'Range', extraDataset]
             : type + 'Range',
-          style: { cssText: css },
         },
         renderCtx.fragment
       );
     }
 
+    rangeEl.style.width = `${width}px`;
+    rangeEl.style.transform = `translateX(${left}px) translateY(${y}px)`;
     if (rounded) {
       addRadiusStyle(rangeEl);
     }
@@ -2453,25 +2451,21 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
 
     const x = left - 1;
     const y = this.#getLineY(line) + wrapLine * this.#metrics.lineHeight;
-    const transform = `translateX(${x}px) translateY(${y}px)`;
 
     let caretEl: HTMLElement;
     if (this.#overlayElements?.has(cacheKey) === true) {
       caretEl = this.#overlayElements.get(cacheKey)!;
-      caretEl.style.transform = transform;
       this.#overlayElements.delete(cacheKey);
     } else {
       caretEl = h(
         'div',
         {
           dataset: 'caret',
-          style: {
-            transform,
-          },
         },
         renderCtx.fragment
       );
     }
+    caretEl.style.transform = `translateX(${x}px) translateY(${y}px)`;
     renderCtx.elements.set(cacheKey, caretEl);
     if (isPrimary) {
       caretEl.style.scrollMargin = this.#getScrollMargin();
@@ -2492,16 +2486,19 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     }
 
     const [left, wrapLine] = this.#getCharX(line, 0);
+    const top = this.#getLineY(line) + wrapLine * this.#metrics.lineHeight;
+
     const cacheKey = 'selectionActionIcon-' + line + '/' + wrapLine;
     if (renderCtx.elements.has(cacheKey)) {
       return;
     }
 
-    const selectionActionIcon = SelectionActionWidget.renderIcon(
-      left,
-      this.#getLineY(line) + wrapLine * this.#metrics.lineHeight,
-      renderCtx.fragment,
-      () => {
+    let icon: HTMLElement;
+    if (this.#overlayElements?.has(cacheKey) === true) {
+      icon = this.#overlayElements.get(cacheKey)!;
+      this.#overlayElements.delete(cacheKey);
+    } else {
+      icon = SelectionActionWidget.renderIcon(renderCtx.fragment, () => {
         const cleanUp = () => {
           this.#selectionAction?.cleanup();
           this.#selectionAction = undefined;
@@ -2570,9 +2567,10 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         if (this.#isLineVisible(line) && this.#contentElement !== undefined) {
           this.#selectionAction.render(this.#contentElement);
         }
-      }
-    );
-    renderCtx.elements.set(cacheKey, selectionActionIcon);
+      });
+    }
+    icon.style.transform = `translateY(${top}px) translateX(${left}px)`;
+    renderCtx.elements.set(cacheKey, icon);
   }
 
   // Opens the search panel in the requested mode. If a panel is already open,

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -133,7 +133,6 @@ export interface EditorState<LAnnotation> {
 
 export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   #options: EditorOptions<LAnnotation>;
-  #wrap = false;
   #metrics = new Metrics();
   #tokenizer?: EditorTokenizer;
 
@@ -144,6 +143,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   #detach?: () => void;
 
   // cache
+  #contentOffset?: { left: number; top: number };
   #gutterWidthCache?: number;
   #contentWidthCache?: number;
   #lineYCache = new Map<number, number>();
@@ -606,7 +606,9 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       });
       this.#resetState();
       this.#selections = this.#initSelections;
-      this.#options.onAttach?.(this, this.#fileInstance!);
+      requestAnimationFrame(() => {
+        this.#options.onAttach?.(this, this.#fileInstance!);
+      });
       if (this.#textDocument !== undefined && this.#options.__debug === true) {
         console.log('[diffs/editor] text document changed !!!');
       }
@@ -649,8 +651,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
 
     if (
       (lineAnnotations !== undefined && lineAnnotations.length > 0) ||
-      (this.#fileInstance?.type === 'file-diff' &&
-        this.#fileInstance.options.diffStyle === 'unified')
+      (this.#isDiff && this.#diffSyle === 'unified')
     ) {
       for (const child of this.#contentElement.children) {
         const el = child as HTMLElement;
@@ -669,7 +670,6 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     // sync so the editor's line-highlight/token colors track the active theme.
     this.#tokenizer?.syncTheme(this.#fileInstance?.options ?? {});
 
-    this.#wrap = this.#fileInstance?.options.overflow === 'wrap';
     this.#lineAnnotations = lineAnnotations;
     this.#renderRange = renderRange;
     this.#tokenizer?.prebuildStateStack(renderRange);
@@ -729,6 +729,18 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       );
     }
   };
+
+  get #diffSyle(): 'unified' | 'split' {
+    return this.#fileInstance?.options.diffStyle ?? 'split';
+  }
+
+  get #isDiff(): boolean {
+    return this.#fileInstance?.type === 'file-diff';
+  }
+
+  get #isWrap(): boolean {
+    return this.#fileInstance?.options.overflow === 'wrap';
+  }
 
   #resetCache(): void {
     this.#lineYCache.clear();
@@ -1308,11 +1320,26 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     this.#markerRenderer?.listenHover(contentEl);
 
     this.#resizeObserver?.disconnect();
-    this.#resizeObserver = new ResizeObserver(() => {
-      this.#handleLayoutResize();
-    });
+    this.#resizeObserver = new ResizeObserver(this.#handleLayoutResize);
     this.#resizeObserver.observe(contentEl);
     this.#resizeObserver.observe(contentEl.parentElement!);
+    this.#computeContentOffset(contentEl);
+  }
+
+  // diff(split) treat the content element as grid item,
+  // that breaks the overlay element positioning.
+  // this function computes the content offset to fix
+  // the overlay element position.
+  #computeContentOffset(contentEl: HTMLElement) {
+    if (this.#isDiff && this.#diffSyle === 'split' && this.#isWrap) {
+      this.#contentOffset = {
+        top: contentEl.offsetTop,
+        left: contentEl.offsetLeft - this.#getGutterWidth(),
+      };
+      if (this.#options.__debug === true) {
+        console.log('[diffs/editor] content offset:', this.#contentOffset);
+      }
+    }
   }
 
   // TODO(@ije): add command registry
@@ -1502,7 +1529,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     }
   }
 
-  #handleLayoutResize() {
+  #handleLayoutResize = () => {
     const lineAnnotations = this.#lineAnnotations?.length ?? 0;
     const prevGutterWidth = this.#gutterWidthCache;
     const prevContentWidth = this.#contentWidthCache;
@@ -1520,7 +1547,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     // web font finished loading) while this same content element survived, so
     // discard memoized non-ASCII text widths and let them re-measure.
     this.#metrics.clearTextWidthCache();
-    if (contentWidthChanged && (this.#wrap || lineAnnotations > 0)) {
+    if (contentWidthChanged && (this.#isWrap || lineAnnotations > 0)) {
       this.#lineYCache.clear();
       this.#wrapLineOffsetsCache.clear();
     }
@@ -1535,7 +1562,8 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       }
     }
     this.#markerRenderer?.removePopup();
-  }
+    this.#computeContentOffset(this.#contentElement!);
+  };
 
   // A custom monospace web font can finish loading after the editor first
   // renders. Until then Metrics measured the '0' width against the fallback
@@ -1693,7 +1721,6 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       }
     }
 
-    const isDiff = this.#fileInstance?.type === 'file-diff';
     const didLineCountChange = change.lineDelta !== 0;
 
     // fix grid layout
@@ -1714,7 +1741,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     fileInstance.updateRenderCache(
       dirtyLines,
       tokenizer.themeType,
-      isDiff && !didLineCountChange,
+      this.#isDiff && !didLineCountChange,
       // On a line-count change we recompute hunk metadata authoritatively in
       // `applyDocumentChange` below, so skip the redundant recompute here.
       didLineCountChange
@@ -1976,36 +2003,8 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     }
   }
 
-  // Anchor the editor overlay to the editable column's origin so the
-  // absolutely-positioned caret/selection/match/marker layers line up with the
-  // text in every layout. `getCharX` measures X from the column's left edge
-  // (gutter included) and `getLineY` measures Y from the content element's top,
-  // so the overlay's top-left must sit at the gutter-left / content-top. In a
-  // single File, a unified diff, or a split diff in scroll mode `[data-code]` is
-  // itself a positioned box at that origin, so these offsets are ~0; in a split
-  // diff in wrap mode `[data-code]` is `display: contents`, so without this the
-  // overlay would resolve to the diff container and render over the wrong (left)
-  // column. The overlay is a sibling of the gutter/content inside `[data-code]`,
-  // so it shares their offsetParent and their offsetLeft/offsetTop are already in
-  // the overlay's own coordinate space. The width is set so overlay widgets that
-  // size against the column (e.g. the marker popup's `max-width: calc(100% - …)`)
-  // stay in bounds instead of collapsing against the overlay's zero box.
-  #syncOverlayOrigin(): void {
-    const overlay = this.#overlayElement;
-    const contentEl = this.#contentElement;
-    if (overlay === undefined || contentEl === undefined) {
-      return;
-    }
-    const originEl = this.#gutterElement ?? contentEl;
-    const originLeft = originEl.offsetLeft;
-    overlay.style.left = `${originLeft}px`;
-    overlay.style.top = `${contentEl.offsetTop}px`;
-    overlay.style.width = `${contentEl.offsetLeft + contentEl.offsetWidth - originLeft}px`;
-  }
-
   #updateSelections(selections: EditorSelection[]) {
     this.__postponeBackgroundTokenizeToNextFrame();
-    this.#syncOverlayOrigin();
 
     this.#primaryCaretElement = undefined;
     this.#setSelectedLinesSafe(null);
@@ -2129,7 +2128,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       const startChar = line === start.line ? start.character : 0;
       const endChar = isLastLine ? end.character : lineText.length;
 
-      if (this.#wrap) {
+      if (this.#isWrap) {
         const contentWidth = this.#getContentWidth();
         const textWidth =
           2 * this.#metrics.ch + this.#metrics.measureTextWidth(lineText);
@@ -2294,11 +2293,11 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     const { ch, lineHeight } = this.#metrics;
     const y = this.#getLineY(line) + wrapLine * lineHeight;
     const css = `width:${width}px;transform:translateX(${left}px) translateY(${y}px);`;
-    const cacheKey = `${type}-${left}-${y}-${width}${extraDataset ?? ''}`;
+    const cacheKey = `${type}-${line}/${wrapLine}-${left}-${width}${extraDataset ?? ''}`;
     const overlayEls = this.#overlayElements;
-
     const rounded =
       (this.#options.roundedSelection ?? true) && type === 'selection';
+
     const addRoundedCorner = (
       line: number,
       wrapLine: number,
@@ -2311,7 +2310,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         selectionCorner: '',
         [radius]: '',
       };
-      const cacheKeyPrefix = `${type}-block-${left}-${top}-1ch`;
+      const cacheKeyPrefix = `${type}-block-${line}/${wrapLine}-${left}-1ch`;
       let cacheKey = cacheKeyPrefix + '-' + radius;
       if (radius === 'rbl') {
         const prevCornerKey = cacheKeyPrefix + '-rtl';
@@ -2329,6 +2328,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       }
       if (overlayEls?.has(cacheKey) === true) {
         cornerEl = overlayEls.get(cacheKey)!;
+        cornerEl.style.cssText = css;
         overlayEls.delete(cacheKey);
       } else {
         cornerEl = h(
@@ -2411,6 +2411,8 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
 
     if (overlayEls?.has(cacheKey) === true) {
       rangeEl = overlayEls.get(cacheKey)!;
+      rangeEl.style.cssText = css;
+      console.log('[diffs/editor] rangeEl', rangeEl);
       overlayEls.delete(cacheKey);
     } else {
       rangeEl = h(
@@ -2448,18 +2450,28 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     if (renderCtx.elements.has(cacheKey)) {
       return;
     }
+
     const x = left - 1;
     const y = this.#getLineY(line) + wrapLine * this.#metrics.lineHeight;
-    const caretEl = h(
-      'div',
-      {
-        dataset: 'caret',
-        style: {
-          transform: `translateX(${x}px) translateY(${y}px)`,
+    const transform = `translateX(${x}px) translateY(${y}px)`;
+
+    let caretEl: HTMLElement;
+    if (this.#overlayElements?.has(cacheKey) === true) {
+      caretEl = this.#overlayElements.get(cacheKey)!;
+      caretEl.style.transform = transform;
+      this.#overlayElements.delete(cacheKey);
+    } else {
+      caretEl = h(
+        'div',
+        {
+          dataset: 'caret',
+          style: {
+            transform,
+          },
         },
-      },
-      renderCtx.fragment
-    );
+        renderCtx.fragment
+      );
+    }
     renderCtx.elements.set(cacheKey, caretEl);
     if (isPrimary) {
       caretEl.style.scrollMargin = this.#getScrollMargin();
@@ -2480,7 +2492,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     }
 
     const [left, wrapLine] = this.#getCharX(line, 0);
-    const cacheKey = 'selectionActionIcon-' + line + '(' + wrapLine + ')';
+    const cacheKey = 'selectionActionIcon-' + line + '/' + wrapLine;
     if (renderCtx.elements.has(cacheKey)) {
       return;
     }
@@ -2870,7 +2882,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     if (selections === undefined || textDocument === undefined) {
       return;
     }
-    const getSoftLineStart = this.#wrap
+    const getSoftLineStart = this.#isWrap
       ? (line: number, character: number) => {
           const wrapOffsets = this.#wrapLineText(line);
           for (let w = 0; w + 1 < wrapOffsets.length; w++) {
@@ -3017,7 +3029,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         }
       }
     }
-    if (this.#wrap) {
+    if (this.#isWrap) {
       for (const line of this.#wrapLineOffsetsCache.keys()) {
         if (line >= change.startLine) {
           this.#wrapLineOffsetsCache.delete(line);
@@ -3139,7 +3151,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     // fallback to query selector
     lineElement ??= contentElement.querySelector<HTMLElement>(
       `[data-line="${line + 1}"]` +
-        (this.#fileInstance?.options.diffStyle === 'unified'
+        (this.#diffSyle === 'unified'
           ? ':not([data-line-type="change-deletion"])'
           : '')
     );
@@ -3221,7 +3233,10 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     }
 
     // cold(slow) path: measure line top position from DOM (will cause reflow)
-    const y = lineElement.offsetTop + this.#metrics.paddingTop;
+    let y = lineElement.offsetTop + this.#metrics.paddingTop;
+    if (this.#contentOffset !== undefined) {
+      y += this.#contentOffset?.top ?? 0;
+    }
     this.#lineYCache.set(line, y);
     return y;
   }
@@ -3240,7 +3255,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     const lineText = this.#textDocument?.getLineText(line);
     const offsetLeft = this.#getGutterWidth() + this.#metrics.ch; // gutter width + inline padding (1ch)
     if (lineText === undefined || lineText.length === 0 || char <= 0) {
-      return [offsetLeft, 0];
+      return [offsetLeft + (this.#contentOffset?.left ?? 0), 0];
     }
 
     const boundedCharacter = snapTextOffsetToUnicodeBoundary(
@@ -3261,7 +3276,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       left = offsetLeft + this.#metrics.measureTextWidth(textBeforeCharacter);
     }
 
-    if (this.#wrap) {
+    if (this.#isWrap) {
       const contentWidth = this.#getContentWidth();
       const textWidth =
         2 * this.#metrics.ch + this.#metrics.measureTextWidth(lineText);
@@ -3289,6 +3304,9 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
             break;
           }
         }
+      }
+      if (this.#contentOffset !== undefined) {
+        left += this.#contentOffset.left;
       }
     }
 

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -663,6 +663,12 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
 
     this.#resetCache();
 
+    // The tokenizer is created once per attached document and reused across
+    // re-renders, so a host-driven theme swap (theme picker, light/dark toggle)
+    // wouldn't otherwise reach it. Re-apply the surface's current theme on every
+    // sync so the editor's line-highlight/token colors track the active theme.
+    this.#tokenizer?.syncTheme(this.#fileInstance?.options ?? {});
+
     this.#wrap = this.#fileInstance?.options.overflow === 'wrap';
     this.#lineAnnotations = lineAnnotations;
     this.#renderRange = renderRange;

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -1976,8 +1976,36 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     }
   }
 
+  // Anchor the editor overlay to the editable column's origin so the
+  // absolutely-positioned caret/selection/match/marker layers line up with the
+  // text in every layout. `getCharX` measures X from the column's left edge
+  // (gutter included) and `getLineY` measures Y from the content element's top,
+  // so the overlay's top-left must sit at the gutter-left / content-top. In a
+  // single File, a unified diff, or a split diff in scroll mode `[data-code]` is
+  // itself a positioned box at that origin, so these offsets are ~0; in a split
+  // diff in wrap mode `[data-code]` is `display: contents`, so without this the
+  // overlay would resolve to the diff container and render over the wrong (left)
+  // column. The overlay is a sibling of the gutter/content inside `[data-code]`,
+  // so it shares their offsetParent and their offsetLeft/offsetTop are already in
+  // the overlay's own coordinate space. The width is set so overlay widgets that
+  // size against the column (e.g. the marker popup's `max-width: calc(100% - …)`)
+  // stay in bounds instead of collapsing against the overlay's zero box.
+  #syncOverlayOrigin(): void {
+    const overlay = this.#overlayElement;
+    const contentEl = this.#contentElement;
+    if (overlay === undefined || contentEl === undefined) {
+      return;
+    }
+    const originEl = this.#gutterElement ?? contentEl;
+    const originLeft = originEl.offsetLeft;
+    overlay.style.left = `${originLeft}px`;
+    overlay.style.top = `${contentEl.offsetTop}px`;
+    overlay.style.width = `${contentEl.offsetLeft + contentEl.offsetWidth - originLeft}px`;
+  }
+
   #updateSelections(selections: EditorSelection[]) {
     this.__postponeBackgroundTokenizeToNextFrame();
+    this.#syncOverlayOrigin();
 
     this.#primaryCaretElement = undefined;
     this.#setSelectedLinesSafe(null);

--- a/packages/diffs/src/editor/selectionAction.ts
+++ b/packages/diffs/src/editor/selectionAction.ts
@@ -20,9 +20,7 @@ export interface SelectionActionContext<LAnnotation> {
 
 export class SelectionActionWidget {
   static renderIcon(
-    x: number,
-    y: number,
-    container: HTMLElement | DocumentFragment,
+    parent: HTMLElement | DocumentFragment,
     onclick: () => void
   ): HTMLElement {
     return h(
@@ -30,13 +28,10 @@ export class SelectionActionWidget {
       {
         dataset: { selectionActionIcon: '', visible: 'false' },
         title: 'Selection Action',
-        style: {
-          transform: `translateY(${y}px) translateX(${x}px)`,
-        },
         innerHTML: getEditorIconSvg('quick'),
         onclick,
       },
-      container
+      parent
     );
   }
 

--- a/packages/diffs/src/editor/tokenzier.ts
+++ b/packages/diffs/src/editor/tokenzier.ts
@@ -35,6 +35,10 @@ export class EditorTokenizer {
   #grammar: IGrammar | undefined;
   #mediaQueryList: MediaQueryList;
   #themeType: 'light' | 'dark';
+  // The resolved name of the theme currently applied to the editor (e.g.
+  // `github-light`). Tracked so `syncTheme` can detect a host-driven theme swap
+  // even when the light/dark mode itself is unchanged.
+  #themeName = '';
   #colorMap: string[];
   #textDocument: TextDocument<unknown>;
   #tokenizeMaxLineLength: number;
@@ -171,7 +175,35 @@ export class EditorTokenizer {
     }
   }
 
+  // Re-apply the editor's theme from the surface's current code options. Edit
+  // mode reuses a single tokenizer across re-renders, so when the host swaps the
+  // theme — a theme picker, a light/dark toggle, etc. — we must recompute the
+  // active theme and re-tokenize. Without this the editor keeps rendering the
+  // theme it captured when it first attached (stale line-highlight background
+  // and token colors). System-driven changes are still handled by the
+  // observers wired up in the constructor; this covers explicit `themeType`/
+  // `theme` option changes that those observers don't see.
+  syncTheme(codeOptions: BaseCodeOptions): void {
+    const { themeType = 'system', theme = DEFAULT_THEMES } = codeOptions;
+    const nextThemeType =
+      themeType === 'system'
+        ? this.#mediaQueryList.matches
+          ? 'dark'
+          : 'light'
+        : themeType;
+    const nextThemeName =
+      typeof theme === 'string' ? theme : theme[nextThemeType];
+    if (
+      nextThemeType === this.#themeType &&
+      nextThemeName === this.#themeName
+    ) {
+      return;
+    }
+    this.#emitThemeChange(nextThemeName, nextThemeType);
+  }
+
   #setTheme(themeName: string) {
+    this.#themeName = themeName;
     this.#colorMap = this.#highlighter.setTheme(themeName).colorMap;
     const { colors = {} } = this.#highlighter.getTheme(themeName);
     const selectionBackground = colors['editor.selectionBackground'];

--- a/packages/diffs/src/editor/tokenzier.ts
+++ b/packages/diffs/src/editor/tokenzier.ts
@@ -208,8 +208,6 @@ export class EditorTokenizer {
     const { colors = {} } = this.#highlighter.getTheme(themeName);
     const selectionBackground = colors['editor.selectionBackground'];
     const lineHighlightBackground = colors['editor.lineHighlightBackground'];
-    const gutterForeground = colors['editorLineNumber.foreground'];
-    const gutterActiveForeground = colors['editorLineNumber.activeForeground'];
     const cursorForeground = colors['editorCursor.foreground'];
     const findMatchBackground = colors['editor.findMatchBackground'];
     const findMatchHighlightBackground =
@@ -221,15 +219,12 @@ export class EditorTokenizer {
     this.#setStyle(`:host {
       --diffs-editor-selection-bg: ${selectionBackground ?? 'var(--diffs-line-bg)'};
       --diffs-editor-line-highlight-bg: ${lineHighlightBackground ?? 'var(--diffs-line-bg)'};
-      --diffs-editor-line-number-fg: ${gutterForeground ?? 'var(--diffs-fg-number)'};
-      --diffs-editor-line-number-active-bg: ${lineHighlightBackground ?? 'var(--diffs-line-bg, var(--diffs-bg))'};
-      --diffs-editor-line-number-active-fg: ${gutterActiveForeground ?? 'var(--diffs-selection-number-fg)'};
       --diffs-editor-match-bg: ${findMatchBackground ?? 'unset'};
       --diffs-editor-match-highlight-bg: ${findMatchHighlightBackground ?? 'unset'};
       --diffs-editor-cursor-fg: ${cursorForeground ?? 'unset'};
       --diffs-editor-hint-fg: ${hintForeground ?? 'unset'};
       --diffs-editor-info-fg: ${infoForeground ?? 'unset'};
-      --diffs-editor-warning-fg: ${warningForeground ?? 'light-dark(var(--diffs-warning-light), var(--diffs-warning-dark))'};
+      --diffs-editor-warning-fg: ${warningForeground ?? 'unset'};
       --diffs-editor-error-fg: ${errorForeground ?? 'unset'};
     }`);
   }

--- a/packages/diffs/src/editor/tokenzier.ts
+++ b/packages/diffs/src/editor/tokenzier.ts
@@ -197,7 +197,7 @@ export class EditorTokenizer {
       --diffs-editor-cursor-fg: ${cursorForeground ?? 'unset'};
       --diffs-editor-hint-fg: ${hintForeground ?? 'unset'};
       --diffs-editor-info-fg: ${infoForeground ?? 'unset'};
-      --diffs-editor-warning-fg: ${warningForeground ?? 'unset'};
+      --diffs-editor-warning-fg: ${warningForeground ?? 'light-dark(var(--diffs-warning-light), var(--diffs-warning-dark))'};
       --diffs-editor-error-fg: ${errorForeground ?? 'unset'};
     }`);
   }

--- a/packages/diffs/src/style.css
+++ b/packages/diffs/src/style.css
@@ -26,6 +26,8 @@
     --diffs-modified-dark: #69b1ff;
     --diffs-deleted-light: #ff2e3f;
     --diffs-deleted-dark: #ff6762;
+    --diffs-warning-light: #d5a910;
+    --diffs-warning-dark: #ffd452;
 
     /*
     // Available CSS Color Overrides


### PR DESCRIPTION
- Remove some custom color changes for edit mode—unsure these were needed? Changing the line number foreground for example felt wrong.
- Consolidate colors for markers (both underline and popups)
- Add edit mode and markers to the `/playground` page
- Update playground button groups to use `size="icon"` in a few places
- Generate a new warning color token from themes