### PR TITLE
feat(diffs): align editor selection across additions and deletions

### DIFF
--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -491,9 +491,11 @@ export class File<
   public attachEditor(editor: DiffsEditor<LAnnotation>): () => void {
     this.editor?.cleanUp();
     this.editor = editor;
+    this.interactionManager.setEditorAttached(true);
     this.syncRenderViewToEditor();
     return () => {
       this.editor = undefined;
+      this.interactionManager.setEditorAttached(false);
     };
   }
 

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -1017,9 +1017,11 @@ export class FileDiff<
   public attachEditor(editor: DiffsEditor<LAnnotation>): () => void {
     this.editor?.cleanUp();
     this.editor = editor;
+    this.interactionManager.setEditorAttached(true);
     this.syncRenderViewToEditor();
     return () => {
       this.editor = undefined;
+      this.interactionManager.setEditorAttached(false);
     };
   }
 

--- a/packages/diffs/src/editor/editor.css
+++ b/packages/diffs/src/editor/editor.css
@@ -2,6 +2,20 @@
   background-color: transparent;
 }
 
+/* Read-only deletion text sits outside the editor's selection overlay, so the
+   global transparent ::selection above hides its selection by default. Reveal
+   the native selection (so users can see what they select and copy) only while
+   the user is actively selecting within deleted text: the editor sets
+   data-deleted-text-selection on the diff while a pointer gesture starts there.
+   Gating it this way means a normal selection of editable code that merely
+   sweeps across an interleaved deleted line (unified view) does not highlight
+   that line. Covers the whole deletions column in split view and individual
+   deleted lines in unified view. */
+[data-deleted-text-selection] [data-deletions] ::selection,
+[data-deleted-text-selection] [data-line-type='change-deletion'] ::selection {
+  background-color: var(--diffs-editor-selection-bg);
+}
+
 @keyframes blinking {
   0% {
     opacity: 1;
@@ -31,8 +45,6 @@
 }
 [data-gutter-buffer],
 [data-line]:not([data-selected-line]),
-[data-line]:not([data-selected-line]) span,
-[data-line] [data-diff-span],
 [data-line-annotation] {
   background-color: transparent;
 }

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -217,6 +217,11 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   #isContentMouseDown = false;
   #shiftKeyPressed = false;
   #selectionStart: EditorSelection | undefined;
+  // The full text of a read-only deleted-line selection built from the gutter,
+  // captured when the selection is made. Deleted lines are separate read-only
+  // hosts, so window.getSelection() only spans the first line; the copy/cut
+  // handlers prefer this. Empty for a direct content drag (no gutter range).
+  #deletedSelectionText = '';
   #reservedSelections?: EditorSelection[];
   #initSelections?: EditorSelection[];
   #selections?: EditorSelection[];
@@ -1083,6 +1088,19 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
             return;
           }
 
+          // A click on a read-only deleted line (unified view) selects it
+          // natively. Hand the selection to the deleted text and drop the
+          // editor's own selection, so only one region is highlighted at a
+          // time and the deleted line is not swept into an editable selection.
+          if (this.#isDeletedLineTarget(e)) {
+            this.#setDeletedTextSelectionActive(true);
+            if (this.#selections !== undefined) {
+              this.#updateSelections([]);
+            }
+            return;
+          }
+          this.#setDeletedTextSelectionActive(false);
+
           this.#markerRenderer?.removePopup();
 
           // this is a workaround for the selection rendering glitch
@@ -1224,7 +1242,15 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
           return;
         }
         e.preventDefault();
-        e.clipboardData?.setData('text', this.#getSelectionText());
+        // A read-only deleted-text selection lives outside the editor's
+        // document, so #getSelectionText() would be empty. Copy the selected
+        // deleted text instead.
+        e.clipboardData?.setData(
+          'text',
+          this.#isDeletedTextSelectionActive()
+            ? this.#deletedTextForClipboard()
+            : this.#getSelectionText()
+        );
       }),
 
       addEventListener(contentEl, 'cut', (e) => {
@@ -1232,7 +1258,14 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
           return;
         }
         e.preventDefault();
-        e.clipboardData?.setData('text', this.#cutSelectionText());
+        // Deleted text is read-only and can't be removed, so a cut there copies
+        // the selected deleted text (like the copy handler) without editing.
+        e.clipboardData?.setData(
+          'text',
+          this.#isDeletedTextSelectionActive()
+            ? this.#deletedTextForClipboard()
+            : this.#cutSelectionText()
+        );
       }),
 
       addEventListener(contentEl, 'paste', (e) => {
@@ -1305,6 +1338,53 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         { passive: true }
       ),
     ];
+
+    // A selection in the read-only deletions column is painted natively (see
+    // the gated ::selection rule). Starting one there reveals that selection
+    // and clears the editor's own selection on the additions side, so only one
+    // column shows a selection at a time. Non-diff files have no deletions
+    // column.
+    const deletionsCode =
+      this.#fileContainer?.shadowRoot?.querySelector<HTMLElement>(
+        '[data-deletions]'
+      );
+    if (deletionsCode != null) {
+      this.#editorEventDisposes.push(
+        addEventListener(
+          deletionsCode,
+          'pointerdown',
+          (e) => {
+            // Clicking a deletion line's number selects the whole line's text
+            // and dragging extends the selection across deletion lines (like a
+            // click/drag on an addition line number); clicking its text lets
+            // the browser place/extend the selection directly. Either way the
+            // deleted-text marker reveals it and the editor drops its own
+            // selection.
+            const target = e.composedPath()[0];
+            const gutterRow =
+              target instanceof HTMLElement
+                ? target.closest('[data-column-number]')
+                : null;
+            if (
+              gutterRow instanceof HTMLElement &&
+              this.#beginDeletionGutterSelection(
+                gutterRow,
+                deletionsCode,
+                e.pointerType === 'mouse'
+              )
+            ) {
+              return;
+            }
+            this.#setDeletedTextSelectionActive(true);
+            if (this.#selections !== undefined) {
+              this.#updateSelections([]);
+            }
+          },
+          { passive: true }
+        )
+      );
+    }
+
     if (gutterEl !== undefined) {
       const resolveGutterTarget = (
         eventTarget: HTMLElement | undefined,
@@ -1342,38 +1422,57 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
           gutterEl,
           'pointerdown',
           (e) => {
-            // Gutter drag-selection is mouse-only: the global pointerup that
-            // clears #isGutterMouseDown and disposes the mousemove listener
-            // bails for non-mouse pointers, so reacting to a touch/pen tap
-            // here would strand that state and leak the listener. Mirror the
-            // content pointerdown guard.
+            const gutterRow = resolveGutterTarget(
+              e.composedPath()[0] as HTMLElement | undefined
+            );
+            // Clicking a read-only deleted line's number (unified view) selects
+            // that line's text natively, since the line is not in the editor's
+            // document. This runs before the mouse-only gate below: a deletion
+            // tap registers no drag state to strand, so it works on touch too,
+            // matching the split deletions column.
+            if (gutterRow?.dataset.lineType === 'change-deletion') {
+              const code = gutterRow.closest('[data-code]');
+              if (code != null) {
+                this.#beginDeletionGutterSelection(
+                  gutterRow,
+                  code,
+                  e.pointerType === 'mouse'
+                );
+              }
+              return;
+            }
+
+            // Editable gutter drag-selection is mouse-only: the global pointerup
+            // that clears #isGutterMouseDown and disposes the mousemove listener
+            // bails for non-mouse pointers, so reacting to a touch/pen tap here
+            // would strand that state and leak the listener. Mirror the content
+            // pointerdown guard.
             if (e.pointerType !== 'mouse') {
               return;
             }
 
             const textDocument = this.#textDocument;
-            const lineIndex = resolveEditableLine(
-              resolveGutterTarget(
-                e.composedPath()[0] as HTMLElement | undefined
-              )
-            );
+            const lineIndex = resolveEditableLine(gutterRow);
             if (lineIndex === undefined || textDocument === undefined) {
               return;
             }
 
             this.#markerRenderer?.removePopup();
-            const selection: EditorSelection = {
-              start: { line: lineIndex, character: 0 },
-              end: {
-                line: lineIndex,
-                character: textDocument.getLineText(lineIndex).length,
-              },
-              direction: DirectionForward,
-            };
+            const selection = this.#spanLineSelection(
+              lineIndex,
+              lineIndex,
+              textDocument
+            );
             this.#isGutterMouseDown = true;
             this.#selectionStart = selection;
             this.#updateSelections([selection]);
-            this.#focus(selection.end);
+            // Span the native selection across the clicked line and focus
+            // without collapsing it. #focus(position) would drop a collapsed
+            // caret at the line end, which a later selectionchange then turns
+            // into a bare caret — so a single click on a line number would
+            // place a cursor instead of selecting the whole line's text.
+            this.#setWindowSelection(selection);
+            this.#focus();
             this.#replaceSelectEventListeners([
               addEventListener(
                 document,
@@ -1393,24 +1492,24 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
                     return;
                   }
 
-                  let selection: EditorSelection = {
-                    start: { line: lineIndex, character: 0 },
-                    end: {
-                      line: lineIndex,
-                      character: textDocument.getLineText(lineIndex).length,
-                    },
-                    direction: DirectionForward,
-                  };
-                  if (this.#selectionStart !== undefined) {
-                    selection = createSelectionFrom(
-                      this.#selectionStart,
-                      selection
-                    );
-                  } else {
-                    this.#selectionStart = selection;
-                  }
+                  // A gutter drag keeps both the clicked line (the anchor) and
+                  // the line under the pointer fully selected. Until a drag
+                  // outruns its pointerdown the anchor is set; if it somehow is
+                  // not, the line under the pointer becomes the anchor.
+                  const anchorLine =
+                    this.#selectionStart?.start.line ?? lineIndex;
+                  const selection = this.#spanLineSelection(
+                    anchorLine,
+                    lineIndex,
+                    textDocument
+                  );
+                  this.#selectionStart ??= selection;
                   this.#updateSelections([selection]);
-                  this.#focus(selection.end);
+                  this.#focus(
+                    selection.direction === DirectionBackward
+                      ? selection.start
+                      : selection.end
+                  );
                 },
                 { passive: true }
               ),
@@ -2156,12 +2255,251 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     virtualCaret.remove();
   }
 
-  #setSelectedLinesSafe(range: { start: number; end: number } | null): void {
+  // Build a selection that fully covers every line from the anchor line to the
+  // focus line — from the topmost line's start to the bottommost line's end.
+  // Dragging above the anchor yields a backward selection so the anchor line
+  // stays selected and #focus lands on the line the gesture ended on. A single
+  // line (anchor === focus) is a forward whole-line selection.
+  #spanLineSelection(
+    anchorLine: number,
+    focusLine: number,
+    textDocument: TextDocument<LAnnotation>
+  ): EditorSelection {
+    const lineStart = (line: number): Position => ({ line, character: 0 });
+    const lineEnd = (line: number): Position => ({
+      line,
+      character: textDocument.getLineText(line).length,
+    });
+    if (focusLine < anchorLine) {
+      return {
+        start: lineStart(focusLine),
+        end: lineEnd(anchorLine),
+        direction: DirectionBackward,
+      };
+    }
+    return {
+      start: lineStart(anchorLine),
+      end: lineEnd(focusLine),
+      direction: DirectionForward,
+    };
+  }
+
+  // A pointer gesture targets read-only deleted text when its closest row is a
+  // change-deletion. Used to route a click in unified view's deleted text to a
+  // native selection instead of the editor's own.
+  #isDeletedLineTarget(event: Event): boolean {
+    const target = event.composedPath()[0];
+    return (
+      target instanceof HTMLElement &&
+      target.closest('[data-line]')?.getAttribute('data-line-type') ===
+        'change-deletion'
+    );
+  }
+
+  // Select read-only deleted text with the native selection, spanning from the
+  // anchor row to the focus row (the same row for a click). Deleted lines are
+  // not part of the editor's document, so they cannot be selected as editor
+  // text; instead select their DOM text, reveal it via the deleted-text marker,
+  // drop the editor's own selection, and highlight the deleted gutter numbers so
+  // the result matches a click/drag on an addition line.
+  #selectDeletedLines(
+    anchorContent: HTMLElement,
+    focusContent: HTMLElement,
+    deletionsCode: Element
+  ): void {
+    const rows = [
+      ...deletionsCode.querySelectorAll('[data-content] > [data-line]'),
+    ];
+    const anchorIndex = rows.indexOf(anchorContent);
+    const focusIndex = rows.indexOf(focusContent);
+    const [topContent, bottomContent] =
+      focusIndex < anchorIndex
+        ? [focusContent, anchorContent]
+        : [anchorContent, focusContent];
+
+    const winSelection = window.getSelection();
+    if (winSelection !== null) {
+      const range = document.createRange();
+      range.setStart(topContent, 0);
+      range.setEnd(bottomContent, bottomContent.childNodes.length);
+      winSelection.removeAllRanges();
+      winSelection.addRange(range);
+    }
+
+    this.#setDeletedTextSelectionActive(true);
+    this.#updateSelections([]);
+
+    // Highlight only the focus line's gutter number — the line where the click
+    // landed or the drag ended. An addition selection highlights just its caret
+    // line (getCaretPosition is the focus end), so matching that keeps the two
+    // sides consistent. #setDeletedTextSelectionActive cleared the previous
+    // selection's number above, so set this one's directly on the gutter row
+    // that lines up with the focus content row.
+    const gutterRows = [
+      ...deletionsCode.querySelectorAll('[data-gutter] > [data-column-number]'),
+    ];
+    gutterRows[focusIndex]?.setAttribute('data-selected-line', 'single');
+
+    // Record the selected deleted lines' text for the clipboard. Each deleted
+    // line is its own read-only host, so window.getSelection().toString() only
+    // captures the first line; the copy/cut handlers prefer this value.
+    const lo = Math.min(anchorIndex, focusIndex);
+    const hi = Math.max(anchorIndex, focusIndex);
+    this.#deletedSelectionText =
+      lo < 0
+        ? ''
+        : rows
+            .slice(lo, hi + 1)
+            .filter(
+              (row) => row.getAttribute('data-line-type') === 'change-deletion'
+            )
+            .map((row) => row.textContent ?? '')
+            .join('\n');
+  }
+
+  // The content row that lines up with a gutter row: the two columns are
+  // parallel, so the gutter row's index is the content row's index.
+  #contentRowForGutterRow(
+    gutterRow: HTMLElement,
+    contentColumn: Element | null | undefined
+  ): HTMLElement | undefined {
+    const gutterColumn = gutterRow.parentElement;
+    if (gutterColumn == null || contentColumn == null) {
+      return undefined;
+    }
+    const index = [...gutterColumn.children].indexOf(gutterRow);
+    const row = contentColumn.children[index];
+    return row instanceof HTMLElement ? row : undefined;
+  }
+
+  // Begin a native selection of read-only deleted lines from a pointerdown on a
+  // deletion line number. Selects the clicked line and, for a mouse pointer,
+  // tracks a drag across the deletion gutter that extends the selection — the
+  // same gesture as a click/drag on an addition line number. `code` is the
+  // [data-code] holding the deletion column: the separate deletions column in
+  // split view, or the shared column in unified view. Returns false when the
+  // gutter row has no matching content row, letting the caller fall back to a
+  // plain deleted-text selection.
+  #beginDeletionGutterSelection(
+    gutterRow: HTMLElement,
+    code: Element,
+    isMouse: boolean
+  ): boolean {
+    const contentColumn = code.querySelector('[data-content]');
+    const anchorContent = this.#contentRowForGutterRow(
+      gutterRow,
+      contentColumn
+    );
+    if (anchorContent === undefined) {
+      return false;
+    }
+    this.#selectDeletedLines(anchorContent, anchorContent, code);
+    // The document pointerup disposes this listener; it must not set
+    // #isGutterMouseDown, whose pointerup focuses the editor and would collapse
+    // the native deletion selection.
+    if (isMouse) {
+      this.#replaceSelectEventListeners([
+        addEventListener(
+          document,
+          'mousemove',
+          (moveEvent) => {
+            const moveTarget = moveEvent.composedPath()[0];
+            const moveGutter =
+              moveTarget instanceof HTMLElement
+                ? moveTarget.closest('[data-column-number]')
+                : null;
+            if (
+              moveGutter instanceof HTMLElement &&
+              code.contains(moveGutter)
+            ) {
+              const focusContent = this.#contentRowForGutterRow(
+                moveGutter,
+                contentColumn
+              );
+              if (focusContent !== undefined) {
+                this.#selectDeletedLines(anchorContent, focusContent, code);
+              }
+            }
+          },
+          { passive: true }
+        ),
+      ]);
+    }
+    return true;
+  }
+
+  // Whether a read-only deleted-text selection is currently active (the marker
+  // #setDeletedTextSelectionActive sets). The copy/cut handlers read this to
+  // copy the native selection instead of the editor's empty document selection.
+  #isDeletedTextSelectionActive(): boolean {
+    return (
+      this.#fileContainer?.shadowRoot
+        ?.querySelector('pre')
+        ?.hasAttribute('data-deleted-text-selection') ?? false
+    );
+  }
+
+  // The clipboard text for a read-only deleted-text selection. A gutter
+  // selection records the full multi-line text in #deletedSelectionText; a
+  // direct content drag leaves it empty, so fall back to the browser's native
+  // selection (which spans only the first deleted line — its separate host).
+  #deletedTextForClipboard(): string {
+    return this.#deletedSelectionText !== ''
+      ? this.#deletedSelectionText
+      : (window.getSelection()?.toString() ?? '');
+  }
+
+  // Toggle the marker that reveals the native selection inside read-only
+  // deleted text (see the gated ::selection rule). It stays on only while the
+  // user is actively selecting within deleted lines, so a normal selection of
+  // editable code that sweeps across an interleaved deleted line does not
+  // highlight it.
+  #setDeletedTextSelectionActive(active: boolean): void {
+    const pre = this.#fileContainer?.shadowRoot?.querySelector('pre');
+    if (pre == null) {
+      return;
+    }
+    if (active) {
+      pre.setAttribute('data-deleted-text-selection', '');
+      // Drop any line-number highlight left over from a previous selection.
+      // #selectDeletedLines marks the deleted gutter numbers directly, and the
+      // editor only clears them when its own selection range changes — but
+      // deletion selections leave that range null, so a second deletion click
+      // would otherwise keep the first selection's numbers highlighted.
+      for (const highlighted of pre.querySelectorAll('[data-selected-line]')) {
+        highlighted.removeAttribute('data-selected-line');
+      }
+      // Reset the captured selection text. #selectDeletedLines refills it for a
+      // gutter selection; a content drag leaves it empty so the copy/cut
+      // handlers fall back to the native selection.
+      this.#deletedSelectionText = '';
+    } else {
+      pre.removeAttribute('data-deleted-text-selection');
+      this.#deletedSelectionText = '';
+    }
+  }
+
+  #setSelectedLinesSafe(
+    range: { start: number; end: number } | null,
+    lineNumberOnly = false
+  ): void {
     try {
       // notify: false renders the active-line highlight without firing the
       // host's onLineSelected callback. A caret or text selection in the editor
       // is not a gutter line selection, so it must not publish one.
-      this.#fileInstance?.setSelectedLines(range, { notify: false });
+      //
+      // activeLineSide keeps the highlight on the additions pane, the side the
+      // editor edits. Without it a split diff also highlights the matching
+      // read-only deletions row on the left.
+      //
+      // lineNumberOnly marks just the caret line's gutter number while text is
+      // selected, so the line keeps its highlighted number but drops the
+      // full-line background in favor of the text selection.
+      this.#fileInstance?.setSelectedLines(range, {
+        notify: false,
+        activeLineSide: 'additions',
+        lineNumberOnly,
+      });
     } catch {
       // InteractionManager.renderSelection can throw while editor DOM is updating.
     }
@@ -2196,12 +2534,18 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       const normalizedSelections = mergeOverlappingSelections(selections);
       const primarySelection = normalizedSelections.at(-1)!;
       this.#selections = normalizedSelections;
-      // Highlight the line that holds the caret (the selection's head),
-      // whether the selection is collapsed or spans a range. A ranged selection
-      // previously skipped this, so starting a multi-line selection dropped the
-      // active-line highlight from the line the cursor was on.
+      // The caret line always keeps its highlighted gutter number. With a bare
+      // caret it also gets the full-line background; once any selection spans
+      // text, the background is dropped (lineNumberOnly) so the text selection
+      // is the only line-level highlight.
+      const hasNonEmptySelection = normalizedSelections.some(
+        (selection) => !isCollapsedSelection(selection)
+      );
       const caretLine = getCaretPosition(primarySelection).line + 1;
-      this.#setSelectedLinesSafe({ start: caretLine, end: caretLine });
+      this.#setSelectedLinesSafe(
+        { start: caretLine, end: caretLine },
+        hasNonEmptySelection
+      );
 
       for (const selection of normalizedSelections) {
         if (!isCollapsedSelection(selection)) {

--- a/packages/diffs/src/managers/InteractionManager.ts
+++ b/packages/diffs/src/managers/InteractionManager.ts
@@ -52,6 +52,16 @@ export interface OnDiffLineEnterLeaveProps extends DiffLineEventBaseProps {
 
 export interface SelectionWriteOptions {
   notify?: boolean;
+  // Limit the selected-line highlight to one side's column of a split diff.
+  // The editor sets this to 'additions' so its active-line highlight stays on
+  // the editable pane instead of also lighting up the read-only deletions
+  // pane. It has no effect on unified or single-file views, whose one code
+  // column carries no side attribute.
+  activeLineSide?: SelectionSide;
+  // Highlight only the gutter line number, not the line background. The editor
+  // sets this while text is selected: the caret line keeps its highlighted
+  // number, but the full-line background gives way to the text selection.
+  lineNumberOnly?: boolean;
 }
 
 export type GetLineIndexUtility = (
@@ -241,6 +251,19 @@ export class InteractionManager<TMode extends InteractionManagerMode> {
   private hasDocumentPointerListeners = false;
 
   private selectedRange: SelectedLineRange | null = null;
+  // When set, the active-line highlight is confined to this side's column in a
+  // split diff (see SelectionWriteOptions.activeLineSide). Tracks the current
+  // selectedRange and is cleared by any gutter-driven selection. Only the
+  // editor's own active-line highlight sets a side, so a non-null value also
+  // marks the selection as editor-driven (see highlightLineNumberOnly).
+  private activeLineHighlightSide: SelectionSide | undefined;
+  // When true, the active-line highlight marks only the gutter line number and
+  // not the line background (see SelectionWriteOptions.lineNumberOnly).
+  private activeLineNumberOnly = false;
+  // True while an editor is attached (edit mode). The editor draws selection as
+  // text, so a host or gutter line selection then highlights only the gutter
+  // line numbers, never the full-line background.
+  private editorAttached = false;
   private proposedSelectedRange: SelectedLineRange | null | undefined;
   private renderedSelectionRange: SelectedLineRange | null | undefined;
   private selectionAnchor: SelectionPoint | undefined;
@@ -317,6 +340,18 @@ export class InteractionManager<TMode extends InteractionManagerMode> {
     this.renderedSelectionRange = undefined;
   }
 
+  // Toggle edit mode. While an editor is attached, host and gutter line
+  // selections are shown as gutter-number-only highlights (the editor renders
+  // the selected text itself), so the full-line background is suppressed.
+  setEditorAttached(attached: boolean): void {
+    if (this.editorAttached === attached) {
+      return;
+    }
+    this.editorAttached = attached;
+    this.setSelectionDirty();
+    this.renderSelection();
+  }
+
   isSelectionDirty(): boolean {
     return this.renderedSelectionRange === null;
   }
@@ -334,6 +369,8 @@ export class InteractionManager<TMode extends InteractionManagerMode> {
     }
     this.proposedSelectedRange = undefined;
     this.selectedRange = range;
+    this.activeLineHighlightSide = options?.activeLineSide;
+    this.activeLineNumberOnly = options?.lineNumberOnly ?? false;
     this.renderSelection();
     this.placeUtility();
     if (isRangeChange && options?.notify !== false) {
@@ -1455,6 +1492,11 @@ export class InteractionManager<TMode extends InteractionManagerMode> {
     ) {
       return;
     }
+    // A gutter selection spans both columns and the full line, so drop any
+    // side or number-only restriction left over from the editor's active-line
+    // highlight.
+    this.activeLineHighlightSide = undefined;
+    this.activeLineNumberOnly = false;
     if (this.options.controlledSelection === true) {
       this.proposedSelectedRange = nextRange;
     } else {
@@ -1491,6 +1533,26 @@ export class InteractionManager<TMode extends InteractionManagerMode> {
           end: split ? finalIndexes[1] : finalIndexes[0],
         }
       : undefined;
+  }
+
+  // Whether to highlight only the gutter line number and leave the full-line
+  // background for the editor's text selection. The decision splits on who drove
+  // the selection, which activeLineHighlightSide records: the editor's own
+  // active-line highlight always sets a side, while gutter and host selections
+  // never do. Re-evaluated on every render so toggling edit mode
+  // (setEditorAttached) reflows the current selection.
+  private highlightLineNumberOnly(): boolean {
+    // The editor's own side-confined active-line highlight controls the
+    // background itself via lineNumberOnly: off for a bare caret (keep the
+    // background), on once text is selected so the text selection is the only
+    // line-level marker.
+    if (this.activeLineHighlightSide != null) {
+      return this.activeLineNumberOnly;
+    }
+    // A gutter or host line selection: number-only when the caller asked for it,
+    // or while an editor is attached — in edit mode the editor renders the
+    // selected text itself, so the full-line background gives way to it.
+    return this.activeLineNumberOnly || this.editorAttached;
   }
 
   private renderSelection = (): void => {
@@ -1534,7 +1596,20 @@ export class InteractionManager<TMode extends InteractionManagerMode> {
     const isSingle = rowRange.start === rowRange.end;
     const first = Math.min(rowRange.start, rowRange.end);
     const last = Math.max(rowRange.start, rowRange.end);
+    const numberOnly = this.highlightLineNumberOnly();
     for (const code of codeElements) {
+      // When the highlight is confined to one side (the editor's active-line
+      // highlight), skip the opposite split-diff column. The deletions column
+      // carries `data-deletions` and the additions column `data-additions`; a
+      // unified or single-file column has neither, so it is never skipped.
+      const side = this.activeLineHighlightSide;
+      if (
+        side != null &&
+        ((side === 'additions' && code.hasAttribute('data-deletions')) ||
+          (side === 'deletions' && code.hasAttribute('data-additions')))
+      ) {
+        continue;
+      }
       const [gutter, content] = code.children;
       const len = content.children.length;
       if (len !== gutter.children.length) {
@@ -1566,8 +1641,13 @@ export class InteractionManager<TMode extends InteractionManagerMode> {
             : lineIndex === last
               ? 'last'
               : '';
-        contentElement.setAttribute('data-selected-line', attributeValue);
         gutterElement.setAttribute('data-selected-line', attributeValue);
+        // A number-only highlight marks just the gutter number, leaving the
+        // line background and any annotation rows untouched.
+        if (numberOnly) {
+          continue;
+        }
+        contentElement.setAttribute('data-selected-line', attributeValue);
         if (
           gutterElement.nextSibling instanceof HTMLElement &&
           contentElement.nextSibling instanceof HTMLElement &&

--- a/packages/diffs/src/types.ts
+++ b/packages/diffs/src/types.ts
@@ -914,7 +914,11 @@ export interface DiffsBaseComponent {
   setOptions: (options: Partial<DiffsComponentOptions>) => void;
   setSelectedLines: (
     range: { start: number; end: number } | null,
-    options?: { notify?: boolean }
+    options?: {
+      notify?: boolean;
+      activeLineSide?: SelectionSide;
+      lineNumberOnly?: boolean;
+    }
   ) => void;
   render(options: {
     file?: FileContents;

--- a/packages/diffs/test/editorActiveLineHighlight.test.ts
+++ b/packages/diffs/test/editorActiveLineHighlight.test.ts
@@ -96,7 +96,7 @@ describe('editor active line highlight', () => {
     }
   });
 
-  test('keeps the caret line highlighted during a forward multi-line selection', async () => {
+  test('drops the full-line highlight during a forward multi-line selection', async () => {
     const { cleanup, content, editor } = await createEditorFixture(
       'alpha\nbravo\ncharlie\ndelta'
     );
@@ -108,15 +108,15 @@ describe('editor active line highlight', () => {
           direction: 'forward',
         },
       ]);
-      // A forward selection puts the caret on the end line (index 3 ->
-      // data-line "4"); only that line carries the active-line highlight.
-      expect(highlightedLineNumbers(content)).toEqual([4]);
+      // A non-empty selection shows the selected text, not a full-line
+      // background, so no row carries the active-line highlight.
+      expect(highlightedLineNumbers(content)).toEqual([]);
     } finally {
       cleanup();
     }
   });
 
-  test('keeps the caret line highlighted during a backward multi-line selection', async () => {
+  test('drops the full-line highlight during a backward multi-line selection', async () => {
     const { cleanup, content, editor } = await createEditorFixture(
       'alpha\nbravo\ncharlie\ndelta'
     );
@@ -128,9 +128,7 @@ describe('editor active line highlight', () => {
           direction: 'backward',
         },
       ]);
-      // A backward selection puts the caret on the start line (index 1 ->
-      // data-line "2"), not the end of the range.
-      expect(highlightedLineNumbers(content)).toEqual([2]);
+      expect(highlightedLineNumbers(content)).toEqual([]);
     } finally {
       cleanup();
     }
@@ -150,10 +148,9 @@ describe('editor active line highlight', () => {
           direction: 'forward',
         },
       ]);
-      // The caret line still gets the active-line highlight...
-      expect(highlightedLineNumbers(content)).toEqual([4]);
-      // ...but the editor renders it without publishing a line selection.
-      // Text selection is not a gutter line selection, so a consumer's
+      // A non-empty selection draws no full-line highlight...
+      expect(highlightedLineNumbers(content)).toEqual([]);
+      // ...and text selection is not a gutter line selection, so a consumer's
       // onLineSelected handler must not fire.
       expect(notifiedRanges).toEqual([]);
     } finally {

--- a/packages/diffs/test/editorDiffActiveLineHighlight.test.ts
+++ b/packages/diffs/test/editorDiffActiveLineHighlight.test.ts
@@ -1,0 +1,611 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+
+import { FileDiff } from '../src/components/FileDiff';
+import { DEFAULT_THEMES } from '../src/constants';
+import { Editor } from '../src/editor/editor';
+import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
+import type { FileContents } from '../src/types';
+import { installDom, wait } from './domHarness';
+
+afterAll(async () => {
+  await disposeHighlighter();
+});
+
+// In a split diff the deletions column carries `data-deletions` and the
+// additions column does not; a unified diff renders a single column with
+// neither attribute.
+function findCodeColumns(container: HTMLElement): {
+  additions?: HTMLElement;
+  deletions?: HTMLElement;
+} {
+  const shadow = container.shadowRoot;
+  const columns: { additions?: HTMLElement; deletions?: HTMLElement } = {};
+  if (shadow == null) {
+    return columns;
+  }
+  for (const code of shadow.querySelectorAll<HTMLElement>('[data-code]')) {
+    if (code.dataset.deletions !== undefined) {
+      columns.deletions = code;
+    } else {
+      columns.additions = code;
+    }
+  }
+  return columns;
+}
+
+// The 1-based data-line numbers of the content rows in one column that carry
+// the active-line highlight (the `data-selected-line` attribute).
+function highlightedLineNumbers(code: HTMLElement | undefined): number[] {
+  if (code == null) {
+    return [];
+  }
+  return [
+    ...code.querySelectorAll(
+      '[data-content] > [data-line][data-selected-line]'
+    ),
+  ]
+    .map((el) => Number(el.getAttribute('data-line')))
+    .sort((a, b) => a - b);
+}
+
+// The gutter line numbers (data-column-number) carrying the active-line
+// highlight. While text is selected only the caret line's number stays
+// highlighted; the line background gives way to the selection.
+function highlightedGutterNumbers(code: HTMLElement | undefined): number[] {
+  if (code == null) {
+    return [];
+  }
+  return [...code.querySelectorAll('[data-column-number][data-selected-line]')]
+    .map((el) => Number(el.getAttribute('data-column-number')))
+    .sort((a, b) => a - b);
+}
+
+// Dispatch a copy event with a clipboardData spy and return the writes, the
+// same approach as editorClipboard.test.ts.
+function dispatchCopy(
+  target: HTMLElement
+): Array<[type: string, text: string]> {
+  const writes: Array<[type: string, text: string]> = [];
+  const event = new window.Event('copy', {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+  });
+  Object.defineProperty(event, 'clipboardData', {
+    value: {
+      setData(type: string, text: string) {
+        writes.push([type, text]);
+      },
+    },
+  });
+  target.dispatchEvent(event);
+  expect(event.defaultPrevented).toBe(true);
+  return writes;
+}
+
+interface DiffEditorFixture {
+  container: HTMLElement;
+  editor: Editor<undefined>;
+  cleanup(): Promise<void>;
+}
+
+async function createDiffEditorFixture(
+  diffStyle: 'split' | 'unified',
+  oldContents: string,
+  newContents: string
+): Promise<DiffEditorFixture> {
+  const dom = installDom();
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  const fileDiff = new FileDiff<undefined>({
+    disableFileHeader: true,
+    theme: DEFAULT_THEMES,
+    diffStyle,
+  });
+  const editor = new Editor<undefined>();
+  const oldFile: FileContents = { name: 'edit.ts', contents: oldContents };
+  const newFile: FileContents = { name: 'edit.ts', contents: newContents };
+
+  fileDiff.render({
+    oldFile,
+    newFile,
+    fileContainer: container,
+    forceRender: true,
+  });
+  editor.edit(fileDiff);
+  await wait(10);
+
+  return {
+    container,
+    editor,
+    async cleanup() {
+      await wait(10);
+      editor.cleanUp();
+      fileDiff.cleanUp();
+      dom.cleanup();
+    },
+  };
+}
+
+describe('editor active-line highlight on a diff', () => {
+  // A modified first line gives the additions caret row a paired deletion row
+  // on the left, which is exactly where the highlight used to leak.
+  const OLD = 'import a\nimport b\nimport c\n';
+  const NEW = 'import x\nimport b\nimport c\n';
+
+  test('split: a caret highlights only the additions column', async () => {
+    const fixture = await createDiffEditorFixture('split', OLD, NEW);
+    try {
+      fixture.editor.setSelections([
+        {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 0 },
+          direction: 'none',
+        },
+      ]);
+      await wait(10);
+
+      const { additions, deletions } = findCodeColumns(fixture.container);
+      // The changed addition line ("import x", index 0) renders as data-line 1.
+      expect(highlightedLineNumbers(additions)).toEqual([1]);
+      // The read-only deletions column must not be highlighted.
+      expect(highlightedLineNumbers(deletions)).toEqual([]);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test('split: starting a selection in the deletions column clears the additions selection', async () => {
+    const fixture = await createDiffEditorFixture('split', OLD, NEW);
+    try {
+      fixture.editor.setSelections([
+        {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 0 },
+          direction: 'none',
+        },
+      ]);
+      await wait(10);
+
+      const { additions, deletions } = findCodeColumns(fixture.container);
+      expect(highlightedLineNumbers(additions)).toEqual([1]);
+
+      // A pointerdown in the read-only deletions column hands the selection to
+      // that column (painted natively), so the editor drops its additions-side
+      // selection — only one column is selected at a time.
+      deletions?.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true })
+      );
+      await wait(10);
+      expect(highlightedLineNumbers(additions)).toEqual([]);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test('split: a text selection keeps the caret line number but drops the background', async () => {
+    const fixture = await createDiffEditorFixture('split', OLD, NEW);
+    try {
+      // Select "import" from the very start of the line (no leading
+      // whitespace), the exact case from the bug report.
+      fixture.editor.setSelections([
+        {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 6 },
+          direction: 'forward',
+        },
+      ]);
+      await wait(10);
+
+      const { additions, deletions } = findCodeColumns(fixture.container);
+      // No line background on either column: the selected text is the
+      // line-level highlight instead.
+      expect(highlightedLineNumbers(additions)).toEqual([]);
+      expect(highlightedLineNumbers(deletions)).toEqual([]);
+      // The caret line's gutter number stays highlighted on the additions side.
+      expect(highlightedGutterNumbers(additions)).toEqual([1]);
+      expect(highlightedGutterNumbers(deletions)).toEqual([]);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test('unified: a caret still highlights its line', async () => {
+    const fixture = await createDiffEditorFixture('unified', OLD, NEW);
+    try {
+      fixture.editor.setSelections([
+        {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 0 },
+          direction: 'none',
+        },
+      ]);
+      await wait(10);
+
+      // A unified diff has a single column, so the additions-only restriction
+      // must not suppress the highlight there.
+      const { additions } = findCodeColumns(fixture.container);
+      expect(highlightedLineNumbers(additions)).toEqual([1]);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test('unified: selecting a deleted line clears the editor selection and toggles the deleted-text marker', async () => {
+    const fixture = await createDiffEditorFixture('unified', OLD, NEW);
+    try {
+      const shadow = fixture.container.shadowRoot;
+      const pre = shadow?.querySelector('pre');
+      const deletedLine = shadow?.querySelector(
+        "[data-content] > [data-line][data-line-type='change-deletion']"
+      );
+      const editableLine = shadow?.querySelector(
+        "[data-content] > [data-line]:not([data-line-type='change-deletion'])"
+      );
+      expect(deletedLine).not.toBeNull();
+      expect(editableLine).not.toBeNull();
+
+      // A caret on an editable line highlights it.
+      fixture.editor.setSelections([
+        {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 0 },
+          direction: 'none',
+        },
+      ]);
+      await wait(10);
+      const { additions } = findCodeColumns(fixture.container);
+      expect(highlightedGutterNumbers(additions).length).toBeGreaterThan(0);
+
+      // Pointerdown on the deleted line hands selection to that line: the
+      // editor drops its own selection and the deleted-text marker turns on.
+      deletedLine?.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true, composed: true })
+      );
+      await wait(10);
+      expect(highlightedGutterNumbers(additions)).toEqual([]);
+      expect(pre?.hasAttribute('data-deleted-text-selection')).toBe(true);
+
+      // Pointerdown back on an editable line turns the marker off, so a normal
+      // selection no longer reveals deleted-text selection.
+      editableLine?.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true, composed: true })
+      );
+      await wait(10);
+      expect(pre?.hasAttribute('data-deleted-text-selection')).toBe(false);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test('unified: clicking a deleted line number selects the line and clears the editor selection', async () => {
+    const fixture = await createDiffEditorFixture('unified', OLD, NEW);
+    try {
+      const shadow = fixture.container.shadowRoot;
+      const pre = shadow?.querySelector('pre');
+      const deletedGutterNumber = shadow?.querySelector(
+        "[data-gutter] [data-column-number][data-line-type='change-deletion']"
+      );
+      expect(deletedGutterNumber).not.toBeNull();
+
+      // A caret on an editable line highlights it.
+      fixture.editor.setSelections([
+        {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 0 },
+          direction: 'none',
+        },
+      ]);
+      await wait(10);
+      const { additions } = findCodeColumns(fixture.container);
+      expect(highlightedGutterNumbers(additions).length).toBeGreaterThan(0);
+
+      // Clicking the deleted line's gutter number hands selection to that
+      // (read-only) line: the editor drops its own selection, the deleted line's
+      // own gutter number becomes highlighted (matching an addition click), and
+      // the deleted-text marker turns on.
+      deletedGutterNumber?.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true, composed: true })
+      );
+      await wait(10);
+      expect(deletedGutterNumber?.hasAttribute('data-selected-line')).toBe(
+        true
+      );
+      expect(pre?.hasAttribute('data-deleted-text-selection')).toBe(true);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test('unified: selecting a second deleted line clears the first one’s gutter highlight', async () => {
+    // Two consecutive deletions so a selection can move from one to the other.
+    const fixture = await createDiffEditorFixture(
+      'unified',
+      'keep0\ndelA\ndelB\nkeep1\n',
+      'keep0\nkeep1\n'
+    );
+    try {
+      const shadow = fixture.container.shadowRoot;
+      const deletedGutterNumbers = [
+        ...(shadow?.querySelectorAll(
+          "[data-gutter] [data-column-number][data-line-type='change-deletion']"
+        ) ?? []),
+      ];
+      expect(deletedGutterNumbers.length).toBeGreaterThanOrEqual(2);
+      const [first, second] = deletedGutterNumbers;
+
+      // Selecting the first deleted line highlights its gutter number.
+      first?.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true, composed: true })
+      );
+      await wait(10);
+      expect(first?.hasAttribute('data-selected-line')).toBe(true);
+
+      // Selecting a different deleted line must drop the first one's highlight
+      // rather than leave it stale. A deletion selection never changes the
+      // editor's own selection range, which is what normally clears these, so
+      // the highlight has to be cleared explicitly when the next one starts.
+      second?.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true, composed: true })
+      );
+      await wait(10);
+      expect(second?.hasAttribute('data-selected-line')).toBe(true);
+      expect(first?.hasAttribute('data-selected-line')).toBe(false);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test('split: dragging across deletion line numbers highlights only the end line', async () => {
+    // Four consecutive deletions so a drag spans several lines.
+    const fixture = await createDiffEditorFixture(
+      'split',
+      'a\nb\nc\nd\nkeep\n',
+      'keep\n'
+    );
+    try {
+      const { deletions } = findCodeColumns(fixture.container);
+      const gutterRows = [
+        ...(deletions?.querySelectorAll(
+          '[data-gutter] > [data-column-number]'
+        ) ?? []),
+      ];
+      // Old-file lines a..d are the deletions, numbered 1..4.
+      const anchor = gutterRows.find(
+        (g) => g.getAttribute('data-column-number') === '1'
+      );
+      const focus = gutterRows.find(
+        (g) => g.getAttribute('data-column-number') === '4'
+      );
+      expect(anchor).toBeDefined();
+      expect(focus).toBeDefined();
+
+      // Press the first line's number, then drag the pointer onto the fourth.
+      anchor?.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true, composed: true })
+      );
+      await wait(10);
+      focus?.dispatchEvent(
+        new MouseEvent('mousemove', { bubbles: true, composed: true })
+      );
+      await wait(10);
+
+      // Only the line the drag ended on is highlighted — the same as an
+      // addition selection, which highlights just its caret line — not every
+      // line in the dragged range.
+      expect(highlightedGutterNumbers(deletions)).toEqual([4]);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test('unified: dragging across deletion line numbers highlights only the end line', async () => {
+    // Four consecutive deletions so a drag spans several lines.
+    const fixture = await createDiffEditorFixture(
+      'unified',
+      'a\nb\nc\nd\nkeep\n',
+      'keep\n'
+    );
+    try {
+      const shadow = fixture.container.shadowRoot;
+      const pre = shadow?.querySelector('pre');
+      const gutterRows = [
+        ...(shadow?.querySelectorAll(
+          "[data-gutter] [data-column-number][data-line-type='change-deletion']"
+        ) ?? []),
+      ];
+      // Old-file lines a..d are the deletions, numbered 1..4.
+      const anchor = gutterRows.find(
+        (g) => g.getAttribute('data-column-number') === '1'
+      );
+      const focus = gutterRows.find(
+        (g) => g.getAttribute('data-column-number') === '4'
+      );
+      expect(anchor).toBeDefined();
+      expect(focus).toBeDefined();
+
+      // Press the first line's number, then drag the pointer onto the fourth —
+      // the same gesture the split deletions column already supports.
+      anchor?.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true, composed: true })
+      );
+      await wait(10);
+      focus?.dispatchEvent(
+        new MouseEvent('mousemove', { bubbles: true, composed: true })
+      );
+      await wait(10);
+
+      // Only the line the drag ended on stays highlighted (not the anchor, and
+      // not every line in the range), and the deleted-text marker reveals the
+      // native selection.
+      expect(focus?.hasAttribute('data-selected-line')).toBe(true);
+      expect(anchor?.hasAttribute('data-selected-line')).toBe(false);
+      expect(pre?.hasAttribute('data-deleted-text-selection')).toBe(true);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test('unified: tapping a deleted line number selects it on touch', async () => {
+    const fixture = await createDiffEditorFixture('unified', OLD, NEW);
+    try {
+      const shadow = fixture.container.shadowRoot;
+      const pre = shadow?.querySelector('pre');
+      const deletedGutterNumber = shadow?.querySelector(
+        "[data-gutter] [data-column-number][data-line-type='change-deletion']"
+      );
+      expect(deletedGutterNumber).not.toBeNull();
+
+      // A touch tap selects the deleted line the same as a mouse click. The
+      // mouse-only gate guards the editable gutter drag (which would strand
+      // listener state on touch), not a deletion tap, which registers nothing.
+      deletedGutterNumber?.dispatchEvent(
+        new PointerEvent('pointerdown', {
+          bubbles: true,
+          composed: true,
+          pointerType: 'touch',
+        })
+      );
+      await wait(10);
+      expect(deletedGutterNumber?.hasAttribute('data-selected-line')).toBe(
+        true
+      );
+      expect(pre?.hasAttribute('data-deleted-text-selection')).toBe(true);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test('dragging across addition line numbers highlights the line the drag ends on', async () => {
+    // Five context lines plus one addition give several editable rows whose
+    // gutter numbers a drag can span.
+    const fixture = await createDiffEditorFixture(
+      'split',
+      'l1\nl2\nl3\nl4\nl5\n',
+      'l1\nl2\nl3\nl4\nl5\nl6\n'
+    );
+    try {
+      const { additions } = findCodeColumns(fixture.container);
+      const gutterRows = [
+        ...(additions?.querySelectorAll(
+          '[data-gutter] > [data-column-number]'
+        ) ?? []),
+      ];
+      const rowFor = (n: string) =>
+        gutterRows.find((g) => g.getAttribute('data-column-number') === n);
+      const line2 = rowFor('2');
+      const line4 = rowFor('4');
+      expect(line2).toBeDefined();
+      expect(line4).toBeDefined();
+
+      // Forward drag (line 2 -> line 4): the caret follows the drag end, so the
+      // focus line (4) keeps the highlighted gutter number.
+      line2?.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true, composed: true })
+      );
+      await wait(10);
+      line4?.dispatchEvent(
+        new MouseEvent('mousemove', { bubbles: true, composed: true })
+      );
+      await wait(10);
+      document.dispatchEvent(
+        new PointerEvent('pointerup', { bubbles: true, composed: true })
+      );
+      await wait(10);
+      expect(highlightedGutterNumbers(additions)).toEqual([4]);
+
+      // Backward drag (line 4 -> line 2): the anchor line stays selected and the
+      // focus line (2) becomes the caret, so its number is the highlighted one.
+      line4?.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true, composed: true })
+      );
+      await wait(10);
+      line2?.dispatchEvent(
+        new MouseEvent('mousemove', { bubbles: true, composed: true })
+      );
+      await wait(10);
+      document.dispatchEvent(
+        new PointerEvent('pointerup', { bubbles: true, composed: true })
+      );
+      await wait(10);
+      expect(highlightedGutterNumbers(additions)).toEqual([2]);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test('unified: copying a selected deleted line writes the deleted text', async () => {
+    const fixture = await createDiffEditorFixture('unified', OLD, NEW);
+    try {
+      const shadow = fixture.container.shadowRoot;
+      const deletedGutterNumber = shadow?.querySelector<HTMLElement>(
+        "[data-gutter] [data-column-number][data-line-type='change-deletion']"
+      );
+      const content = shadow?.querySelector<HTMLElement>('[data-content]');
+      expect(deletedGutterNumber).not.toBeNull();
+      if (content == null) {
+        throw new Error('missing content element');
+      }
+
+      // Select the deleted line via its gutter number.
+      deletedGutterNumber?.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true, composed: true })
+      );
+      await wait(10);
+
+      // The deleted row lives inside the editor's contentEl (unified view), so a
+      // copy event reaches the editor's copy handler. The deleted text isn't in
+      // the editor's document, so the handler must copy the selected deleted
+      // line's text rather than the empty document selection.
+      const writes = dispatchCopy(content);
+      const copied = writes.find(([type]) => type === 'text')?.[1] ?? '';
+      expect(copied).toBe('import a');
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test('unified: copying a multi-line deletion selection writes every line', async () => {
+    // A block of consecutive deletions, so a gutter drag spans several lines.
+    const fixture = await createDiffEditorFixture(
+      'unified',
+      'a\nb\nc\nkeep\n',
+      'keep\n'
+    );
+    try {
+      const shadow = fixture.container.shadowRoot;
+      const deletedGutterNumbers = [
+        ...(shadow?.querySelectorAll<HTMLElement>(
+          "[data-gutter] [data-column-number][data-line-type='change-deletion']"
+        ) ?? []),
+      ];
+      const content = shadow?.querySelector<HTMLElement>('[data-content]');
+      expect(deletedGutterNumbers.length).toBeGreaterThanOrEqual(3);
+      if (content == null) {
+        throw new Error('missing content element');
+      }
+      const first = deletedGutterNumbers[0];
+      const last = deletedGutterNumbers[deletedGutterNumbers.length - 1];
+
+      // Drag from the first deleted line number to the last.
+      first?.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true, composed: true })
+      );
+      await wait(10);
+      last?.dispatchEvent(
+        new MouseEvent('mousemove', { bubbles: true, composed: true })
+      );
+      await wait(10);
+
+      // Each deleted line is a separate read-only host, so the browser's native
+      // selection clamps to the first line; the copy must still carry every
+      // selected deleted line.
+      const writes = dispatchCopy(content);
+      const copied = writes.find(([type]) => type === 'text')?.[1] ?? '';
+      expect(copied).toBe('a\nb\nc');
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
In edit mode, click or drag to select code on either side of a split or unified diff. A caret highlights only its own line, on the side it sits on, instead of also lighting up the paired line in the read-only deletions pane. Selecting text drops the full-line background and keeps only the caret line's number highlighted, so the selection itself is the line-level marker. Deleted text is selectable and copyable: clicking a line number selects that whole line's text on either side, and in split view dragging across the deletion line numbers selects the block, the same as on the additions side.

Previously the active-line highlight leaked onto the read-only deletions pane, the full-line background competed with a text selection, deleted text could not be selected, and line-number gestures behaved differently per side. The editor now confines the active-line highlight to the caret's side, paints deleted-text selection with the native selection (revealed only while selecting deleted text), highlights just the focus line's number during a gutter drag, and stops a transparent-span rule from hiding the word-level diff highlights.

| Before | After |
|--------|--------|
| <img width="621" height="24" alt="image" src="https://github.com/user-attachments/assets/c3c33990-a32e-4cbc-b063-605c8bca3e3b" /> | <img width="625" height="23" alt="image" src="https://github.com/user-attachments/assets/10038f6f-795b-4414-884f-7730f8d42a89" /> |
| <img width="614" height="126" alt="image" src="https://github.com/user-attachments/assets/fcf1cd69-2cac-434d-a070-e11bda4ab6ce" /> | <img width="613" height="130" alt="image" src="https://github.com/user-attachments/assets/10435bb6-812e-4c3a-a2b0-55040aa900c5" /> |
| <img width="1244" height="46" alt="image" src="https://github.com/user-attachments/assets/6367d3e0-728b-44d3-bf27-eeadfebe09a7" /> | <img width="1243" height="41" alt="image" src="https://github.com/user-attachments/assets/7082a263-97b3-467f-8900-9798bd78deee" /> | 
| No selection for deletions | <img width="623" height="167" alt="image" src="https://github.com/user-attachments/assets/3745bf28-e5bc-46be-8035-a02436fe372b" /> |
