### PR TITLE
fix(diffs): move focus when a diff line number is clicked

### DIFF
--- a/packages/diffs/src/managers/InteractionManager.ts
+++ b/packages/diffs/src/managers/InteractionManager.ts
@@ -758,7 +758,11 @@ export class InteractionManager<TMode extends InteractionManagerMode> {
       return;
     }
 
-    event.preventDefault();
+    // Intentionally no preventDefault here. The line-number gutter uses
+    // `user-select: none`, so a drag that starts on it never begins a native
+    // text selection. Calling preventDefault would also cancel the browser's
+    // native focus change, which stops a focusable host wrapper from receiving
+    // focus (and the keyboard events it needs) when a line number is clicked.
     const { lineNumber, eventSide, lineIndex } = pointerInfo;
 
     if (event.shiftKey && this.selectedRange != null) {

--- a/packages/diffs/src/utils/createPreElement.ts
+++ b/packages/diffs/src/utils/createPreElement.ts
@@ -35,7 +35,10 @@ export function createPreWrapperProperties({
       diffIndicators === 'bars' || diffIndicators === 'classic'
         ? diffIndicators
         : undefined,
-    tabIndex: 0,
+    // The pre is intentionally not focusable. It is not the scroll container
+    // (`[data-code]` inside it is) and has no keyboard behavior of its own, so
+    // a tabindex would only add a tab stop per diff and steal focus from a host
+    // wrapper that wants to own keyboard navigation of the selection.
     style: `--diffs-min-number-column-width-default:${`${totalLines}`.length}ch;`,
   };
 

--- a/packages/diffs/src/utils/setWrapperNodeProps.ts
+++ b/packages/diffs/src/utils/setWrapperNodeProps.ts
@@ -55,7 +55,6 @@ export function setPreNodeProperties(
     pre.removeAttribute('data-diff-type');
   }
   pre.setAttribute('data-overflow', overflow);
-  pre.tabIndex = 0;
   // Set CSS custom property for line number column width
   pre.style.setProperty(
     '--diffs-min-number-column-width-default',

--- a/packages/diffs/test/FileRenderer.ast.test.ts
+++ b/packages/diffs/test/FileRenderer.ast.test.ts
@@ -214,7 +214,8 @@ describe('FileRenderer AST Structure', () => {
     expect(preAST.properties['data-file']).toBe('');
     expect(preAST.properties['data-diff']).toBeUndefined();
     expect(preAST.properties['data-overflow']).toBe('scroll');
-    expect(preAST.properties.tabIndex).toBe(0);
+    // The pre is intentionally not focusable (no tabindex); the host owns focus.
+    expect(preAST.properties.tabIndex).toBeUndefined();
     // The gutter width var reserves one ch per digit of the line count
     expect(preAST.properties.style).toBe(
       `--diffs-min-number-column-width-default:${`${totalLines}`.length}ch;`


### PR DESCRIPTION
Steps to reproduce:

1. Wrap a CodeView in a focusable element (the host wrapper).
2. Enable line selection.
3. Focus some other element on the page.
4. Click a diff line number.

The line range is selected, but focus never moves into the diff, so the host wrapper can't receive the keyboard events it needs to drive navigation of the selection.

The line-selection pointerdown called preventDefault, which also cancels the browser's native focus change. Line numbers already use `user-select: none` and `touch-action: none`, so that preventDefault only blocked focus. Each `pre` also had `tabindex="0"`, so any focus that did move landed on the `pre` instead of the wrapper, even though the `pre` is not the scroll container and has no keyboard behavior.

Remove both. A click now moves focus to the nearest focusable ancestor, the host wrapper, which can own keyboard navigation.

Fix #898
