### PR TITLE
fix(diffs): memoize and round DOM text measurements

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -1490,6 +1490,10 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
 
     this.#lastAccessedLineElement = undefined;
     this.#lastAccessedCharX = undefined;
+    // A width change means the inherited font/metrics may have changed (e.g. a
+    // web font finished loading) while this same content element survived, so
+    // discard memoized non-ASCII text widths and let them re-measure.
+    this.#metrics.clearTextWidthCache();
     if (contentWidthChanged && (this.#wrap || lineAnnotations > 0)) {
       this.#lineYCache.clear();
       this.#wrapLineOffsetsCache.clear();

--- a/packages/diffs/src/editor/textMeasure.ts
+++ b/packages/diffs/src/editor/textMeasure.ts
@@ -1,9 +1,22 @@
 import { h, round } from './utils';
 
+// Upper bound on cached DOM text-width measurements. The cache only holds
+// non-ASCII runs (emoji, ZWJ sequences, variation selectors), so it stays
+// small for ordinary code, but capping it prevents unbounded growth on
+// emoji-heavy documents. Past the cap the oldest entry is evicted.
+const DOM_WIDTH_CACHE_LIMIT = 4096;
+
 export class Metrics {
   #root?: HTMLElement;
   #canvasCtx?: CanvasRenderingContext2D;
   #font?: string;
+
+  // Memoizes domMeasureTextWidth() results keyed by the (tab-expanded) text it
+  // measured. That path inserts a span and reads getBoundingClientRect(), which
+  // forces a synchronous layout every call; without this cache, caret and
+  // selection updates on emoji-heavy lines re-measure the same runs on every
+  // render. Cleared in init() whenever the font changes (see below).
+  #domWidthCache = new Map<string, number>();
 
   /** Width of the '0' character. */
   ch: number = -1;
@@ -54,6 +67,8 @@ export class Metrics {
       this.#font = font;
       this.#canvasCtx.font = font;
       this.ch = this.canvasMeasureTextWidth('0');
+      // Cached DOM widths were measured against the previous font.
+      this.#domWidthCache.clear();
     }
     const nextTabSize = parseInt(tabSize, 10);
     if (!Number.isNaN(nextTabSize)) {
@@ -108,11 +123,16 @@ export class Metrics {
 
   /**
    * measure the width of the text using the DOM
-   * this is slow because it cause a reflow, use it for non-ascii text
+   * this is slow because it cause a reflow, use it for non-ascii text;
+   * results are memoized per text so repeated measurements skip the reflow
    */
   domMeasureTextWidth(text: string): number {
     if (this.#root === undefined) {
       throw new Error('Metrics not initialized');
+    }
+    const cached = this.#domWidthCache.get(text);
+    if (cached !== undefined) {
+      return cached;
     }
     const measureEl = h(
       'span',
@@ -130,11 +150,23 @@ export class Metrics {
       },
       this.#root
     );
+    let width: number;
     try {
-      return measureEl.getBoundingClientRect().width;
+      // round() to match canvasMeasureTextWidth and ch; otherwise the DOM path
+      // returns raw sub-pixel widths and caret/selection offsets drift between
+      // ASCII and non-ASCII runs on the same line.
+      width = round(measureEl.getBoundingClientRect().width);
     } finally {
       measureEl.remove();
     }
+    if (this.#domWidthCache.size >= DOM_WIDTH_CACHE_LIMIT) {
+      const oldestKey = this.#domWidthCache.keys().next().value;
+      if (oldestKey !== undefined) {
+        this.#domWidthCache.delete(oldestKey);
+      }
+    }
+    this.#domWidthCache.set(text, width);
+    return width;
   }
 }
 

--- a/packages/diffs/src/editor/textMeasure.ts
+++ b/packages/diffs/src/editor/textMeasure.ts
@@ -4,22 +4,15 @@ import { h, round } from './utils';
 // non-ASCII runs (emoji, ZWJ sequences, variation selectors), so it stays
 // small for ordinary code, but capping it prevents unbounded growth on
 // emoji-heavy documents. Past the cap the oldest entry is evicted.
-const DOM_WIDTH_CACHE_LIMIT = 4096;
+const TEXT_WIDTH_CACHE_LIMIT = 4096;
 
 export class Metrics {
   #root?: HTMLElement;
   #canvasCtx?: CanvasRenderingContext2D;
   #font?: string;
 
-  // Memoizes domMeasureTextWidth() results keyed by the (tab-expanded) text it
-  // measured. That path inserts a span and reads getBoundingClientRect(), which
-  // forces a synchronous layout every call; without this cache, caret and
-  // selection updates on emoji-heavy lines re-measure the same runs on every
-  // render. Cleared via clearTextWidthCache() whenever the inherited font may
-  // have changed: on a font change in init(), and on a layout reflow the
-  // editor reports through its resize handler (e.g. a web font finishing
-  // loading without the content element being replaced).
-  #domWidthCache = new Map<string, number>();
+  // Memoizes domMeasureTextWidth() results
+  #textWidthCache = new Map<string, number>();
 
   /** Width of the '0' character. */
   ch: number = -1;
@@ -27,7 +20,7 @@ export class Metrics {
   tabSize: number = 2;
   /** Height of the code line. */
   lineHeight: number = 20;
-
+  /** Padding top of the root element. */
   paddingTop: number = 0;
 
   /** initialize the metrics */
@@ -133,7 +126,8 @@ export class Metrics {
     if (this.#root === undefined) {
       throw new Error('Metrics not initialized');
     }
-    const cached = this.#domWidthCache.get(text);
+    const cacheKey = text + '|' + this.#font;
+    const cached = this.#textWidthCache.get(cacheKey);
     if (cached !== undefined) {
       return cached;
     }
@@ -162,13 +156,13 @@ export class Metrics {
     } finally {
       measureEl.remove();
     }
-    if (this.#domWidthCache.size >= DOM_WIDTH_CACHE_LIMIT) {
-      const oldestKey = this.#domWidthCache.keys().next().value;
+    if (this.#textWidthCache.size >= TEXT_WIDTH_CACHE_LIMIT) {
+      const oldestKey = this.#textWidthCache.keys().next().value;
       if (oldestKey !== undefined) {
-        this.#domWidthCache.delete(oldestKey);
+        this.#textWidthCache.delete(oldestKey);
       }
     }
-    this.#domWidthCache.set(text, width);
+    this.#textWidthCache.set(cacheKey, width);
     return width;
   }
 
@@ -178,7 +172,7 @@ export class Metrics {
    * init(), e.g. on a layout reflow, so stale widths are not reused
    */
   clearTextWidthCache(): void {
-    this.#domWidthCache.clear();
+    this.#textWidthCache.clear();
   }
 }
 

--- a/packages/diffs/src/editor/textMeasure.ts
+++ b/packages/diffs/src/editor/textMeasure.ts
@@ -15,7 +15,10 @@ export class Metrics {
   // measured. That path inserts a span and reads getBoundingClientRect(), which
   // forces a synchronous layout every call; without this cache, caret and
   // selection updates on emoji-heavy lines re-measure the same runs on every
-  // render. Cleared in init() whenever the font changes (see below).
+  // render. Cleared via clearTextWidthCache() whenever the inherited font may
+  // have changed: on a font change in init(), and on a layout reflow the
+  // editor reports through its resize handler (e.g. a web font finishing
+  // loading without the content element being replaced).
   #domWidthCache = new Map<string, number>();
 
   /** Width of the '0' character. */
@@ -68,7 +71,7 @@ export class Metrics {
       this.#canvasCtx.font = font;
       this.ch = this.canvasMeasureTextWidth('0');
       // Cached DOM widths were measured against the previous font.
-      this.#domWidthCache.clear();
+      this.clearTextWidthCache();
     }
     const nextTabSize = parseInt(tabSize, 10);
     if (!Number.isNaN(nextTabSize)) {
@@ -167,6 +170,15 @@ export class Metrics {
     }
     this.#domWidthCache.set(text, width);
     return width;
+  }
+
+  /**
+   * discard memoized DOM text widths
+   * call this when the inherited font may have changed without re-running
+   * init(), e.g. on a layout reflow, so stale widths are not reused
+   */
+  clearTextWidthCache(): void {
+    this.#domWidthCache.clear();
   }
 }
 

--- a/packages/diffs/test/editorTextMeasure.test.ts
+++ b/packages/diffs/test/editorTextMeasure.test.ts
@@ -268,4 +268,30 @@ describe('Metrics.measureTextWidth (DOM path)', () => {
       cleanup();
     }
   });
+
+  test('re-measures after the cache is cleared on a layout change', () => {
+    const { cleanup } = installDom();
+    const rect = stubBoundingClientRectWidth(20);
+    try {
+      const root = document.createElement('div');
+      document.body.appendChild(root);
+      const metrics = new Metrics();
+      metrics.init(root);
+
+      const emoji = '😀';
+      metrics.measureTextWidth(emoji);
+      metrics.measureTextWidth(emoji);
+      expect(rect.getCallCount()).toBe(1);
+
+      // The editor calls this from handleLayoutResize, so a reflow that the
+      // same content element survives (e.g. a web font finishing loading)
+      // re-measures instead of returning the width from the previous font.
+      metrics.clearTextWidthCache();
+      metrics.measureTextWidth(emoji);
+      expect(rect.getCallCount()).toBe(2);
+    } finally {
+      rect.restore();
+      cleanup();
+    }
+  });
 });

--- a/packages/diffs/test/editorTextMeasure.test.ts
+++ b/packages/diffs/test/editorTextMeasure.test.ts
@@ -6,7 +6,47 @@ import {
   needsDomTextMeasurement,
   snapTextOffsetToUnicodeBoundary,
 } from '../src/editor/textMeasure';
+import { round } from '../src/editor/utils';
 import { type DomHandle, installDom } from './domHarness';
+
+// Replaces HTMLElement.prototype.getBoundingClientRect with a stub that counts
+// invocations and reports a fixed sub-pixel width. domMeasureTextWidth() is the
+// only code under test that calls getBoundingClientRect, so the count equals the
+// number of forced layouts it performed. Returns the call counter and a restore
+// function.
+function stubBoundingClientRectWidth(width: number): {
+  getCallCount: () => number;
+  restore: () => void;
+} {
+  const original = HTMLElement.prototype.getBoundingClientRect;
+  let calls = 0;
+  Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+    configurable: true,
+    value(): DOMRect {
+      calls++;
+      return {
+        width,
+        height: 0,
+        top: 0,
+        left: 0,
+        right: width,
+        bottom: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      };
+    },
+  });
+  return {
+    getCallCount: () => calls,
+    restore: () => {
+      Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+        configurable: true,
+        value: original,
+      });
+    },
+  };
+}
 
 describe('needsDomTextMeasurement', () => {
   test('returns false for empty and plain ASCII text', () => {
@@ -148,5 +188,84 @@ describe('Metrics.remeasureCharacterWidth', () => {
     const metrics = new Metrics();
     expect(metrics.remeasureCharacterWidth()).toBe(false);
     expect(metrics.ch).toBe(-1);
+  });
+});
+
+describe('Metrics.measureTextWidth (DOM path)', () => {
+  test('rounds measured widths and memoizes repeated measurements', () => {
+    const { cleanup } = installDom();
+    const rawWidth = 41.6789;
+    const rect = stubBoundingClientRectWidth(rawWidth);
+    try {
+      const root = document.createElement('div');
+      document.body.appendChild(root);
+      const metrics = new Metrics();
+      metrics.init(root);
+
+      const emoji = '😀';
+      const first = metrics.measureTextWidth(emoji);
+      const second = metrics.measureTextWidth(emoji);
+      const third = metrics.measureTextWidth(emoji);
+
+      // The DOM path now rounds like canvasMeasureTextWidth and ch instead of
+      // leaking the raw sub-pixel value.
+      expect(first).toBe(round(rawWidth));
+      expect(first).not.toBe(rawWidth);
+      expect(second).toBe(first);
+      expect(third).toBe(first);
+
+      // The forced layout happens once; repeats are served from the cache.
+      expect(rect.getCallCount()).toBe(1);
+
+      // A different string is measured once, then also cached.
+      const other = metrics.measureTextWidth('a😀b');
+      expect(other).toBe(round(rawWidth));
+      expect(rect.getCallCount()).toBe(2);
+      metrics.measureTextWidth('a😀b');
+      expect(rect.getCallCount()).toBe(2);
+    } finally {
+      rect.restore();
+      cleanup();
+    }
+  });
+
+  test('re-measures after the font changes', () => {
+    const { cleanup } = installDom();
+    const rect = stubBoundingClientRectWidth(10);
+    const realGetComputedStyle = globalThis.getComputedStyle;
+    let fontFamily = 'monospace';
+    // Drive the font Metrics.init() reads so the test controls when the font
+    // string changes, independent of jsdom's computed-style behavior.
+    globalThis.getComputedStyle = (() =>
+      ({
+        fontSize: '12px',
+        fontFamily,
+        tabSize: '2',
+        lineHeight: '20px',
+        paddingTop: '0px',
+      }) as CSSStyleDeclaration) as typeof getComputedStyle;
+    try {
+      const rootA = document.createElement('div');
+      document.body.appendChild(rootA);
+      const metrics = new Metrics();
+      metrics.init(rootA);
+
+      const emoji = '😀';
+      metrics.measureTextWidth(emoji);
+      metrics.measureTextWidth(emoji);
+      expect(rect.getCallCount()).toBe(1);
+
+      // A new content element with a different font invalidates cached widths.
+      fontFamily = 'serif';
+      const rootB = document.createElement('div');
+      document.body.appendChild(rootB);
+      metrics.init(rootB);
+      metrics.measureTextWidth(emoji);
+      expect(rect.getCallCount()).toBe(2);
+    } finally {
+      globalThis.getComputedStyle = realGetComputedStyle;
+      rect.restore();
+      cleanup();
+    }
   });
 });


### PR DESCRIPTION
Steps to reproduce:
1. Open the diffs editor on a line containing an emoji, such as const greeting = "😀 hello".
2. Move the caret along that line or extend a selection over it.
3. Watch the Performance panel: every caret or selection update forces a synchronous layout. For each non-ASCII run the editor inserts a hidden span, reads getBoundingClientRect(), and removes it, with no caching, so the same runs are re-measured on every render. That path also returns the raw sub-pixel width while the canvas and ASCII paths round, so offsets are quantized inconsistently across runs on the same line.

Fix:
- Memoize domMeasureTextWidth() by measured text, capped at 4096 entries with FIFO eviction, so repeats skip the reflow.
- Clear the cache in init() when the font changes, since cached widths are font-specific.
- Round the DOM-measured width to match canvasMeasureTextWidth and the ch metric.

Add regression tests for the rounding, one measurement per distinct run, and cache invalidation on font change.
