### PR TITLE
fix(diffs): normalize pasted text to the document line ending

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -1144,10 +1144,16 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         }
         e.preventDefault();
         const text = e.clipboardData?.getData('text');
-        if (text !== undefined) {
+        const textDocument = this.#textDocument;
+        if (text !== undefined && textDocument !== undefined) {
+          // Rewrite clipboard line breaks to the document's EOL so a Windows
+          // clipboard (\r\n or \r) doesn't leave mixed line endings behind.
           // TODO(@ije): Add support of multiple selections copy&paste
-          // TODO(@ije): normalize the pasted text with textDocument.EOF
-          this.#replaceSelectionText(text, undefined, true);
+          this.#replaceSelectionText(
+            textDocument.normalizeEol(text),
+            undefined,
+            true
+          );
         }
       }),
 

--- a/packages/diffs/src/editor/selection.ts
+++ b/packages/diffs/src/editor/selection.ts
@@ -8,6 +8,7 @@ import type {
   TextDocumentChange,
   TextEdit,
 } from './textDocument';
+import { endsWithLineBreak } from './utils';
 
 export const DirectionBackward = -1;
 export const DirectionNone = 0;
@@ -1419,22 +1420,6 @@ function resolveClipboardRegions(
     });
 }
 
-function endsWithLineBreak(text: string): boolean {
-  return text.endsWith('\n') || text.endsWith('\r');
-}
-
-// Detects the document's line ending so separators synthesized between
-// non-contiguous clipboard regions match the rest of the file.
-function detectEol(textDocument: TextDocument<unknown>): string {
-  if (
-    textDocument.lineCount > 1 &&
-    textDocument.getLineText(0, true).endsWith('\r\n')
-  ) {
-    return '\r\n';
-  }
-  return '\n';
-}
-
 /**
  * Get the clipboard text of the selections for the given text document. Used by
  * both copy and cut so the two stay in sync. Overlapping regions (e.g. several
@@ -1447,7 +1432,7 @@ export function getSelectionText(
   selections: EditorSelection[]
 ): string {
   const regions = resolveClipboardRegions(textDocument, selections);
-  const eol = detectEol(textDocument);
+  const eol = textDocument.eol;
   let result = '';
   let prevEnd = -1;
   for (const region of regions) {

--- a/packages/diffs/src/editor/selection.ts
+++ b/packages/diffs/src/editor/selection.ts
@@ -1877,7 +1877,7 @@ function expandSingleNewlineInsert(
   insertText: string,
   insertStartOffset: number
 ): string {
-  if (insertText !== '\n' && insertText !== '\r\n') {
+  if (insertText !== '\n' && insertText !== '\r' && insertText !== '\r\n') {
     return insertText;
   }
   const line = textDocument.positionAt(insertStartOffset).line;

--- a/packages/diffs/src/editor/textDocument.ts
+++ b/packages/diffs/src/editor/textDocument.ts
@@ -153,6 +153,24 @@ export class TextDocument<LAnnotation> {
     return this.#pieceTable.lineCount;
   }
 
+  // The line ending the document uses, detected from its first line. Lets
+  // inserted or pasted text match the rest of the file instead of leaving
+  // mixed endings behind. Recognizes Windows `\r\n` and classic-Mac lone `\r`
+  // breaks (both of which the piece table already splits on), defaulting to
+  // Unix `\n`.
+  get eol(): string {
+    if (this.lineCount > 1) {
+      const firstLineBreak = this.getLineText(0, true);
+      if (firstLineBreak.endsWith('\r\n')) {
+        return '\r\n';
+      }
+      if (firstLineBreak.endsWith('\r')) {
+        return '\r';
+      }
+    }
+    return '\n';
+  }
+
   get canUndo(): boolean {
     return this.#editStack.canUndo;
   }
@@ -191,6 +209,13 @@ export class TextDocument<LAnnotation> {
 
   getLineText(line: number, includeLineBreak?: boolean): string {
     return this.#pieceTable.getLineText(line, includeLineBreak);
+  }
+
+  // Rewrites every line break in `text` to the document's EOL. Clipboard text
+  // can carry Windows (`\r\n`) or classic-Mac (`\r`) breaks; inserting it
+  // verbatim would leave mixed line endings in a file that uses one style.
+  normalizeEol(text: string): string {
+    return text.replace(/\r\n|\r|\n/g, this.eol);
   }
 
   getLineLength(line: number, includeLineBreak?: boolean): number {

--- a/packages/diffs/src/editor/utils.ts
+++ b/packages/diffs/src/editor/utils.ts
@@ -116,3 +116,7 @@ export function debounce<T extends (...args: any[]) => void>(
 export function round(value: number, precision: number = 1000): number {
   return Math.round(value * precision) / precision;
 }
+
+export function endsWithLineBreak(text: string): boolean {
+  return text.endsWith('\n') || text.endsWith('\r');
+}

--- a/packages/diffs/test/editorClipboard.test.ts
+++ b/packages/diffs/test/editorClipboard.test.ts
@@ -201,6 +201,24 @@ function dispatchCopy(
   return writes;
 }
 
+function dispatchPaste(target: HTMLElement, text: string): void {
+  const event = new window.Event('paste', {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+  });
+  Object.defineProperty(event, 'clipboardData', {
+    value: {
+      getData(_type: string) {
+        return text;
+      },
+    },
+  });
+
+  target.dispatchEvent(event);
+  expect(event.defaultPrevented).toBe(true);
+}
+
 describe('Editor clipboard events', () => {
   test('cuts the current line when the primary selection is collapsed', () => {
     const { cleanup } = installDom();
@@ -471,6 +489,131 @@ describe('Editor clipboard events', () => {
       const writes = dispatchCopy(component.contentElement);
 
       expect(writes).toEqual([['text', 'charlie']]);
+    } finally {
+      editor.cleanUp();
+      cleanup();
+    }
+  });
+
+  test('rewrites Windows clipboard line breaks to the document EOL on paste', () => {
+    const { cleanup } = installDom();
+
+    const editor = new Editor<undefined>();
+    const component = new TestEditableComponent({
+      name: 'example.txt',
+      contents: 'alpha\nbravo\ncharlie',
+      lang: 'text',
+    });
+
+    try {
+      editor.edit(component);
+      editor.setSelections([
+        {
+          start: { line: 2, character: 7 },
+          end: { line: 2, character: 7 },
+          direction: 'none',
+        },
+      ]);
+
+      dispatchPaste(component.contentElement, 'X\r\nY');
+
+      // The clipboard \r\n is rewritten to the document's \n, so no stray
+      // carriage return survives in the file.
+      expect(editor.getState().file.contents).toBe('alpha\nbravo\ncharlieX\nY');
+      expect(editor.getState().file.contents).not.toContain('\r');
+    } finally {
+      editor.cleanUp();
+      cleanup();
+    }
+  });
+
+  test('rewrites lone carriage returns to the document EOL on paste', () => {
+    const { cleanup } = installDom();
+
+    const editor = new Editor<undefined>();
+    const component = new TestEditableComponent({
+      name: 'example.txt',
+      contents: 'alpha\nbravo',
+      lang: 'text',
+    });
+
+    try {
+      editor.edit(component);
+      editor.setSelections([
+        {
+          start: { line: 1, character: 5 },
+          end: { line: 1, character: 5 },
+          direction: 'none',
+        },
+      ]);
+
+      dispatchPaste(component.contentElement, 'X\rY');
+
+      expect(editor.getState().file.contents).toBe('alpha\nbravoX\nY');
+      expect(editor.getState().file.contents).not.toContain('\r');
+    } finally {
+      editor.cleanUp();
+      cleanup();
+    }
+  });
+
+  test('matches the document EOL when the file uses CRLF', () => {
+    const { cleanup } = installDom();
+
+    const editor = new Editor<undefined>();
+    const component = new TestEditableComponent({
+      name: 'example.txt',
+      contents: 'alpha\r\nbravo',
+      lang: 'text',
+    });
+
+    try {
+      editor.edit(component);
+      editor.setSelections([
+        {
+          start: { line: 1, character: 5 },
+          end: { line: 1, character: 5 },
+          direction: 'none',
+        },
+      ]);
+
+      // The clipboard carries Unix \n but the document is CRLF, so the paste
+      // is rewritten to \r\n rather than left as a mismatched \n.
+      dispatchPaste(component.contentElement, 'X\nY');
+
+      expect(editor.getState().file.contents).toBe('alpha\r\nbravoX\r\nY');
+    } finally {
+      editor.cleanUp();
+      cleanup();
+    }
+  });
+
+  test('matches the document EOL when the file uses lone CR', () => {
+    const { cleanup } = installDom();
+
+    const editor = new Editor<undefined>();
+    const component = new TestEditableComponent({
+      name: 'example.txt',
+      contents: 'a\rb',
+      lang: 'text',
+    });
+
+    try {
+      editor.edit(component);
+      editor.setSelections([
+        {
+          start: { line: 1, character: 1 },
+          end: { line: 1, character: 1 },
+          direction: 'none',
+        },
+      ]);
+
+      // Classic-Mac files break lines on a lone \r, so the paste is rewritten
+      // to \r rather than left as a mismatched \n.
+      dispatchPaste(component.contentElement, 'x\ny');
+
+      expect(editor.getState().file.contents).toBe('a\rbx\ry');
+      expect(editor.getState().file.contents).not.toContain('\n');
     } finally {
       editor.cleanUp();
       cleanup();


### PR DESCRIPTION
Paste inserted clipboard text verbatim, so a Windows clipboard (CRLF or CR) left mixed line endings in a file that otherwise uses one style, showing up as spurious diff noise. Rewrite clipboard line breaks to the document's detected EOL before inserting, matching what copy already does.

Expose the line ending as TextDocument.eol with a normalizeEol() helper and move the generic endsWithLineBreak() predicate into editor utils, so this logic no longer sits among the selection helpers.
