### PR TITLE
fix(diffs): keep editing working after deleting a diff's new side

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -213,6 +213,13 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   #searchPanel?: SearchPanelWidget;
   #selectionAction?: SelectionActionWidget;
   #shouldIgnoreSelectionChange = false;
+  // Set by select-all, cleared on the next keydown/pointerdown. Select-all
+  // mirrors the whole document onto the native selection so WebKit fires a
+  // delete beforeinput, but a newline-terminated document's empty trailing line
+  // has no rendered row, so the native range stops one line short. Without this
+  // guard a selectionchange would read that shorter native range back over
+  // #selections, and the next delete would leave the trailing line behind.
+  #suppressNativeSelectionSync = false;
   // Whether the contenteditable holds (or is claiming) focus. Synced by
   // focus/blur listeners and set eagerly by #focus(), whose real focus() call is
   // deferred to a rAF. Lets applyEdits skip focus/scroll only on unfocused
@@ -899,6 +906,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
           // overwrite the remapped #selections before the user returns to type.
           if (
             this.#shouldIgnoreSelectionChange ||
+            this.#suppressNativeSelectionSync ||
             shadowRoot == null ||
             !this.#contentHasFocus
           ) {
@@ -1103,6 +1111,9 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
           if (e.pointerType !== 'mouse') {
             return;
           }
+          // A click moves off the select-all selection; let selectionchange
+          // sync #selections from the new native selection again.
+          this.#suppressNativeSelectionSync = false;
 
           // A click on a read-only deleted line (unified view) selects it
           // natively. Hand the selection to the deleted text and drop the
@@ -1200,6 +1211,9 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         if (!targetIsContentElement(e)) {
           return;
         }
+        // A keystroke is the user acting on the select-all selection (deleting,
+        // typing, moving); let selectionchange sync #selections again.
+        this.#suppressNativeSelectionSync = false;
 
         // handle the cursor move events manually for multiple selections and virtual viewport
         const mvShortcut = isMoveCursorShortcut(e);
@@ -1715,10 +1729,35 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         }
         break;
 
-      case 'selectAll':
-        this.#updateSelections([getDocumentFullSelection(textDocument)]);
+      case 'selectAll': {
+        const fullSelection = getDocumentFullSelection(textDocument);
+        this.#updateSelections([fullSelection]);
         this.focus();
+        // The editor paints selections with an overlay and otherwise leaves the
+        // native selection a collapsed caret. focus() above collapses it to the
+        // document start, and Safari/WebKit then fires no delete beforeinput for
+        // a following Backspace — nothing sits before a caret at offset 0 — so
+        // select-all then delete is silently dropped. Mirror the range onto the
+        // native selection so WebKit emits the delete; Chrome already deletes via
+        // #selections regardless. A document that ends in a newline has an empty
+        // trailing line that splitFileContents drops, leaving no row to anchor
+        // the native end to, so clamp it to the last rendered line — the native
+        // range only needs to be non-collapsed, and the edit uses #selections,
+        // which still spans the whole document. #suppressNativeSelectionSync then
+        // stops the resulting selectionchange from reading that clamped (shorter)
+        // range back over #selections before the delete runs.
+        let nativeEnd = fullSelection.end;
+        if (this.#isLastLineEmpty() && nativeEnd.line > 0) {
+          const lastRenderedLine = nativeEnd.line - 1;
+          nativeEnd = {
+            line: lastRenderedLine,
+            character: textDocument.getLineLength(lastRenderedLine),
+          };
+        }
+        this.#suppressNativeSelectionSync = true;
+        this.#setWindowSelection({ ...fullSelection, end: nativeEnd });
         break;
+      }
 
       case 'moveCursorToDocStart':
       case 'moveCursorToDocEnd':
@@ -2095,6 +2134,12 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         this.#deleteSelectionText(true);
         break;
       case 'deleteSoftLineBackward':
+      // Safari emits deleteHardLineBackward for cmd+backspace where Chrome emits
+      // deleteSoftLineBackward; treat them the same so cmd+backspace deletes to
+      // the line start in both. They differ only on a wrapped line (hard goes to
+      // the logical line start, soft to the visual one), and Chrome's soft
+      // behavior is what we match.
+      case 'deleteHardLineBackward':
         this.#deleteSoftLineBackward();
         break;
       case 'deleteHardLineForward':

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -169,6 +169,12 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   #contentWidthCache?: number;
   #lineYCache = new Map<number, number>();
   #wrapLineOffsetsCache = new Map<number, Uint32Array>();
+  // Tracks whether the document's last line is empty (text is empty or ends in
+  // a newline). The diff renders one editable row per addition line from
+  // splitFileContents, which drops that trailing empty line, so when this state
+  // flips the diff's editable row count changes even if the editor's line count
+  // does not. See #applyChange for how that forces a diff rebuild.
+  #lastLineEmpty = false;
   #lastAccessedLineElement?: [number, HTMLElement];
   #lastAccessedCharX?: [
     line: number,
@@ -640,6 +646,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       const { name, lang, cacheKey } = fileOrDiff;
       this.#fileInfo = { name, lang, cacheKey };
       this.#textDocument = textDocument;
+      this.#lastLineEmpty = this.#isLastLineEmpty();
       this.#tokenizer?.cleanUp();
       this.#tokenizer = new EditorTokenizer({
         highlighter,
@@ -1838,7 +1845,12 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     change: TextDocumentChange,
     newLineAnnotations?: DiffLineAnnotation<LAnnotation>[],
     renderRange = this.#renderRange,
-    shouldUpdateBuffer?: boolean
+    shouldUpdateBuffer?: boolean,
+    // Forces the diff metadata rebuild below even when the editor's line count is
+    // unchanged. Set when an edit changes the diff's editable row count without
+    // changing the line count (the document's trailing-empty state flipped); see
+    // #applyChange.
+    forceDiffRebuild = false
   ) {
     const tokenizer = this.#tokenizer;
     const fileInstance = this.#fileInstance;
@@ -1953,7 +1965,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       }
     }
 
-    const didLineCountChange = change.lineDelta !== 0;
+    const didLineCountChange = change.lineDelta !== 0 || forceDiffRebuild;
 
     // fix grid layout
     if (didLineCountChange) {
@@ -3514,13 +3526,31 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       onChange(fileRef, newLineAnnotations ?? this.#lineAnnotations);
     }
 
+    // The diff renders one editable row per addition line from
+    // splitFileContents, which drops the trailing empty line of a document that
+    // ends in a newline. So the editable row count is the editor's line count
+    // minus one whenever the last line is empty. An edit that toggles that
+    // trailing-empty state without changing the line count — typing the first
+    // character onto the empty last line, or deleting it back to empty — changes
+    // the editable row count even though change.lineDelta is 0. Force a diff
+    // rebuild in that case so the row is added or dropped in its correct place;
+    // otherwise #rerender only patches the editor's own line elements and leaves
+    // the new row appended after the deletion buffer, sending the caret to the
+    // bottom of the file.
+    const lastLineEmpty = this.#isLastLineEmpty();
+    const additionRowCountChanged =
+      change.lineDelta === 0 && lastLineEmpty !== this.#lastLineEmpty;
+    this.#lastLineEmpty = lastLineEmpty;
+
     // Invalidate layout caches touched by the edit. Clear cached line Y
     // positions from startLine onward when either:
     // - the line count changed (inserts/deletes renumber every later line), or
+    // - the editable row count changed (the diff rebuild below shifts every
+    //   later row), or
     // - wrap is on, where editing a line can add or remove a wrapped row and
     //   shift the Y of every line after it even though the line count is the
     //   same.
-    if (change.lineDelta !== 0 || this.#isWrap) {
+    if (change.lineDelta !== 0 || additionRowCountChanged || this.#isWrap) {
       for (const line of this.#lineYCache.keys()) {
         if (line >= change.startLine) {
           this.#lineYCache.delete(line);
@@ -3602,7 +3632,13 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         }
       }
     }
-    this.#rerender(change, newLineAnnotations, renderRange, shouldUpdateBuffer);
+    this.#rerender(
+      change,
+      newLineAnnotations,
+      renderRange,
+      shouldUpdateBuffer,
+      additionRowCountChanged
+    );
 
     if (
       options?.skipSearchRefresh !== true &&
@@ -3763,6 +3799,20 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     return this.#contentWidthCache;
   }
 
+  // True when the document's last line is empty, i.e. the text is empty or ends
+  // in a newline. splitFileContents drops that trailing empty line, so the diff
+  // renders one fewer editable row than the editor's line count; the editor must
+  // account for it when rebuilding the diff and when placing the caret there.
+  #isLastLineEmpty(): boolean {
+    const textDocument = this.#textDocument;
+    if (textDocument === undefined) {
+      return false;
+    }
+    return (
+      textDocument.getLineText(Math.max(0, textDocument.lineCount - 1)) === ''
+    );
+  }
+
   // get line top(y-coordinate) position
   #getLineY(line: number) {
     const cachedY = this.#lineYCache.get(line);
@@ -3772,6 +3822,23 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
 
     const lineElement = this.#getLineElement(line);
     if (lineElement === undefined) {
+      // The empty trailing line of a document that ends in a newline has no row
+      // of its own in the diff (splitFileContents collapses it into the prior
+      // row), so there is no element to measure. Place the caret one row below
+      // the preceding line instead of falling back to the document top. Only the
+      // very last line can be missing this way, so the previous line always has
+      // a row to measure from.
+      const previousElement =
+        line > 0 ? this.#getLineElement(line - 1) : undefined;
+      if (previousElement !== undefined) {
+        const y =
+          previousElement.offsetTop +
+          previousElement.offsetHeight +
+          this.#metrics.paddingTop +
+          (this.#activeContentOffset?.top ?? 0);
+        this.#lineYCache.set(line, y);
+        return y;
+      }
       return -1;
     }
 

--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -76,8 +76,8 @@ import { renderDiffWithHighlighter } from '../utils/renderDiffWithHighlighter';
 import { shouldUseTokenTransformer } from '../utils/shouldUseTokenTransformer';
 import { splitFileContents } from '../utils/splitFileContents';
 import {
+  appendTrailingEmptyAdditionRow,
   recomputeDiffHunks,
-  recomputeEmptyDocumentDiff,
   updateDiffHunks,
 } from '../utils/updateDiffHunks';
 import { getTrailingContextRangeSize } from '../utils/virtualDiffLayout';
@@ -461,20 +461,27 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
       additionHastLines[i] ??= createPlainAdditionLineElement(i, textDocument);
     }
     if (!diff.isPartial) {
-      // An empty document splits into zero addition lines, which would recompute
-      // to a diff with no editable rows and leave the attached host with no
-      // line element for its caret (the additions column vanishes in split;
-      // unified shows only deletions). Keep one empty editable line instead.
-      if (newLength === 0) {
-        Object.assign(
-          diff,
-          recomputeEmptyDocumentDiff(diff, this.options.parseDiffOptions)
-        );
-        additionHastLines[0] = createPlainAdditionLineElement(0, textDocument);
-      } else {
-        Object.assign(
-          diff,
-          recomputeDiffHunks(diff, this.options.parseDiffOptions)
+      Object.assign(
+        diff,
+        recomputeDiffHunks(diff, this.options.parseDiffOptions)
+      );
+      // The editor counts a trailing newline (and an emptied document) as an
+      // extra empty line, but splitFileContents/the diff collapse it away, so the
+      // diff has no row for that caret line. Append one empty editable row so it
+      // renders and the caret/native input can anchor to it — in split this
+      // avoids a caret stuck at the document top, and in unified it avoids the
+      // line being unreachable among the deletion rows. For the emptied document
+      // this also renders one clean change-addition after the deletions, instead
+      // of the older sentinel diff that matched an empty deletion line via LCS
+      // and mis-placed the row mid-document (a "1" line over a deletion). The
+      // highlighted HAST may be a row short here (the re-highlight also drops the
+      // trailing line); processDiffResult fills that row's content empty.
+      if (textDocument.lineCount > diff.additionLines.length) {
+        appendTrailingEmptyAdditionRow(diff);
+        const trailingIndex = diff.additionLines.length - 1;
+        additionHastLines[trailingIndex] = createPlainAdditionLineElement(
+          trailingIndex,
+          textDocument
         );
       }
     }
@@ -1081,20 +1088,14 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
           if (injectedRows?.before != null) {
             pushUnifiedInjectedRows(injectedRows.before, context);
           }
-          let deletionLineContent =
-            deletionLine != null
-              ? deletionLines[deletionLine.lineIndex]
-              : undefined;
-          let additionLineContent =
-            additionLine != null
-              ? additionLines[additionLine.lineIndex]
-              : undefined;
-          if (deletionLineContent == null && additionLineContent == null) {
-            const errorMessage =
-              'DiffHunksRenderer.processDiffResult: deletionLine and additionLine are null, something is wrong';
-            console.error(errorMessage, { file: fileDiff.name });
-            throw new Error(errorMessage);
-          }
+          let { deletionLineContent, additionLineContent } =
+            resolveDiffLineContents(
+              deletionLine,
+              additionLine,
+              deletionLines,
+              additionLines,
+              fileDiff.name
+            );
           const lineType =
             type === 'change'
               ? additionLine != null
@@ -1171,14 +1172,14 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
             );
           }
 
-          let deletionLineContent =
-            deletionLine != null
-              ? deletionLines[deletionLine.lineIndex]
-              : undefined;
-          let additionLineContent =
-            additionLine != null
-              ? additionLines[additionLine.lineIndex]
-              : undefined;
+          let { deletionLineContent, additionLineContent } =
+            resolveDiffLineContents(
+              deletionLine,
+              additionLine,
+              deletionLines,
+              additionLines,
+              fileDiff.name
+            );
           const deletionLineDecoration = this.getSplitLineDecoration({
             side: 'deletions',
             type,
@@ -1189,13 +1190,6 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
             type,
             lineIndex: additionLine?.lineIndex,
           });
-
-          if (deletionLineContent == null && additionLineContent == null) {
-            const errorMessage =
-              'DiffHunksRenderer.processDiffResult: deletionLine and additionLine are null, something is wrong';
-            console.error(errorMessage, { file: fileDiff.name });
-            throw new Error(errorMessage);
-          }
 
           const missingSide = (() => {
             if (type === 'change') {
@@ -1957,6 +1951,62 @@ function withContentProperties(
       ...extendProperties,
     },
   };
+}
+
+// An empty editable line element for a row the diff carries but the highlighted
+// HAST does not. This happens for the editor's trailing empty line (a document
+// that ends in a newline, or an emptied document): splitFileContents and the
+// re-highlight's cleanLastNewline both drop that line, so its content slot is
+// missing even though iterateOverDiff still emits the row. Rendering it empty
+// keeps the row (so the caret/native input can anchor to it) instead of failing.
+function createEmptyDiffLineElement(lineNumber: number): HASTElement {
+  return {
+    type: 'element',
+    tagName: 'div',
+    properties: { 'data-line': lineNumber },
+    children: [
+      {
+        type: 'element',
+        tagName: 'span',
+        properties: { 'data-char': 0 },
+        children: [{ type: 'text', value: '' }],
+      },
+    ],
+  };
+}
+
+// Resolves the highlighted content for a diff row's two sides, shared by the
+// unified and split branches of processDiffResult. A side that has a line but no
+// HAST content is the editor's trailing empty line, dropped from the highlight
+// (see createEmptyDiffLineElement) — render it empty. A row with neither side is
+// a real bug, so throw.
+function resolveDiffLineContents(
+  deletionLine: DiffLineMetadata | undefined,
+  additionLine: DiffLineMetadata | undefined,
+  deletionLines: ElementContent[],
+  additionLines: ElementContent[],
+  fileName: string | undefined
+): {
+  deletionLineContent: ElementContent | undefined;
+  additionLineContent: ElementContent | undefined;
+} {
+  let deletionLineContent =
+    deletionLine != null ? deletionLines[deletionLine.lineIndex] : undefined;
+  let additionLineContent =
+    additionLine != null ? additionLines[additionLine.lineIndex] : undefined;
+  if (additionLine != null && additionLineContent == null) {
+    additionLineContent = createEmptyDiffLineElement(additionLine.lineNumber);
+  }
+  if (deletionLine != null && deletionLineContent == null) {
+    deletionLineContent = createEmptyDiffLineElement(deletionLine.lineNumber);
+  }
+  if (deletionLineContent == null && additionLineContent == null) {
+    const errorMessage =
+      'DiffHunksRenderer.processDiffResult: deletionLine and additionLine are null, something is wrong';
+    console.error(errorMessage, { file: fileName });
+    throw new Error(errorMessage);
+  }
+  return { deletionLineContent, additionLineContent };
 }
 
 function createPlainAdditionLineElement(

--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -477,12 +477,16 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
       // highlighted HAST may be a row short here (the re-highlight also drops the
       // trailing line); processDiffResult fills that row's content empty.
       if (textDocument.lineCount > diff.additionLines.length) {
-        appendTrailingEmptyAdditionRow(diff);
-        const trailingIndex = diff.additionLines.length - 1;
-        additionHastLines[trailingIndex] = createPlainAdditionLineElement(
-          trailingIndex,
-          textDocument
+        const trailingIndex = appendTrailingEmptyAdditionRow(
+          diff,
+          this.options.parseDiffOptions
         );
+        if (trailingIndex >= 0) {
+          additionHastLines[trailingIndex] = createPlainAdditionLineElement(
+            trailingIndex,
+            textDocument
+          );
+        }
       }
     }
 

--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -426,6 +426,14 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
     ) {
       return;
     }
+    // A document that ends in a newline carries a synthetic trailing empty
+    // addition row (see appendTrailingEmptyAdditionRow); splitFileContents never
+    // emits a trailing empty entry on its own, so one here is always that row.
+    // updateDiffHunks may rejoin additionLines and re-split, which drops it (the
+    // final newline collapses again). Re-append it so the editor keeps its caret
+    // row — otherwise editing any other line of such a document removes the
+    // editable final line on the next refresh.
+    const hadTrailingEmptyRow = diff.additionLines.at(-1) === '';
     Object.assign(
       diff,
       updateDiffHunks(
@@ -434,6 +442,9 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
         this.options.parseDiffOptions
       )
     );
+    if (hadTrailingEmptyRow && diff.additionLines.at(-1) !== '') {
+      appendTrailingEmptyAdditionRow(diff, this.options.parseDiffOptions);
+    }
     this.renderCache.isDirty = true;
   }
 

--- a/packages/diffs/src/utils/updateDiffHunks.ts
+++ b/packages/diffs/src/utils/updateDiffHunks.ts
@@ -64,10 +64,37 @@ export function recomputeDiffHunks(
 // older sentinel-diff approach for the fully-empty document, which placed the
 // row by diffing the deletions against a blank line — that blank line matched an
 // empty deletion line via LCS and rendered the row mid-document as "context".
-export function appendTrailingEmptyAdditionRow(diff: FileDiffMetadata): void {
+//
+// Returns the addition-line index of the row it added, or -1 when it added none.
+export function appendTrailingEmptyAdditionRow(
+  diff: FileDiffMetadata,
+  parseDiffOptions?: CreatePatchOptionsNonabortable
+): number {
   const hunk = diff.hunks.at(-1);
   if (hunk == null) {
-    return;
+    // No hunk means the recompute found no change. When the document is also
+    // empty this is an emptied added file (its old side is empty too), so
+    // comparing empty against empty produces nothing to grow. Synthesize the
+    // single empty addition row a brand-new one-line file would have, so the
+    // editor still has a row to host its caret. (A non-empty file with no hunk
+    // is unchanged and has no addition row to anchor, so leave it alone.)
+    if (diff.additionLines.length === 0) {
+      const recomputed = parseDiffFromFile(
+        {
+          name: diff.prevName ?? diff.name,
+          contents: diff.deletionLines.join(''),
+        },
+        { name: diff.name, contents: '\n', lang: diff.lang },
+        parseDiffOptions
+      );
+      diff.hunks = recomputed.hunks;
+      diff.splitLineCount = recomputed.splitLineCount;
+      diff.unifiedLineCount = recomputed.unifiedLineCount;
+      diff.type = recomputed.type;
+      diff.additionLines = [''];
+      return 0;
+    }
+    return -1;
   }
 
   const trailingIndex = diff.additionLines.length;
@@ -105,6 +132,7 @@ export function appendTrailingEmptyAdditionRow(diff: FileDiffMetadata): void {
   diff.type = 'change';
 
   recomputeDiffRenderLineCounts(diff);
+  return trailingIndex;
 }
 
 /** Updates hunk metadata after addition lines change; re-parses affected hunks only. */

--- a/packages/diffs/src/utils/updateDiffHunks.ts
+++ b/packages/diffs/src/utils/updateDiffHunks.ts
@@ -47,46 +47,64 @@ export function recomputeDiffHunks(
   };
 }
 
-// Rebuilds hunk metadata when the editable side has been emptied of all text.
+// Adds an editable row for the editor's empty trailing line after a recompute.
 //
-// The host always keeps one (empty) line for an empty document, but an empty
-// string splits into zero addition lines, so a normal recompute produces a diff
-// with no addition rows at all. Rendering that leaves the attached host with
-// no line element for its caret. To keep one editable row, diff the
-// unchanged deletions against a single line (which yields a hunk that places
-// exactly one addition row), then store the addition as `['']` so it still
-// joins back to the host's empty document.
+// The diff derives its addition rows from `splitFileContents`, which collapses
+// the final newline. So a document that is empty or ends in a newline produces
+// one fewer addition row than the editor's line count, leaving the editor's
+// trailing (empty) line with no rendered row. The editor needs a real DOM row
+// there: in split it avoids the caret falling back to the document top, and in
+// unified — where addition rows sit interleaved with non-editable deletion
+// rows — it lets native contenteditable input anchor to the line at all.
 //
-// The sentinel only has to differ from the deletion side so a hunk is produced;
-// its text is discarded by the `['']` override below. When the old side is
-// itself a single blank line the empty sentinel would be identical and yield no
-// hunk (and so no editable row), so fall back to a non-blank line there.
-export function recomputeEmptyDocumentDiff(
-  diff: FileDiffMetadata,
-  parseDiffOptions?: CreatePatchOptionsNonabortable
-): FullDiffHunkUpdate {
-  const deletionContents = diff.deletionLines.join('');
-  const additionSentinel = deletionContents === '\n' ? ' \n' : '\n';
-  const recomputed = parseDiffFromFile(
-    {
-      name: diff.prevName ?? diff.name,
-      contents: deletionContents,
-    },
-    {
-      name: diff.name,
-      contents: additionSentinel,
-      lang: diff.lang,
-    },
-    parseDiffOptions
-  );
-  return {
-    hunks: recomputed.hunks,
-    splitLineCount: recomputed.splitLineCount,
-    unifiedLineCount: recomputed.unifiedLineCount,
-    additionLines: [''],
-    deletionLines: recomputed.deletionLines,
-    type: recomputed.type,
-  };
+// This grows the last hunk by a single `+` line and appends one empty addition
+// line, producing the same hunk shape a genuine one-line edit would. Both
+// unified and split then render the trailing line like any other addition,
+// after the last addition and before any deletion buffer. This also replaces an
+// older sentinel-diff approach for the fully-empty document, which placed the
+// row by diffing the deletions against a blank line — that blank line matched an
+// empty deletion line via LCS and rendered the row mid-document as "context".
+export function appendTrailingEmptyAdditionRow(diff: FileDiffMetadata): void {
+  const hunk = diff.hunks.at(-1);
+  if (hunk == null) {
+    return;
+  }
+
+  const trailingIndex = diff.additionLines.length;
+  diff.additionLines = [...diff.additionLines, ''];
+
+  const lastContent = hunk.hunkContent.at(-1);
+  if (lastContent != null && lastContent.type === 'change') {
+    // Extend the final change block. When it had only deletions (an emptied
+    // document), this new line becomes its first addition.
+    if (lastContent.additions === 0) {
+      lastContent.additionLineIndex = trailingIndex;
+    }
+    lastContent.additions += 1;
+  } else {
+    // The hunk ends in a context block, so add a dedicated addition-only block.
+    hunk.hunkContent.push({
+      type: 'change',
+      additions: 1,
+      deletions: 0,
+      additionLineIndex: trailingIndex,
+      deletionLineIndex: hunk.deletionLineIndex + hunk.deletionCount,
+    });
+  }
+
+  // An all-deletions hunk reports no additions (additionLineIndex -1,
+  // additionStart 0); seed them from the row we just added.
+  if (hunk.additionLineIndex < 0) {
+    hunk.additionLineIndex = trailingIndex;
+  }
+  if (hunk.additionStart < 1) {
+    hunk.additionStart = trailingIndex + 1;
+  }
+  hunk.additionCount += 1;
+  hunk.additionLines += 1;
+  diff.type = 'change';
+
+  recomputeDiffRenderLineCounts(diff);
 }
 
 /** Updates hunk metadata after addition lines change; re-parses affected hunks only. */

--- a/packages/diffs/src/utils/updateDiffHunks.ts
+++ b/packages/diffs/src/utils/updateDiffHunks.ts
@@ -100,6 +100,25 @@ export function appendTrailingEmptyAdditionRow(
   const trailingIndex = diff.additionLines.length;
   diff.additionLines = [...diff.additionLines, ''];
 
+  // Only grow the last hunk when its content runs to the end of the file (a
+  // change on the last line, or an emptied document whose all-deletions hunk
+  // reports additionLineIndex -1 and is grown below to seed its first
+  // addition). When unchanged lines follow the last hunk, growing it would
+  // render the line right after the hunk as a `+`. Instead append a matching
+  // empty row to both sides so the trailing context region renders one more
+  // paired (unchanged) row at EOF — the addition side is the editor's caret
+  // row, and pairing keeps the additions/deletions trailing-context counts
+  // equal (an unpaired addition would trip the trailing-context-mismatch
+  // guard).
+  if (
+    hunk.additionLineIndex >= 0 &&
+    hunk.additionLineIndex + hunk.additionCount < trailingIndex
+  ) {
+    diff.deletionLines = [...diff.deletionLines, ''];
+    recomputeDiffRenderLineCounts(diff);
+    return trailingIndex;
+  }
+
   const lastContent = hunk.hunkContent.at(-1);
   if (lastContent != null && lastContent.type === 'change') {
     // Extend the final change block. When it had only deletions (an emptied

--- a/packages/diffs/test/editorDiffEmptyDocument.test.ts
+++ b/packages/diffs/test/editorDiffEmptyDocument.test.ts
@@ -386,3 +386,58 @@ describe('diff editor: delete-all on an added file (empty old side)', () => {
     });
   }
 });
+
+// Fires the beforeinput the browser would send, so the editor's own handler
+// runs (it reads e.inputType and edits #selections). cancelable lets the
+// handler preventDefault as it does in the browser. InputEvent lives on the
+// jsdom window rather than globalThis, so reach it through the element.
+function dispatchBeforeInput(content: HTMLElement, inputType: string): void {
+  const view = content.ownerDocument.defaultView;
+  if (view == null) {
+    throw new Error('content element is not attached to a window');
+  }
+  content.dispatchEvent(
+    new view.InputEvent('beforeinput', {
+      inputType,
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      data: null,
+    })
+  );
+}
+
+// cmd+backspace deletes to the start of the line. Chrome reports it as
+// deleteSoftLineBackward, but Safari reports deleteHardLineBackward; the editor
+// must treat both the same or Safari's cmd+backspace silently does nothing.
+describe('diff editor: cmd+backspace (deleteHardLineBackward) deletes to line start', () => {
+  for (const diffStyle of ['split', 'unified'] as const) {
+    test(`Safari's deleteHardLineBackward matches Chrome's deleteSoftLineBackward (${diffStyle})`, async () => {
+      const fixture = await createDiffEditorFixture(
+        diffStyle,
+        'a\nb\n',
+        'hello world\nfoo\n'
+      );
+      const { editor, container } = fixture;
+      try {
+        const content = findAdditionContent(container);
+        expect(content).toBeDefined();
+        if (content == null) return;
+
+        // Caret at the end of "hello world", then Safari's cmd+backspace.
+        editor.setSelections([
+          {
+            start: { line: 0, character: 11 },
+            end: { line: 0, character: 11 },
+            direction: 'none',
+          },
+        ]);
+        dispatchBeforeInput(content, 'deleteHardLineBackward');
+        await wait(0);
+        expect(editor.getState().file.contents).toBe('\nfoo\n');
+      } finally {
+        await fixture.cleanup();
+      }
+    });
+  }
+});

--- a/packages/diffs/test/editorDiffEmptyDocument.test.ts
+++ b/packages/diffs/test/editorDiffEmptyDocument.test.ts
@@ -354,3 +354,35 @@ describe('diff editor: switching diff style after delete-all', () => {
     });
   }
 });
+
+// Deleting everything from a newly added file empties both sides of the diff, so
+// a recompute compares empty against empty and produces no hunks. The editor
+// still needs one editable row to host its caret, so an empty addition row must
+// be synthesized even when there is no hunk to grow.
+describe('diff editor: delete-all on an added file (empty old side)', () => {
+  for (const diffStyle of ['split', 'unified'] as const) {
+    test(`keeps an editable line and accepts typing (${diffStyle})`, async () => {
+      const fixture = await createDiffEditorFixture(
+        diffStyle,
+        '',
+        'alpha\nbravo\n'
+      );
+      const { editor, container } = fixture;
+      try {
+        replaceAll(editor, '');
+        await wait(0);
+        expect(editor.getState().file.contents).toBe('');
+
+        const content = findAdditionContent(container);
+        expect(content).toBeDefined();
+        expect(countEditableLineEls(content!)).toBeGreaterThanOrEqual(1);
+
+        editor.applyEdits([insertAt(0, 0, 'hello')], true);
+        await wait(0);
+        expect(editor.getState().file.contents).toBe('hello');
+      } finally {
+        await fixture.cleanup();
+      }
+    });
+  }
+});

--- a/packages/diffs/test/editorDiffEmptyDocument.test.ts
+++ b/packages/diffs/test/editorDiffEmptyDocument.test.ts
@@ -441,3 +441,103 @@ describe('diff editor: cmd+backspace (deleteHardLineBackward) deletes to line st
     });
   }
 });
+
+// Lists the addition-side rows as [lineType, text] so a test can assert how
+// each document line is classified (e.g. that an unchanged line is not a `+`).
+function additionRowTypes(content: HTMLElement): Array<[string, string]> {
+  const rows: Array<[string, string]> = [];
+  for (const child of content.children) {
+    const el = child as HTMLElement;
+    if (
+      el.dataset.line === undefined ||
+      el.dataset.lineType === 'change-deletion'
+    ) {
+      continue;
+    }
+    rows.push([el.dataset.lineType ?? '', el.textContent ?? '']);
+  }
+  return rows;
+}
+
+// Editing one line of a document that ends in a newline must keep the editor's
+// trailing empty caret row. The content edit recomputes hunks from
+// additionLines.join(''), which drops the synthetic trailing row (the final
+// newline collapses again). A unified diff re-renders its rows from that
+// metadata on every edit, so without re-appending the row the editable final
+// line vanishes after editing any other line.
+describe('diff editor: editing a line keeps the trailing empty row', () => {
+  test('unified diff preserves the trailing caret row after a content edit', async () => {
+    const fixture = await createDiffEditorFixture(
+      'unified',
+      'a\nb\nX\n',
+      'a\nb\nc\n'
+    );
+    const { editor, container } = fixture;
+    try {
+      replaceAll(editor, '');
+      await wait(0);
+      editor.applyEdits([insertAt(0, 0, 'x')], true);
+      await wait(0);
+      editor.applyEdits([insertAt(0, 1, '\n')], true); // "x\n"
+      await wait(0);
+      // The additions side has the typed line plus the trailing empty row.
+      expect(countEditableLineEls(findAdditionContent(container)!)).toBe(2);
+
+      // Edit "x" -> "xy": the line count is unchanged and the document still
+      // ends in a newline, so this takes the content-edit path rather than
+      // applyDocumentChange. The trailing row must survive the recompute.
+      editor.applyEdits([insertAt(0, 1, 'y')], true);
+      await wait(0);
+      expect(editor.getState().file.contents).toBe('xy\n');
+      expect(countEditableLineEls(findAdditionContent(container)!)).toBe(2);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+});
+
+// When a document ends in a newline but its only diff hunk sits earlier in the
+// file (a change near the top with unchanged lines after it), the trailing
+// empty caret row must render at EOF. Growing the last hunk to host it would
+// instead mark the line right after the hunk as a `+`; the row belongs after
+// the unchanged tail.
+describe('diff editor: trailing empty row lands at EOF past an earlier hunk', () => {
+  for (const diffStyle of ['split', 'unified'] as const) {
+    test(`unchanged tail stays context, caret row at EOF (${diffStyle})`, async () => {
+      const fixture = await createDiffEditorFixture(
+        diffStyle,
+        'a\nb\nc\nd\ne\nf\ng\nh\n',
+        'A\nb\nc\nd\ne\nf\ng\nh\n'
+      );
+      const { editor, container } = fixture;
+      try {
+        // Insert a newline after "A": "A\n\nb\nc\nd\ne\nf\ng\nh\n" (10 lines,
+        // the last empty). The line-count change routes through
+        // applyDocumentChange, which appends the trailing empty row.
+        editor.applyEdits([insertAt(0, 1, '\n')], true);
+        await wait(0);
+        const expectTrailingRowAtEof = () => {
+          const content = findAdditionContent(container)!;
+          // 10 editable rows: A, "", b, c, d, e, f, g, h, and the trailing empty.
+          expect(countEditableLineEls(content)).toBe(10);
+          // Lines after the hunk are unchanged and must not render as additions.
+          for (const [lineType, text] of additionRowTypes(content)) {
+            if (['b', 'c', 'd', 'e', 'f', 'g', 'h'].includes(text)) {
+              expect(lineType).not.toBe('change-addition');
+            }
+          }
+        };
+        expectTrailingRowAtEof();
+
+        // Editing another line keeps the line count and the trailing newline, so
+        // this takes the content-edit path. The trailing row must be re-appended
+        // (the recompute drops it) and still land past the unchanged tail.
+        editor.applyEdits([insertAt(0, 1, 'Z')], true); // "AZ\n\nb..h\n"
+        await wait(0);
+        expectTrailingRowAtEof();
+      } finally {
+        await fixture.cleanup();
+      }
+    });
+  }
+});

--- a/packages/diffs/test/editorDiffEmptyDocument.test.ts
+++ b/packages/diffs/test/editorDiffEmptyDocument.test.ts
@@ -50,6 +50,9 @@ function countEditableLineEls(content: HTMLElement): number {
 interface DiffEditorFixture {
   container: HTMLElement;
   editor: Editor<undefined>;
+  fileDiff: FileDiff<undefined>;
+  oldFile: FileContents;
+  newFile: FileContents;
   cleanup(): Promise<void>;
 }
 
@@ -90,6 +93,9 @@ async function createDiffEditorFixture(
   return {
     container,
     editor,
+    fileDiff,
+    oldFile,
+    newFile,
     async cleanup() {
       // Drain any pending highlighter/sync callbacks before tearing down the DOM
       // so a late re-attach does not run against a destroyed document.
@@ -158,6 +164,190 @@ describe('diff editor: select-all then delete', () => {
         editor.undo();
         await wait(0);
         expect(editor.getState().file.contents).toBe('a\nb\nc\n');
+      } finally {
+        await fixture.cleanup();
+      }
+    });
+  }
+});
+
+// Distinct from the editor's default 20px line height so an assertion against a
+// ROW multiple can't coincidentally match the built-in metric.
+const CARET_ROW = 30;
+
+// jsdom performs no layout, so every offsetTop/offsetHeight is 0. The split
+// additions column lays out as a CSS grid where DOM order drives placement and
+// the deletion buffer spans `data-buffer-size` rows. Model that: a row's top is
+// the number of grid rows its earlier siblings occupy (buffers occupy their
+// size, everything else one), and a row's height is its own span. This lets the
+// caret's measured Y reflect where a row actually sits relative to the buffer.
+function installGridLayout(): { restore(): void } {
+  const proto = HTMLElement.prototype;
+  const originalTop = Object.getOwnPropertyDescriptor(proto, 'offsetTop');
+  const originalHeight = Object.getOwnPropertyDescriptor(proto, 'offsetHeight');
+  const rowSpan = (el: HTMLElement): number => {
+    const buffer = el.dataset?.bufferSize;
+    return buffer != null ? parseInt(buffer, 10) : 1;
+  };
+  Object.defineProperty(proto, 'offsetTop', {
+    configurable: true,
+    get(this: HTMLElement): number {
+      let rows = 0;
+      let sibling = this.previousElementSibling as HTMLElement | null;
+      while (sibling != null) {
+        rows += rowSpan(sibling);
+        sibling = sibling.previousElementSibling as HTMLElement | null;
+      }
+      return rows * CARET_ROW;
+    },
+  });
+  Object.defineProperty(proto, 'offsetHeight', {
+    configurable: true,
+    get(this: HTMLElement): number {
+      return rowSpan(this) * CARET_ROW;
+    },
+  });
+  return {
+    restore(): void {
+      for (const [key, original] of [
+        ['offsetTop', originalTop],
+        ['offsetHeight', originalHeight],
+      ] as const) {
+        if (original !== undefined) {
+          Object.defineProperty(proto, key, original);
+        } else {
+          Object.defineProperty(proto, key, {
+            configurable: true,
+            get: () => 0,
+          });
+        }
+      }
+    },
+  };
+}
+
+function caretTranslateY(container: HTMLElement): number {
+  const caret = container.shadowRoot?.querySelector('[data-caret]');
+  if (!(caret instanceof HTMLElement)) {
+    throw new Error('no caret element rendered');
+  }
+  const match = /translateY\(([-\d.]+)px\)/.exec(caret.style.transform);
+  if (match === null) {
+    throw new Error(`caret has no translateY: ${caret.style.transform}`);
+  }
+  return parseFloat(match[1]);
+}
+
+function caretAt(line: number) {
+  return [
+    {
+      start: { line, character: 0 },
+      end: { line, character: 0 },
+      direction: 'none' as const,
+    },
+  ];
+}
+
+function insertAt(line: number, character: number, newText: string) {
+  return {
+    range: { start: { line, character }, end: { line, character } },
+    newText,
+  };
+}
+
+// After deleting every addition the editable column is a single empty row above
+// a deletion buffer that spans the rest of the file. Typing there used to send
+// the caret to the document top (the empty line has no diff row, so the lookup
+// returned -1) and then to the bottom (a newly typed line was appended after the
+// buffer). Each new line must instead stay one row below the one above it.
+describe('diff editor: caret tracks typed lines after delete-all', () => {
+  for (const diffStyle of ['split', 'unified'] as const) {
+    test(`keeps the caret on the line being edited (${diffStyle})`, async () => {
+      const fixture = await createDiffEditorFixture(
+        diffStyle,
+        '1\n2\n3\n4\n5\n',
+        'a\nb\nc\nd\ne\n'
+      );
+      const { editor, container } = fixture;
+      const layout = installGridLayout();
+      try {
+        replaceAll(editor, '');
+        await wait(0);
+
+        editor.setSelections(caretAt(0));
+        const lineZeroY = caretTranslateY(container);
+
+        // Type a character, then Enter. The caret moves to the new trailing
+        // line, exactly one row below line 0 — not to the document top.
+        editor.applyEdits([insertAt(0, 0, 'x')], true);
+        await wait(0);
+        editor.applyEdits([insertAt(0, 1, '\n')], true);
+        await wait(0);
+        editor.setSelections(caretAt(1));
+        expect(caretTranslateY(container) - lineZeroY).toBe(CARET_ROW);
+
+        // Typing on that new line keeps the caret on it — not at the bottom of
+        // the file after the deletion buffer.
+        editor.applyEdits([insertAt(1, 0, 'y')], true);
+        await wait(0);
+        editor.setSelections(caretAt(1));
+        expect(caretTranslateY(container) - lineZeroY).toBe(CARET_ROW);
+        expect(editor.getState().file.contents).toBe('x\ny');
+
+        // A second Enter plus typing lands the caret two rows below line 0.
+        editor.applyEdits([insertAt(1, 1, '\n')], true);
+        await wait(0);
+        editor.applyEdits([insertAt(2, 0, 'z')], true);
+        await wait(0);
+        editor.setSelections(caretAt(2));
+        expect(caretTranslateY(container) - lineZeroY).toBe(2 * CARET_ROW);
+        expect(editor.getState().file.contents).toBe('x\ny\nz');
+      } finally {
+        layout.restore();
+        await fixture.cleanup();
+      }
+    });
+  }
+});
+
+// Switching the diff style after delete-all re-renders from the document
+// (`rerenderFromDocument`), which re-highlights and produces one fewer addition
+// row than the diff carries for the editor's empty trailing line. Rendering must
+// fill that row empty instead of throwing "deletionLine and additionLine are
+// null" (the reported crash on split → delete-all → switch to unified).
+describe('diff editor: switching diff style after delete-all', () => {
+  for (const [from, to] of [
+    ['split', 'unified'],
+    ['unified', 'split'],
+  ] as const) {
+    test(`does not crash and keeps an editable line (${from} → ${to})`, async () => {
+      const fixture = await createDiffEditorFixture(
+        from,
+        '1\n2\n3\n4\n5\n',
+        'a\nb\nc\nd\ne\n'
+      );
+      const { editor, container, fileDiff, oldFile, newFile } = fixture;
+      try {
+        replaceAll(editor, '');
+        await wait(0);
+
+        fileDiff.setOptions({ ...fileDiff.options, diffStyle: to });
+        fileDiff.render({
+          oldFile,
+          newFile,
+          fileContainer: container,
+          forceRender: true,
+        });
+        await wait(10);
+
+        const content = findAdditionContent(container);
+        expect(content).toBeDefined();
+        expect(countEditableLineEls(content!)).toBeGreaterThanOrEqual(1);
+
+        // Typing still lands in the document after the switch.
+        editor.applyEdits([insertAt(0, 0, 'hi')], true);
+        await wait(0);
+        expect(editor.getState().file.contents).toBe('hi');
       } finally {
         await fixture.cleanup();
       }

--- a/packages/diffs/test/updateDiffHunks.test.ts
+++ b/packages/diffs/test/updateDiffHunks.test.ts
@@ -4,6 +4,7 @@ import type { FileDiffMetadata, Hunk } from '../src/types';
 import { cleanLastNewline } from '../src/utils/cleanLastNewline';
 import { parseDiffFromFile } from '../src/utils/parseDiffFromFile';
 import {
+  appendTrailingEmptyAdditionRow,
   recomputeDiffHunks,
   updateDiffHunks,
 } from '../src/utils/updateDiffHunks';
@@ -342,5 +343,53 @@ describe('updateDiffHunks', () => {
 
     expect(diff.hunks[0]?.noEOFCRAdditions).toBe(false);
     expect(diff.hunks.at(-1)?.noEOFCRAdditions).toBe(false);
+  });
+});
+
+describe('appendTrailingEmptyAdditionRow', () => {
+  // An emptied document must render one clean editable addition row after the
+  // deletions, so the editor keeps a caret line. The previous sentinel diff
+  // matched an empty deletion line via LCS and emitted that row as "context"
+  // mid-document (in unified, a "1" line drawn over a deletion). The deletions
+  // here include an empty line (4) so this guards against that regression.
+  test('emptied document yields one clean change-addition after the deletions', () => {
+    const base = parseDiffFromFile(
+      { name: 'f.ts', contents: '1\n2\n3\n\n5\n' },
+      { name: 'f.ts', contents: 'a\nb\nc\nd\ne\n' },
+      PARSE_OPTIONS
+    );
+    const diff = cloneDiff(base);
+    diff.additionLines = [];
+    Object.assign(diff, recomputeDiffHunks(diff, PARSE_OPTIONS));
+    appendTrailingEmptyAdditionRow(diff);
+
+    expect(diff.additionLines).toEqual(['']);
+    expect(diff.type).toBe('change');
+    const lastHunk = diff.hunks.at(-1)!;
+    expect(lastHunk.additionLines).toBe(1);
+    // The row is a real addition, never a context (unchanged) match.
+    expect(
+      lastHunk.hunkContent.every((content) => content.type === 'change')
+    ).toBe(true);
+    expect(verifyFileDiffHunkValues(diff)).toEqual({ valid: true, errors: [] });
+  });
+
+  // A document that ends in a newline has a trailing empty line the editor can
+  // place a caret on; the helper grows the last change block by one `+` line so
+  // it renders, matching the shape a genuine trailing-line edit produces.
+  test('document ending in a newline gains a trailing empty addition row', () => {
+    const base = parseDiffFromFile(
+      { name: 'f.ts', contents: '1\n2\n3\n' },
+      { name: 'f.ts', contents: 'a\n' },
+      PARSE_OPTIONS
+    );
+    const diff = cloneDiff(base);
+    diff.additionLines = ['a\n'];
+    Object.assign(diff, recomputeDiffHunks(diff, PARSE_OPTIONS));
+    appendTrailingEmptyAdditionRow(diff);
+
+    expect(diff.additionLines).toEqual(['a\n', '']);
+    expect(diff.hunks.at(-1)!.additionLines).toBe(2);
+    expect(verifyFileDiffHunkValues(diff)).toEqual({ valid: true, errors: [] });
   });
 });


### PR DESCRIPTION
To reproduce:

1. Open a diff in the editor and switch to edit mode.
2. Select everything on the new-file side and delete it.
3. Type a character, press Enter, and keep typing.

The caret jumps to the top of the file and then to the bottom instead of staying on the line being edited. In a unified diff the empty editable row also renders on top of a deletion line, newly typed lines fail to render or land on top of one another, and switching from split to unified after the delete throws "deletionLine and additionLine are null".

The editor treats a document that is empty or ends in a newline as having a trailing empty line the caret can sit on, but the diff drops that line: splitFileContents collapses it during the recompute and cleanLastNewline drops it again during re-highlight. The editable column then has one fewer row than the editor's line count, so the caret line has no element (drawn at the top) and a line typed onto it is appended after the deletion buffer (drawn at the bottom). In unified the dropped row also has no content slot, which crashed the renderer.

Render an editable row for the trailing line and rebuild the diff when an edit adds or removes it, place the caret from the previous line when a row has no element yet, and render an empty row instead of throwing when the highlight lacks a row the diff still emits. This replaces the empty-document sentinel, which matched a blank deletion line and drew the editable row in the middle of the file.
