### PR TITLE
[docs] Sync diff editor with app theme in system mode

### DIFF
--- a/apps/docs/app/(diffs)/playground/PlaygroundClient.tsx
+++ b/apps/docs/app/(diffs)/playground/PlaygroundClient.tsx
@@ -94,7 +94,7 @@ type EditorMode = 'review' | 'edit';
 // Default values for URL param comparison
 const DEFAULTS = {
   diffStyle: 'split',
-  themeType: 'system',
+  colorMode: 'system',
   lightTheme: 'pierre-light',
   darkTheme: 'pierre-dark',
   diffIndicators: 'bars',
@@ -118,8 +118,8 @@ interface PlaygroundClientProps {
 interface PlaygroundControlsContentProps {
   diffStyle: 'split' | 'unified';
   setDiffStyle: (v: 'split' | 'unified') => void;
-  themeType: 'system' | 'light' | 'dark';
-  setThemeType: (v: 'system' | 'light' | 'dark') => void;
+  colorMode: 'system' | 'light' | 'dark';
+  setColorMode: (v: 'system' | 'light' | 'dark') => void;
   selectedLightTheme: (typeof LIGHT_THEMES)[number];
   setSelectedLightTheme: (v: (typeof LIGHT_THEMES)[number]) => void;
   selectedDarkTheme: (typeof DARK_THEMES)[number];
@@ -158,8 +158,8 @@ interface PlaygroundControlsContentProps {
 function PlaygroundControlsContent({
   diffStyle,
   setDiffStyle,
-  themeType,
-  setThemeType,
+  colorMode,
+  setColorMode,
   selectedLightTheme,
   setSelectedLightTheme,
   selectedDarkTheme,
@@ -270,7 +270,7 @@ function PlaygroundControlsContent({
                 key={theme}
                 onClick={() => {
                   setSelectedLightTheme(theme);
-                  setThemeType('light');
+                  setColorMode('light');
                 }}
                 selected={selectedLightTheme === theme}
               >
@@ -301,7 +301,7 @@ function PlaygroundControlsContent({
                 key={theme}
                 onClick={() => {
                   setSelectedDarkTheme(theme);
-                  setThemeType('dark');
+                  setColorMode('dark');
                 }}
                 selected={selectedDarkTheme === theme}
               >
@@ -315,9 +315,9 @@ function PlaygroundControlsContent({
         </DropdownMenu>
 
         <ButtonGroup
-          value={themeType}
+          value={colorMode}
           onValueChange={(value) =>
-            setThemeType(value as 'system' | 'light' | 'dark')
+            setColorMode(value as 'system' | 'light' | 'dark')
           }
           size="icon"
         >
@@ -541,10 +541,10 @@ export function PlaygroundClient({ prerenderedDiff }: PlaygroundClientProps) {
   const searchParams = useSearchParams();
   const router = useRouter();
 
-  // The app-wide color scheme resolved by @pierre/theming (the shared
-  // theme controller). The diff's "system" mode must follow this so the
-  // editor stays in sync with the rest of the app. See `effectiveThemeType`.
-  const { resolvedTheme } = useTheme();
+  // The app-wide color scheme resolved by @pierre/theming (the shared theme
+  // controller). The diff's "system" mode must follow this so the editor stays
+  // in sync with the rest of the app. See `effectiveColorMode`.
+  const { resolvedColorScheme } = useTheme();
 
   const getParam = <T extends string>(key: string, defaultValue: T): T => {
     return (searchParams.get(key) as T) ?? defaultValue;
@@ -568,8 +568,8 @@ export function PlaygroundClient({ prerenderedDiff }: PlaygroundClientProps) {
     getParam('layout', DEFAULTS.diffStyle) as 'split' | 'unified'
   );
 
-  const [themeType, setThemeType] = useState<'system' | 'light' | 'dark'>(
-    getParam('mode', DEFAULTS.themeType) as 'system' | 'light' | 'dark'
+  const [colorMode, setColorMode] = useState<'system' | 'light' | 'dark'>(
+    getParam('mode', DEFAULTS.colorMode) as 'system' | 'light' | 'dark'
   );
   const [selectedLightTheme, setSelectedLightTheme] = useState<
     (typeof LIGHT_THEMES)[number]
@@ -699,7 +699,7 @@ export function PlaygroundClient({ prerenderedDiff }: PlaygroundClientProps) {
 
     // Only add non-default values to keep URL clean
     if (diffStyle !== DEFAULTS.diffStyle) params.set('layout', diffStyle);
-    if (themeType !== DEFAULTS.themeType) params.set('mode', themeType);
+    if (colorMode !== DEFAULTS.colorMode) params.set('mode', colorMode);
     if (selectedLightTheme !== DEFAULTS.lightTheme)
       params.set('light', selectedLightTheme);
     if (selectedDarkTheme !== DEFAULTS.darkTheme)
@@ -743,7 +743,7 @@ export function PlaygroundClient({ prerenderedDiff }: PlaygroundClientProps) {
       : '/playground';
   }, [
     diffStyle,
-    themeType,
+    colorMode,
     selectedLightTheme,
     selectedDarkTheme,
     diffIndicators,
@@ -841,8 +841,8 @@ export function PlaygroundClient({ prerenderedDiff }: PlaygroundClientProps) {
   const controlsContentProps = {
     diffStyle,
     setDiffStyle,
-    themeType,
-    setThemeType,
+    colorMode,
+    setColorMode,
     selectedLightTheme,
     setSelectedLightTheme,
     selectedDarkTheme,
@@ -879,10 +879,11 @@ export function PlaygroundClient({ prerenderedDiff }: PlaygroundClientProps) {
   // theme differs from the OS preference. To keep the editor in sync with the
   // app, resolve "system" to the app's current scheme from @pierre/theming and
   // pass that concrete light/dark to the diff; "light"/"dark" still force the
-  // editor independently. Before the controller has mounted `resolvedTheme` is
-  // undefined, so fall back to "system" to match the prerendered diff.
-  const effectiveThemeType =
-    themeType === 'system' ? (resolvedTheme ?? 'system') : themeType;
+  // editor independently. Before the controller has mounted
+  // `resolvedColorScheme` is undefined, so fall back to "system" to match the
+  // prerendered diff.
+  const effectiveColorMode =
+    colorMode === 'system' ? (resolvedColorScheme ?? 'system') : colorMode;
 
   // Editing takes over click targets, so line selection and gutter comments are
   // disabled while in Edit mode (they only make sense in read-only Review).
@@ -902,7 +903,7 @@ export function PlaygroundClient({ prerenderedDiff }: PlaygroundClientProps) {
         disableBackground,
         disableLineNumbers,
         overflow,
-        themeType: effectiveThemeType,
+        themeType: effectiveColorMode,
         theme: { dark: selectedDarkTheme, light: selectedLightTheme },
         enableLineSelection: contentEditable ? false : canSelectLines,
         enableGutterUtility: contentEditable ? false : canUseGutterComments,

--- a/apps/docs/app/(diffs)/playground/PlaygroundClient.tsx
+++ b/apps/docs/app/(diffs)/playground/PlaygroundClient.tsx
@@ -39,6 +39,7 @@ import { toast } from 'sonner';
 
 import type { PlaygroundAnnotationMetadata } from './constants';
 import { PLAYGROUND_MARKERS } from './constants';
+import { useTheme } from '@/components/theme-provider';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { ButtonGroup, ButtonGroupItem } from '@/components/ui/button-group';
@@ -540,6 +541,11 @@ export function PlaygroundClient({ prerenderedDiff }: PlaygroundClientProps) {
   const searchParams = useSearchParams();
   const router = useRouter();
 
+  // The app-wide color scheme resolved by @pierre/theming (the shared
+  // theme controller). The diff's "system" mode must follow this so the
+  // editor stays in sync with the rest of the app. See `effectiveThemeType`.
+  const { resolvedTheme } = useTheme();
+
   const getParam = <T extends string>(key: string, defaultValue: T): T => {
     return (searchParams.get(key) as T) ?? defaultValue;
   };
@@ -868,6 +874,16 @@ export function PlaygroundClient({ prerenderedDiff }: PlaygroundClientProps) {
     handleCopyLink,
   };
 
+  // The diff's own "system" mode follows the OS (its shadow root declares
+  // `color-scheme: light dark`), which drifts from the app whenever the app's
+  // theme differs from the OS preference. To keep the editor in sync with the
+  // app, resolve "system" to the app's current scheme from @pierre/theming and
+  // pass that concrete light/dark to the diff; "light"/"dark" still force the
+  // editor independently. Before the controller has mounted `resolvedTheme` is
+  // undefined, so fall back to "system" to match the prerendered diff.
+  const effectiveThemeType =
+    themeType === 'system' ? (resolvedTheme ?? 'system') : themeType;
+
   // Editing takes over click targets, so line selection and gutter comments are
   // disabled while in Edit mode (they only make sense in read-only Review).
   const fileDiff = (
@@ -886,7 +902,7 @@ export function PlaygroundClient({ prerenderedDiff }: PlaygroundClientProps) {
         disableBackground,
         disableLineNumbers,
         overflow,
-        themeType,
+        themeType: effectiveThemeType,
         theme: { dark: selectedDarkTheme, light: selectedLightTheme },
         enableLineSelection: contentEditable ? false : canSelectLines,
         enableGutterUtility: contentEditable ? false : canUseGutterComments,

--- a/apps/docs/app/(diffs)/theme/ThemeDemo.tsx
+++ b/apps/docs/app/(diffs)/theme/ThemeDemo.tsx
@@ -310,7 +310,7 @@ interface WorkingFile {
 }
 
 export function ThemeDemo() {
-  const { resolvedTheme } = useTheme();
+  const { resolvedColorScheme } = useTheme();
   const [colorMode, setColorMode] = useState<'light' | 'dark'>('dark');
   const [activeTab, setActiveTab] = useState<TabId>('typescript');
   const [mounted, setMounted] = useState(false);
@@ -351,10 +351,10 @@ export function ThemeDemo() {
   // Sync with system theme on mount
   useEffect(() => {
     setMounted(true);
-    if (resolvedTheme === 'light' || resolvedTheme === 'dark') {
-      setColorMode(resolvedTheme);
+    if (resolvedColorScheme === 'light' || resolvedColorScheme === 'dark') {
+      setColorMode(resolvedColorScheme);
     }
-  }, [resolvedTheme]);
+  }, [resolvedColorScheme]);
 
   // Close dropdown when clicking outside
   useEffect(() => {

--- a/apps/docs/app/(diffs)/theme/ThemeScreenshots.tsx
+++ b/apps/docs/app/(diffs)/theme/ThemeScreenshots.tsx
@@ -10,16 +10,16 @@ import { useTheme } from '@/components/theme-provider';
 import { ButtonGroup, ButtonGroupItem } from '@/components/ui/button-group';
 
 export function ThemeScreenshots() {
-  const { resolvedTheme } = useTheme();
+  const { resolvedColorScheme } = useTheme();
   const [activeTheme, setActiveTheme] = useState<'light' | 'dark'>('dark');
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     setMounted(true);
-    if (resolvedTheme === 'light' || resolvedTheme === 'dark') {
-      setActiveTheme(resolvedTheme);
+    if (resolvedColorScheme === 'light' || resolvedColorScheme === 'dark') {
+      setActiveTheme(resolvedColorScheme);
     }
-  }, [resolvedTheme]);
+  }, [resolvedColorScheme]);
 
   if (!mounted) {
     return (

--- a/apps/docs/app/(trees)/_components/tree-examples/TreeCssViewer.tsx
+++ b/apps/docs/app/(trees)/_components/tree-examples/TreeCssViewer.tsx
@@ -11,8 +11,8 @@ export function TreeCssViewer({
   contents: string;
   filename?: string;
 }) {
-  const { resolvedTheme } = useTheme();
-  const isDark = resolvedTheme === 'dark';
+  const { resolvedColorScheme } = useTheme();
+  const isDark = resolvedColorScheme === 'dark';
   const theme = isDark ? 'pierre-dark' : 'pierre-light';
   const themeType = isDark ? 'dark' : 'light';
 

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -144,22 +144,22 @@ const SITE_OG_IMAGE = SITE_OG_IMAGE_BY_SITE[SITE];
 const SITE_TWITTER_IMAGE = SITE_TWITTER_IMAGE_BY_SITE[SITE];
 const themeBootstrapScript = `(${String(function applyInitialTheme() {
   try {
-    const storedTheme = window.localStorage.getItem('theme');
-    const theme =
-      storedTheme === 'light' || storedTheme === 'dark'
-        ? storedTheme
+    const storedColorMode = window.localStorage.getItem('theme');
+    const colorMode =
+      storedColorMode === 'light' || storedColorMode === 'dark'
+        ? storedColorMode
         : 'system';
-    const resolvedTheme =
-      theme === 'system'
+    const resolvedColorScheme =
+      colorMode === 'system'
         ? window.matchMedia('(prefers-color-scheme: dark)').matches
           ? 'dark'
           : 'light'
-        : theme;
+        : colorMode;
     const root = document.documentElement;
 
     root.classList.remove('light', 'dark');
-    root.classList.add(resolvedTheme);
-    root.style.colorScheme = resolvedTheme;
+    root.classList.add(resolvedColorScheme);
+    root.style.colorScheme = resolvedColorScheme;
 
     // Set the iOS navbar tint before first paint so it matches the resolved
     // mode immediately. The meta is created here (not authored in JSX, which
@@ -174,7 +174,7 @@ const themeBootstrapScript = `(${String(function applyInitialTheme() {
     }
     themeColorMeta.setAttribute(
       'content',
-      resolvedTheme === 'dark' ? '#0a0a0a' : '#ffffff'
+      resolvedColorScheme === 'dark' ? '#0a0a0a' : '#ffffff'
     );
   } catch {
     // Ignore storage/media failures and let CSS defaults apply.

--- a/apps/docs/components/theme-provider.tsx
+++ b/apps/docs/components/theme-provider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { ColorMode } from '@pierre/theming';
+import type { ColorMode, ColorScheme } from '@pierre/theming';
 import {
   createContext,
   type ReactNode,
@@ -14,32 +14,33 @@ import {
 
 import { themeController } from './themeController';
 
-type ResolvedTheme = 'light' | 'dark';
-
 interface ThemeProviderProps {
   attribute?: 'class' | `data-${string}` | Array<'class' | `data-${string}`>;
   children: ReactNode;
   enableColorScheme?: boolean;
-  value?: Partial<Record<ResolvedTheme, string>>;
+  value?: Partial<Record<ColorScheme, string>>;
 }
 
+// Mirrors @pierre/theming's vocabulary: `colorMode` is the selected
+// light/dark/system mode, `resolvedColorScheme` is the concrete light/dark it
+// resolves to, and `setColorMode` drives the controller.
 interface ThemeContextValue {
-  resolvedTheme?: ResolvedTheme;
-  setTheme: (theme: ColorMode) => void;
-  systemTheme?: ResolvedTheme;
-  theme?: ColorMode;
-  themes: ColorMode[];
+  colorMode?: ColorMode;
+  colorModes: ColorMode[];
+  resolvedColorScheme?: ColorScheme;
+  setColorMode: (mode: ColorMode) => void;
+  systemColorScheme?: ColorScheme;
 }
 
-const RESOLVED_THEMES: ResolvedTheme[] = ['light', 'dark'];
-const AVAILABLE_MODES: ColorMode[] = ['light', 'dark', 'system'];
+const COLOR_SCHEMES: ColorScheme[] = ['light', 'dark'];
+const COLOR_MODES: ColorMode[] = ['light', 'dark', 'system'];
 
-// Navbar tint (iOS Safari's <meta name="theme-color">) for each resolved
-// color mode. These match the global body `--background` (oklch(1)/oklch(0.145))
+// Navbar tint (iOS Safari's <meta name="theme-color">) for each resolved color
+// scheme. These match the global body `--background` (oklch(1)/oklch(0.145))
 // that iOS samples at the top of the page, so the navbar blends with the page
 // instead of contrasting it. Kept in sync with the same literals hardcoded in
 // the layout's pre-paint bootstrap script (which can't import this module).
-const MODE_THEME_COLOR: Record<ResolvedTheme, string> = {
+const MODE_THEME_COLOR: Record<ColorScheme, string> = {
   light: '#ffffff',
   dark: '#0a0a0a',
 };
@@ -61,25 +62,25 @@ function setThemeColorMeta(color: string) {
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
-// Applies the already-resolved color mode to <html>: the class/data-attribute
+// Applies the already-resolved color scheme to <html>: the class/data-attribute
 // contract, the native color-scheme, and the iOS navbar tint. The resolved
 // 'light'/'dark' comes straight from the theme controller, so this no longer
 // re-derives it from a raw mode + system preference.
 function applyTheme({
   attribute,
   enableColorScheme,
-  resolvedTheme,
+  resolvedColorScheme,
   value,
 }: {
   attribute: ThemeProviderProps['attribute'];
   enableColorScheme: boolean;
-  resolvedTheme: ResolvedTheme;
-  value: Partial<Record<ResolvedTheme, string>> | undefined;
+  resolvedColorScheme: ColorScheme;
+  value: Partial<Record<ColorScheme, string>> | undefined;
 }) {
   const root = document.documentElement;
-  const resolvedValue = value?.[resolvedTheme] ?? resolvedTheme;
+  const resolvedValue = value?.[resolvedColorScheme] ?? resolvedColorScheme;
   const attributes = Array.isArray(attribute) ? attribute : [attribute];
-  const classValues = RESOLVED_THEMES.map((theme) => value?.[theme] ?? theme);
+  const classValues = COLOR_SCHEMES.map((scheme) => value?.[scheme] ?? scheme);
 
   for (const currentAttribute of attributes) {
     if (currentAttribute === 'class') {
@@ -93,16 +94,16 @@ function applyTheme({
   }
 
   if (enableColorScheme) {
-    root.style.colorScheme = resolvedTheme;
+    root.style.colorScheme = resolvedColorScheme;
   }
 
-  // Keep the iOS navbar tint in step with the resolved color mode.
-  setThemeColorMeta(MODE_THEME_COLOR[resolvedTheme]);
+  // Keep the iOS navbar tint in step with the resolved color scheme.
+  setThemeColorMeta(MODE_THEME_COLOR[resolvedColorScheme]);
 }
 
 // Thin React binding over the @pierre/theming controller (the single owner of
 // theming state). It subscribes to the controller for mode +
-// resolvedColorScheme, applies the resolved mode to the DOM, and exposes the
+// resolvedColorScheme, applies the resolved scheme to the DOM, and exposes the
 // useTheme() API the app already depends on. Selection and persistence live in
 // the controller — this component holds no theming state of its own.
 export function ThemeProvider({
@@ -122,37 +123,37 @@ export function ThemeProvider({
   // first render — but the server rendered the defaults. Expose the resolved
   // values to consumers only after mount, so any render output derived from
   // useTheme() (e.g. diffshub's chrome) matches the SSR markup first, then
-  // flips. The DOM application below still uses the real resolved mode (the
+  // flips. The DOM application below still uses the real resolved scheme (the
   // pre-paint bootstrap script already painted it), so this gate is invisible.
   const [mounted, setMounted] = useState(false);
   useEffect(() => {
     setMounted(true);
   }, []);
 
-  const theme = mounted ? state.mode : undefined;
-  const resolvedTheme = mounted ? state.resolvedColorScheme : undefined;
+  const colorMode = mounted ? state.mode : undefined;
+  const resolvedColorScheme = mounted ? state.resolvedColorScheme : undefined;
 
   useEffect(() => {
     applyTheme({
       attribute,
       enableColorScheme,
-      resolvedTheme: state.resolvedColorScheme,
+      resolvedColorScheme: state.resolvedColorScheme,
       value,
     });
   }, [attribute, enableColorScheme, state.resolvedColorScheme, value]);
 
-  const setTheme = useCallback((next: ColorMode) => {
+  const setColorMode = useCallback((next: ColorMode) => {
     themeController.setColorMode(next);
   }, []);
 
   const contextValue = useMemo<ThemeContextValue>(
     () => ({
-      resolvedTheme,
-      setTheme,
-      theme,
-      themes: AVAILABLE_MODES,
+      colorMode,
+      colorModes: COLOR_MODES,
+      resolvedColorScheme,
+      setColorMode,
     }),
-    [resolvedTheme, setTheme, theme]
+    [colorMode, resolvedColorScheme, setColorMode]
   );
 
   return (
@@ -165,8 +166,8 @@ export function ThemeProvider({
 export function useTheme(): ThemeContextValue {
   return (
     useContext(ThemeContext) ?? {
-      setTheme: () => {},
-      themes: [],
+      colorModes: [],
+      setColorMode: () => {},
     }
   );
 }

--- a/apps/docs/components/ui/sonner.tsx
+++ b/apps/docs/components/ui/sonner.tsx
@@ -7,11 +7,11 @@ import { useTheme } from '@/components/theme-provider';
 type ToasterProps = React.ComponentProps<typeof Sonner>;
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = 'system' } = useTheme();
+  const { colorMode = 'system' } = useTheme();
 
   return (
     <Sonner
-      theme={theme as ToasterProps['theme']}
+      theme={colorMode as ToasterProps['theme']}
       className="toaster group"
       toastOptions={{
         classNames: {


### PR DESCRIPTION
The diff editor's "system" themeType follows the OS prefers-color-scheme (its shadow root declares `color-scheme: light dark`), so it drifted from the app whenever the app theme differed from the OS. Resolve "system" to the app's scheme from `@pierre/theming` so the editor stays in sync; the switcher stays editor-only and "light"/"dark" remain independent overrides.

Rename the `useTheme()` binding and every consumer to the controller's vocabulary so the docs match the library, not just one file:

```
resolvedTheme -> resolvedColorScheme
theme         -> colorMode
setTheme      -> setColorMode
systemTheme   -> systemColorScheme
themes        -> colorModes
```

Also rename the playground's local switcher state (`themeType` -> `colorMode`, the diffs `themeType` option key is unchanged) and the pre-paint bootstrap script's locals. Pure rename — no behavior change.
