### PR TITLE
fix(diffs): clear `bufferBefore` and `bufferAfter` on reset

### DIFF
--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -316,7 +316,9 @@ export class File<
     }
     this.annotationCache.clear();
     this.pre = undefined;
+    this.bufferBefore?.remove();
     this.bufferBefore = undefined;
+    this.bufferAfter?.remove();
     this.bufferAfter = undefined;
     this.appliedPreAttributes = undefined;
     this.lastRowCount = undefined;

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -518,7 +518,9 @@ export class FileDiff<
     this.codeUnified = undefined;
     this.codeDeletions = undefined;
     this.codeAdditions = undefined;
+    this.bufferBefore?.remove();
     this.bufferBefore = undefined;
+    this.bufferAfter?.remove();
     this.bufferAfter = undefined;
     this.appliedPreAttributes = undefined;
     this.headerElement = undefined;


### PR DESCRIPTION
The patch closes #887

this is not related to the editor, the original diff component has same issue, see [codesandbox](https://codesandbox.io/p/devbox/pierre-virtualization-editor-repro-forked-ft5wd4?workspaceId=ws_6L4d3NJePaAgy3Yb6wgGpp)

**root cause:**

`FileDiff`/`File.cleanUp()` does not remove `[data-virtualizer-buffer]` nodes when React manages the container, so StrictMode’s element reuse leaves stale spacers behind.

