### PR TITLE
fix(diffs): keep the caret line highlighted during selection

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -1997,7 +1997,10 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
 
   #setSelectedLinesSafe(range: { start: number; end: number } | null): void {
     try {
-      this.#fileInstance?.setSelectedLines(range);
+      // notify: false renders the active-line highlight without firing the
+      // host's onLineSelected callback. A caret or text selection in the editor
+      // is not a gutter line selection, so it must not publish one.
+      this.#fileInstance?.setSelectedLines(range, { notify: false });
     } catch {
       // InteractionManager.renderSelection can throw while editor DOM is updating.
     }

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -2008,9 +2008,6 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
 
     this.#primaryCaretElement = undefined;
     this.#setSelectedLinesSafe(null);
-    this.#gutterElement
-      ?.querySelectorAll('[data-active]')
-      .forEach((el) => el.removeAttribute('data-active'));
 
     if (
       selections.length === 0 &&
@@ -2033,18 +2030,12 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       const normalizedSelections = mergeOverlappingSelections(selections);
       const primarySelection = normalizedSelections.at(-1)!;
       this.#selections = normalizedSelections;
-      if (isCollapsedSelection(primarySelection)) {
-        const line = primarySelection.start.line + 1;
-        this.#setSelectedLinesSafe({
-          start: line,
-          end: line,
-        });
-      } else if (this.#gutterElement !== undefined) {
-        const pos = getCaretPosition(primarySelection);
-        this.#gutterElement
-          .querySelector(`[data-column-number="${pos.line + 1}"]`)
-          ?.setAttribute('data-active', '');
-      }
+      // Highlight the line that holds the caret (the selection's head),
+      // whether the selection is collapsed or spans a range. A ranged selection
+      // previously skipped this, so starting a multi-line selection dropped the
+      // active-line highlight from the line the cursor was on.
+      const caretLine = getCaretPosition(primarySelection).line + 1;
+      this.#setSelectedLinesSafe({ start: caretLine, end: caretLine });
 
       for (const selection of normalizedSelections) {
         if (!isCollapsedSelection(selection)) {

--- a/packages/diffs/src/types.ts
+++ b/packages/diffs/src/types.ts
@@ -908,9 +908,6 @@ export interface DiffsBaseComponent {
   readonly top?: number;
   readonly options: DiffsComponentOptions;
   setOptions: (options: Partial<DiffsComponentOptions>) => void;
-  // `notify: false` updates the line-selection highlight without invoking the
-  // onLineSelected callback. The editor uses this to render its active-line
-  // highlight without publishing it as a user line selection.
   setSelectedLines: (
     range: { start: number; end: number } | null,
     options?: { notify?: boolean }

--- a/packages/diffs/src/types.ts
+++ b/packages/diffs/src/types.ts
@@ -908,7 +908,13 @@ export interface DiffsBaseComponent {
   readonly top?: number;
   readonly options: DiffsComponentOptions;
   setOptions: (options: Partial<DiffsComponentOptions>) => void;
-  setSelectedLines: (range: { start: number; end: number } | null) => void;
+  // `notify: false` updates the line-selection highlight without invoking the
+  // onLineSelected callback. The editor uses this to render its active-line
+  // highlight without publishing it as a user line selection.
+  setSelectedLines: (
+    range: { start: number; end: number } | null,
+    options?: { notify?: boolean }
+  ) => void;
   render(options: {
     file?: FileContents;
     fileDiff?: FileDiffMetadata;

--- a/packages/diffs/test/editorActiveLineHighlight.test.ts
+++ b/packages/diffs/test/editorActiveLineHighlight.test.ts
@@ -1,10 +1,10 @@
 import { afterAll, describe, expect, test } from 'bun:test';
 
-import { File } from '../src/components/File';
+import { File, type FileOptions } from '../src/components/File';
 import { DEFAULT_THEMES } from '../src/constants';
 import { Editor } from '../src/editor/editor';
 import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
-import type { FileContents } from '../src/types';
+import type { FileContents, SelectedLineRange } from '../src/types';
 import { installDom, wait } from './domHarness';
 
 afterAll(async () => {
@@ -35,7 +35,10 @@ interface EditorFixture {
   editor: Editor<undefined>;
 }
 
-async function createEditorFixture(contents: string): Promise<EditorFixture> {
+async function createEditorFixture(
+  contents: string,
+  fileOptions?: Partial<FileOptions<undefined>>
+): Promise<EditorFixture> {
   const dom = installDom();
   const fileContainer = document.createElement('div');
   document.body.appendChild(fileContainer);
@@ -43,6 +46,7 @@ async function createEditorFixture(contents: string): Promise<EditorFixture> {
   const file = new File<undefined>({
     disableFileHeader: true,
     theme: DEFAULT_THEMES,
+    ...fileOptions,
   });
   const editor = new Editor<undefined>();
   const initialFile: FileContents = { name: 'highlight.ts', contents };
@@ -127,6 +131,31 @@ describe('editor active line highlight', () => {
       // A backward selection puts the caret on the start line (index 1 ->
       // data-line "2"), not the end of the range.
       expect(highlightedLineNumbers(content)).toEqual([2]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('does not publish a line-selection notification for an editor selection', async () => {
+    const notifiedRanges: (SelectedLineRange | null)[] = [];
+    const { cleanup, content, editor } = await createEditorFixture(
+      'alpha\nbravo\ncharlie\ndelta',
+      { onLineSelected: (range) => notifiedRanges.push(range) }
+    );
+    try {
+      editor.setSelections([
+        {
+          start: { line: 1, character: 0 },
+          end: { line: 3, character: 2 },
+          direction: 'forward',
+        },
+      ]);
+      // The caret line still gets the active-line highlight...
+      expect(highlightedLineNumbers(content)).toEqual([4]);
+      // ...but the editor renders it without publishing a line selection.
+      // Text selection is not a gutter line selection, so a consumer's
+      // onLineSelected handler must not fire.
+      expect(notifiedRanges).toEqual([]);
     } finally {
       cleanup();
     }

--- a/packages/diffs/test/editorActiveLineHighlight.test.ts
+++ b/packages/diffs/test/editorActiveLineHighlight.test.ts
@@ -1,0 +1,134 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+
+import { File } from '../src/components/File';
+import { DEFAULT_THEMES } from '../src/constants';
+import { Editor } from '../src/editor/editor';
+import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
+import type { FileContents } from '../src/types';
+import { installDom, wait } from './domHarness';
+
+afterAll(async () => {
+  await disposeHighlighter();
+});
+
+async function waitForEditableContent(
+  container: HTMLElement
+): Promise<HTMLElement> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const content = container.shadowRoot?.querySelector('[data-content]');
+    if (
+      content instanceof HTMLElement &&
+      (content.contentEditable === 'true' ||
+        content.getAttribute('contenteditable') === 'true')
+    ) {
+      return content;
+    }
+    await wait(0);
+  }
+
+  throw new Error('editor content did not become editable');
+}
+
+interface EditorFixture {
+  cleanup(): void;
+  content: HTMLElement;
+  editor: Editor<undefined>;
+}
+
+async function createEditorFixture(contents: string): Promise<EditorFixture> {
+  const dom = installDom();
+  const fileContainer = document.createElement('div');
+  document.body.appendChild(fileContainer);
+
+  const file = new File<undefined>({
+    disableFileHeader: true,
+    theme: DEFAULT_THEMES,
+  });
+  const editor = new Editor<undefined>();
+  const initialFile: FileContents = { name: 'highlight.ts', contents };
+
+  file.render({ file: initialFile, fileContainer, forceRender: true });
+  editor.edit(file);
+
+  const content = await waitForEditableContent(fileContainer);
+
+  return {
+    cleanup() {
+      editor.cleanUp();
+      file.cleanUp();
+      dom.cleanup();
+    },
+    content,
+    editor,
+  };
+}
+
+// The active-line highlight is the full-line background applied via the
+// data-selected-line attribute. This returns the 1-based data-line numbers of
+// the content rows currently carrying that attribute.
+function highlightedLineNumbers(content: HTMLElement): number[] {
+  return [...content.querySelectorAll('[data-line][data-selected-line]')]
+    .map((el) => Number(el.getAttribute('data-line')))
+    .sort((a, b) => a - b);
+}
+
+describe('editor active line highlight', () => {
+  test('highlights the caret line for a collapsed selection', async () => {
+    const { cleanup, content, editor } = await createEditorFixture(
+      'alpha\nbravo\ncharlie\ndelta'
+    );
+    try {
+      editor.setSelections([
+        {
+          start: { line: 1, character: 0 },
+          end: { line: 1, character: 0 },
+          direction: 'none',
+        },
+      ]);
+      // Line index 1 ("bravo") renders as data-line "2".
+      expect(highlightedLineNumbers(content)).toEqual([2]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('keeps the caret line highlighted during a forward multi-line selection', async () => {
+    const { cleanup, content, editor } = await createEditorFixture(
+      'alpha\nbravo\ncharlie\ndelta'
+    );
+    try {
+      editor.setSelections([
+        {
+          start: { line: 1, character: 0 },
+          end: { line: 3, character: 2 },
+          direction: 'forward',
+        },
+      ]);
+      // A forward selection puts the caret on the end line (index 3 ->
+      // data-line "4"); only that line carries the active-line highlight.
+      expect(highlightedLineNumbers(content)).toEqual([4]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('keeps the caret line highlighted during a backward multi-line selection', async () => {
+    const { cleanup, content, editor } = await createEditorFixture(
+      'alpha\nbravo\ncharlie\ndelta'
+    );
+    try {
+      editor.setSelections([
+        {
+          start: { line: 1, character: 0 },
+          end: { line: 3, character: 2 },
+          direction: 'backward',
+        },
+      ]);
+      // A backward selection puts the caret on the start line (index 1 ->
+      // data-line "2"), not the end of the range.
+      expect(highlightedLineNumbers(content)).toEqual([2]);
+    } finally {
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
Repro:
1. Place a cursor on a line; the whole line is highlighted.
2. Select across multiple lines.
3. The line the cursor is on is no longer highlighted.

\#updateSelections only applied the active-line highlight for a collapsed cursor. A ranged selection set a data-active attribute on the gutter line number instead, but that attribute has no CSS rule and is read nowhere, so the line lost its highlight as soon as the selection gained any width.

Highlight the line holding the caret (the selection head) for both collapsed and ranged selections, and remove the dead data-active path. getCaretPosition resolves the selection head, so backward selections highlight the start line. This also removes a per-update querySelectorAll, and the gutter number now highlights through data-selected-line.

Cover the collapsed and multi-line cases with a regression test.