### PR TITLE
fix(diffs): keep editor edits visible across host re-renders

### DIFF
--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -1046,6 +1046,25 @@ export class FileDiff<
     }
   }
 
+  // Re-render the diff from the editor's document after a host-driven full
+  // re-render rebuilt the rows from the host's (now stale) file contents.
+  // applyDocumentChange re-derives the diff (addition lines + hunks) from the
+  // document, but the cached highlighted AST still holds the host's content for
+  // rows that already existed, and renderDiff reuses it. Clearing the render
+  // cache forces the re-render to re-highlight from the document, so every row
+  // matches it - text, syntax colors, and line count - in one pass. Mutating
+  // the diff in place keeps its cacheKey, so the editor's document and undo
+  // history survive the re-render.
+  public rerenderFromDocument(textDocument: DiffsTextDocument): void {
+    this.hunksRenderer.applyDocumentChange(textDocument);
+    const renderDiff = this.hunksRenderer.getRenderDiff();
+    if (renderDiff != null) {
+      this.fileDiff = renderDiff;
+    }
+    this.hunksRenderer.clearRenderCache();
+    this.rerender();
+  }
+
   public updateRenderCache(
     dirtyLines: Map<number, Array<HighlightedToken>>,
     themeType: 'dark' | 'light',

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -591,13 +591,17 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       }
     }
 
-    if (
+    // Whether this sync replaces the document with a freshly parsed one (a new
+    // file, language, or cache key) versus reusing the existing one. A reused
+    // document keeps any edits the host's file contents do not have, which the
+    // rebuilt line DOM below must be reconciled against.
+    const documentReplaced =
       this.#textDocument === undefined ||
       this.#fileInfo === undefined ||
       this.#fileInfo.name !== fileOrDiff.name ||
       this.#fileInfo.lang !== fileOrDiff.lang ||
-      this.#fileInfo.cacheKey !== fileOrDiff.cacheKey
-    ) {
+      this.#fileInfo.cacheKey !== fileOrDiff.cacheKey;
+    if (documentReplaced) {
       let contents = '';
       if ('contents' in fileOrDiff) {
         contents = fileOrDiff.contents;
@@ -638,7 +642,16 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       }
     }
 
+    // A full re-render swaps in a new content element, so comparing identity
+    // detects one. This is reliable for FileDiff, which rebuilds the column
+    // (a new node) on a full render and reuses it on a partial one (scrolling).
+    // File reuses its content element in place, so this would not fire for a
+    // File full render - but File has no rerenderFromDocument path, so the
+    // re-render gate below never applies to it. If File ever gains one, this
+    // detection must be revisited.
+    let fullRerender = false;
     if (this.#contentElement !== contentEl) {
+      fullRerender = true;
       this.#gutterElement = gutterEl;
       this.#contentElement = extend(contentEl, {
         contentEditable: 'true',
@@ -701,6 +714,38 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     // undefined/Infinity windows leave the clamp disabled.
     this.#viewportWindowLines = renderRange?.totalLines;
     this.#tokenizer?.prebuildStateStack(renderRange);
+
+    // A host-driven full re-render (theme, diff style, wrap, or line-number
+    // toggle) rebuilds the diff rows from the file contents the host passes in.
+    // When the editor's document survived that re-render it stays the source of
+    // truth and may hold edits the host's contents do not, so the rebuilt rows
+    // show the pre-edit content. Re-render the diff from the editor's document
+    // instead, so the rows match it - text, syntax colors, and line count - in
+    // one pass, rather than reconciling the rebuilt rows after the fact.
+    //
+    // Gated three ways:
+    // - documentReplaced: a new file/lang/cacheKey already rebuilt the document
+    //   from the host's contents, so there is nothing to restore.
+    // - contentRebuilt: a partial render (scrolling a virtualized file) reuses
+    //   the existing edited rows, so it needs no re-render.
+    // - divergence: when the rebuilt content already matches the document there
+    //   is nothing to do. This also stops the recursion, since the re-render
+    //   below comes back through here with content that now matches.
+    // Only components with a document-backed re-render (FileDiff) implement
+    // rerenderFromDocument; the plain File has no such path yet and is skipped.
+    const fileInstance = this.#fileInstance;
+    const textDocument = this.#textDocument;
+    if (
+      !documentReplaced &&
+      fullRerender &&
+      fileInstance?.rerenderFromDocument !== undefined &&
+      textDocument !== undefined &&
+      this.#shouldRenderDivergeFromDocument(textDocument)
+    ) {
+      fileInstance.rerenderFromDocument(textDocument);
+      return;
+    }
+
     this.#markerRenderer?.removePopup();
 
     // re-render the existing selections, matches, and markers
@@ -752,7 +797,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         'RenderRange:',
         startingLine + '-' + (startingLine + totalLines),
         'of',
-        this.#textDocument.lineCount,
+        this.#textDocument?.lineCount,
         'lines'
       );
     }
@@ -1830,6 +1875,42 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         `tokenize in: ${round(t2 - t)}ms (${dirtyLines.size} dirty lines)`
       );
     }
+  }
+
+  // Whether the rendered editable rows no longer match the editor's document -
+  // a row's text drifted, a row's line number is past the document (a stale row
+  // left after a deletion), or a row that should exist is missing/shifted (an
+  // insertion shows the following line's text). Reads the DOM rather than the
+  // diff metadata so it catches rows whose cached highlight is stale even after
+  // the underlying text was updated, and it only inspects the rendered rows so
+  // it stays correct under virtualization.
+  #shouldRenderDivergeFromDocument(
+    textDocument: TextDocument<LAnnotation>
+  ): boolean {
+    const contentEl = this.#contentElement;
+    if (contentEl === undefined) {
+      return false;
+    }
+    for (const child of contentEl.children) {
+      const el = child as HTMLElement;
+      const lineType = el.dataset.lineType;
+      const lineNumber = getLineNumberAttr(el);
+      if (
+        lineNumber === undefined ||
+        lineType === undefined ||
+        !isLineEditable(lineType)
+      ) {
+        continue;
+      }
+      const lineIndex = lineNumber - 1;
+      if (
+        lineIndex >= textDocument.lineCount ||
+        el.textContent !== textDocument.getLineText(lineIndex)
+      ) {
+        return true;
+      }
+    }
+    return false;
   }
 
   // input type doc: https://developer.mozilla.org/en-US/docs/Web/API/InputEvent/inputType

--- a/packages/diffs/src/types.ts
+++ b/packages/diffs/src/types.ts
@@ -945,6 +945,13 @@ export interface DiffsEditableComponent<
     // recompute here (token/line content updates still apply).
     skipDiffRecompute?: boolean
   ) => void;
+  // Re-render the component from the editor's document, discarding the cached
+  // (host-derived) rendered content. The editor calls this after a host-driven
+  // full re-render rebuilt the rows from the host's stale file contents, so the
+  // visible rows match the document - text, syntax colors, and line count - in
+  // one pass. Optional: components without a document-backed re-render (the
+  // plain File) leave it unset and are skipped.
+  rerenderFromDocument?: (textDocument: DiffsTextDocument) => void;
 }
 
 export interface DiffsEditor<LAnnotation> {

--- a/packages/diffs/test/editorDisplayOptionResync.test.ts
+++ b/packages/diffs/test/editorDisplayOptionResync.test.ts
@@ -1,0 +1,336 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+
+import { FileDiff } from '../src/components/FileDiff';
+import { DEFAULT_THEMES } from '../src/constants';
+import { Editor } from '../src/editor/editor';
+import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
+import type { FileContents } from '../src/types';
+import { parseDiffFromFile } from '../src/utils/parseDiffFromFile';
+import { installDom, wait } from './domHarness';
+
+afterAll(async () => {
+  await disposeHighlighter();
+});
+
+// The editor attaches to the additions (new-file) side of a diff. That column
+// is the `[data-code]` element without `data-deletions`; its editable lines
+// live in the child marked `data-content`.
+function findAdditionContent(container: HTMLElement): HTMLElement | undefined {
+  const shadow = container.shadowRoot;
+  if (shadow == null) {
+    return undefined;
+  }
+  for (const code of shadow.querySelectorAll<HTMLElement>('[data-code]')) {
+    if (code.dataset.deletions !== undefined) {
+      continue;
+    }
+    for (const child of code.children) {
+      const el = child as HTMLElement;
+      if (el.dataset.content !== undefined) {
+        return el;
+      }
+    }
+  }
+  return undefined;
+}
+
+// Reads the on-screen text of a 1-based line on the additions side.
+function lineText(
+  container: HTMLElement,
+  lineNumber: number
+): string | undefined {
+  const content = findAdditionContent(container);
+  const line = content?.querySelector(`[data-line="${lineNumber}"]`);
+  return line == null ? undefined : (line.textContent ?? undefined);
+}
+
+// Counts the syntax-highlight token spans on a 1-based line. A line of normal
+// code splits into several tokens; the same text inside a block comment renders
+// as a single comment token, so this distinguishes the two highlight states
+// without asserting on exact colors or markup.
+function lineTokenCount(
+  container: HTMLElement,
+  lineNumber: number
+): number | undefined {
+  const content = findAdditionContent(container);
+  const line = content?.querySelector(`[data-line="${lineNumber}"]`);
+  return line == null ? undefined : line.childElementCount;
+}
+
+interface DisplayOptionFixture {
+  container: HTMLElement;
+  editor: Editor<undefined>;
+  // Toggles a display option and forces a re-render, exactly as the React bridge
+  // does on any display-option change: setOptions(newOptions) then a forced
+  // re-render. The bug report's headline trigger is the word-wrap toggle, but
+  // every display option (theme, diff style, line numbers, wrap) shares the same
+  // forced-render path; line numbers is used here because wrap measurement needs
+  // browser layout APIs jsdom lacks.
+  toggleDisplayOption(): Promise<void>;
+  cleanup(): Promise<void>;
+}
+
+async function createFixture(
+  oldContents: string,
+  newContents: string
+): Promise<DisplayOptionFixture> {
+  const dom = installDom();
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  const fileDiff = new FileDiff<undefined>({
+    disableFileHeader: true,
+    theme: DEFAULT_THEMES,
+    diffStyle: 'split',
+  });
+  const editor = new Editor<undefined>();
+  const oldFile: FileContents = { name: 'edit.ts', contents: oldContents };
+  const newFile: FileContents = { name: 'edit.ts', contents: newContents };
+
+  fileDiff.render({
+    oldFile,
+    newFile,
+    fileContainer: container,
+    forceRender: true,
+  });
+  editor.edit(fileDiff);
+
+  for (let attempt = 0; attempt < 40; attempt++) {
+    const content = findAdditionContent(container);
+    if (content != null && content.getAttribute('contenteditable') === 'true') {
+      break;
+    }
+    await wait(0);
+  }
+
+  return {
+    container,
+    editor,
+    async toggleDisplayOption() {
+      fileDiff.setOptions({
+        ...fileDiff.options,
+        disableLineNumbers: !(fileDiff.options.disableLineNumbers ?? false),
+      });
+      fileDiff.render({
+        oldFile,
+        newFile,
+        fileContainer: container,
+        forceRender: true,
+      });
+      // Let syncRenderViewToEditor's highlighter promise resolve.
+      await wait(10);
+    },
+    async cleanup() {
+      await wait(10);
+      editor.cleanUp();
+      fileDiff.cleanUp();
+      dom.cleanup();
+    },
+  };
+}
+
+// Inserts text at a collapsed caret on the additions side.
+function typeAt(
+  editor: Editor<undefined>,
+  line: number,
+  character: number,
+  text: string
+): void {
+  const position = { line, character };
+  editor.setSelections([{ start: position, end: position, direction: 'none' }]);
+  editor.applyEdits(
+    [{ range: { start: position, end: position }, newText: text }],
+    true
+  );
+}
+
+describe('diff editor: display-option toggle mid-edit', () => {
+  test('keeps the edited line text visible when a display option is toggled', async () => {
+    // old/new differ so the additions column (the editor's target) renders; the
+    // edit targets line 0 ("alpha"), an unchanged context line — the "rename a
+    // function" case from the bug report.
+    const fixture = await createFixture('alpha\nbravo\n', 'alpha\nCHANGED\n');
+    const { container, editor } = fixture;
+
+    try {
+      typeAt(editor, 0, 5, 'X');
+      await wait(0);
+      expect(editor.getState().file.contents).toBe('alphaX\nCHANGED\n');
+      // The edit is on screen before the toggle.
+      expect(lineText(container, 1)).toBe('alphaX');
+
+      await fixture.toggleDisplayOption();
+
+      // The edit must still be visible without an extra keystroke.
+      expect(lineText(container, 1)).toBe('alphaX');
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test('accepts further typing after the toggle without duplicating the edit', async () => {
+    const fixture = await createFixture('alpha\nbravo\n', 'alpha\nCHANGED\n');
+    const { container, editor } = fixture;
+
+    try {
+      typeAt(editor, 0, 5, 'X');
+      await wait(0);
+      await fixture.toggleDisplayOption();
+
+      // Typing one more character must append to the edit, not re-introduce it.
+      // Pre-fix the DOM held the pre-edit text while the document held the edit,
+      // so the next keystroke repainted the edit and the new character together.
+      typeAt(editor, 0, 6, 'Y');
+      await wait(0);
+
+      expect(editor.getState().file.contents).toBe('alphaXY\nCHANGED\n');
+      expect(lineText(container, 1)).toBe('alphaXY');
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test('leaves an unedited line untouched when a display option is toggled', async () => {
+    const fixture = await createFixture('alpha\nbravo\n', 'alpha\nCHANGED\n');
+    const { container, editor } = fixture;
+
+    try {
+      // No edit is made: the rebuilt rows already match the document, so the
+      // resync must repaint nothing and leave the original text in place.
+      expect(lineText(container, 1)).toBe('alpha');
+
+      await fixture.toggleDisplayOption();
+
+      expect(lineText(container, 1)).toBe('alpha');
+      expect(editor.getState().file.contents).toBe('alpha\nCHANGED\n');
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test('refreshes downstream highlighting when an edit changes tokenizer state', async () => {
+    // Lines 0 and 1 are unchanged context lines; line 2 is the actual diff.
+    const fixture = await createFixture(
+      'const a = 1;\nconst b = 2;\nOLD\n',
+      'const a = 1;\nconst b = 2;\nNEW\n'
+    );
+    const { container, editor } = fixture;
+
+    try {
+      // As normal code, line 1 highlights into several tokens.
+      expect(lineTokenCount(container, 2)).toBeGreaterThan(1);
+
+      // Open a block comment on line 0. Line 1's text does not change, but it is
+      // now inside the comment, so it collapses to a single comment token.
+      typeAt(editor, 0, 0, '/*');
+      await wait(0);
+      expect(lineText(container, 2)).toBe('const b = 2;');
+      expect(lineTokenCount(container, 2)).toBe(1);
+
+      await fixture.toggleDisplayOption();
+
+      // Line 1's text was never edited, so reconciling text alone would leave
+      // the stale multi-token code highlighting from the rebuilt source. After
+      // re-rendering from the document it stays a single comment token.
+      expect(lineText(container, 2)).toBe('const b = 2;');
+      expect(lineTokenCount(container, 2)).toBe(1);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test('keeps a newly inserted line across the toggle', async () => {
+    const fixture = await createFixture('alpha\nbravo\n', 'alpha\nCHANGED\n');
+    const { container, editor } = fixture;
+
+    try {
+      // A line-count-changing edit: split line 0 into two lines.
+      typeAt(editor, 0, 5, '\nINSERTED');
+      await wait(0);
+      expect(editor.getState().file.contents).toBe(
+        'alpha\nINSERTED\nCHANGED\n'
+      );
+      expect(lineText(container, 1)).toBe('alpha');
+      expect(lineText(container, 2)).toBe('INSERTED');
+
+      await fixture.toggleDisplayOption();
+
+      // Both the edited line and the inserted line must survive the re-render.
+      expect(lineText(container, 1)).toBe('alpha');
+      expect(lineText(container, 2)).toBe('INSERTED');
+      expect(editor.getState().file.contents).toBe(
+        'alpha\nINSERTED\nCHANGED\n'
+      );
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  // Exercises the fileDiff-prop path the React bridge uses: the host holds one
+  // diff object. A line-count edit followed by a forced re-render that re-passes
+  // a fresh diff object resets the rendered rows to the original count, so the
+  // re-render must come from the document - otherwise inserted lines are never
+  // created (and deleted lines never removed).
+  test('keeps an inserted line when the host re-passes a fresh diff object', async () => {
+    const dom = installDom();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const fileDiff = new FileDiff<undefined>({
+      disableFileHeader: true,
+      theme: DEFAULT_THEMES,
+      diffStyle: 'split',
+    });
+    const editor = new Editor<undefined>();
+    const oldContents = 'alpha\nbravo\n';
+    const newContents = 'alpha\nCHANGED\n';
+    const file = { name: 'edit.ts' };
+
+    fileDiff.render({
+      fileDiff: parseDiffFromFile(
+        { ...file, contents: oldContents },
+        { ...file, contents: newContents }
+      ),
+      fileContainer: container,
+      forceRender: true,
+    });
+    editor.edit(fileDiff);
+    for (let attempt = 0; attempt < 40; attempt++) {
+      const content = findAdditionContent(container);
+      if (
+        content != null &&
+        content.getAttribute('contenteditable') === 'true'
+      ) {
+        break;
+      }
+      await wait(0);
+    }
+
+    try {
+      typeAt(editor, 0, 5, '\nINSERTED');
+      await wait(0);
+      expect(lineText(container, 2)).toBe('INSERTED');
+
+      // Forced re-render with a brand-new diff object (as a host that re-derives
+      // its fileDiff each render would pass), which resets the rendered rows.
+      fileDiff.setOptions({ ...fileDiff.options, disableLineNumbers: true });
+      fileDiff.render({
+        fileDiff: parseDiffFromFile(
+          { ...file, contents: oldContents },
+          { ...file, contents: newContents }
+        ),
+        fileContainer: container,
+        forceRender: true,
+      });
+      await wait(10);
+
+      expect(lineText(container, 1)).toBe('alpha');
+      expect(lineText(container, 2)).toBe('INSERTED');
+      expect(lineText(container, 3)).toBe('CHANGED');
+    } finally {
+      await wait(10);
+      editor.cleanUp();
+      fileDiff.cleanUp();
+      dom.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
Steps to reproduce:
1. Open a diff in edit mode and edit a line (e.g. rename a symbol).
2. Toggle any display option - word wrap, theme, diff style, line numbers.
3. The edit vanishes and the line shows its original text again; it only reappears on the next keystroke.

When an editor is attached, its document is the source of truth for the content, but the host passes a static fileDiff. A display-option change forces a full re-render that rebuilds the diff rows from that fileDiff, so the in-progress edits are painted over with the original content - and inserted or deleted lines are lost.

After a full re-render, when the editor's document survived it and the rendered rows no longer match it, re-render the diff from the document: rerenderFromDocument re-derives the diff and clears the render cache so the rebuild re-highlights from the edited contents. One pass restores text, syntax colors, and line count, with no per-row reconciliation. The diff is mutated in place so its cacheKey is kept and the editor's document and undo history survive.

Gated to full re-renders (a scroll's partial render reuses the existing rows) and to components with a document-backed re-render (FileDiff; the plain File has no such path yet). Host-agnostic: this holds whether or not the host sets a cacheKey. Adds a regression test covering the toggle, further typing, an inserted line via both render APIs, and downstream block-comment highlighting - all with no cacheKey.