### PR TITLE
fix(diffs): Pluralize the "0 unmodified lines" hunk label

### DIFF
--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -1499,8 +1499,13 @@ function getAnnotationNames<LAnnotation>(
   );
 }
 
+// Use the platform's English plural rules to pick "line" vs "lines" so a
+// count of 0 reads as "0 unmodified lines". en-US returns "one" only for 1.
+const EN_PLURAL_RULES = new Intl.PluralRules('en-US');
+
 function getModifiedLinesString(lines: number) {
-  return `${lines} unmodified line${lines > 1 ? 's' : ''}`;
+  const suffix = EN_PLURAL_RULES.select(lines) === 'one' ? '' : 's';
+  return `${lines} unmodified line${suffix}`;
 }
 
 function pushUnifiedInjectedRows(


### PR DESCRIPTION
A collapsed hunk separator shows how many unchanged lines are hidden. When that count was zero, the label read "0 unmodified line" instead of "0 unmodified lines".

The suffix added an "s" only when the count was greater than one, so zero fell through to the singular form. Select the form with the platform's English plural rules, which treat every count other than one as plural.
