### PR TITLE
Add additional mts and cts typescript extensions

### DIFF
--- a/packages/diffs/src/utils/getFiletypeFromFileName.ts
+++ b/packages/diffs/src/utils/getFiletypeFromFileName.ts
@@ -314,6 +314,8 @@ export const EXTENSION_TO_FILE_FORMAT: ExtensionFormatMap = {
   tfvars: 'tfvars',
   toml: 'toml',
   ts: 'typescript',
+  mts: 'typescript',
+  cts: 'typescript',
   tsp: 'typespec',
   tsv: 'tsv',
   tsx: 'tsx',


### PR DESCRIPTION
Node supports running typescript natively.

By default (from [nodejs docs](https://nodejs.org/api/typescript.html#determining-module-system)):

- `.ts` files use the package.json type
- `.cts` files run as CommonJS
- `.mts` files run as ES modules