### PR TITLE
fix(diffs): keep scroll position stable when editing a unified diff

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -1977,6 +1977,19 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       );
     }
 
+    // A diff re-renders its rows in place after the edits above: a unified diff
+    // rebuilds its content column on every edit (FileDiff.refreshDiffView swaps
+    // the column's innerHTML), and any diff rebuilds on a line-count change
+    // (applyDocumentChange -> full render). That detaches the line elements this
+    // editor memoized for caret/selection geometry (#lineYCache,
+    // #lastAccessedLineElement), so a detached row would measure offsetTop 0 and
+    // the caret would render at the top - the following #scrollToPrimaryCaret
+    // then scrolls the viewport there. Drop the geometry caches so the overlay
+    // re-measures against the freshly rebuilt rows and the caret stays put.
+    if (this.#isDiff && (this.#diffSyle === 'unified' || didLineCountChange)) {
+      this.#resetCache();
+    }
+
     if (newLineAnnotations !== undefined) {
       this.#lineAnnotations = newLineAnnotations;
       renderLineAnnotations(newLineAnnotations, contentEl, gutterEl);


### PR DESCRIPTION
Editing a scrolled unified diff snaps the view back to the top. To reproduce:

1. Open the editor on a unified diff.
2. Scroll down within the editor.
3. Edit a visible line (type a character, press Enter, etc.).

The view jumps to the top of the diff instead of staying where you were. Split diffs are unaffected.

On every edit a unified diff re-renders its rows in place: FileDiff.refreshDiffView rewrites the content column's innerHTML, which detaches the line elements the editor cached for caret geometry. The editor then measures a detached row (offsetTop 0) and places the caret at the top, so the follow-up scrollIntoView pulls the viewport up to it.

Reset the editor's line-geometry caches after a diff rebuilds its rows, so the caret re-measures against the fresh DOM and the viewport stays put.
