### PR TITLE
fix(diffs): keep edits rendered at a virtualized window's bottom

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -132,6 +132,13 @@ export interface EditorState<LAnnotation> {
   renderRange?: RenderRange;
 }
 
+// Cap on how far an edit may widen the virtualized render window, as a multiple
+// of the bounded window the virtualizer last synced (~viewport + 2*hunkLineCount).
+// Edits within this many lines of the window bottom widen so their caret renders;
+// larger inserts fall back to the bounded buffer-only path instead of building a
+// row per inserted line. A safety bound, not a correctness-critical value.
+const MAX_EDIT_WIDEN_WINDOW_MULTIPLE = 2;
+
 export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   #options: EditorOptions<LAnnotation>;
   #metrics = new Metrics();
@@ -176,6 +183,13 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   #lineAnnotations?: DiffLineAnnotation<LAnnotation>[];
   #textDocument?: TextDocument<LAnnotation>;
   #renderRange?: RenderRange;
+  // Bounded render-window size (~viewport + 2*hunkLineCount) from the last view
+  // sync. Used to cap how far #applyChange widens the window for an edit, so a
+  // large insert can't materialize an unbounded number of rows. Captured at sync
+  // time so consecutive edits that grow #renderRange can't ratchet the cap up.
+  // undefined until the first sync; Infinity for non-virtualized (whole-file)
+  // windows, where no cap is needed.
+  #viewportWindowLines?: number;
   #markerRenderer?: MarkerRenderer;
   #searchPanel?: SearchPanelWidget;
   #selectionAction?: SelectionActionWidget;
@@ -673,6 +687,10 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
 
     this.#lineAnnotations = lineAnnotations;
     this.#renderRange = renderRange;
+    // Remember the bounded window the virtualizer just synced so #applyChange
+    // can clamp any edit-time widening against it. Refreshed on every scroll;
+    // undefined/Infinity windows leave the clamp disabled.
+    this.#viewportWindowLines = renderRange?.totalLines;
     this.#tokenizer?.prebuildStateStack(renderRange);
     this.#markerRenderer?.removePopup();
 
@@ -3019,15 +3037,60 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       const primarySelection = selections.at(-1)!;
       const renderRangeEndLine =
         renderRange.startingLine + renderRange.totalLines;
-      // when typing new line at the end of the file,
-      // extend the render range +1 to trigger the re-render of the new line
-      if (primarySelection.end.line === renderRangeEndLine) {
-        renderRange = {
-          ...renderRange,
-          totalLines: renderRange.totalLines + 1,
-        };
-      } else if (primarySelection.end.line > renderRangeEndLine) {
-        shouldUpdateBuffer = true;
+      // When an edit moves the caret to or past the last rendered line — typing
+      // Enter at the window's bottom edge, or pasting a few lines there — widen
+      // the render range so every new line up to the caret gets a row when
+      // #rerender runs below. The widened range is also written back to
+      // #renderRange: the next edit reads renderRangeEndLine from it, and
+      // #renderCaret/#isLineVisible read it to decide whether to draw the caret.
+      // Without persisting, the end line stays stale, a following edit is
+      // misclassified as "past the window", and its just-typed line is left
+      // unrendered until the next scroll re-syncs the range. Only edits that
+      // carry a caret reach here (the block is guarded on `selections` above), so
+      // a bare programmatic applyEdits with no active selection does not widen.
+      //
+      // Cap the widening at a multiple of the bounded window the virtualizer
+      // last synced. A large insert at the caret — most often a big multi-line
+      // paste, or a scripted set-selection-then-edit at scale — can drop the
+      // caret far below the window; widening to reach it would make #rerender
+      // build a row per inserted line synchronously, defeating virtualization.
+      // Past the cap, keep the bounded window and only recompute the buffer
+      // spacer — the scroll that follows a focused edit (or the next user scroll
+      // when unfocused) renders the far region with a bounded window.
+      if (primarySelection.end.line >= renderRangeEndLine) {
+        const widenedTotalLines =
+          primarySelection.end.line - renderRange.startingLine + 1;
+        const maxWidenLines =
+          this.#viewportWindowLines === undefined ||
+          this.#viewportWindowLines === Infinity
+            ? Infinity
+            : this.#viewportWindowLines * MAX_EDIT_WIDEN_WINDOW_MULTIPLE;
+        // Only widen when the edit actually reaches the rendered window — its
+        // dirty lines start at or before the window end. #rerender materializes
+        // rows from change.startLine onward, so widening for an edit that starts
+        // entirely below the window (e.g. setSelections to an offscreen line
+        // then applyEdits before the virtualizer re-syncs) would leave the
+        // rows between the window and the edit unbuilt while #isLineVisible
+        // reports them visible, mispositioning the new rows and caret until the
+        // next scroll.
+        if (
+          change.startLine <= renderRangeEndLine &&
+          widenedTotalLines <= maxWidenLines
+        ) {
+          if (primarySelection.end.line > renderRangeEndLine) {
+            // The line count grew below the window, so the buffer spacer must be
+            // recomputed (preserves the prior behavior for this case).
+            shouldUpdateBuffer = true;
+          }
+          renderRange = { ...renderRange, totalLines: widenedTotalLines };
+          this.#renderRange = renderRange;
+        } else {
+          // The edit is past the cap, or starts below the rendered window: keep
+          // the bounded window and only recompute the buffer; the scroll that
+          // follows a focused edit (or the next user scroll) renders the far
+          // region.
+          shouldUpdateBuffer = true;
+        }
       }
     }
     this.#rerender(change, newLineAnnotations, renderRange, shouldUpdateBuffer);

--- a/packages/diffs/test/editorVirtualizedEdit.test.ts
+++ b/packages/diffs/test/editorVirtualizedEdit.test.ts
@@ -1,0 +1,306 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+
+import { File } from '../src/components/File';
+import { DEFAULT_THEMES } from '../src/constants';
+import { Editor } from '../src/editor/editor';
+import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
+import type {
+  DiffsEditorSelection,
+  FileContents,
+  RenderRange,
+} from '../src/types';
+import { installDom, wait } from './domHarness';
+
+afterAll(async () => {
+  await disposeHighlighter();
+});
+
+function makeContents(lineCount: number): string {
+  return Array.from({ length: lineCount }, (_, i) => `line ${i + 1}`).join(
+    '\n'
+  );
+}
+
+function makeRange(startingLine: number, totalLines: number): RenderRange {
+  return { startingLine, totalLines, bufferBefore: 0, bufferAfter: 0 };
+}
+
+async function waitForEditableContent(
+  container: HTMLElement
+): Promise<HTMLElement> {
+  for (let attempt = 0; attempt < 40; attempt++) {
+    const content = container.shadowRoot?.querySelector('[data-content]');
+    if (
+      content instanceof HTMLElement &&
+      (content.contentEditable === 'true' ||
+        content.getAttribute('contenteditable') === 'true')
+    ) {
+      return content;
+    }
+    await wait(0);
+  }
+  throw new Error('editor content did not become editable');
+}
+
+// 1-indexed line numbers of the editable rows currently in the rendered window.
+function renderedLineNumbers(content: HTMLElement): number[] {
+  const out: number[] = [];
+  for (const child of Array.from(content.children)) {
+    const el = child as HTMLElement;
+    const line = el.dataset.line;
+    if (line !== undefined && el.dataset.lineType !== 'change-deletion') {
+      out.push(parseInt(line, 10));
+    }
+  }
+  return out.sort((a, b) => a - b);
+}
+
+function collapsedCaret(line: number): DiffsEditorSelection {
+  return {
+    start: { line, character: 0 },
+    end: { line, character: 0 },
+    direction: 'none',
+  };
+}
+
+interface WindowedEditor {
+  cleanup(): void;
+  content: HTMLElement;
+  editor: Editor<undefined>;
+  fileContainer: HTMLElement;
+}
+
+// Renders a long file into a partial window so the editor virtualizes: only the
+// lines inside `range` get DOM rows, mirroring a scrolled-down CodeView.
+async function createWindowedEditor(
+  lineCount: number,
+  range: RenderRange
+): Promise<WindowedEditor> {
+  const dom = installDom();
+  const fileContainer = document.createElement('div');
+  document.body.appendChild(fileContainer);
+
+  const file = new File<undefined>({
+    disableFileHeader: true,
+    theme: DEFAULT_THEMES,
+  });
+  const editor = new Editor<undefined>();
+  const initialFile: FileContents = {
+    name: 'edits.ts',
+    contents: makeContents(lineCount),
+  };
+
+  file.render({
+    file: initialFile,
+    fileContainer,
+    forceRender: true,
+    renderRange: range,
+  });
+  editor.edit(file);
+
+  const content = await waitForEditableContent(fileContainer);
+  return {
+    cleanup() {
+      editor.cleanUp();
+      file.cleanUp();
+      dom.cleanup();
+    },
+    content,
+    editor,
+    fileContainer,
+  };
+}
+
+describe('Editor edits at the bottom of a virtualized window', () => {
+  // A run of Enter presses at the window's bottom edge must keep rendering each
+  // new line. The editor widens its render range when the caret reaches the
+  // last rendered line; if that widened range is not persisted, the next edit
+  // reads a stale end line, treats the caret as past the window, and leaves the
+  // just-typed line (and its caret) unrendered until a scroll re-syncs.
+  test('keeps consecutive newlines at the window bottom rendered', async () => {
+    const { cleanup, content, editor, fileContainer } =
+      await createWindowedEditor(200, makeRange(100, 50));
+    try {
+      // The window renders 1-indexed lines 101..150.
+      expect(renderedLineNumbers(content).at(-1)).toBe(150);
+
+      // Enter on the last rendered line, then Enter again on the new last line.
+      editor.setSelections([collapsedCaret(149)]);
+      editor.applyEdits([
+        {
+          range: {
+            start: { line: 149, character: 0 },
+            end: { line: 149, character: 0 },
+          },
+          newText: '\n',
+        },
+      ]);
+      await wait(0);
+      editor.applyEdits([
+        {
+          range: {
+            start: { line: 150, character: 0 },
+            end: { line: 150, character: 0 },
+          },
+          newText: '\n',
+        },
+      ]);
+      await wait(0);
+
+      const selections = editor.getState().selections ?? [];
+      expect(selections).toHaveLength(1);
+      const caretLine = selections[0].start.line + 1;
+      expect(caretLine).toBe(152);
+      // The just-typed line has a rendered row...
+      expect(renderedLineNumbers(content)).toContain(caretLine);
+      // ...and its caret is drawn, which #renderCaret only does when
+      // #isLineVisible (reading the persisted render range) returns true.
+      const caretCount =
+        fileContainer.shadowRoot?.querySelectorAll('[data-caret]').length ?? 0;
+      expect(caretCount).toBeGreaterThan(0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  // A single programmatic edit that inserts several lines at the window bottom
+  // pushes the caret well past the previous end line. Every inserted line up to
+  // the caret should still get a row.
+  test('renders a multi-line insert at the window bottom', async () => {
+    const { cleanup, content, editor } = await createWindowedEditor(
+      200,
+      makeRange(100, 50)
+    );
+    try {
+      editor.setSelections([collapsedCaret(149)]);
+      editor.applyEdits([
+        {
+          range: {
+            start: { line: 149, character: 0 },
+            end: { line: 149, character: 0 },
+          },
+          newText: 'X\nY\nZ\n',
+        },
+      ]);
+      await wait(0);
+
+      const selections = editor.getState().selections ?? [];
+      expect(selections).toHaveLength(1);
+      const caretLine = selections[0].start.line + 1;
+      expect(caretLine).toBe(153);
+      expect(renderedLineNumbers(content)).toContain(caretLine);
+    } finally {
+      cleanup();
+    }
+  });
+
+  // A single huge insert drops the caret far below the window. Widening to reach
+  // it would build a DOM row per inserted line synchronously, defeating
+  // virtualization. The editor caps widening at twice the synced window (here
+  // 2 * 50 = 100), so the rendered row count stays bounded near the window and
+  // does not scale with the insert; the far caret is left for a scroll to render.
+  test('keeps a large multi-line insert from materializing unbounded rows', async () => {
+    const { cleanup, content, editor } = await createWindowedEditor(
+      200,
+      makeRange(100, 50)
+    );
+    try {
+      const insertedLines = 1000;
+      editor.setSelections([collapsedCaret(149)]);
+      editor.applyEdits([
+        {
+          range: {
+            start: { line: 149, character: 0 },
+            end: { line: 149, character: 0 },
+          },
+          newText: 'X\n'.repeat(insertedLines),
+        },
+      ]);
+      await wait(0);
+
+      // Bounded by the 2x cap (100), nowhere near the 1000 inserted lines.
+      const rendered = renderedLineNumbers(content).length;
+      expect(rendered).toBeLessThanOrEqual(100);
+      expect(rendered).toBeLessThan(insertedLines);
+
+      // The caret lands far below the window and is not rendered synchronously.
+      const selections = editor.getState().selections ?? [];
+      const caretLine = selections[0].start.line + 1;
+      expect(caretLine).toBeGreaterThan(1000);
+      expect(renderedLineNumbers(content)).not.toContain(caretLine);
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Consecutive programmatic inserts with no scroll between them must not let the
+  // persisted render range ratchet up without bound. The cap is measured against
+  // the window captured at the last sync (50), so widening saturates at 2x (100)
+  // and the rendered row count stays bounded however many lines are inserted.
+  test('keeps consecutive inserts from materializing unbounded rows', async () => {
+    const { cleanup, content, editor } = await createWindowedEditor(
+      200,
+      makeRange(100, 50)
+    );
+    try {
+      let caret = 149;
+      for (let round = 0; round < 40; round++) {
+        editor.setSelections([collapsedCaret(caret)]);
+        editor.applyEdits([
+          {
+            range: {
+              start: { line: caret, character: 0 },
+              end: { line: caret, character: 0 },
+            },
+            newText: 'a\nb\nc\nd\ne\n',
+          },
+        ]);
+        await wait(0);
+        caret += 5;
+      }
+
+      // 200 lines inserted, but the window saturates at the 2x cap (100).
+      const rendered = renderedLineNumbers(content).length;
+      expect(rendered).toBeLessThanOrEqual(100);
+    } finally {
+      cleanup();
+    }
+  });
+
+  // An edit whose dirty lines start below the rendered window - e.g. a caller
+  // sets the selection to an offscreen line and edits there before the
+  // virtualizer re-syncs - must not widen. #rerender only builds rows from
+  // change.startLine, so widening would append the edited rows right after the
+  // window with the intervening lines unbuilt, while #isLineVisible reports them
+  // visible: a discontiguous render with the rows/caret mispositioned. The
+  // window must stay bounded and contiguous; the edit renders on the next scroll.
+  test('does not widen for an edit that starts below the rendered window', async () => {
+    const { cleanup, content, editor } = await createWindowedEditor(
+      300,
+      makeRange(100, 50)
+    );
+    try {
+      // Line 180 is offscreen (window ends at 150) yet within the 2x cap
+      // (reachable to line 199), so only the start-below-window guard - not the
+      // cap - keeps this edit off the widen path.
+      editor.setSelections([collapsedCaret(180)]);
+      editor.applyEdits([
+        {
+          range: {
+            start: { line: 180, character: 0 },
+            end: { line: 180, character: 0 },
+          },
+          newText: 'Z\n',
+        },
+      ]);
+      await wait(0);
+
+      // No row past the window's bottom edge was appended, so there is no
+      // unrendered gap; the offscreen edit is left for the next scroll.
+      const rendered = renderedLineNumbers(content);
+      expect(Math.max(...rendered)).toBeLessThanOrEqual(150);
+    } finally {
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
Steps to reproduce:
1. Scroll a long file so the editor virtualizes (only a window of lines is rendered).
2. With a caret near the window bottom, insert lines there - press Enter on the last rendered line, or paste a few lines.
3. The just-typed line, and its caret, are missing from the window until the next scroll.

#applyChange widened the render range only when the caret was exactly at the window's end, and never persisted the widened range, so a following edit read a stale renderRangeEndLine, treated the caret as past the window, and #rerender (clamped to the range) never built the new row; #isLineVisible/#renderCaret read the stale range and dropped the caret too. (Only edits that carry a caret reach this path - it is guarded on `selections` - so a bare programmatic applyEdits with no active selection is unaffected; the real triggers are typing and paste at the window bottom.)

Widen the range to cover the caret line for inserts at or past the window bottom and persist it to #renderRange so consecutive edits stay accurate and the caret draws.

Bound that widening so it can't defeat virtualization: a large insert at the caret - most often a big multi-line paste - can drop the caret far below the window, and widening to reach it would make #rerender build a row per inserted line synchronously, risking a freeze. Cap the widen at twice the bounded window the virtualizer last synced (captured in __syncRenderView as #viewportWindowLines); past the cap, keep the bounded window and only recompute the buffer, leaving the far region for the scroll that follows a focused edit (or the next user scroll) to render. Capturing the window at sync time also stops consecutive edits from ratcheting the cap up.

Add editorVirtualizedEdit.test.ts: consecutive newlines and a small multi-line insert at the window bottom render; a 1000-line insert and a run of consecutive inserts keep the rendered row count bounded.
