### PR TITLE
chore(theme): Keep the formatter off generated theme JSON

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -44,6 +44,8 @@
     ".vercel",
     "apps/docs/public/r/*",
     "apps/docs/next-env.d.ts",
+    "packages/theme/themes/*.json",
+    "packages/theme/zed/themes/*.json",
     "packages/tree-test-data/*-files.json",
     "*.patch",
     "README"

--- a/packages/theme/scripts/build.ts
+++ b/packages/theme/scripts/build.ts
@@ -117,8 +117,10 @@ const vscodeThemes = [
   },
 ];
 
+// oxfmt skips these files (.oxfmtrc.json), so append the trailing newline it
+// would otherwise add.
 for (const { file, theme } of vscodeThemes) {
-  writeFileSync(file, JSON.stringify(theme, null, 2), 'utf8');
+  writeFileSync(file, JSON.stringify(theme, null, 2) + '\n', 'utf8');
   console.log('Wrote', file);
 }
 
@@ -154,7 +156,7 @@ const zedTheme = createZedTheme('Pierre', 'pierrecomputer', [
 
 writeFileSync(
   'zed/themes/pierre.json',
-  JSON.stringify(zedTheme, null, 2),
+  JSON.stringify(zedTheme, null, 2) + '\n',
   'utf8'
 );
 console.log('Wrote zed/themes/pierre.json');

--- a/packages/theme/themes/pierre-dark-protanopia-deuteranopia.json
+++ b/packages/theme/themes/pierre-dark-protanopia-deuteranopia.json
@@ -123,7 +123,10 @@
   },
   "tokenColors": [
     {
-      "scope": ["comment", "punctuation.definition.comment"],
+      "scope": [
+        "comment",
+        "punctuation.definition.comment"
+      ],
       "settings": {
         "foreground": "#737373"
       }
@@ -135,7 +138,10 @@
       }
     },
     {
-      "scope": ["string", "constant.other.symbol"],
+      "scope": [
+        "string",
+        "constant.other.symbol"
+      ],
       "settings": {
         "foreground": "#97c4ff"
       }
@@ -150,7 +156,10 @@
       }
     },
     {
-      "scope": ["constant.numeric", "constant.language.boolean"],
+      "scope": [
+        "constant.numeric",
+        "constant.language.boolean"
+      ],
       "settings": {
         "foreground": "#96d9f6"
       }
@@ -192,7 +201,11 @@
       }
     },
     {
-      "scope": ["storage", "storage.type", "storage.modifier"],
+      "scope": [
+        "storage",
+        "storage.type",
+        "storage.modifier"
+      ],
       "settings": {
         "foreground": "#b969f3"
       }
@@ -225,7 +238,11 @@
       }
     },
     {
-      "scope": ["variable", "identifier", "meta.definition.variable"],
+      "scope": [
+        "variable",
+        "identifier",
+        "meta.definition.variable"
+      ],
       "settings": {
         "foreground": "#ffa359"
       }
@@ -321,7 +338,10 @@
       }
     },
     {
-      "scope": ["support.class", "entity.name.type.class"],
+      "scope": [
+        "support.class",
+        "entity.name.type.class"
+      ],
       "settings": {
         "foreground": "#e290f0"
       }
@@ -479,13 +499,21 @@
       }
     },
     {
-      "scope": ["punctuation.definition.block", "punctuation.definition.tag"],
+      "scope": [
+        "punctuation.definition.block",
+        "punctuation.definition.tag"
+      ],
       "settings": {
         "foreground": "#636363"
       }
     },
     {
-      "scope": ["meta.tag.tsx", "meta.tag.jsx", "meta.tag.js", "meta.tag.ts"],
+      "scope": [
+        "meta.tag.tsx",
+        "meta.tag.jsx",
+        "meta.tag.js",
+        "meta.tag.ts"
+      ],
       "settings": {
         "foreground": "#636363"
       }
@@ -543,7 +571,10 @@
       }
     },
     {
-      "scope": ["support.variable.dom", "support.variable.property.dom"],
+      "scope": [
+        "support.variable.dom",
+        "support.variable.property.dom"
+      ],
       "settings": {
         "foreground": "#ffa359"
       }
@@ -567,7 +598,10 @@
       }
     },
     {
-      "scope": ["keyword.other.template.begin", "keyword.other.template.end"],
+      "scope": [
+        "keyword.other.template.begin",
+        "keyword.other.template.end"
+      ],
       "settings": {
         "foreground": "#97c4ff"
       }
@@ -647,7 +681,10 @@
       }
     },
     {
-      "scope": ["meta.decorator", "meta.decorator punctuation.decorator"],
+      "scope": [
+        "meta.decorator",
+        "meta.decorator punctuation.decorator"
+      ],
       "settings": {
         "foreground": "#69b1ff"
       }
@@ -781,7 +818,10 @@
       }
     },
     {
-      "scope": ["meta.function.c", "meta.function.cpp"],
+      "scope": [
+        "meta.function.c",
+        "meta.function.cpp"
+      ],
       "settings": {
         "foreground": "#ffa359"
       }
@@ -829,7 +869,10 @@
       }
     },
     {
-      "scope": ["punctuation.separator.c", "punctuation.separator.cpp"],
+      "scope": [
+        "punctuation.separator.c",
+        "punctuation.separator.cpp"
+      ],
       "settings": {
         "foreground": "#b969f3"
       }
@@ -844,7 +887,10 @@
       }
     },
     {
-      "scope": ["keyword.operator.sizeof.c", "keyword.operator.sizeof.cpp"],
+      "scope": [
+        "keyword.operator.sizeof.c",
+        "keyword.operator.sizeof.cpp"
+      ],
       "settings": {
         "foreground": "#b969f3"
       }
@@ -1070,7 +1116,10 @@
       }
     },
     {
-      "scope": ["entity.name.goto-label.php", "support.other.php"],
+      "scope": [
+        "entity.name.goto-label.php",
+        "support.other.php"
+      ],
       "settings": {
         "foreground": "#ba8ffd"
       }
@@ -1098,7 +1147,10 @@
       }
     },
     {
-      "scope": ["keyword.operator.heredoc.php", "keyword.operator.nowdoc.php"],
+      "scope": [
+        "keyword.operator.heredoc.php",
+        "keyword.operator.nowdoc.php"
+      ],
       "settings": {
         "foreground": "#b969f3"
       }
@@ -1207,7 +1259,10 @@
       }
     },
     {
-      "scope": ["meta.arguments.coffee", "variable.parameter.function.coffee"],
+      "scope": [
+        "meta.arguments.coffee",
+        "variable.parameter.function.coffee"
+      ],
       "settings": {
         "foreground": "#ffa359"
       }
@@ -1256,13 +1311,19 @@
       }
     },
     {
-      "scope": ["text.variable", "text.bracketed"],
+      "scope": [
+        "text.variable",
+        "text.bracketed"
+      ],
       "settings": {
         "foreground": "#ffa359"
       }
     },
     {
-      "scope": ["support.type.swift", "support.type.vb.asp"],
+      "scope": [
+        "support.type.swift",
+        "support.type.vb.asp"
+      ],
       "settings": {
         "foreground": "#ffbc56"
       }
@@ -1292,7 +1353,10 @@
       }
     },
     {
-      "scope": ["function.parameter.ruby", "function.parameter.cs"],
+      "scope": [
+        "function.parameter.ruby",
+        "function.parameter.cs"
+      ],
       "settings": {
         "foreground": "#636363"
       }
@@ -1596,7 +1660,10 @@
       }
     },
     {
-      "scope": ["markup.bold", "todo.bold"],
+      "scope": [
+        "markup.bold",
+        "todo.bold"
+      ],
       "settings": {
         "foreground": "#ffcc81"
       }

--- a/packages/theme/themes/pierre-dark-soft.json
+++ b/packages/theme/themes/pierre-dark-soft.json
@@ -123,7 +123,10 @@
   },
   "tokenColors": [
     {
-      "scope": ["comment", "punctuation.definition.comment"],
+      "scope": [
+        "comment",
+        "punctuation.definition.comment"
+      ],
       "settings": {
         "foreground": "#636363"
       }
@@ -135,7 +138,10 @@
       }
     },
     {
-      "scope": ["string", "constant.other.symbol"],
+      "scope": [
+        "string",
+        "constant.other.symbol"
+      ],
       "settings": {
         "foreground": "#8cda94"
       }
@@ -150,7 +156,10 @@
       }
     },
     {
-      "scope": ["constant.numeric", "constant.language.boolean"],
+      "scope": [
+        "constant.numeric",
+        "constant.language.boolean"
+      ],
       "settings": {
         "foreground": "#96d9f6"
       }
@@ -192,7 +201,11 @@
       }
     },
     {
-      "scope": ["storage", "storage.type", "storage.modifier"],
+      "scope": [
+        "storage",
+        "storage.type",
+        "storage.modifier"
+      ],
       "settings": {
         "foreground": "#ff91a8"
       }
@@ -225,7 +238,11 @@
       }
     },
     {
-      "scope": ["variable", "identifier", "meta.definition.variable"],
+      "scope": [
+        "variable",
+        "identifier",
+        "meta.definition.variable"
+      ],
       "settings": {
         "foreground": "#ffba82"
       }
@@ -321,7 +338,10 @@
       }
     },
     {
-      "scope": ["support.class", "entity.name.type.class"],
+      "scope": [
+        "support.class",
+        "entity.name.type.class"
+      ],
       "settings": {
         "foreground": "#e290f0"
       }
@@ -479,13 +499,21 @@
       }
     },
     {
-      "scope": ["punctuation.definition.block", "punctuation.definition.tag"],
+      "scope": [
+        "punctuation.definition.block",
+        "punctuation.definition.tag"
+      ],
       "settings": {
         "foreground": "#737373"
       }
     },
     {
-      "scope": ["meta.tag.tsx", "meta.tag.jsx", "meta.tag.js", "meta.tag.ts"],
+      "scope": [
+        "meta.tag.tsx",
+        "meta.tag.jsx",
+        "meta.tag.js",
+        "meta.tag.ts"
+      ],
       "settings": {
         "foreground": "#737373"
       }
@@ -543,7 +571,10 @@
       }
     },
     {
-      "scope": ["support.variable.dom", "support.variable.property.dom"],
+      "scope": [
+        "support.variable.dom",
+        "support.variable.property.dom"
+      ],
       "settings": {
         "foreground": "#ffba82"
       }
@@ -567,7 +598,10 @@
       }
     },
     {
-      "scope": ["keyword.other.template.begin", "keyword.other.template.end"],
+      "scope": [
+        "keyword.other.template.begin",
+        "keyword.other.template.end"
+      ],
       "settings": {
         "foreground": "#8cda94"
       }
@@ -647,7 +681,10 @@
       }
     },
     {
-      "scope": ["meta.decorator", "meta.decorator punctuation.decorator"],
+      "scope": [
+        "meta.decorator",
+        "meta.decorator punctuation.decorator"
+      ],
       "settings": {
         "foreground": "#97c4ff"
       }
@@ -781,7 +818,10 @@
       }
     },
     {
-      "scope": ["meta.function.c", "meta.function.cpp"],
+      "scope": [
+        "meta.function.c",
+        "meta.function.cpp"
+      ],
       "settings": {
         "foreground": "#ffa685"
       }
@@ -829,7 +869,10 @@
       }
     },
     {
-      "scope": ["punctuation.separator.c", "punctuation.separator.cpp"],
+      "scope": [
+        "punctuation.separator.c",
+        "punctuation.separator.cpp"
+      ],
       "settings": {
         "foreground": "#ff91a8"
       }
@@ -844,7 +887,10 @@
       }
     },
     {
-      "scope": ["keyword.operator.sizeof.c", "keyword.operator.sizeof.cpp"],
+      "scope": [
+        "keyword.operator.sizeof.c",
+        "keyword.operator.sizeof.cpp"
+      ],
       "settings": {
         "foreground": "#ff91a8"
       }
@@ -1070,7 +1116,10 @@
       }
     },
     {
-      "scope": ["entity.name.goto-label.php", "support.other.php"],
+      "scope": [
+        "entity.name.goto-label.php",
+        "support.other.php"
+      ],
       "settings": {
         "foreground": "#ba8ffd"
       }
@@ -1098,7 +1147,10 @@
       }
     },
     {
-      "scope": ["keyword.operator.heredoc.php", "keyword.operator.nowdoc.php"],
+      "scope": [
+        "keyword.operator.heredoc.php",
+        "keyword.operator.nowdoc.php"
+      ],
       "settings": {
         "foreground": "#ff91a8"
       }
@@ -1207,7 +1259,10 @@
       }
     },
     {
-      "scope": ["meta.arguments.coffee", "variable.parameter.function.coffee"],
+      "scope": [
+        "meta.arguments.coffee",
+        "variable.parameter.function.coffee"
+      ],
       "settings": {
         "foreground": "#ffa685"
       }
@@ -1256,13 +1311,19 @@
       }
     },
     {
-      "scope": ["text.variable", "text.bracketed"],
+      "scope": [
+        "text.variable",
+        "text.bracketed"
+      ],
       "settings": {
         "foreground": "#ffa685"
       }
     },
     {
-      "scope": ["support.type.swift", "support.type.vb.asp"],
+      "scope": [
+        "support.type.swift",
+        "support.type.vb.asp"
+      ],
       "settings": {
         "foreground": "#ffbc56"
       }
@@ -1292,7 +1353,10 @@
       }
     },
     {
-      "scope": ["function.parameter.ruby", "function.parameter.cs"],
+      "scope": [
+        "function.parameter.ruby",
+        "function.parameter.cs"
+      ],
       "settings": {
         "foreground": "#737373"
       }
@@ -1596,7 +1660,10 @@
       }
     },
     {
-      "scope": ["markup.bold", "todo.bold"],
+      "scope": [
+        "markup.bold",
+        "todo.bold"
+      ],
       "settings": {
         "foreground": "#ffde80"
       }

--- a/packages/theme/themes/pierre-dark-tritanopia.json
+++ b/packages/theme/themes/pierre-dark-tritanopia.json
@@ -123,7 +123,10 @@
   },
   "tokenColors": [
     {
-      "scope": ["comment", "punctuation.definition.comment"],
+      "scope": [
+        "comment",
+        "punctuation.definition.comment"
+      ],
       "settings": {
         "foreground": "#737373"
       }
@@ -135,7 +138,10 @@
       }
     },
     {
-      "scope": ["string", "constant.other.symbol"],
+      "scope": [
+        "string",
+        "constant.other.symbol"
+      ],
       "settings": {
         "foreground": "#92dde4"
       }
@@ -150,7 +156,10 @@
       }
     },
     {
-      "scope": ["constant.numeric", "constant.language.boolean"],
+      "scope": [
+        "constant.numeric",
+        "constant.language.boolean"
+      ],
       "settings": {
         "foreground": "#69b1ff"
       }
@@ -192,7 +201,11 @@
       }
     },
     {
-      "scope": ["storage", "storage.type", "storage.modifier"],
+      "scope": [
+        "storage",
+        "storage.type",
+        "storage.modifier"
+      ],
       "settings": {
         "foreground": "#d568ea"
       }
@@ -225,7 +238,11 @@
       }
     },
     {
-      "scope": ["variable", "identifier", "meta.definition.variable"],
+      "scope": [
+        "variable",
+        "identifier",
+        "meta.definition.variable"
+      ],
       "settings": {
         "foreground": "#ff855e"
       }
@@ -321,7 +338,10 @@
       }
     },
     {
-      "scope": ["support.class", "entity.name.type.class"],
+      "scope": [
+        "support.class",
+        "entity.name.type.class"
+      ],
       "settings": {
         "foreground": "#ea68bc"
       }
@@ -479,13 +499,21 @@
       }
     },
     {
-      "scope": ["punctuation.definition.block", "punctuation.definition.tag"],
+      "scope": [
+        "punctuation.definition.block",
+        "punctuation.definition.tag"
+      ],
       "settings": {
         "foreground": "#636363"
       }
     },
     {
-      "scope": ["meta.tag.tsx", "meta.tag.jsx", "meta.tag.js", "meta.tag.ts"],
+      "scope": [
+        "meta.tag.tsx",
+        "meta.tag.jsx",
+        "meta.tag.js",
+        "meta.tag.ts"
+      ],
       "settings": {
         "foreground": "#636363"
       }
@@ -543,7 +571,10 @@
       }
     },
     {
-      "scope": ["support.variable.dom", "support.variable.property.dom"],
+      "scope": [
+        "support.variable.dom",
+        "support.variable.property.dom"
+      ],
       "settings": {
         "foreground": "#ff855e"
       }
@@ -567,7 +598,10 @@
       }
     },
     {
-      "scope": ["keyword.other.template.begin", "keyword.other.template.end"],
+      "scope": [
+        "keyword.other.template.begin",
+        "keyword.other.template.end"
+      ],
       "settings": {
         "foreground": "#92dde4"
       }
@@ -647,7 +681,10 @@
       }
     },
     {
-      "scope": ["meta.decorator", "meta.decorator punctuation.decorator"],
+      "scope": [
+        "meta.decorator",
+        "meta.decorator punctuation.decorator"
+      ],
       "settings": {
         "foreground": "#69b1ff"
       }
@@ -781,7 +818,10 @@
       }
     },
     {
-      "scope": ["meta.function.c", "meta.function.cpp"],
+      "scope": [
+        "meta.function.c",
+        "meta.function.cpp"
+      ],
       "settings": {
         "foreground": "#ff855e"
       }
@@ -829,7 +869,10 @@
       }
     },
     {
-      "scope": ["punctuation.separator.c", "punctuation.separator.cpp"],
+      "scope": [
+        "punctuation.separator.c",
+        "punctuation.separator.cpp"
+      ],
       "settings": {
         "foreground": "#d568ea"
       }
@@ -844,7 +887,10 @@
       }
     },
     {
-      "scope": ["keyword.operator.sizeof.c", "keyword.operator.sizeof.cpp"],
+      "scope": [
+        "keyword.operator.sizeof.c",
+        "keyword.operator.sizeof.cpp"
+      ],
       "settings": {
         "foreground": "#d568ea"
       }
@@ -1070,7 +1116,10 @@
       }
     },
     {
-      "scope": ["entity.name.goto-label.php", "support.other.php"],
+      "scope": [
+        "entity.name.goto-label.php",
+        "support.other.php"
+      ],
       "settings": {
         "foreground": "#97c4ff"
       }
@@ -1098,7 +1147,10 @@
       }
     },
     {
-      "scope": ["keyword.operator.heredoc.php", "keyword.operator.nowdoc.php"],
+      "scope": [
+        "keyword.operator.heredoc.php",
+        "keyword.operator.nowdoc.php"
+      ],
       "settings": {
         "foreground": "#d568ea"
       }
@@ -1207,7 +1259,10 @@
       }
     },
     {
-      "scope": ["meta.arguments.coffee", "variable.parameter.function.coffee"],
+      "scope": [
+        "meta.arguments.coffee",
+        "variable.parameter.function.coffee"
+      ],
       "settings": {
         "foreground": "#ff855e"
       }
@@ -1256,13 +1311,19 @@
       }
     },
     {
-      "scope": ["text.variable", "text.bracketed"],
+      "scope": [
+        "text.variable",
+        "text.bracketed"
+      ],
       "settings": {
         "foreground": "#ff855e"
       }
     },
     {
-      "scope": ["support.type.swift", "support.type.vb.asp"],
+      "scope": [
+        "support.type.swift",
+        "support.type.vb.asp"
+      ],
       "settings": {
         "foreground": "#ff855e"
       }
@@ -1292,7 +1353,10 @@
       }
     },
     {
-      "scope": ["function.parameter.ruby", "function.parameter.cs"],
+      "scope": [
+        "function.parameter.ruby",
+        "function.parameter.cs"
+      ],
       "settings": {
         "foreground": "#636363"
       }
@@ -1596,7 +1660,10 @@
       }
     },
     {
-      "scope": ["markup.bold", "todo.bold"],
+      "scope": [
+        "markup.bold",
+        "todo.bold"
+      ],
       "settings": {
         "foreground": "#ffcc81"
       }

--- a/packages/theme/themes/pierre-dark-vibrant.json
+++ b/packages/theme/themes/pierre-dark-vibrant.json
@@ -123,7 +123,10 @@
   },
   "tokenColors": [
     {
-      "scope": ["comment", "punctuation.definition.comment"],
+      "scope": [
+        "comment",
+        "punctuation.definition.comment"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.450980 0.450980 0.450980)"
       }
@@ -135,7 +138,10 @@
       }
     },
     {
-      "scope": ["string", "constant.other.symbol"],
+      "scope": [
+        "string",
+        "constant.other.symbol"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.451324 0.823458 0.446819)"
       }
@@ -150,7 +156,10 @@
       }
     },
     {
-      "scope": ["constant.numeric", "constant.language.boolean"],
+      "scope": [
+        "constant.numeric",
+        "constant.language.boolean"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.452682 0.814110 0.989434)"
       }
@@ -192,7 +201,11 @@
       }
     },
     {
-      "scope": ["storage", "storage.type", "storage.modifier"],
+      "scope": [
+        "storage",
+        "storage.type",
+        "storage.modifier"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.994741 0.445201 0.573499)"
       }
@@ -225,7 +238,11 @@
       }
     },
     {
-      "scope": ["variable", "identifier", "meta.definition.variable"],
+      "scope": [
+        "variable",
+        "identifier",
+        "meta.definition.variable"
+      ],
       "settings": {
         "foreground": "color(display-p3 1.000000 0.688063 0.418777)"
       }
@@ -321,7 +338,10 @@
       }
     },
     {
-      "scope": ["support.class", "entity.name.type.class"],
+      "scope": [
+        "support.class",
+        "entity.name.type.class"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.829375 0.434619 0.954315)"
       }
@@ -479,13 +499,21 @@
       }
     },
     {
-      "scope": ["punctuation.definition.block", "punctuation.definition.tag"],
+      "scope": [
+        "punctuation.definition.block",
+        "punctuation.definition.tag"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.388235 0.388235 0.388235)"
       }
     },
     {
-      "scope": ["meta.tag.tsx", "meta.tag.jsx", "meta.tag.js", "meta.tag.ts"],
+      "scope": [
+        "meta.tag.tsx",
+        "meta.tag.jsx",
+        "meta.tag.js",
+        "meta.tag.ts"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.388235 0.388235 0.388235)"
       }
@@ -543,7 +571,10 @@
       }
     },
     {
-      "scope": ["support.variable.dom", "support.variable.property.dom"],
+      "scope": [
+        "support.variable.dom",
+        "support.variable.property.dom"
+      ],
       "settings": {
         "foreground": "color(display-p3 1.000000 0.688063 0.418777)"
       }
@@ -567,7 +598,10 @@
       }
     },
     {
-      "scope": ["keyword.other.template.begin", "keyword.other.template.end"],
+      "scope": [
+        "keyword.other.template.begin",
+        "keyword.other.template.end"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.451324 0.823458 0.446819)"
       }
@@ -647,7 +681,10 @@
       }
     },
     {
-      "scope": ["meta.decorator", "meta.decorator punctuation.decorator"],
+      "scope": [
+        "meta.decorator",
+        "meta.decorator punctuation.decorator"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.453315 0.683106 1.000000)"
       }
@@ -781,7 +818,10 @@
       }
     },
     {
-      "scope": ["meta.function.c", "meta.function.cpp"],
+      "scope": [
+        "meta.function.c",
+        "meta.function.cpp"
+      ],
       "settings": {
         "foreground": "color(display-p3 1.000000 0.566977 0.409224)"
       }
@@ -829,7 +869,10 @@
       }
     },
     {
-      "scope": ["punctuation.separator.c", "punctuation.separator.cpp"],
+      "scope": [
+        "punctuation.separator.c",
+        "punctuation.separator.cpp"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.994741 0.445201 0.573499)"
       }
@@ -844,7 +887,10 @@
       }
     },
     {
-      "scope": ["keyword.operator.sizeof.c", "keyword.operator.sizeof.cpp"],
+      "scope": [
+        "keyword.operator.sizeof.c",
+        "keyword.operator.sizeof.cpp"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.994741 0.445201 0.573499)"
       }
@@ -1070,7 +1116,10 @@
       }
     },
     {
-      "scope": ["entity.name.goto-label.php", "support.other.php"],
+      "scope": [
+        "entity.name.goto-label.php",
+        "support.other.php"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.615613 0.445256 1.000000)"
       }
@@ -1098,7 +1147,10 @@
       }
     },
     {
-      "scope": ["keyword.operator.heredoc.php", "keyword.operator.nowdoc.php"],
+      "scope": [
+        "keyword.operator.heredoc.php",
+        "keyword.operator.nowdoc.php"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.994741 0.445201 0.573499)"
       }
@@ -1207,7 +1259,10 @@
       }
     },
     {
-      "scope": ["meta.arguments.coffee", "variable.parameter.function.coffee"],
+      "scope": [
+        "meta.arguments.coffee",
+        "variable.parameter.function.coffee"
+      ],
       "settings": {
         "foreground": "color(display-p3 1.000000 0.566977 0.409224)"
       }
@@ -1256,13 +1311,19 @@
       }
     },
     {
-      "scope": ["text.variable", "text.bracketed"],
+      "scope": [
+        "text.variable",
+        "text.bracketed"
+      ],
       "settings": {
         "foreground": "color(display-p3 1.000000 0.566977 0.409224)"
       }
     },
     {
-      "scope": ["support.type.swift", "support.type.vb.asp"],
+      "scope": [
+        "support.type.swift",
+        "support.type.vb.asp"
+      ],
       "settings": {
         "foreground": "color(display-p3 1.000000 0.719280 0.270071)"
       }
@@ -1292,7 +1353,10 @@
       }
     },
     {
-      "scope": ["function.parameter.ruby", "function.parameter.cs"],
+      "scope": [
+        "function.parameter.ruby",
+        "function.parameter.cs"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.388235 0.388235 0.388235)"
       }
@@ -1596,7 +1660,10 @@
       }
     },
     {
-      "scope": ["markup.bold", "todo.bold"],
+      "scope": [
+        "markup.bold",
+        "todo.bold"
+      ],
       "settings": {
         "foreground": "color(display-p3 1.000000 0.868456 0.454295)"
       }

--- a/packages/theme/themes/pierre-dark.json
+++ b/packages/theme/themes/pierre-dark.json
@@ -123,7 +123,10 @@
   },
   "tokenColors": [
     {
-      "scope": ["comment", "punctuation.definition.comment"],
+      "scope": [
+        "comment",
+        "punctuation.definition.comment"
+      ],
       "settings": {
         "foreground": "#737373"
       }
@@ -135,7 +138,10 @@
       }
     },
     {
-      "scope": ["string", "constant.other.symbol"],
+      "scope": [
+        "string",
+        "constant.other.symbol"
+      ],
       "settings": {
         "foreground": "#5ecc71"
       }
@@ -150,7 +156,10 @@
       }
     },
     {
-      "scope": ["constant.numeric", "constant.language.boolean"],
+      "scope": [
+        "constant.numeric",
+        "constant.language.boolean"
+      ],
       "settings": {
         "foreground": "#68cdf2"
       }
@@ -192,7 +201,11 @@
       }
     },
     {
-      "scope": ["storage", "storage.type", "storage.modifier"],
+      "scope": [
+        "storage",
+        "storage.type",
+        "storage.modifier"
+      ],
       "settings": {
         "foreground": "#ff678d"
       }
@@ -225,7 +238,11 @@
       }
     },
     {
-      "scope": ["variable", "identifier", "meta.definition.variable"],
+      "scope": [
+        "variable",
+        "identifier",
+        "meta.definition.variable"
+      ],
       "settings": {
         "foreground": "#ffa359"
       }
@@ -321,7 +338,10 @@
       }
     },
     {
-      "scope": ["support.class", "entity.name.type.class"],
+      "scope": [
+        "support.class",
+        "entity.name.type.class"
+      ],
       "settings": {
         "foreground": "#d568ea"
       }
@@ -479,13 +499,21 @@
       }
     },
     {
-      "scope": ["punctuation.definition.block", "punctuation.definition.tag"],
+      "scope": [
+        "punctuation.definition.block",
+        "punctuation.definition.tag"
+      ],
       "settings": {
         "foreground": "#636363"
       }
     },
     {
-      "scope": ["meta.tag.tsx", "meta.tag.jsx", "meta.tag.js", "meta.tag.ts"],
+      "scope": [
+        "meta.tag.tsx",
+        "meta.tag.jsx",
+        "meta.tag.js",
+        "meta.tag.ts"
+      ],
       "settings": {
         "foreground": "#636363"
       }
@@ -543,7 +571,10 @@
       }
     },
     {
-      "scope": ["support.variable.dom", "support.variable.property.dom"],
+      "scope": [
+        "support.variable.dom",
+        "support.variable.property.dom"
+      ],
       "settings": {
         "foreground": "#ffa359"
       }
@@ -567,7 +598,10 @@
       }
     },
     {
-      "scope": ["keyword.other.template.begin", "keyword.other.template.end"],
+      "scope": [
+        "keyword.other.template.begin",
+        "keyword.other.template.end"
+      ],
       "settings": {
         "foreground": "#5ecc71"
       }
@@ -647,7 +681,10 @@
       }
     },
     {
-      "scope": ["meta.decorator", "meta.decorator punctuation.decorator"],
+      "scope": [
+        "meta.decorator",
+        "meta.decorator punctuation.decorator"
+      ],
       "settings": {
         "foreground": "#69b1ff"
       }
@@ -781,7 +818,10 @@
       }
     },
     {
-      "scope": ["meta.function.c", "meta.function.cpp"],
+      "scope": [
+        "meta.function.c",
+        "meta.function.cpp"
+      ],
       "settings": {
         "foreground": "#ff855e"
       }
@@ -829,7 +869,10 @@
       }
     },
     {
-      "scope": ["punctuation.separator.c", "punctuation.separator.cpp"],
+      "scope": [
+        "punctuation.separator.c",
+        "punctuation.separator.cpp"
+      ],
       "settings": {
         "foreground": "#ff678d"
       }
@@ -844,7 +887,10 @@
       }
     },
     {
-      "scope": ["keyword.operator.sizeof.c", "keyword.operator.sizeof.cpp"],
+      "scope": [
+        "keyword.operator.sizeof.c",
+        "keyword.operator.sizeof.cpp"
+      ],
       "settings": {
         "foreground": "#ff678d"
       }
@@ -1070,7 +1116,10 @@
       }
     },
     {
-      "scope": ["entity.name.goto-label.php", "support.other.php"],
+      "scope": [
+        "entity.name.goto-label.php",
+        "support.other.php"
+      ],
       "settings": {
         "foreground": "#9d6afb"
       }
@@ -1098,7 +1147,10 @@
       }
     },
     {
-      "scope": ["keyword.operator.heredoc.php", "keyword.operator.nowdoc.php"],
+      "scope": [
+        "keyword.operator.heredoc.php",
+        "keyword.operator.nowdoc.php"
+      ],
       "settings": {
         "foreground": "#ff678d"
       }
@@ -1207,7 +1259,10 @@
       }
     },
     {
-      "scope": ["meta.arguments.coffee", "variable.parameter.function.coffee"],
+      "scope": [
+        "meta.arguments.coffee",
+        "variable.parameter.function.coffee"
+      ],
       "settings": {
         "foreground": "#ff855e"
       }
@@ -1256,13 +1311,19 @@
       }
     },
     {
-      "scope": ["text.variable", "text.bracketed"],
+      "scope": [
+        "text.variable",
+        "text.bracketed"
+      ],
       "settings": {
         "foreground": "#ff855e"
       }
     },
     {
-      "scope": ["support.type.swift", "support.type.vb.asp"],
+      "scope": [
+        "support.type.swift",
+        "support.type.vb.asp"
+      ],
       "settings": {
         "foreground": "#ffab16"
       }
@@ -1292,7 +1353,10 @@
       }
     },
     {
-      "scope": ["function.parameter.ruby", "function.parameter.cs"],
+      "scope": [
+        "function.parameter.ruby",
+        "function.parameter.cs"
+      ],
       "settings": {
         "foreground": "#636363"
       }
@@ -1596,7 +1660,10 @@
       }
     },
     {
-      "scope": ["markup.bold", "todo.bold"],
+      "scope": [
+        "markup.bold",
+        "todo.bold"
+      ],
       "settings": {
         "foreground": "#ffd452"
       }

--- a/packages/theme/themes/pierre-light-protanopia-deuteranopia.json
+++ b/packages/theme/themes/pierre-light-protanopia-deuteranopia.json
@@ -123,7 +123,10 @@
   },
   "tokenColors": [
     {
-      "scope": ["comment", "punctuation.definition.comment"],
+      "scope": [
+        "comment",
+        "punctuation.definition.comment"
+      ],
       "settings": {
         "foreground": "#737373"
       }
@@ -135,7 +138,10 @@
       }
     },
     {
-      "scope": ["string", "constant.other.symbol"],
+      "scope": [
+        "string",
+        "constant.other.symbol"
+      ],
       "settings": {
         "foreground": "#215584"
       }
@@ -150,7 +156,10 @@
       }
     },
     {
-      "scope": ["constant.numeric", "constant.language.boolean"],
+      "scope": [
+        "constant.numeric",
+        "constant.language.boolean"
+      ],
       "settings": {
         "foreground": "#2182a1"
       }
@@ -192,7 +201,11 @@
       }
     },
     {
-      "scope": ["storage", "storage.type", "storage.modifier"],
+      "scope": [
+        "storage",
+        "storage.type",
+        "storage.modifier"
+      ],
       "settings": {
         "foreground": "#8836c7"
       }
@@ -225,7 +238,11 @@
       }
     },
     {
-      "scope": ["variable", "identifier", "meta.definition.variable"],
+      "scope": [
+        "variable",
+        "identifier",
+        "meta.definition.variable"
+      ],
       "settings": {
         "foreground": "#ac6023"
       }
@@ -321,7 +338,10 @@
       }
     },
     {
-      "scope": ["support.class", "entity.name.type.class"],
+      "scope": [
+        "support.class",
+        "entity.name.type.class"
+      ],
       "settings": {
         "foreground": "#a631be"
       }
@@ -479,13 +499,21 @@
       }
     },
     {
-      "scope": ["punctuation.definition.block", "punctuation.definition.tag"],
+      "scope": [
+        "punctuation.definition.block",
+        "punctuation.definition.tag"
+      ],
       "settings": {
         "foreground": "#636363"
       }
     },
     {
-      "scope": ["meta.tag.tsx", "meta.tag.jsx", "meta.tag.js", "meta.tag.ts"],
+      "scope": [
+        "meta.tag.tsx",
+        "meta.tag.jsx",
+        "meta.tag.js",
+        "meta.tag.ts"
+      ],
       "settings": {
         "foreground": "#636363"
       }
@@ -543,7 +571,10 @@
       }
     },
     {
-      "scope": ["support.variable.dom", "support.variable.property.dom"],
+      "scope": [
+        "support.variable.dom",
+        "support.variable.property.dom"
+      ],
       "settings": {
         "foreground": "#ac6023"
       }
@@ -567,7 +598,10 @@
       }
     },
     {
-      "scope": ["keyword.other.template.begin", "keyword.other.template.end"],
+      "scope": [
+        "keyword.other.template.begin",
+        "keyword.other.template.end"
+      ],
       "settings": {
         "foreground": "#215584"
       }
@@ -647,7 +681,10 @@
       }
     },
     {
-      "scope": ["meta.decorator", "meta.decorator punctuation.decorator"],
+      "scope": [
+        "meta.decorator",
+        "meta.decorator punctuation.decorator"
+      ],
       "settings": {
         "foreground": "#216cab"
       }
@@ -781,7 +818,10 @@
       }
     },
     {
-      "scope": ["meta.function.c", "meta.function.cpp"],
+      "scope": [
+        "meta.function.c",
+        "meta.function.cpp"
+      ],
       "settings": {
         "foreground": "#ac6023"
       }
@@ -829,7 +869,10 @@
       }
     },
     {
-      "scope": ["punctuation.separator.c", "punctuation.separator.cpp"],
+      "scope": [
+        "punctuation.separator.c",
+        "punctuation.separator.cpp"
+      ],
       "settings": {
         "foreground": "#8836c7"
       }
@@ -844,7 +887,10 @@
       }
     },
     {
-      "scope": ["keyword.operator.sizeof.c", "keyword.operator.sizeof.cpp"],
+      "scope": [
+        "keyword.operator.sizeof.c",
+        "keyword.operator.sizeof.cpp"
+      ],
       "settings": {
         "foreground": "#8836c7"
       }
@@ -1070,7 +1116,10 @@
       }
     },
     {
-      "scope": ["entity.name.goto-label.php", "support.other.php"],
+      "scope": [
+        "entity.name.goto-label.php",
+        "support.other.php"
+      ],
       "settings": {
         "foreground": "#5731a7"
       }
@@ -1098,7 +1147,10 @@
       }
     },
     {
-      "scope": ["keyword.operator.heredoc.php", "keyword.operator.nowdoc.php"],
+      "scope": [
+        "keyword.operator.heredoc.php",
+        "keyword.operator.nowdoc.php"
+      ],
       "settings": {
         "foreground": "#8836c7"
       }
@@ -1207,7 +1259,10 @@
       }
     },
     {
-      "scope": ["meta.arguments.coffee", "variable.parameter.function.coffee"],
+      "scope": [
+        "meta.arguments.coffee",
+        "variable.parameter.function.coffee"
+      ],
       "settings": {
         "foreground": "#ac6023"
       }
@@ -1256,13 +1311,19 @@
       }
     },
     {
-      "scope": ["text.variable", "text.bracketed"],
+      "scope": [
+        "text.variable",
+        "text.bracketed"
+      ],
       "settings": {
         "foreground": "#ac6023"
       }
     },
     {
-      "scope": ["support.type.swift", "support.type.vb.asp"],
+      "scope": [
+        "support.type.swift",
+        "support.type.vb.asp"
+      ],
       "settings": {
         "foreground": "#ac741d"
       }
@@ -1292,7 +1353,10 @@
       }
     },
     {
-      "scope": ["function.parameter.ruby", "function.parameter.cs"],
+      "scope": [
+        "function.parameter.ruby",
+        "function.parameter.cs"
+      ],
       "settings": {
         "foreground": "#636363"
       }
@@ -1596,7 +1660,10 @@
       }
     },
     {
-      "scope": ["markup.bold", "todo.bold"],
+      "scope": [
+        "markup.bold",
+        "todo.bold"
+      ],
       "settings": {
         "foreground": "#ac741d"
       }

--- a/packages/theme/themes/pierre-light-soft.json
+++ b/packages/theme/themes/pierre-light-soft.json
@@ -123,7 +123,10 @@
   },
   "tokenColors": [
     {
-      "scope": ["comment", "punctuation.definition.comment"],
+      "scope": [
+        "comment",
+        "punctuation.definition.comment"
+      ],
       "settings": {
         "foreground": "#8a8a8a"
       }
@@ -135,7 +138,10 @@
       }
     },
     {
-      "scope": ["string", "constant.other.symbol"],
+      "scope": [
+        "string",
+        "constant.other.symbol"
+      ],
       "settings": {
         "foreground": "#0dbe4e"
       }
@@ -150,7 +156,10 @@
       }
     },
     {
-      "scope": ["constant.numeric", "constant.language.boolean"],
+      "scope": [
+        "constant.numeric",
+        "constant.language.boolean"
+      ],
       "settings": {
         "foreground": "#08c0ef"
       }
@@ -192,7 +201,11 @@
       }
     },
     {
-      "scope": ["storage", "storage.type", "storage.modifier"],
+      "scope": [
+        "storage",
+        "storage.type",
+        "storage.modifier"
+      ],
       "settings": {
         "foreground": "#ff678d"
       }
@@ -225,7 +238,11 @@
       }
     },
     {
-      "scope": ["variable", "identifier", "meta.definition.variable"],
+      "scope": [
+        "variable",
+        "identifier",
+        "meta.definition.variable"
+      ],
       "settings": {
         "foreground": "#fe8c2c"
       }
@@ -321,7 +338,10 @@
       }
     },
     {
-      "scope": ["support.class", "entity.name.type.class"],
+      "scope": [
+        "support.class",
+        "entity.name.type.class"
+      ],
       "settings": {
         "foreground": "#d568ea"
       }
@@ -479,13 +499,21 @@
       }
     },
     {
-      "scope": ["punctuation.definition.block", "punctuation.definition.tag"],
+      "scope": [
+        "punctuation.definition.block",
+        "punctuation.definition.tag"
+      ],
       "settings": {
         "foreground": "#737373"
       }
     },
     {
-      "scope": ["meta.tag.tsx", "meta.tag.jsx", "meta.tag.js", "meta.tag.ts"],
+      "scope": [
+        "meta.tag.tsx",
+        "meta.tag.jsx",
+        "meta.tag.js",
+        "meta.tag.ts"
+      ],
       "settings": {
         "foreground": "#737373"
       }
@@ -543,7 +571,10 @@
       }
     },
     {
-      "scope": ["support.variable.dom", "support.variable.property.dom"],
+      "scope": [
+        "support.variable.dom",
+        "support.variable.property.dom"
+      ],
       "settings": {
         "foreground": "#fe8c2c"
       }
@@ -567,7 +598,10 @@
       }
     },
     {
-      "scope": ["keyword.other.template.begin", "keyword.other.template.end"],
+      "scope": [
+        "keyword.other.template.begin",
+        "keyword.other.template.end"
+      ],
       "settings": {
         "foreground": "#0dbe4e"
       }
@@ -647,7 +681,10 @@
       }
     },
     {
-      "scope": ["meta.decorator", "meta.decorator punctuation.decorator"],
+      "scope": [
+        "meta.decorator",
+        "meta.decorator punctuation.decorator"
+      ],
       "settings": {
         "foreground": "#69b1ff"
       }
@@ -781,7 +818,10 @@
       }
     },
     {
-      "scope": ["meta.function.c", "meta.function.cpp"],
+      "scope": [
+        "meta.function.c",
+        "meta.function.cpp"
+      ],
       "settings": {
         "foreground": "#ff5d36"
       }
@@ -829,7 +869,10 @@
       }
     },
     {
-      "scope": ["punctuation.separator.c", "punctuation.separator.cpp"],
+      "scope": [
+        "punctuation.separator.c",
+        "punctuation.separator.cpp"
+      ],
       "settings": {
         "foreground": "#ff678d"
       }
@@ -844,7 +887,10 @@
       }
     },
     {
-      "scope": ["keyword.operator.sizeof.c", "keyword.operator.sizeof.cpp"],
+      "scope": [
+        "keyword.operator.sizeof.c",
+        "keyword.operator.sizeof.cpp"
+      ],
       "settings": {
         "foreground": "#ff678d"
       }
@@ -1070,7 +1116,10 @@
       }
     },
     {
-      "scope": ["entity.name.goto-label.php", "support.other.php"],
+      "scope": [
+        "entity.name.goto-label.php",
+        "support.other.php"
+      ],
       "settings": {
         "foreground": "#9d6afb"
       }
@@ -1098,7 +1147,10 @@
       }
     },
     {
-      "scope": ["keyword.operator.heredoc.php", "keyword.operator.nowdoc.php"],
+      "scope": [
+        "keyword.operator.heredoc.php",
+        "keyword.operator.nowdoc.php"
+      ],
       "settings": {
         "foreground": "#ff678d"
       }
@@ -1207,7 +1259,10 @@
       }
     },
     {
-      "scope": ["meta.arguments.coffee", "variable.parameter.function.coffee"],
+      "scope": [
+        "meta.arguments.coffee",
+        "variable.parameter.function.coffee"
+      ],
       "settings": {
         "foreground": "#ff5d36"
       }
@@ -1256,13 +1311,19 @@
       }
     },
     {
-      "scope": ["text.variable", "text.bracketed"],
+      "scope": [
+        "text.variable",
+        "text.bracketed"
+      ],
       "settings": {
         "foreground": "#ff5d36"
       }
     },
     {
-      "scope": ["support.type.swift", "support.type.vb.asp"],
+      "scope": [
+        "support.type.swift",
+        "support.type.vb.asp"
+      ],
       "settings": {
         "foreground": "#ffab16"
       }
@@ -1292,7 +1353,10 @@
       }
     },
     {
-      "scope": ["function.parameter.ruby", "function.parameter.cs"],
+      "scope": [
+        "function.parameter.ruby",
+        "function.parameter.cs"
+      ],
       "settings": {
         "foreground": "#737373"
       }
@@ -1596,7 +1660,10 @@
       }
     },
     {
-      "scope": ["markup.bold", "todo.bold"],
+      "scope": [
+        "markup.bold",
+        "todo.bold"
+      ],
       "settings": {
         "foreground": "#ffca00"
       }

--- a/packages/theme/themes/pierre-light-tritanopia.json
+++ b/packages/theme/themes/pierre-light-tritanopia.json
@@ -123,7 +123,10 @@
   },
   "tokenColors": [
     {
-      "scope": ["comment", "punctuation.definition.comment"],
+      "scope": [
+        "comment",
+        "punctuation.definition.comment"
+      ],
       "settings": {
         "foreground": "#737373"
       }
@@ -135,7 +138,10 @@
       }
     },
     {
-      "scope": ["string", "constant.other.symbol"],
+      "scope": [
+        "string",
+        "constant.other.symbol"
+      ],
       "settings": {
         "foreground": "#1e858e"
       }
@@ -150,7 +156,10 @@
       }
     },
     {
-      "scope": ["constant.numeric", "constant.language.boolean"],
+      "scope": [
+        "constant.numeric",
+        "constant.language.boolean"
+      ],
       "settings": {
         "foreground": "#1a85d4"
       }
@@ -192,7 +201,11 @@
       }
     },
     {
-      "scope": ["storage", "storage.type", "storage.modifier"],
+      "scope": [
+        "storage",
+        "storage.type",
+        "storage.modifier"
+      ],
       "settings": {
         "foreground": "#a631be"
       }
@@ -225,7 +238,11 @@
       }
     },
     {
-      "scope": ["variable", "identifier", "meta.definition.variable"],
+      "scope": [
+        "variable",
+        "identifier",
+        "meta.definition.variable"
+      ],
       "settings": {
         "foreground": "#ad4529"
       }
@@ -321,7 +338,10 @@
       }
     },
     {
-      "scope": ["support.class", "entity.name.type.class"],
+      "scope": [
+        "support.class",
+        "entity.name.type.class"
+      ],
       "settings": {
         "foreground": "#bd2e90"
       }
@@ -479,13 +499,21 @@
       }
     },
     {
-      "scope": ["punctuation.definition.block", "punctuation.definition.tag"],
+      "scope": [
+        "punctuation.definition.block",
+        "punctuation.definition.tag"
+      ],
       "settings": {
         "foreground": "#636363"
       }
     },
     {
-      "scope": ["meta.tag.tsx", "meta.tag.jsx", "meta.tag.js", "meta.tag.ts"],
+      "scope": [
+        "meta.tag.tsx",
+        "meta.tag.jsx",
+        "meta.tag.js",
+        "meta.tag.ts"
+      ],
       "settings": {
         "foreground": "#636363"
       }
@@ -543,7 +571,10 @@
       }
     },
     {
-      "scope": ["support.variable.dom", "support.variable.property.dom"],
+      "scope": [
+        "support.variable.dom",
+        "support.variable.property.dom"
+      ],
       "settings": {
         "foreground": "#ad4529"
       }
@@ -567,7 +598,10 @@
       }
     },
     {
-      "scope": ["keyword.other.template.begin", "keyword.other.template.end"],
+      "scope": [
+        "keyword.other.template.begin",
+        "keyword.other.template.end"
+      ],
       "settings": {
         "foreground": "#1e858e"
       }
@@ -647,7 +681,10 @@
       }
     },
     {
-      "scope": ["meta.decorator", "meta.decorator punctuation.decorator"],
+      "scope": [
+        "meta.decorator",
+        "meta.decorator punctuation.decorator"
+      ],
       "settings": {
         "foreground": "#1a85d4"
       }
@@ -781,7 +818,10 @@
       }
     },
     {
-      "scope": ["meta.function.c", "meta.function.cpp"],
+      "scope": [
+        "meta.function.c",
+        "meta.function.cpp"
+      ],
       "settings": {
         "foreground": "#d5512f"
       }
@@ -829,7 +869,10 @@
       }
     },
     {
-      "scope": ["punctuation.separator.c", "punctuation.separator.cpp"],
+      "scope": [
+        "punctuation.separator.c",
+        "punctuation.separator.cpp"
+      ],
       "settings": {
         "foreground": "#a631be"
       }
@@ -844,7 +887,10 @@
       }
     },
     {
-      "scope": ["keyword.operator.sizeof.c", "keyword.operator.sizeof.cpp"],
+      "scope": [
+        "keyword.operator.sizeof.c",
+        "keyword.operator.sizeof.cpp"
+      ],
       "settings": {
         "foreground": "#a631be"
       }
@@ -1070,7 +1116,10 @@
       }
     },
     {
-      "scope": ["entity.name.goto-label.php", "support.other.php"],
+      "scope": [
+        "entity.name.goto-label.php",
+        "support.other.php"
+      ],
       "settings": {
         "foreground": "#216cab"
       }
@@ -1098,7 +1147,10 @@
       }
     },
     {
-      "scope": ["keyword.operator.heredoc.php", "keyword.operator.nowdoc.php"],
+      "scope": [
+        "keyword.operator.heredoc.php",
+        "keyword.operator.nowdoc.php"
+      ],
       "settings": {
         "foreground": "#a631be"
       }
@@ -1207,7 +1259,10 @@
       }
     },
     {
-      "scope": ["meta.arguments.coffee", "variable.parameter.function.coffee"],
+      "scope": [
+        "meta.arguments.coffee",
+        "variable.parameter.function.coffee"
+      ],
       "settings": {
         "foreground": "#d5512f"
       }
@@ -1256,13 +1311,19 @@
       }
     },
     {
-      "scope": ["text.variable", "text.bracketed"],
+      "scope": [
+        "text.variable",
+        "text.bracketed"
+      ],
       "settings": {
         "foreground": "#d5512f"
       }
     },
     {
-      "scope": ["support.type.swift", "support.type.vb.asp"],
+      "scope": [
+        "support.type.swift",
+        "support.type.vb.asp"
+      ],
       "settings": {
         "foreground": "#d5512f"
       }
@@ -1292,7 +1353,10 @@
       }
     },
     {
-      "scope": ["function.parameter.ruby", "function.parameter.cs"],
+      "scope": [
+        "function.parameter.ruby",
+        "function.parameter.cs"
+      ],
       "settings": {
         "foreground": "#636363"
       }
@@ -1596,7 +1660,10 @@
       }
     },
     {
-      "scope": ["markup.bold", "todo.bold"],
+      "scope": [
+        "markup.bold",
+        "todo.bold"
+      ],
       "settings": {
         "foreground": "#ac741d"
       }

--- a/packages/theme/themes/pierre-light-vibrant.json
+++ b/packages/theme/themes/pierre-light-vibrant.json
@@ -123,7 +123,10 @@
   },
   "tokenColors": [
     {
-      "scope": ["comment", "punctuation.definition.comment"],
+      "scope": [
+        "comment",
+        "punctuation.definition.comment"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.450980 0.450980 0.450980)"
       }
@@ -135,7 +138,10 @@
       }
     },
     {
-      "scope": ["string", "constant.other.symbol"],
+      "scope": [
+        "string",
+        "constant.other.symbol"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.259723 0.647032 0.276349)"
       }
@@ -150,7 +156,10 @@
       }
     },
     {
-      "scope": ["constant.numeric", "constant.language.boolean"],
+      "scope": [
+        "constant.numeric",
+        "constant.language.boolean"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.246852 0.642335 0.817202)"
       }
@@ -192,7 +201,11 @@
       }
     },
     {
-      "scope": ["storage", "storage.type", "storage.modifier"],
+      "scope": [
+        "storage",
+        "storage.type",
+        "storage.modifier"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.834880 0.207921 0.387456)"
       }
@@ -225,7 +238,11 @@
       }
     },
     {
-      "scope": ["variable", "identifier", "meta.definition.variable"],
+      "scope": [
+        "variable",
+        "identifier",
+        "meta.definition.variable"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.854172 0.502144 0.209646)"
       }
@@ -321,7 +338,10 @@
       }
     },
     {
-      "scope": ["support.class", "entity.name.type.class"],
+      "scope": [
+        "support.class",
+        "entity.name.type.class"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.660755 0.179954 0.815400)"
       }
@@ -479,13 +499,21 @@
       }
     },
     {
-      "scope": ["punctuation.definition.block", "punctuation.definition.tag"],
+      "scope": [
+        "punctuation.definition.block",
+        "punctuation.definition.tag"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.388235 0.388235 0.388235)"
       }
     },
     {
-      "scope": ["meta.tag.tsx", "meta.tag.jsx", "meta.tag.js", "meta.tag.ts"],
+      "scope": [
+        "meta.tag.tsx",
+        "meta.tag.jsx",
+        "meta.tag.js",
+        "meta.tag.ts"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.388235 0.388235 0.388235)"
       }
@@ -543,7 +571,10 @@
       }
     },
     {
-      "scope": ["support.variable.dom", "support.variable.property.dom"],
+      "scope": [
+        "support.variable.dom",
+        "support.variable.property.dom"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.854172 0.502144 0.209646)"
       }
@@ -567,7 +598,10 @@
       }
     },
     {
-      "scope": ["keyword.other.template.begin", "keyword.other.template.end"],
+      "scope": [
+        "keyword.other.template.begin",
+        "keyword.other.template.end"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.259723 0.647032 0.276349)"
       }
@@ -647,7 +681,10 @@
       }
     },
     {
-      "scope": ["meta.decorator", "meta.decorator punctuation.decorator"],
+      "scope": [
+        "meta.decorator",
+        "meta.decorator punctuation.decorator"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.227104 0.537899 0.881328)"
       }
@@ -781,7 +818,10 @@
       }
     },
     {
-      "scope": ["meta.function.c", "meta.function.cpp"],
+      "scope": [
+        "meta.function.c",
+        "meta.function.cpp"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.846123 0.351499 0.208754)"
       }
@@ -829,7 +869,10 @@
       }
     },
     {
-      "scope": ["punctuation.separator.c", "punctuation.separator.cpp"],
+      "scope": [
+        "punctuation.separator.c",
+        "punctuation.separator.cpp"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.834880 0.207921 0.387456)"
       }
@@ -844,7 +887,10 @@
       }
     },
     {
-      "scope": ["keyword.operator.sizeof.c", "keyword.operator.sizeof.cpp"],
+      "scope": [
+        "keyword.operator.sizeof.c",
+        "keyword.operator.sizeof.cpp"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.834880 0.207921 0.387456)"
       }
@@ -1070,7 +1116,10 @@
       }
     },
     {
-      "scope": ["entity.name.goto-label.php", "support.other.php"],
+      "scope": [
+        "entity.name.goto-label.php",
+        "support.other.php"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.391345 0.215644 0.853560)"
       }
@@ -1098,7 +1147,10 @@
       }
     },
     {
-      "scope": ["keyword.operator.heredoc.php", "keyword.operator.nowdoc.php"],
+      "scope": [
+        "keyword.operator.heredoc.php",
+        "keyword.operator.nowdoc.php"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.834880 0.207921 0.387456)"
       }
@@ -1207,7 +1259,10 @@
       }
     },
     {
-      "scope": ["meta.arguments.coffee", "variable.parameter.function.coffee"],
+      "scope": [
+        "meta.arguments.coffee",
+        "variable.parameter.function.coffee"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.846123 0.351499 0.208754)"
       }
@@ -1256,13 +1311,19 @@
       }
     },
     {
-      "scope": ["text.variable", "text.bracketed"],
+      "scope": [
+        "text.variable",
+        "text.bracketed"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.846123 0.351499 0.208754)"
       }
     },
     {
-      "scope": ["support.type.swift", "support.type.vb.asp"],
+      "scope": [
+        "support.type.swift",
+        "support.type.vb.asp"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.870477 0.613222 0.203432)"
       }
@@ -1292,7 +1353,10 @@
       }
     },
     {
-      "scope": ["function.parameter.ruby", "function.parameter.cs"],
+      "scope": [
+        "function.parameter.ruby",
+        "function.parameter.cs"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.388235 0.388235 0.388235)"
       }
@@ -1596,7 +1660,10 @@
       }
     },
     {
-      "scope": ["markup.bold", "todo.bold"],
+      "scope": [
+        "markup.bold",
+        "todo.bold"
+      ],
       "settings": {
         "foreground": "color(display-p3 0.883654 0.721037 0.210874)"
       }

--- a/packages/theme/themes/pierre-light.json
+++ b/packages/theme/themes/pierre-light.json
@@ -123,7 +123,10 @@
   },
   "tokenColors": [
     {
-      "scope": ["comment", "punctuation.definition.comment"],
+      "scope": [
+        "comment",
+        "punctuation.definition.comment"
+      ],
       "settings": {
         "foreground": "#737373"
       }
@@ -135,7 +138,10 @@
       }
     },
     {
-      "scope": ["string", "constant.other.symbol"],
+      "scope": [
+        "string",
+        "constant.other.symbol"
+      ],
       "settings": {
         "foreground": "#199f43"
       }
@@ -150,7 +156,10 @@
       }
     },
     {
-      "scope": ["constant.numeric", "constant.language.boolean"],
+      "scope": [
+        "constant.numeric",
+        "constant.language.boolean"
+      ],
       "settings": {
         "foreground": "#1ca1c7"
       }
@@ -192,7 +201,11 @@
       }
     },
     {
-      "scope": ["storage", "storage.type", "storage.modifier"],
+      "scope": [
+        "storage",
+        "storage.type",
+        "storage.modifier"
+      ],
       "settings": {
         "foreground": "#d32a61"
       }
@@ -225,7 +238,11 @@
       }
     },
     {
-      "scope": ["variable", "identifier", "meta.definition.variable"],
+      "scope": [
+        "variable",
+        "identifier",
+        "meta.definition.variable"
+      ],
       "settings": {
         "foreground": "#d47628"
       }
@@ -321,7 +338,10 @@
       }
     },
     {
-      "scope": ["support.class", "entity.name.type.class"],
+      "scope": [
+        "support.class",
+        "entity.name.type.class"
+      ],
       "settings": {
         "foreground": "#a631be"
       }
@@ -479,13 +499,21 @@
       }
     },
     {
-      "scope": ["punctuation.definition.block", "punctuation.definition.tag"],
+      "scope": [
+        "punctuation.definition.block",
+        "punctuation.definition.tag"
+      ],
       "settings": {
         "foreground": "#636363"
       }
     },
     {
-      "scope": ["meta.tag.tsx", "meta.tag.jsx", "meta.tag.js", "meta.tag.ts"],
+      "scope": [
+        "meta.tag.tsx",
+        "meta.tag.jsx",
+        "meta.tag.js",
+        "meta.tag.ts"
+      ],
       "settings": {
         "foreground": "#636363"
       }
@@ -543,7 +571,10 @@
       }
     },
     {
-      "scope": ["support.variable.dom", "support.variable.property.dom"],
+      "scope": [
+        "support.variable.dom",
+        "support.variable.property.dom"
+      ],
       "settings": {
         "foreground": "#d47628"
       }
@@ -567,7 +598,10 @@
       }
     },
     {
-      "scope": ["keyword.other.template.begin", "keyword.other.template.end"],
+      "scope": [
+        "keyword.other.template.begin",
+        "keyword.other.template.end"
+      ],
       "settings": {
         "foreground": "#199f43"
       }
@@ -647,7 +681,10 @@
       }
     },
     {
-      "scope": ["meta.decorator", "meta.decorator punctuation.decorator"],
+      "scope": [
+        "meta.decorator",
+        "meta.decorator punctuation.decorator"
+      ],
       "settings": {
         "foreground": "#1a85d4"
       }
@@ -781,7 +818,10 @@
       }
     },
     {
-      "scope": ["meta.function.c", "meta.function.cpp"],
+      "scope": [
+        "meta.function.c",
+        "meta.function.cpp"
+      ],
       "settings": {
         "foreground": "#d5512f"
       }
@@ -829,7 +869,10 @@
       }
     },
     {
-      "scope": ["punctuation.separator.c", "punctuation.separator.cpp"],
+      "scope": [
+        "punctuation.separator.c",
+        "punctuation.separator.cpp"
+      ],
       "settings": {
         "foreground": "#d32a61"
       }
@@ -844,7 +887,10 @@
       }
     },
     {
-      "scope": ["keyword.operator.sizeof.c", "keyword.operator.sizeof.cpp"],
+      "scope": [
+        "keyword.operator.sizeof.c",
+        "keyword.operator.sizeof.cpp"
+      ],
       "settings": {
         "foreground": "#d32a61"
       }
@@ -1070,7 +1116,10 @@
       }
     },
     {
-      "scope": ["entity.name.goto-label.php", "support.other.php"],
+      "scope": [
+        "entity.name.goto-label.php",
+        "support.other.php"
+      ],
       "settings": {
         "foreground": "#693acf"
       }
@@ -1098,7 +1147,10 @@
       }
     },
     {
-      "scope": ["keyword.operator.heredoc.php", "keyword.operator.nowdoc.php"],
+      "scope": [
+        "keyword.operator.heredoc.php",
+        "keyword.operator.nowdoc.php"
+      ],
       "settings": {
         "foreground": "#d32a61"
       }
@@ -1207,7 +1259,10 @@
       }
     },
     {
-      "scope": ["meta.arguments.coffee", "variable.parameter.function.coffee"],
+      "scope": [
+        "meta.arguments.coffee",
+        "variable.parameter.function.coffee"
+      ],
       "settings": {
         "foreground": "#d5512f"
       }
@@ -1256,13 +1311,19 @@
       }
     },
     {
-      "scope": ["text.variable", "text.bracketed"],
+      "scope": [
+        "text.variable",
+        "text.bracketed"
+      ],
       "settings": {
         "foreground": "#d5512f"
       }
     },
     {
-      "scope": ["support.type.swift", "support.type.vb.asp"],
+      "scope": [
+        "support.type.swift",
+        "support.type.vb.asp"
+      ],
       "settings": {
         "foreground": "#d5901c"
       }
@@ -1292,7 +1353,10 @@
       }
     },
     {
-      "scope": ["function.parameter.ruby", "function.parameter.cs"],
+      "scope": [
+        "function.parameter.ruby",
+        "function.parameter.cs"
+      ],
       "settings": {
         "foreground": "#636363"
       }
@@ -1596,7 +1660,10 @@
       }
     },
     {
-      "scope": ["markup.bold", "todo.bold"],
+      "scope": [
+        "markup.bold",
+        "todo.bold"
+      ],
       "settings": {
         "foreground": "#d5a910"
       }


### PR DESCRIPTION
Running the theme build rewrote every generated themes/*.json file into its raw JSON.stringify layout, so the working tree showed a diff on each build until oxfmt reformatted the files.

Add the generated theme paths to the oxfmt ignore list and store the files exactly as the build writes them, with a trailing newline the build now appends itself.