### PR TITLE
fix(diffs): keep an editable line when the editor is emptied

### DIFF
--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -74,7 +74,11 @@ import { iterateOverDiff } from '../utils/iterateOverDiff';
 import { renderDiffWithHighlighter } from '../utils/renderDiffWithHighlighter';
 import { shouldUseTokenTransformer } from '../utils/shouldUseTokenTransformer';
 import { splitFileContents } from '../utils/splitFileContents';
-import { recomputeDiffHunks, updateDiffHunks } from '../utils/updateDiffHunks';
+import {
+  recomputeDiffHunks,
+  recomputeEmptyDocumentDiff,
+  updateDiffHunks,
+} from '../utils/updateDiffHunks';
 import { getTrailingContextRangeSize } from '../utils/virtualDiffLayout';
 import type { WorkerPoolManager } from '../worker';
 
@@ -444,10 +448,22 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
       additionHastLines[i] ??= createPlainAdditionLineElement(i, textDocument);
     }
     if (!diff.isPartial) {
-      Object.assign(
-        diff,
-        recomputeDiffHunks(diff, this.options.parseDiffOptions)
-      );
+      // An empty document splits into zero addition lines, which would recompute
+      // to a diff with no editable rows and leave the attached editor with no
+      // line element to host its caret (the additions column vanishes in split;
+      // unified shows only deletions). Keep one empty editable line instead.
+      if (newLength === 0) {
+        Object.assign(
+          diff,
+          recomputeEmptyDocumentDiff(diff, this.options.parseDiffOptions)
+        );
+        additionHastLines[0] = createPlainAdditionLineElement(0, textDocument);
+      } else {
+        Object.assign(
+          diff,
+          recomputeDiffHunks(diff, this.options.parseDiffOptions)
+        );
+      }
     }
 
     this.renderCache.isDirty = true;

--- a/packages/diffs/src/utils/updateDiffHunks.ts
+++ b/packages/diffs/src/utils/updateDiffHunks.ts
@@ -53,21 +53,28 @@ export function recomputeDiffHunks(
 // string splits into zero addition lines, so a normal recompute produces a diff
 // with no addition rows at all. Rendering that leaves the attached editor with
 // no line element to host its caret. To keep one editable row, diff the
-// unchanged deletions against a single empty line (which yields an ordinary
-// "replace everything with one empty line" change) and store the addition as
-// `['']` so it still joins back to the editor's empty document.
+// unchanged deletions against a single line (which yields a hunk that places
+// exactly one addition row), then store the addition as `['']` so it still
+// joins back to the editor's empty document.
+//
+// The sentinel only has to differ from the deletion side so a hunk is produced;
+// its text is discarded by the `['']` override below. When the old side is
+// itself a single blank line the empty sentinel would be identical and yield no
+// hunk (and so no editable row), so fall back to a non-blank line there.
 export function recomputeEmptyDocumentDiff(
   diff: FileDiffMetadata,
   parseDiffOptions?: CreatePatchOptionsNonabortable
 ): FullDiffHunkUpdate {
+  const deletionContents = diff.deletionLines.join('');
+  const additionSentinel = deletionContents === '\n' ? ' \n' : '\n';
   const recomputed = parseDiffFromFile(
     {
       name: diff.prevName ?? diff.name,
-      contents: diff.deletionLines.join(''),
+      contents: deletionContents,
     },
     {
       name: diff.name,
-      contents: '\n',
+      contents: additionSentinel,
       lang: diff.lang,
     },
     parseDiffOptions

--- a/packages/diffs/src/utils/updateDiffHunks.ts
+++ b/packages/diffs/src/utils/updateDiffHunks.ts
@@ -47,6 +47,41 @@ export function recomputeDiffHunks(
   };
 }
 
+// Rebuilds hunk metadata when the editable side has been emptied of all text.
+//
+// The editor always keeps one (empty) line for an empty document, but an empty
+// string splits into zero addition lines, so a normal recompute produces a diff
+// with no addition rows at all. Rendering that leaves the attached editor with
+// no line element to host its caret. To keep one editable row, diff the
+// unchanged deletions against a single empty line (which yields an ordinary
+// "replace everything with one empty line" change) and store the addition as
+// `['']` so it still joins back to the editor's empty document.
+export function recomputeEmptyDocumentDiff(
+  diff: FileDiffMetadata,
+  parseDiffOptions?: CreatePatchOptionsNonabortable
+): FullDiffHunkUpdate {
+  const recomputed = parseDiffFromFile(
+    {
+      name: diff.prevName ?? diff.name,
+      contents: diff.deletionLines.join(''),
+    },
+    {
+      name: diff.name,
+      contents: '\n',
+      lang: diff.lang,
+    },
+    parseDiffOptions
+  );
+  return {
+    hunks: recomputed.hunks,
+    splitLineCount: recomputed.splitLineCount,
+    unifiedLineCount: recomputed.unifiedLineCount,
+    additionLines: [''],
+    deletionLines: recomputed.deletionLines,
+    type: recomputed.type,
+  };
+}
+
 /** Updates hunk metadata after addition lines change; re-parses affected hunks only. */
 export function updateDiffHunks(
   diff: FileDiffMetadata,

--- a/packages/diffs/test/DiffHunksRendererRecompute.test.ts
+++ b/packages/diffs/test/DiffHunksRendererRecompute.test.ts
@@ -70,8 +70,10 @@ function makeDirtyLines(
 
 // Builds a renderer with a populated (highlighted) render cache, mirroring the
 // state the editor operates on mid-session.
-async function createPrimedRenderer(): Promise<DiffHunksRenderer> {
-  const renderer = new DiffHunksRenderer({ theme: 'github-light' });
+async function createPrimedRenderer(
+  diffStyle: 'split' | 'unified' = 'split'
+): Promise<DiffHunksRenderer> {
+  const renderer = new DiffHunksRenderer({ theme: 'github-light', diffStyle });
   const diff = parseDiffFromFile(
     { name: 'greet.ts', contents: OLD_CONTENTS },
     { name: 'greet.ts', contents: NEW_CONTENTS }
@@ -168,4 +170,41 @@ describe('DiffHunksRenderer.updateRenderCache skipDiffRecompute', () => {
       legacy.renderFullHTML(legacyResult)
     );
   });
+});
+
+// Deleting every character empties the editor's document, whose text is "".
+// splitFileContents("") is [], so a naive recompute drops the addition side to
+// zero lines — but the editor always keeps one (empty) line, so the addition
+// column must keep one empty editable row. Without it the attached editor has
+// no element to host its caret: the additions column disappears entirely in
+// split (an uneditable view) and unified renders only deletions (nothing to
+// type into).
+describe('DiffHunksRenderer.applyDocumentChange empty document', () => {
+  // The editor reports a single empty line for an emptied document ([''] joins
+  // to "", the editor's empty text).
+  const EMPTY_DOCUMENT = makeTextDocument(['']);
+
+  for (const diffStyle of ['split', 'unified'] as const) {
+    test(`keeps one empty editable addition line (${diffStyle})`, async () => {
+      const renderer = await createPrimedRenderer(diffStyle);
+      renderer.applyDocumentChange(EMPTY_DOCUMENT);
+
+      const diff = renderer.getRenderDiff();
+      expect(diff).toBeDefined();
+      if (diff == null) return;
+
+      // One empty line, not zero — this is the regression guard.
+      expect(diff.additionLines).toEqual(['']);
+      // The old content is still the deletion side.
+      expect(diff.deletionLines.length).toBeGreaterThan(0);
+
+      // The diff must still render (a zero-addition diff threw mid-render).
+      const result = renderer.renderDiff();
+      expect(result).toBeDefined();
+      if (result == null) return;
+      const html = renderer.renderFullHTML(result);
+      // The editable addition line is emitted as an added change row.
+      expect(html).toContain('change-addition');
+    });
+  }
 });

--- a/packages/diffs/test/DiffHunksRendererRecompute.test.ts
+++ b/packages/diffs/test/DiffHunksRendererRecompute.test.ts
@@ -206,5 +206,37 @@ describe('DiffHunksRenderer.applyDocumentChange empty document', () => {
       // The editable addition line is emitted as an added change row.
       expect(html).toContain('change-addition');
     });
+
+    // When the old side is itself a single blank line, diffing the emptied
+    // document against an empty line would be a no-op (zero hunks, so zero
+    // rendered rows). The recompute must still produce one editable row.
+    test(`keeps an editable line when the old side is one blank line (${diffStyle})`, async () => {
+      const renderer = new DiffHunksRenderer({
+        theme: 'github-light',
+        diffStyle,
+      });
+      const diff = parseDiffFromFile(
+        { name: 'blank.ts', contents: '\n' },
+        { name: 'blank.ts', contents: 'typed\n' }
+      );
+      await renderer.asyncRender(diff);
+      renderer.renderDiff(diff);
+
+      renderer.applyDocumentChange(EMPTY_DOCUMENT);
+
+      const rendered = renderer.getRenderDiff();
+      expect(rendered).toBeDefined();
+      if (rendered == null) return;
+      expect(rendered.additionLines).toEqual(['']);
+      // The blank old line is still recorded as the deletion side.
+      expect(rendered.deletionLines.join('')).toBe('\n');
+      // At least one hunk, so iterateOverDiff has a row to emit.
+      expect(rendered.hunks.length).toBeGreaterThanOrEqual(1);
+
+      const result = renderer.renderDiff();
+      expect(result).toBeDefined();
+      if (result == null) return;
+      expect(renderer.renderFullHTML(result)).toContain('change-addition');
+    });
   }
 });

--- a/packages/diffs/test/editorDiffEmptyDocument.test.ts
+++ b/packages/diffs/test/editorDiffEmptyDocument.test.ts
@@ -1,0 +1,166 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+
+import { FileDiff } from '../src/components/FileDiff';
+import { DEFAULT_THEMES } from '../src/constants';
+import { Editor } from '../src/editor/editor';
+import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
+import type { FileContents } from '../src/types';
+import { installDom, wait } from './domHarness';
+
+afterAll(async () => {
+  await disposeHighlighter();
+});
+
+// The editor attaches to the additions (new-file) side of a diff. That column
+// is the `[data-code]` element without `data-deletions`; its editable lines
+// live in the child marked `data-content`.
+function findAdditionContent(container: HTMLElement): HTMLElement | undefined {
+  const shadow = container.shadowRoot;
+  if (shadow == null) {
+    return undefined;
+  }
+  for (const code of shadow.querySelectorAll<HTMLElement>('[data-code]')) {
+    if (code.dataset.deletions !== undefined) {
+      continue;
+    }
+    for (const child of code.children) {
+      const el = child as HTMLElement;
+      if (el.dataset.content !== undefined) {
+        return el;
+      }
+    }
+  }
+  return undefined;
+}
+
+function countEditableLineEls(content: HTMLElement): number {
+  let count = 0;
+  for (const child of content.children) {
+    const el = child as HTMLElement;
+    if (
+      el.dataset.line !== undefined &&
+      el.dataset.lineType !== 'change-deletion'
+    ) {
+      count++;
+    }
+  }
+  return count;
+}
+
+interface DiffEditorFixture {
+  container: HTMLElement;
+  editor: Editor<undefined>;
+  cleanup(): Promise<void>;
+}
+
+async function createDiffEditorFixture(
+  diffStyle: 'split' | 'unified',
+  oldContents: string,
+  newContents: string
+): Promise<DiffEditorFixture> {
+  const dom = installDom();
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  const fileDiff = new FileDiff<undefined>({
+    disableFileHeader: true,
+    theme: DEFAULT_THEMES,
+    diffStyle,
+  });
+  const editor = new Editor<undefined>();
+  const oldFile: FileContents = { name: 'edit.ts', contents: oldContents };
+  const newFile: FileContents = { name: 'edit.ts', contents: newContents };
+
+  fileDiff.render({
+    oldFile,
+    newFile,
+    fileContainer: container,
+    forceRender: true,
+  });
+  editor.edit(fileDiff);
+
+  for (let attempt = 0; attempt < 40; attempt++) {
+    const content = findAdditionContent(container);
+    if (content != null && content.getAttribute('contenteditable') === 'true') {
+      break;
+    }
+    await wait(0);
+  }
+
+  return {
+    container,
+    editor,
+    async cleanup() {
+      // Drain any pending highlighter/sync callbacks before tearing down the DOM
+      // so a late re-attach does not run against a destroyed document.
+      await wait(10);
+      editor.cleanUp();
+      fileDiff.cleanUp();
+      dom.cleanup();
+    },
+  };
+}
+
+// Replaces the whole document with `newText`, mirroring select-all then a
+// delete or paste.
+function replaceAll(editor: Editor<undefined>, newText: string): void {
+  const lines = editor.getState().file.contents.split('\n');
+  const end = { line: lines.length - 1, character: lines.at(-1)!.length };
+  editor.setSelections([
+    { start: { line: 0, character: 0 }, end, direction: 'none' },
+  ]);
+  editor.applyEdits(
+    [{ range: { start: { line: 0, character: 0 }, end }, newText }],
+    true
+  );
+}
+
+describe('diff editor: select-all then delete', () => {
+  for (const diffStyle of ['split', 'unified'] as const) {
+    test(`keeps an editable line, accepts typing, and undoes (${diffStyle})`, async () => {
+      const fixture = await createDiffEditorFixture(
+        diffStyle,
+        'a\nb\nX\n',
+        'a\nb\nc\n'
+      );
+      const { editor, container } = fixture;
+
+      try {
+        // Delete everything.
+        replaceAll(editor, '');
+        await wait(0);
+        expect(editor.getState().file.contents).toBe('');
+
+        // The additions column must still exist with one empty editable line.
+        const content = findAdditionContent(container);
+        expect(content).toBeDefined();
+        if (content == null) return;
+        expect(countEditableLineEls(content)).toBeGreaterThanOrEqual(1);
+
+        // Typing must still land in the document.
+        editor.applyEdits(
+          [
+            {
+              range: {
+                start: { line: 0, character: 0 },
+                end: { line: 0, character: 0 },
+              },
+              newText: 'hello',
+            },
+          ],
+          true
+        );
+        await wait(0);
+        expect(editor.getState().file.contents).toBe('hello');
+
+        // Undo reverts the typing, then the deletion, back to the original.
+        editor.undo();
+        editor.undo();
+        await wait(0);
+        expect(editor.getState().file.contents).toBe('a\nb\nc\n');
+      } finally {
+        await fixture.cleanup();
+      }
+    });
+  }
+});


### PR DESCRIPTION
Repro (diffs /playground, edit mode): 1. Select all text in the editor. 2. Press delete/backspace. Before this fix the editor breaks: split mode collapses to a single uneditable view and undo does nothing; unified mode keeps the view but you can no longer type. The editor's text document always keeps one (empty) line, but splitFileContents('') returns [], so emptying the editable side recomputed the diff with zero addition lines. The additions column then rendered no line elements, leaving the attached editor with nothing to host its caret. Now an emptied document is represented as one empty editable line: diff the unchanged deletions against a single empty line and store the addition as [''] so it still joins back to the editor's empty document. Covered by model- and DOM-level regression tests in both split and unified modes.