### PR TITLE
refactor(diffs): Give diff hunk recompute a single owner per edit

### DIFF
--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -10,6 +10,7 @@ import {
   HEADER_FILENAME_SUFFIX_SLOT_ID,
   HEADER_METADATA_SLOT_ID,
   HEADER_PREFIX_SLOT_ID,
+  NO_CHANGED_ADDITION_LINES,
   THEME_CSS_ATTRIBUTE,
   UNSAFE_CSS_ATTRIBUTE,
 } from '../constants';
@@ -501,7 +502,7 @@ export class File<
     };
   }
 
-  // normally triggered by the editor when the document line count changes
+  // normally triggered by the host when the document line count changes
   public applyDocumentChange(
     textDocument: DiffsTextDocument,
     newLineAnnotations?: LineAnnotation<LAnnotation>[]
@@ -521,9 +522,17 @@ export class File<
   public updateRenderCache(
     dirtyLines: Map<number, Array<HighlightedToken>>,
     themeType: 'dark' | 'light'
-  ): void {
+  ): readonly number[] {
     this.fileRenderer.updateRenderCache(dirtyLines, themeType);
+    // Plain files have no diff hunks to recompute.
+    return NO_CHANGED_ADDITION_LINES;
   }
+
+  // Plain files render edits via the host's inline DOM patch; nothing to do.
+  public applyContentEdit(): void {}
+
+  // Plain files have no diff hunks to recompute.
+  public recomputeContentHunks(): void {}
 
   public render({
     file,

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -291,7 +291,7 @@ export class FileDiff<
     side: SelectionSide = 'additions'
   ) => {
     // use the fileDiff from the hunksRenderer if it exists, it maybe updated
-    // by the editor
+    // by the host
     const fileDiff = this.hunksRenderer.getRenderDiff() ?? this.fileDiff;
     if (fileDiff == null) {
       return undefined;
@@ -1027,7 +1027,7 @@ export class FileDiff<
     };
   }
 
-  // normally triggered by the editor when the document line count changes
+  // normally triggered by the host when the document line count changes
   public applyDocumentChange(
     textDocument: DiffsTextDocument,
     newLineAnnotations?: DiffLineAnnotation<LAnnotation>[]
@@ -1050,14 +1050,14 @@ export class FileDiff<
     }
   }
 
-  // Re-render the diff from the editor's document after a host-driven full
+  // Re-render the diff from the host's document after a host-driven full
   // re-render rebuilt the rows from the host's (now stale) file contents.
   // applyDocumentChange re-derives the diff (addition lines + hunks) from the
   // document, but the cached highlighted AST still holds the host's content for
   // rows that already existed, and renderDiff reuses it. Clearing the render
   // cache forces the re-render to re-highlight from the document, so every row
   // matches it - text, syntax colors, and line count - in one pass. Mutating
-  // the diff in place keeps its cacheKey, so the editor's document and undo
+  // the diff in place keeps its cacheKey, so the host's document and undo
   // history survive the re-render.
   public rerenderFromDocument(textDocument: DiffsTextDocument): void {
     this.hunksRenderer.applyDocumentChange(textDocument);
@@ -1071,27 +1071,29 @@ export class FileDiff<
 
   public updateRenderCache(
     dirtyLines: Map<number, Array<HighlightedToken>>,
-    themeType: 'dark' | 'light',
-    shouldRefreshView?: boolean,
-    skipDiffRecompute?: boolean
+    themeType: 'dark' | 'light'
+  ): readonly number[] {
+    return this.hunksRenderer.updateRenderCache(dirtyLines, themeType);
+  }
+
+  public recomputeContentHunks(
+    changedAdditionLineIndexes: readonly number[]
   ): void {
-    this.hunksRenderer.updateRenderCache(
-      dirtyLines,
-      themeType,
-      skipDiffRecompute
-    );
-    if (shouldRefreshView === true) {
-      if (this.options.diffStyle === 'split') {
-        if (this.fastRefreshTimeout != null) {
-          clearTimeout(this.fastRefreshTimeout);
-        }
-        this.fastRefreshTimeout = setTimeout(() => {
-          this.fastRefreshTimeout = undefined;
-          this.fastRefreshDiffView();
-        }, 100);
-      } else {
-        this.refreshDiffView();
+    this.hunksRenderer.recomputeContentHunks(changedAdditionLineIndexes);
+  }
+
+  public applyContentEdit(changedAdditionLineIndexes: readonly number[]): void {
+    this.recomputeContentHunks(changedAdditionLineIndexes);
+    if (this.options.diffStyle === 'split') {
+      if (this.fastRefreshTimeout != null) {
+        clearTimeout(this.fastRefreshTimeout);
       }
+      this.fastRefreshTimeout = setTimeout(() => {
+        this.fastRefreshTimeout = undefined;
+        this.fastRefreshDiffView();
+      }, 100);
+    } else {
+      this.refreshDiffView();
     }
   }
 

--- a/packages/diffs/src/components/VirtualizedFile.ts
+++ b/packages/diffs/src/components/VirtualizedFile.ts
@@ -623,7 +623,7 @@ export class VirtualizedFile<
     this.virtualizer.instanceChanged(this, false);
   }
 
-  // normally triggered by the editor when the document line count changes
+  // normally triggered by the host when the document line count changes
   override applyDocumentChange(
     textDocument: DiffsTextDocument,
     newLineAnnotations?: LineAnnotation<LAnnotation>[],
@@ -647,7 +647,7 @@ export class VirtualizedFile<
       this.computeApproximateSize();
     }
 
-    // Update the buffers caused by the line-count change to ensure the editor
+    // Update the buffers caused by the line-count change to ensure the host
     // scrolls to the correct position before re-rendering
     if (
       shouldUpdateBuffer &&

--- a/packages/diffs/src/components/VirtualizedFileDiff.ts
+++ b/packages/diffs/src/components/VirtualizedFileDiff.ts
@@ -770,7 +770,7 @@ export class VirtualizedFileDiff<
     this.virtualizer.instanceChanged(this, false);
   }
 
-  // Normally triggered by the editor when the document line count changes.
+  // Normally triggered by the host when the document line count changes.
   override applyDocumentChange(
     textDocument: DiffsTextDocument,
     newLineAnnotations?: DiffLineAnnotation<LAnnotation>[],
@@ -786,7 +786,7 @@ export class VirtualizedFileDiff<
       includeEstimatedHeights: true,
     });
 
-    // Update the buffers caused by the line-count change to ensure the editor
+    // Update the buffers caused by the line-count change to ensure the host
     // scrolls to the correct position before re-rendering
     if (
       shouldUpdateBuffer &&

--- a/packages/diffs/src/constants.ts
+++ b/packages/diffs/src/constants.ts
@@ -101,3 +101,7 @@ export const EMPTY_RENDER_RANGE: RenderRange = {
   bufferBefore: 0,
   bufferAfter: 0,
 };
+
+// Shared empty result returned by `updateRenderCache` when no addition-line
+// text changed, so the no-op path does not allocate a new array each call.
+export const NO_CHANGED_ADDITION_LINES: readonly number[] = [];

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -236,7 +236,16 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     lines: Map<number, Array<HighlightedToken>>,
     themeType: 'light' | 'dark'
   ) => {
-    this.#fileInstance?.updateRenderCache(lines, themeType);
+    const changedAdditionLines = this.#fileInstance?.updateRenderCache(
+      lines,
+      themeType
+    );
+    // Background/offscreen tokens can carry a content-only edit that landed
+    // outside the render window; keep hunk metadata in sync without refreshing
+    // the view (the visible rows are patched below).
+    if (changedAdditionLines != null && changedAdditionLines.length > 0) {
+      this.#fileInstance?.recomputeContentHunks(changedAdditionLines);
+    }
     // update the view if the render range is updated by scrolling
     // and the deferred tokenized lines inside the render range
     if (
@@ -1961,20 +1970,22 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       }
     }
 
-    fileInstance.updateRenderCache(
+    const changedAdditionLines = fileInstance.updateRenderCache(
       dirtyLines,
-      tokenizer.themeType,
-      this.#isDiff && !didLineCountChange,
-      // On a line-count change we recompute hunk metadata authoritatively in
-      // `applyDocumentChange` below, so skip the redundant recompute here.
-      didLineCountChange
+      tokenizer.themeType
     );
     if (didLineCountChange) {
+      // Line-count change: recompute hunks from the full document and re-render.
       fileInstance.applyDocumentChange(
         textDocument,
         newLineAnnotations,
         shouldUpdateBuffer
       );
+    } else if (changedAdditionLines.length > 0) {
+      // In-place content edit: incremental hunk recompute + view refresh.
+      // When no addition line text changed there is no hunk impact, so we skip
+      // the refresh entirely (the editor already patched the edited rows inline).
+      fileInstance.applyContentEdit(changedAdditionLines);
     }
 
     if (newLineAnnotations !== undefined) {

--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_RENDER_RANGE,
   DEFAULT_THEMES,
   DEFAULT_TOKENIZE_MAX_LENGTH,
+  NO_CHANGED_ADDITION_LINES,
 } from '../constants';
 import { areLanguagesAttached } from '../highlighter/languages/areLanguagesAttached';
 import {
@@ -269,7 +270,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
       renderCache.isDirty === true &&
       renderCache.diff.cacheKey != null
     ) {
-      // The render cache has been updated by the editor, let's purge it
+      // The render cache has been updated by the host, let's purge it
       // from the worker manager cache.
       this.workerManager?.evictDiffFromCache(renderCache.diff.cacheKey);
     }
@@ -339,20 +340,14 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
 
   public updateRenderCache(
     dirtyLines: Map<number, Array<HighlightedToken>>,
-    themeType: 'dark' | 'light',
-    // When a line-count change is being applied in the same edit pass,
-    // `applyDocumentChange` recomputes hunk metadata from the full document
-    // text immediately after this call, so recomputing here is wasted work
-    // (and runs against a mid-update line array). Skip it but keep syncing the
-    // per-line token/text content below, which `applyDocumentChange` preserves.
-    skipDiffRecompute = false
-  ): void {
+    themeType: 'dark' | 'light'
+  ): readonly number[] {
     if (this.renderCache == null) {
-      return;
+      return NO_CHANGED_ADDITION_LINES;
     }
     const { result, diff } = this.renderCache;
     if (result == null) {
-      return;
+      return NO_CHANGED_ADDITION_LINES;
     }
     if (diff.isPartial) {
       throw new Error('Could not update render cache for partial diff');
@@ -367,7 +362,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
       const canSyncDiffLine = line < diff.additionLines.length;
       const prevLine = canSyncDiffLine ? (diff.additionLines[line] ?? '') : '';
       const prevText = cleanLastNewline(prevLine);
-      // The editor text document can expose one extra trailing empty line when
+      // The host text document can expose one extra trailing empty line when
       // the file ends with a newline. Deferred tokenization must not grow
       // additionLines from that mismatch or hunk trailing context desyncs.
       if (canSyncDiffLine) {
@@ -409,22 +404,40 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
       };
     }
 
-    if (!skipDiffRecompute && changedAdditionLines.length > 0) {
-      Object.assign(
-        diff,
-        updateDiffHunks(
-          diff,
-          changedAdditionLines,
-          this.options.parseDiffOptions
-        )
-      );
-    }
-
     result.baseThemeType = themeType;
+    this.renderCache.isDirty = true;
+    return changedAdditionLines;
+  }
+
+  // Incrementally recompute hunk metadata after an in-place content edit
+  // (no line-count change). For a line-count change the host calls
+  // `applyDocumentChange` instead, which recomputes from the full document.
+  public recomputeContentHunks(
+    changedAdditionLineIndexes: readonly number[]
+  ): void {
+    if (this.renderCache == null) {
+      return;
+    }
+    const { diff, result } = this.renderCache;
+    if (
+      result == null ||
+      diff.isPartial ||
+      changedAdditionLineIndexes.length === 0
+    ) {
+      return;
+    }
+    Object.assign(
+      diff,
+      updateDiffHunks(
+        diff,
+        changedAdditionLineIndexes,
+        this.options.parseDiffOptions
+      )
+    );
     this.renderCache.isDirty = true;
   }
 
-  // Normally triggered by the editor when the document line count changes.
+  // Normally triggered by the host when the document line count changes.
   public applyDocumentChange(textDocument: DiffsTextDocument): void {
     if (this.renderCache == null) {
       return;
@@ -449,8 +462,8 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
     }
     if (!diff.isPartial) {
       // An empty document splits into zero addition lines, which would recompute
-      // to a diff with no editable rows and leave the attached editor with no
-      // line element to host its caret (the additions column vanishes in split;
+      // to a diff with no editable rows and leave the attached host with no
+      // line element for its caret (the additions column vanishes in split;
       // unified shows only deletions). Keep one empty editable line instead.
       if (newLength === 0) {
         Object.assign(
@@ -1976,7 +1989,7 @@ function createPlainAdditionLineElement(
   };
 }
 
-// Editor line text omits line endings; diff line arrays keep the suffix from parsing.
+// Host line text omits line endings; diff line arrays keep the suffix from parsing.
 function applyLineTextWithNewline(line: string, lineText: string): string {
   if (line.endsWith('\r\n')) {
     return lineText + '\r\n';

--- a/packages/diffs/src/renderers/FileRenderer.ts
+++ b/packages/diffs/src/renderers/FileRenderer.ts
@@ -154,7 +154,7 @@ export class FileRenderer<LAnnotation = undefined> {
       renderCache.isDirty === true &&
       renderCache.file.cacheKey != null
     ) {
-      // The render cache has been updated by the editor, let's purge it
+      // The render cache has been updated by the host, let's purge it
       // from the worker manager cache.
       this.workerManager?.evictFileFromCache(renderCache.file.cacheKey);
     }
@@ -295,7 +295,7 @@ export class FileRenderer<LAnnotation = undefined> {
     this.renderCache.isDirty = true;
   }
 
-  // normally triggered by the editor when the document line count changes
+  // normally triggered by the host when the document line count changes
   public applyDocumentChange(textDocument: DiffsTextDocument): void {
     if (this.renderCache == null) {
       return undefined;

--- a/packages/diffs/src/types.ts
+++ b/packages/diffs/src/types.ts
@@ -935,7 +935,7 @@ export interface DiffsEditableComponent<
 > extends DiffsBaseComponent {
   /**
    * Return the position and height of a one-based line relative to this component.
-   * The editor uses it to scroll to virtualized lines before their DOM nodes exist.
+   * The host uses it to scroll to virtualized lines before their DOM nodes exist.
    * A zero height means the line is not currently renderable.
    * In a file diff, `lineNumber` is the line number in the new file.
    */
@@ -950,16 +950,22 @@ export interface DiffsEditableComponent<
   ) => void;
   updateRenderCache: (
     lines: Map<number, Array<HighlightedToken>>,
-    themeType: 'dark' | 'light',
-    shouldRefreshView?: boolean,
-    // When the same edit pass also changes the document line count, the editor
-    // follows up with `applyDocumentChange`, which recomputes hunk metadata from
-    // the authoritative document text. Set this to skip the redundant hunk
-    // recompute here (token/line content updates still apply).
-    skipDiffRecompute?: boolean
+    themeType: 'dark' | 'light'
+  ) => readonly number[];
+  // Apply an in-place content edit (no line-count change): incrementally
+  // recompute hunk metadata for the changed lines and refresh the view.
+  // No-op for plain files. For a line-count change the host calls
+  // applyDocumentChange instead.
+  applyContentEdit: (changedAdditionLineIndexes: readonly number[]) => void;
+  // Recompute hunk metadata for changed addition lines WITHOUT refreshing the
+  // view. The host calls this for background/offscreen token updates — a
+  // content-only edit that landed outside the render window — where the visible
+  // rows are patched separately. No-op for plain files.
+  recomputeContentHunks: (
+    changedAdditionLineIndexes: readonly number[]
   ) => void;
-  // Re-render the component from the editor's document, discarding the cached
-  // (host-derived) rendered content. The editor calls this after a host-driven
+  // Re-render the component from the host's document, discarding the cached
+  // (host-derived) rendered content. The host calls this after a host-driven
   // full re-render rebuilt the rows from the host's stale file contents, so the
   // visible rows match the document - text, syntax colors, and line count - in
   // one pass. Optional: components without a document-backed re-render (the

--- a/packages/diffs/src/utils/updateDiffHunks.ts
+++ b/packages/diffs/src/utils/updateDiffHunks.ts
@@ -49,13 +49,13 @@ export function recomputeDiffHunks(
 
 // Rebuilds hunk metadata when the editable side has been emptied of all text.
 //
-// The editor always keeps one (empty) line for an empty document, but an empty
+// The host always keeps one (empty) line for an empty document, but an empty
 // string splits into zero addition lines, so a normal recompute produces a diff
-// with no addition rows at all. Rendering that leaves the attached editor with
-// no line element to host its caret. To keep one editable row, diff the
+// with no addition rows at all. Rendering that leaves the attached host with
+// no line element for its caret. To keep one editable row, diff the
 // unchanged deletions against a single line (which yields a hunk that places
 // exactly one addition row), then store the addition as `['']` so it still
-// joins back to the editor's empty document.
+// joins back to the host's empty document.
 //
 // The sentinel only has to differ from the deletion side so a hunk is produced;
 // its text is discarded by the `['']` override below. When the old side is

--- a/packages/diffs/test/DiffHunksRendererRecompute.test.ts
+++ b/packages/diffs/test/DiffHunksRendererRecompute.test.ts
@@ -11,10 +11,6 @@ afterAll(async () => {
   await disposeHighlighter();
 });
 
-// A diff where the addition and deletion sides have different line counts
-// (one line deleted) — the common case. `updateDiffHunks` cannot incrementally
-// recompute across a line-count mismatch, so without the skip flag
-// `updateRenderCache` falls back to a full `recomputeDiffHunks`.
 const OLD_CONTENTS = [
   'function greet(name) {',
   '  const msg = "hi";',
@@ -31,32 +27,6 @@ const NEW_CONTENTS = [
   '',
 ].join('\n');
 
-// Addition-side document after pressing Enter in the middle of
-// "  console.log(msg);" (index 1), splitting it into two lines.
-const EDITED_LINES = [
-  'function greet(name) {',
-  '  console.log(',
-  'msg);',
-  '  return msg;',
-  '}',
-  '',
-];
-// The tokenizer reports the truncated line and the new line as dirty, using the
-// post-edit line indexes.
-const DIRTY_EDIT: ReadonlyArray<[number, string]> = [
-  [1, '  console.log('],
-  [2, 'msg);'],
-];
-
-function makeTextDocument(lines: string[]): DiffsTextDocument {
-  const text = lines.join('\n');
-  return {
-    lineCount: lines.length,
-    getText: () => text,
-    getLineText: (lineNumber: number) => lines[lineNumber] ?? '',
-  };
-}
-
 function makeDirtyLines(
   edits: ReadonlyArray<[number, string]>
 ): Map<number, HighlightedToken[]> {
@@ -66,6 +36,15 @@ function makeDirtyLines(
     dirty.set(line, [[0, '', lineText]]);
   }
   return dirty;
+}
+
+function makeTextDocument(lines: string[]): DiffsTextDocument {
+  const text = lines.join('\n');
+  return {
+    lineCount: lines.length,
+    getText: () => text,
+    getLineText: (lineNumber: number) => lines[lineNumber] ?? '',
+  };
 }
 
 // Builds a renderer with a populated (highlighted) render cache, mirroring the
@@ -83,92 +62,53 @@ async function createPrimedRenderer(
   return renderer;
 }
 
-describe('DiffHunksRenderer.updateRenderCache skipDiffRecompute', () => {
-  test('baseline: without the skip flag, a line-count edit recomputes hunks twice', async () => {
-    const renderer = await createPrimedRenderer();
-    const cacheDiff = renderer.getRenderDiff();
-    expect(cacheDiff).toBeDefined();
-    if (cacheDiff == null) return;
-    // Sanity check the fixture is the unequal-length (recompute-fallback) case.
-    expect(cacheDiff.additionLines.length).not.toBe(
-      cacheDiff.deletionLines.length
-    );
-
-    const hunksBeforeUpdate = cacheDiff.hunks;
-    renderer.updateRenderCache(makeDirtyLines(DIRTY_EDIT), 'light');
-    // A fresh hunks array reference proves a full `recomputeDiffHunks` ran.
-    expect(cacheDiff.hunks).not.toBe(hunksBeforeUpdate);
-
-    const hunksAfterUpdate = cacheDiff.hunks;
-    renderer.applyDocumentChange(makeTextDocument(EDITED_LINES));
-    expect(renderer.getRenderDiff()?.hunks).not.toBe(hunksAfterUpdate);
-  });
-
-  test('skip flag avoids the recompute in updateRenderCache', async () => {
+describe('DiffHunksRenderer content-edit recompute split', () => {
+  test('updateRenderCache returns changed addition lines and does not recompute', async () => {
     const renderer = await createPrimedRenderer();
     const cacheDiff = renderer.getRenderDiff();
     expect(cacheDiff).toBeDefined();
     if (cacheDiff == null) return;
 
-    const hunksBeforeUpdate = cacheDiff.hunks;
-    renderer.updateRenderCache(
-      makeDirtyLines(DIRTY_EDIT),
-      'light',
-      /* skipDiffRecompute */ true
+    const hunksBefore = cacheDiff.hunks;
+    // In-place edit of an existing line (no line-count change).
+    const changed = renderer.updateRenderCache(
+      makeDirtyLines([[1, '  console.log(msg) // edited']]),
+      'light'
     );
-    // No recompute: the hunks array reference is untouched.
-    expect(cacheDiff.hunks).toBe(hunksBeforeUpdate);
+    // Token sync ran but hunks were NOT recomputed here.
+    expect(cacheDiff.hunks).toBe(hunksBefore);
+    expect([...changed]).toEqual([1]);
   });
 
-  test('skip flag preserves the final diff after applyDocumentChange', async () => {
-    const legacy = await createPrimedRenderer();
-    legacy.updateRenderCache(
-      makeDirtyLines(DIRTY_EDIT),
-      'light',
-      /* skipDiffRecompute */ false
+  test('recomputeContentHunks matches a full recompute for a content-only edit', async () => {
+    const split = await createPrimedRenderer();
+    const changed = split.updateRenderCache(
+      makeDirtyLines([[1, '  console.log(msg) // edited']]),
+      'light'
     );
-    legacy.applyDocumentChange(makeTextDocument(EDITED_LINES));
-    const legacyDiff = legacy.getRenderDiff();
+    split.recomputeContentHunks(changed);
+    const incremental = split.getRenderDiff();
 
-    const optimized = await createPrimedRenderer();
-    optimized.updateRenderCache(
-      makeDirtyLines(DIRTY_EDIT),
-      'light',
-      /* skipDiffRecompute */ true
+    // Expected result: a full re-parse of the same edited content from scratch.
+    const full = parseDiffFromFile(
+      { name: 'greet.ts', contents: OLD_CONTENTS },
+      {
+        name: 'greet.ts',
+        contents: [
+          'function greet(name) {',
+          '  console.log(msg) // edited',
+          '  return msg;',
+          '}',
+          '',
+        ].join('\n'),
+      }
     );
-    optimized.applyDocumentChange(makeTextDocument(EDITED_LINES));
-    const optimizedDiff = optimized.getRenderDiff();
 
-    expect(legacyDiff).toBeDefined();
-    expect(optimizedDiff).toBeDefined();
-    if (legacyDiff == null || optimizedDiff == null) return;
-
-    expect(optimizedDiff.hunks).toEqual(legacyDiff.hunks);
-    expect(optimizedDiff.additionLines).toEqual(legacyDiff.additionLines);
-    expect(optimizedDiff.deletionLines).toEqual(legacyDiff.deletionLines);
-    expect(optimizedDiff.splitLineCount).toBe(legacyDiff.splitLineCount);
-    expect(optimizedDiff.unifiedLineCount).toBe(legacyDiff.unifiedLineCount);
-    expect(optimizedDiff.type).toBe(legacyDiff.type);
-  });
-
-  test('skip flag preserves the rendered output after applyDocumentChange', async () => {
-    const legacy = await createPrimedRenderer();
-    legacy.updateRenderCache(makeDirtyLines(DIRTY_EDIT), 'light', false);
-    legacy.applyDocumentChange(makeTextDocument(EDITED_LINES));
-    const legacyResult = legacy.renderDiff();
-
-    const optimized = await createPrimedRenderer();
-    optimized.updateRenderCache(makeDirtyLines(DIRTY_EDIT), 'light', true);
-    optimized.applyDocumentChange(makeTextDocument(EDITED_LINES));
-    const optimizedResult = optimized.renderDiff();
-
-    expect(legacyResult).toBeDefined();
-    expect(optimizedResult).toBeDefined();
-    if (legacyResult == null || optimizedResult == null) return;
-
-    expect(optimized.renderFullHTML(optimizedResult)).toBe(
-      legacy.renderFullHTML(legacyResult)
-    );
+    expect(incremental).toBeDefined();
+    if (incremental == null) return;
+    expect(incremental.hunks).toEqual(full.hunks);
+    expect(incremental.splitLineCount).toBe(full.splitLineCount);
+    expect(incremental.unifiedLineCount).toBe(full.unifiedLineCount);
   });
 });
 

--- a/packages/diffs/test/editorClipboard.test.ts
+++ b/packages/diffs/test/editorClipboard.test.ts
@@ -106,9 +106,14 @@ class TestEditableComponent implements DiffsEditableComponent<undefined> {
 
   updateRenderCache(
     _lines: Map<number, Array<HighlightedToken>>,
-    _themeType: 'dark' | 'light',
-    _shouldRerender?: boolean
-  ): void {}
+    _themeType: 'dark' | 'light'
+  ): readonly number[] {
+    return [];
+  }
+
+  applyContentEdit(_changedAdditionLineIndexes: readonly number[]): void {}
+
+  recomputeContentHunks(_changedAdditionLineIndexes: readonly number[]): void {}
 
   #syncRenderView(): void {
     this.#editor?.__syncRenderView(

--- a/packages/diffs/test/editorVirtualizedReveal.test.ts
+++ b/packages/diffs/test/editorVirtualizedReveal.test.ts
@@ -87,7 +87,13 @@ class VirtualizedEditableComponent implements DiffsEditableComponent<undefined> 
   updateRenderCache(
     _lines: Map<number, Array<HighlightedToken>>,
     _themeType: 'dark' | 'light'
-  ): void {}
+  ): readonly number[] {
+    return [];
+  }
+
+  applyContentEdit(_changedAdditionLineIndexes: readonly number[]): void {}
+
+  recomputeContentHunks(_changedAdditionLineIndexes: readonly number[]): void {}
 
   #syncRenderView(): void {
     this.#editor?.__syncRenderView(


### PR DESCRIPTION
updateRenderCache is now a token-content sync that returns the addition lines whose text changed; the incremental hunk recompute moves to recomputeContentHunks, surfaced through a new method applyContentEdit. The host drives exactly one recompute path per edit: applyContentEdit (incremental) for in-place content edits and applyDocumentChange (full) for line-count changes. Removes the skipDiffRecompute and shouldRefreshView parameters and the coordination they required. No behavior change.

