### PR TITLE
Update edit mode docs

### DIFF
--- a/apps/docs/app/(diffs)/_edit/EditHero.tsx
+++ b/apps/docs/app/(diffs)/_edit/EditHero.tsx
@@ -28,7 +28,7 @@ export function EditHero() {
         size="xl"
         className="text-md h-[auto] self-start rounded-lg px-0 md:mt-auto lg:text-lg"
       >
-        <Link href="/docs#editor">
+        <Link href="/docs#edit-mode">
           <IconBook className="opacity-65" />
           Explore the docs
           <IconArrowRight className="opacity-40" />

--- a/apps/docs/app/(diffs)/docs/Editor/EditorDemo.tsx
+++ b/apps/docs/app/(diffs)/docs/Editor/EditorDemo.tsx
@@ -76,9 +76,9 @@ export function EditorDemo() {
     <div className="not-prose bg-card overflow-hidden rounded-lg border">
       <div className="flex flex-wrap items-center justify-between gap-3 border-b px-4 py-3">
         <div>
-          <h5 className="text-sm font-medium">Editor Demo</h5>
+          <h5 className="text-sm font-medium">Edit mode demo</h5>
           <p className="text-muted-foreground text-xs">
-            Click into the code and type to try the editor.
+            Click into the code and type to try edit mode.
           </p>
         </div>
         <div className="text-muted-foreground text-xs">

--- a/apps/docs/app/(diffs)/docs/Editor/content.mdx
+++ b/apps/docs/app/(diffs)/docs/Editor/content.mdx
@@ -1,24 +1,24 @@
-## Editor
+## Edit mode
 
 <Notice variant="warning" icon={<IconCiWarningFill />}>
-  Editor is experimental and subject to change.
+  Edit mode is experimental and subject to change.
 </Notice>
 
-The editor is a pluggable editing layer for `File`-style code surfaces. It adds
+Edit mode is a pluggable editing layer for `File`-style code surfaces. It adds
 keyboard-driven editing to an already-rendered `File` or `FileDiff` while the
 existing renderer continues to own syntax highlighting, layout, annotations, and
-virtualization. Editor includes:
+virtualization. Edit mode includes:
 
 - Text editing
 - Selection management, including multiple cursors
 - Automatic indentation
 - History (undo and redo)
 - Find-in-file search and replace
-- [Selection Action](#editor-selection-action) (opt-in, custom UI)
+- [Selection Action](#edit-mode-selection-action) (opt-in, custom UI)
 - SSR support
 - Mobile-friendly
 
-To attach the editor to a `File` instance, import it from
+To enable edit mode on a `File` instance, import `Editor` from
 `@pierre/diffs/editor`. It is intentionally separate from the core bundle so you
 can lazy-load it when editing is optional.
 
@@ -26,7 +26,7 @@ can lazy-load it when editing is optional.
 
 ### How It Works
 
-The editor does not replace `File`, `FileDiff`, or their virtualized variants.
+Edit mode does not replace `File`, `FileDiff`, or their virtualized variants.
 You render the surface first, then attach editing:
 
 1. **Attach** — Call `editor.edit(component)` in vanilla JS, or pass
@@ -34,9 +34,9 @@ You render the surface first, then attach editing:
    `PatchDiff` wrapped in `EditorProvider`. The hookup returns a dispose
    function (vanilla) or runs automatically when `contentEditable` toggles
    (React).
-2. **Edit surface** — The editor sets `contentEditable` on the code content
+2. **Edit surface** — Edit mode sets `contentEditable` on the code content
    element so mobile keyboards, paste, and native selection UI work as users
-   expect. Clipboard shortcuts are handled by the browser; editor commands
+   expect. Clipboard shortcuts are handled by the browser; edit mode commands
    handle structure-aware actions like indent and undo.
 3. **Selections** — Carets and ranges are tracked with the native `Selection`
    API. Multiple non-overlapping selections are supported; Cmd/Ctrl-click adds
@@ -46,12 +46,12 @@ You render the surface first, then attach editing:
    mode. Your `onChange` handler receives updated `FileContents` (and line
    annotations when present).
 
-When attaching, the editor normalizes component options that conflict with
+When attaching, edit mode normalizes component options that conflict with
 editing and triggers a re-render: it turns on the token transformer, turns off
 gutter utilities, line selection, and line-hover highlighting, and expands any
-collapsed unchanged regions. Diffs are also forced into split view, so a
-`FileDiff` or `MultiFileDiff` rendered as unified switches to split while
-editing.
+collapsed unchanged regions. The diff layout is preserved, so a `FileDiff` or
+`MultiFileDiff` stays in whatever view it was rendered in; in unified diffs,
+deleted lines and annotation lines remain read-only.
 
 ### React
 
@@ -94,8 +94,8 @@ query state, apply edits, and control selections programmatically.
 
 ### Using Worker Pool
 
-When you offload syntax highlighting to a worker pool, the editor still needs
-the token transformer pipeline to re-highlight lines as you type. Set
+When you offload syntax highlighting to a worker pool, edit mode still needs the
+token transformer pipeline to re-highlight lines as you type. Set
 `useTokenTransformer: true` on the pool's `highlighterOptions`.
 
 See [Worker Pool](#worker-pool) for worker factory setup and pool options. In
@@ -119,11 +119,11 @@ where editing is rare.
 
 ### Selection Action
 
-Selection Action is an opt-in editor feature for showing custom UI inline with
-the current selection—useful for quick transforms, refactor prompts, or other
-selection-scoped tools. Set `enabledSelectionAction: true`, return your UI from
-`renderSelectionAction`, and open it from the gutter icon that appears on the
-active selection.
+Selection Action is an opt-in edit mode feature for showing custom UI inline
+with the current selection—useful for quick transforms, refactor prompts, or
+other selection-scoped tools. Set `enabledSelectionAction: true`, return your UI
+from `renderSelectionAction`, and open it from the gutter icon that appears on
+the active selection.
 
 <DocsCodeExample {...editorSelectionActionExample} />
 

--- a/apps/docs/app/(diffs)/docs/Installation/content.mdx
+++ b/apps/docs/app/(diffs)/docs/Installation/content.mdx
@@ -14,6 +14,6 @@ The package provides several entry points for different use cases:
 | ---------------------- | ------------------------------------------------------------------------------------------------------------ |
 | `@pierre/diffs`        | [Vanilla JS components](#vanilla-js-api) and [utility functions](#utilities) for parsing and rendering diffs |
 | `@pierre/diffs/react`  | [React components](#react-api) for rendering diffs with full interactivity                                   |
-| `@pierre/diffs/editor` | [Editor](#editor) for making file views editable                                                             |
+| `@pierre/diffs/editor` | [Edit mode](#edit-mode) for making file views editable                                                       |
 | `@pierre/diffs/ssr`    | [Server-side rendering utilities](#ssr) for pre-rendering diffs with syntax highlighting                     |
 | `@pierre/diffs/worker` | [Worker pool utilities](#worker-pool) for offloading syntax highlighting to background threads               |

--- a/apps/docs/lib/mdx.tsx
+++ b/apps/docs/lib/mdx.tsx
@@ -58,7 +58,7 @@ function MdxLink(props: ComponentPropsWithoutRef<'a'>) {
 // Section headings whose `## ` slug should render a "Beta" badge. The badge is
 // appended after the heading text (not part of the markdown) so the slug—and
 // therefore the anchor and any child heading ids—stays unchanged.
-const BETA_DOC_HEADING_IDS = new Set(['editor']);
+const BETA_DOC_HEADING_IDS = new Set(['edit-mode']);
 
 function MdxHeading2({
   id,


### PR DESCRIPTION
Primarily, `Editor` to `Edit mode` rename, plus a few accuracy bits.