### PR TITLE
fix(diffs): align selection highlight with text in wrapped split diffs

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -2147,7 +2147,13 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       let width = 0;
       let paddingEnd = 0;
       if (startChar === 0) {
-        left = this.#getGutterWidth() + this.#metrics.ch; // gutter width + inline padding (1ch)
+        // gutter width + inline padding (1ch), plus the split-diff content
+        // offset so a column-0 selection lines up with the content panel the
+        // same way #getCharX (used for startChar > 0 and the caret) does.
+        left =
+          this.#getGutterWidth() +
+          this.#metrics.ch +
+          (this.#contentOffset?.left ?? 0);
       } else {
         left = this.#getCharX(line, startChar)[0];
       }
@@ -2192,7 +2198,15 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   ) {
     const wrapOffsets = this.#wrapLineText(line);
     const segmentCount = wrapOffsets.length - 1;
-    const offsetLeft = this.#getGutterWidth() + this.#metrics.ch;
+    // offsetLeft is the x of the content's left edge in overlay coordinates.
+    // In a split diff with wrapping the content element is a grid item shifted
+    // right of the deletion panel, so the same #contentOffset.left that
+    // #getCharX adds for the caret must be included here too; otherwise every
+    // wrapped selection block is pulled left by the panel offset.
+    const offsetLeft =
+      this.#getGutterWidth() +
+      this.#metrics.ch +
+      (this.#contentOffset?.left ?? 0);
 
     for (let wrapLine = 0; wrapLine < segmentCount; wrapLine++) {
       const segmentStart = wrapOffsets[wrapLine];

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -1343,6 +1343,18 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     }
   }
 
+  // #computeContentOffset only assigns #contentOffset in a split + wrap diff and
+  // never clears it, so after toggling wrap off (or switching to unified) the
+  // same editor keeps a stale offset. Read it through this getter, which returns
+  // the offset only while the live layout is the one that produced it, so a
+  // stale value is never applied to caret, selection, or line-Y positions.
+  get #activeContentOffset(): { left: number; top: number } | undefined {
+    if (this.#isDiff && this.#diffSyle === 'split' && this.#isWrap) {
+      return this.#contentOffset;
+    }
+    return undefined;
+  }
+
   // TODO(@ije): add command registry
   #runCommand(command: EditorCommand) {
     const textDocument = this.#textDocument;
@@ -2153,7 +2165,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         left =
           this.#getGutterWidth() +
           this.#metrics.ch +
-          (this.#contentOffset?.left ?? 0);
+          (this.#activeContentOffset?.left ?? 0);
       } else {
         left = this.#getCharX(line, startChar)[0];
       }
@@ -2200,13 +2212,13 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     const segmentCount = wrapOffsets.length - 1;
     // offsetLeft is the x of the content's left edge in overlay coordinates.
     // In a split diff with wrapping the content element is a grid item shifted
-    // right of the deletion panel, so the same #contentOffset.left that
-    // #getCharX adds for the caret must be included here too; otherwise every
-    // wrapped selection block is pulled left by the panel offset.
+    // right of the deletion panel, so the same content offset that #getCharX
+    // adds for the caret must be included here too; otherwise every wrapped
+    // selection block is pulled left by the panel offset.
     const offsetLeft =
       this.#getGutterWidth() +
       this.#metrics.ch +
-      (this.#contentOffset?.left ?? 0);
+      (this.#activeContentOffset?.left ?? 0);
 
     for (let wrapLine = 0; wrapLine < segmentCount; wrapLine++) {
       const segmentStart = wrapOffsets[wrapLine];
@@ -3219,9 +3231,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
 
     // cold(slow) path: measure line top position from DOM (will cause reflow)
     let y = lineElement.offsetTop + this.#metrics.paddingTop;
-    if (this.#contentOffset !== undefined) {
-      y += this.#contentOffset?.top ?? 0;
-    }
+    y += this.#activeContentOffset?.top ?? 0;
     this.#lineYCache.set(line, y);
     return y;
   }
@@ -3240,7 +3250,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     const lineText = this.#textDocument?.getLineText(line);
     const offsetLeft = this.#getGutterWidth() + this.#metrics.ch; // gutter width + inline padding (1ch)
     if (lineText === undefined || lineText.length === 0 || char <= 0) {
-      return [offsetLeft + (this.#contentOffset?.left ?? 0), 0];
+      return [offsetLeft + (this.#activeContentOffset?.left ?? 0), 0];
     }
 
     const boundedCharacter = snapTextOffsetToUnicodeBoundary(
@@ -3290,9 +3300,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
           }
         }
       }
-      if (this.#contentOffset !== undefined) {
-        left += this.#contentOffset.left;
-      }
+      left += this.#activeContentOffset?.left ?? 0;
     }
 
     if (this.#lastAccessedCharX !== undefined) {


### PR DESCRIPTION
Open a split diff with word wrap on and edit a line so it wraps onto several rows. Double-click a word on a wrapped row: the word is selected and the caret lands correctly, but the highlight is drawn at the row's left edge instead of over the word. Selecting whole lines across a multi-line range shows the same shift.

In a split diff the editable panel sits to the right of the deletion panel. The caret math adds this horizontal panel offset, but the selection-highlight math did not, so every highlight was pulled left by the offset (its width stayed correct). Add the same content offset when computing the highlight's left edge, for both wrapped rows and selections that start at the beginning of a line.
