### PR TITLE
fix(diffs): Refresh reshaped split edits safely

### DIFF
--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -178,6 +178,7 @@ export class File<
   protected enabled = true;
 
   protected editor: DiffsEditor<LAnnotation> | undefined;
+  private renderViewSyncVersion = 0;
 
   constructor(
     public options: FileOptions<LAnnotation> = { theme: DEFAULT_THEMES },
@@ -478,14 +479,25 @@ export class File<
     const editor = this.editor;
     const fileContainer = this.fileContainer;
     const file = this.file;
+    const lineAnnotations = this.lineAnnotations;
+    const renderRange = this.renderRange;
     if (editor != null && fileContainer != null && file != null) {
+      const syncVersion = ++this.renderViewSyncVersion;
       void this.fileRenderer.initializeHighlighter().then((highlighter) => {
+        if (
+          syncVersion !== this.renderViewSyncVersion ||
+          editor !== this.editor ||
+          fileContainer !== this.fileContainer ||
+          file !== this.file
+        ) {
+          return;
+        }
         editor.__syncRenderView(
           highlighter,
           fileContainer,
           file,
-          this.lineAnnotations,
-          this.renderRange
+          lineAnnotations,
+          renderRange
         );
       });
     }
@@ -529,10 +541,15 @@ export class File<
   }
 
   // Plain files render edits via the host's inline DOM patch; nothing to do.
-  public applyContentEdit(): void {}
+  // Returns false because no rows were rebuilt (see DiffsEditableComponent).
+  public applyContentEdit(): boolean {
+    return false;
+  }
 
-  // Plain files have no diff hunks to recompute.
-  public recomputeContentHunks(): void {}
+  // Plain files have no diff hunks to recompute, so the shape never changes.
+  public recomputeContentHunks(): boolean {
+    return false;
+  }
 
   public render({
     file,

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -241,6 +241,7 @@ export class FileDiff<
 
   protected editor: DiffsEditor<LAnnotation> | undefined;
   protected fastRefreshTimeout: ReturnType<typeof setTimeout> | undefined;
+  private renderViewSyncVersion = 0;
 
   constructor(
     public options: FileDiffOptions<LAnnotation> = { theme: DEFAULT_THEMES },
@@ -998,19 +999,30 @@ export class FileDiff<
     const editor = this.editor;
     const fileContainer = this.fileContainer;
     const fileDiff = this.fileDiff;
+    const lineAnnotations = this.lineAnnotations;
+    const renderRange = this.renderRange;
     if (
       editor != null &&
       fileContainer != null &&
       fileDiff != null &&
       !fileDiff.isPartial
     ) {
+      const syncVersion = ++this.renderViewSyncVersion;
       void this.hunksRenderer.initializeHighlighter().then((highlighter) => {
+        if (
+          syncVersion !== this.renderViewSyncVersion ||
+          editor !== this.editor ||
+          fileContainer !== this.fileContainer ||
+          fileDiff !== this.fileDiff
+        ) {
+          return;
+        }
         editor.__syncRenderView(
           highlighter,
           fileContainer,
           fileDiff,
-          this.lineAnnotations,
-          this.renderRange
+          lineAnnotations,
+          renderRange
         );
       });
     }
@@ -1078,23 +1090,36 @@ export class FileDiff<
 
   public recomputeContentHunks(
     changedAdditionLineIndexes: readonly number[]
-  ): void {
-    this.hunksRenderer.recomputeContentHunks(changedAdditionLineIndexes);
+  ): boolean {
+    return this.hunksRenderer.recomputeContentHunks(changedAdditionLineIndexes);
   }
 
-  public applyContentEdit(changedAdditionLineIndexes: readonly number[]): void {
-    this.recomputeContentHunks(changedAdditionLineIndexes);
-    if (this.options.diffStyle === 'split') {
-      if (this.fastRefreshTimeout != null) {
-        clearTimeout(this.fastRefreshTimeout);
-      }
+  // Returns true when it rebuilt the rendered rows via a full refresh (the host
+  // must then drop caret/selection caches that point at the detached rows), and
+  // false when it only scheduled the split fast path, which patches the existing
+  // rows in place.
+  public applyContentEdit(
+    changedAdditionLineIndexes: readonly number[]
+  ): boolean {
+    const hunkShapeChanged = this.recomputeContentHunks(
+      changedAdditionLineIndexes
+    );
+    if (this.fastRefreshTimeout != null) {
+      clearTimeout(this.fastRefreshTimeout);
+      this.fastRefreshTimeout = undefined;
+    }
+    if (this.options.diffStyle === 'split' && !hunkShapeChanged) {
       this.fastRefreshTimeout = setTimeout(() => {
         this.fastRefreshTimeout = undefined;
         this.fastRefreshDiffView();
       }, 100);
-    } else {
-      this.refreshDiffView();
+      return false;
     }
+    if (hunkShapeChanged) {
+      this.hunksRenderer.clearRenderCache();
+    }
+    this.refreshDiffView();
+    return true;
   }
 
   private removeRenderedCode(): void {
@@ -1965,12 +1990,17 @@ export class FileDiff<
       return;
     }
 
+    // Patch the line-type attribute on the existing rows in index order.
+    // Returns false when a column's freshly rendered row count no longer matches
+    // the DOM: getDiffRenderShapeKey approximates the rendered shape from hunk
+    // metadata, so a reshaping edit it fails to flag would otherwise leave stale
+    // rows here. The caller then falls back to a full rebuild.
     const applyLineType = (
       type: 'deletions' | 'additions',
       column: ColumnElements | undefined
-    ) => {
+    ): boolean => {
       if (column == null) {
-        return;
+        return true;
       }
       const ast = this.hunksRenderer.renderCodeAST(type, hunksResult);
       const gutterChildren = getElementChildren(ast?.[0]);
@@ -1979,29 +2009,35 @@ export class FileDiff<
         [column.gutter, gutterChildren],
         [column.content, contentChildren],
       ] as const) {
-        if (
-          astChildren != null &&
-          el.childElementCount === astChildren.length
-        ) {
-          for (let i = 0; i < astChildren.length; i++) {
-            const gutterElement = el.children[i] as HTMLElement;
-            const gutterChild = astChildren[i] as HASTElement;
-            const lineType = gutterChild.properties['data-line-type'] as
-              | string
-              | undefined;
-            if (
-              lineType != null &&
-              gutterElement.dataset.lineType !== lineType
-            ) {
-              gutterElement.dataset.lineType = lineType;
-            }
+        if (astChildren == null) {
+          continue;
+        }
+        if (el.childElementCount !== astChildren.length) {
+          return false;
+        }
+        for (let i = 0; i < astChildren.length; i++) {
+          const gutterElement = el.children[i] as HTMLElement;
+          const gutterChild = astChildren[i] as HASTElement;
+          const lineType = gutterChild.properties['data-line-type'] as
+            | string
+            | undefined;
+          if (lineType != null && gutterElement.dataset.lineType !== lineType) {
+            gutterElement.dataset.lineType = lineType;
           }
         }
       }
+      return true;
     };
 
-    applyLineType('deletions', columns[0]);
-    applyLineType('additions', columns[1]);
+    // applyLineType patches the rows it inspects, so call it for both columns up
+    // front (never short-circuit) and keep the results. A diverged row count
+    // means the fast path cannot align DOM rows to AST rows by index, so if
+    // either column diverged, rebuild the whole view instead.
+    const deletionsPatched = applyLineType('deletions', columns[0]);
+    const additionsPatched = applyLineType('additions', columns[1]);
+    if (!deletionsPatched || !additionsPatched) {
+      this.refreshDiffView();
+    }
   }
 
   // full diff view re-rendering
@@ -2040,6 +2076,8 @@ export class FileDiff<
       ] as const) {
         if (astChildren != null) {
           el.innerHTML = toHtml(astChildren);
+        } else {
+          el.innerHTML = '';
         }
       }
     };

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -1974,6 +1974,10 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       dirtyLines,
       tokenizer.themeType
     );
+    // Whether the in-place content edit below rebuilt the rendered rows (full
+    // refresh) rather than patching them where they sit. A rebuild detaches the
+    // rows the geometry caches point at, so those caches must be dropped below.
+    let contentEditRebuiltRows = false;
     if (didLineCountChange) {
       // Line-count change: recompute hunks from the full document and re-render.
       fileInstance.applyDocumentChange(
@@ -1985,19 +1989,27 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       // In-place content edit: incremental hunk recompute + view refresh.
       // When no addition line text changed there is no hunk impact, so we skip
       // the refresh entirely (the editor already patched the edited rows inline).
-      fileInstance.applyContentEdit(changedAdditionLines);
+      contentEditRebuiltRows =
+        fileInstance.applyContentEdit(changedAdditionLines);
     }
 
     // A diff re-renders its rows in place after the edits above: a unified diff
     // rebuilds its content column on every edit (FileDiff.refreshDiffView swaps
-    // the column's innerHTML), and any diff rebuilds on a line-count change
-    // (applyDocumentChange -> full render). That detaches the line elements this
-    // editor memoized for caret/selection geometry (#lineYCache,
-    // #lastAccessedLineElement), so a detached row would measure offsetTop 0 and
-    // the caret would render at the top - the following #scrollToPrimaryCaret
-    // then scrolls the viewport there. Drop the geometry caches so the overlay
-    // re-measures against the freshly rebuilt rows and the caret stays put.
-    if (this.#isDiff && (this.#diffSyle === 'unified' || didLineCountChange)) {
+    // the column's innerHTML), any diff rebuilds on a line-count change
+    // (applyDocumentChange -> full render), and a split diff rebuilds when a
+    // content edit reshapes its hunks (applyContentEdit reports that via its
+    // return value). That detaches the line elements this editor memoized for
+    // caret/selection geometry (#lineYCache, #lastAccessedLineElement), so a
+    // detached row would measure offsetTop 0 and the caret would render at the
+    // top - the following #scrollToPrimaryCaret then scrolls the viewport there.
+    // Drop the geometry caches so the overlay re-measures against the freshly
+    // rebuilt rows and the caret stays put.
+    if (
+      this.#isDiff &&
+      (this.#diffSyle === 'unified' ||
+        didLineCountChange ||
+        contentEditRebuiltRows)
+    ) {
       this.#resetCache();
     }
 

--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -128,6 +128,41 @@ interface ProcessContext {
   incrementRowCount(count?: number): void;
 }
 
+// Serializes the structure that decides how a diff lays out its rendered rows:
+// hunk count, split/unified line counts, and each hunk's boundaries plus the
+// type and size of its content blocks. applyContentEdit compares this key from
+// before and after recomputing hunks to choose a split edit's refresh path - an
+// unchanged key takes the in-place fast patch (fastRefreshDiffView), a changed
+// key clears the render cache and rebuilds the rows (refreshDiffView).
+//
+// It exists because fastRefreshDiffView's own check only compares row *counts*,
+// so it cannot see a reshape that keeps the split row count while changing which
+// rows are changes vs context. Reverting one line of a two-line change, for
+// example, leaves the same number of split rows but turns that row from a change
+// into context; this key catches it (via the unified count and per-block layout)
+// and forces the rebuild those rows need.
+//
+// It approximates the rendered shape rather than reading it: an edit that does
+// not change the rendered rows can still change the key, because the initial
+// parse and an incremental reparse describe the same hunk differently. That only
+// costs an unnecessary - but always safe - full rebuild. Keep it aligned with
+// anything that affects rendered rows; a layout-affecting field it omits could
+// let a real reshape slip onto the fast path and leave stale rows behind.
+function getDiffRenderShapeKey(diff: FileDiffMetadata): string {
+  let key = `${diff.hunks.length}:${diff.splitLineCount}:${diff.unifiedLineCount}`;
+  for (const hunk of diff.hunks) {
+    key += `|${hunk.collapsedBefore}:${hunk.splitLineStart}:${hunk.splitLineCount}:${hunk.unifiedLineStart}:${hunk.unifiedLineCount}`;
+    for (const content of hunk.hunkContent) {
+      if (content.type === 'context') {
+        key += `;context:${content.lines}:${content.additionLineIndex}:${content.deletionLineIndex}`;
+      } else {
+        key += `;change:${content.additions}:${content.deletions}:${content.additionLineIndex}:${content.deletionLineIndex}`;
+      }
+    }
+  }
+  return key;
+}
+
 export interface DiffHunksRendererOptions extends BaseDiffOptions {
   headerRenderMode?: FileHeaderRenderMode;
 }
@@ -414,9 +449,9 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
   // `applyDocumentChange` instead, which recomputes from the full document.
   public recomputeContentHunks(
     changedAdditionLineIndexes: readonly number[]
-  ): void {
+  ): boolean {
     if (this.renderCache == null) {
-      return;
+      return false;
     }
     const { diff, result } = this.renderCache;
     if (
@@ -424,17 +459,19 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
       diff.isPartial ||
       changedAdditionLineIndexes.length === 0
     ) {
-      return;
+      return false;
     }
-    Object.assign(
+    const previousRenderShape = getDiffRenderShapeKey(diff);
+    // updateDiffHunks mutates `diff` in place with the recomputed hunks, so it
+    // is called for that side effect; its return value just repeats what it
+    // already wrote back, which is why there is no Object.assign here.
+    updateDiffHunks(
       diff,
-      updateDiffHunks(
-        diff,
-        changedAdditionLineIndexes,
-        this.options.parseDiffOptions
-      )
+      changedAdditionLineIndexes,
+      this.options.parseDiffOptions
     );
     this.renderCache.isDirty = true;
+    return getDiffRenderShapeKey(diff) !== previousRenderShape;
   }
 
   // Normally triggered by the host when the document line count changes.

--- a/packages/diffs/src/types.ts
+++ b/packages/diffs/src/types.ts
@@ -954,16 +954,20 @@ export interface DiffsEditableComponent<
   ) => readonly number[];
   // Apply an in-place content edit (no line-count change): incrementally
   // recompute hunk metadata for the changed lines and refresh the view.
+  // Returns true when the refresh rebuilt the rendered rows (so the host must
+  // drop caret/selection caches that point at the now-detached row elements),
+  // and false when it only patched existing rows in place or did nothing.
   // No-op for plain files. For a line-count change the host calls
   // applyDocumentChange instead.
-  applyContentEdit: (changedAdditionLineIndexes: readonly number[]) => void;
+  applyContentEdit: (changedAdditionLineIndexes: readonly number[]) => boolean;
   // Recompute hunk metadata for changed addition lines WITHOUT refreshing the
   // view. The host calls this for background/offscreen token updates — a
   // content-only edit that landed outside the render window — where the visible
-  // rows are patched separately. No-op for plain files.
+  // rows are patched separately. Returns true when the recompute changed the
+  // rendered hunk shape; always false for plain files, which have no hunks.
   recomputeContentHunks: (
     changedAdditionLineIndexes: readonly number[]
-  ) => void;
+  ) => boolean;
   // Re-render the component from the host's document, discarding the cached
   // (host-derived) rendered content. The host calls this after a host-driven
   // full re-render rebuilt the rows from the host's stale file contents, so the

--- a/packages/diffs/test/editorClipboard.test.ts
+++ b/packages/diffs/test/editorClipboard.test.ts
@@ -111,9 +111,15 @@ class TestEditableComponent implements DiffsEditableComponent<undefined> {
     return [];
   }
 
-  applyContentEdit(_changedAdditionLineIndexes: readonly number[]): void {}
+  applyContentEdit(_changedAdditionLineIndexes: readonly number[]): boolean {
+    return false;
+  }
 
-  recomputeContentHunks(_changedAdditionLineIndexes: readonly number[]): void {}
+  recomputeContentHunks(
+    _changedAdditionLineIndexes: readonly number[]
+  ): boolean {
+    return false;
+  }
 
   #syncRenderView(): void {
     this.#editor?.__syncRenderView(

--- a/packages/diffs/test/editorDisplayOptionResync.test.ts
+++ b/packages/diffs/test/editorDisplayOptionResync.test.ts
@@ -4,7 +4,12 @@ import { FileDiff } from '../src/components/FileDiff';
 import { DEFAULT_THEMES } from '../src/constants';
 import { Editor } from '../src/editor/editor';
 import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
-import type { FileContents } from '../src/types';
+import type {
+  DiffsEditor,
+  DiffsHighlighter,
+  FileContents,
+  HighlightedToken,
+} from '../src/types';
 import { parseDiffFromFile } from '../src/utils/parseDiffFromFile';
 import { installDom, wait } from './domHarness';
 
@@ -55,6 +60,35 @@ function lineTokenCount(
   const content = findAdditionContent(container);
   const line = content?.querySelector(`[data-line="${lineNumber}"]`);
   return line == null ? undefined : line.childElementCount;
+}
+
+function additionChangeRowCount(container: HTMLElement): number {
+  return (
+    findAdditionContent(container)?.querySelectorAll(
+      '[data-line-type="change-addition"]'
+    ).length ?? 0
+  );
+}
+
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function makeDirtyLines(
+  edits: ReadonlyArray<[number, string]>
+): Map<number, HighlightedToken[]> {
+  const dirty = new Map<number, HighlightedToken[]>();
+  for (const [line, lineText] of edits) {
+    dirty.set(line, [[0, '', lineText]]);
+  }
+  return dirty;
 }
 
 interface DisplayOptionFixture {
@@ -263,6 +297,168 @@ describe('diff editor: display-option toggle mid-edit', () => {
       );
     } finally {
       await fixture.cleanup();
+    }
+  });
+
+  test('fully refreshes split rows when content edit removes a hunk', async () => {
+    const dom = installDom();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const fileDiff = new FileDiff<undefined>({
+      disableFileHeader: true,
+      theme: DEFAULT_THEMES,
+      diffStyle: 'split',
+    });
+    fileDiff.render({
+      oldFile: { name: 'edit.ts', contents: 'alpha\nbravo\ncharlie\n' },
+      newFile: { name: 'edit.ts', contents: 'alpha\nBRAVO\ncharlie\n' },
+      fileContainer: container,
+      forceRender: true,
+    });
+
+    try {
+      expect(additionChangeRowCount(container)).toBeGreaterThan(0);
+
+      const changed = fileDiff.updateRenderCache(
+        makeDirtyLines([[1, 'bravo']]),
+        'light'
+      );
+      fileDiff.applyContentEdit(changed);
+      await wait(150);
+
+      expect(additionChangeRowCount(container)).toBe(0);
+    } finally {
+      fileDiff.cleanUp();
+      dom.cleanup();
+    }
+  });
+
+  // getDiffRenderShapeKey is what lets applyContentEdit tell a reshaping split
+  // edit (which needs a full rebuild) from an in-place one (the fast patch).
+  // These two lock the part fastRefreshDiffView's row-count check cannot cover:
+  // a reshape that keeps the same split row count must still be flagged, and a
+  // settled hunk must stay eligible for the fast path.
+  test('flags a reshape that keeps the same split row count', () => {
+    const dom = installDom();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const fileDiff = new FileDiff<undefined>({
+      disableFileHeader: true,
+      theme: DEFAULT_THEMES,
+      diffStyle: 'split',
+    });
+    fileDiff.render({
+      oldFile: { name: 'edit.ts', contents: 'alpha\nbravo\ncharlie\ndelta\n' },
+      newFile: { name: 'edit.ts', contents: 'alpha\nBRAVO\nCHARLIE\ndelta\n' },
+      fileContainer: container,
+      forceRender: true,
+    });
+
+    try {
+      const splitRowsBefore = fileDiff.fileDiff?.splitLineCount;
+
+      // Revert only line 2 of the two-line change; line 3 stays changed. One
+      // split row turns from a change into context, but the split row count is
+      // unchanged - so fastRefreshDiffView's row-count check would miss it.
+      const changed = fileDiff.updateRenderCache(
+        makeDirtyLines([[1, 'bravo']]),
+        'light'
+      );
+      const hunkShapeChanged = fileDiff.recomputeContentHunks(changed);
+
+      expect(fileDiff.fileDiff?.splitLineCount).toBe(splitRowsBefore);
+      expect(hunkShapeChanged).toBe(true);
+    } finally {
+      fileDiff.cleanUp();
+      dom.cleanup();
+    }
+  });
+
+  test('keeps a settled hunk on the fast path for a follow-up edit', () => {
+    const dom = installDom();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const fileDiff = new FileDiff<undefined>({
+      disableFileHeader: true,
+      theme: DEFAULT_THEMES,
+      diffStyle: 'split',
+    });
+    fileDiff.render({
+      oldFile: { name: 'edit.ts', contents: 'alpha\nbravo\ncharlie\n' },
+      newFile: { name: 'edit.ts', contents: 'alpha\nBRAVO\ncharlie\n' },
+      fileContainer: container,
+      forceRender: true,
+    });
+
+    try {
+      // The first edit reparses the hunk and settles its representation. A
+      // follow-up edit that keeps the change shape then recomputes to the same
+      // key, so it stays on the in-place fast path instead of a full rebuild.
+      const first = fileDiff.updateRenderCache(
+        makeDirtyLines([[1, 'DELTA']]),
+        'light'
+      );
+      fileDiff.recomputeContentHunks(first);
+
+      const second = fileDiff.updateRenderCache(
+        makeDirtyLines([[1, 'EPSILON']]),
+        'light'
+      );
+      const hunkShapeChanged = fileDiff.recomputeContentHunks(second);
+
+      expect(hunkShapeChanged).toBe(false);
+    } finally {
+      fileDiff.cleanUp();
+      dom.cleanup();
+    }
+  });
+
+  test('does not sync a detached editor after highlighter initialization resolves', async () => {
+    const dom = installDom();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const fileDiff = new FileDiff<undefined>({
+      disableFileHeader: true,
+      theme: DEFAULT_THEMES,
+      diffStyle: 'split',
+    });
+    fileDiff.render({
+      oldFile: { name: 'edit.ts', contents: 'alpha\nbravo\n' },
+      newFile: { name: 'edit.ts', contents: 'alpha\nCHANGED\n' },
+      fileContainer: container,
+      forceRender: true,
+    });
+    const renderer = (
+      fileDiff as unknown as {
+        hunksRenderer: {
+          initializeHighlighter(): Promise<DiffsHighlighter>;
+        };
+      }
+    ).hunksRenderer;
+    const originalInitializeHighlighter =
+      renderer.initializeHighlighter.bind(renderer);
+    const deferred = createDeferred<DiffsHighlighter>();
+    renderer.initializeHighlighter = () => deferred.promise;
+    let syncCount = 0;
+    const editor = {
+      __postponeBackgroundTokenizeToNextFrame() {},
+      __syncRenderView() {
+        syncCount++;
+      },
+      cleanUp() {},
+    } as unknown as DiffsEditor<undefined>;
+
+    try {
+      const detach = fileDiff.attachEditor(editor);
+      detach();
+      deferred.resolve({} as DiffsHighlighter);
+      await wait(0);
+
+      expect(syncCount).toBe(0);
+    } finally {
+      renderer.initializeHighlighter = originalInitializeHighlighter;
+      fileDiff.cleanUp();
+      dom.cleanup();
     }
   });
 

--- a/packages/diffs/test/editorVirtualizedReveal.test.ts
+++ b/packages/diffs/test/editorVirtualizedReveal.test.ts
@@ -91,9 +91,15 @@ class VirtualizedEditableComponent implements DiffsEditableComponent<undefined> 
     return [];
   }
 
-  applyContentEdit(_changedAdditionLineIndexes: readonly number[]): void {}
+  applyContentEdit(_changedAdditionLineIndexes: readonly number[]): boolean {
+    return false;
+  }
 
-  recomputeContentHunks(_changedAdditionLineIndexes: readonly number[]): void {}
+  recomputeContentHunks(
+    _changedAdditionLineIndexes: readonly number[]
+  ): boolean {
+    return false;
+  }
 
   #syncRenderView(): void {
     this.#editor?.__syncRenderView(


### PR DESCRIPTION
Fixes split-diff edit-mode rerendering issues surfaced by the Codex review on this branch.

**Reproduction**
1. Open a split editable diff (e.g. `/playground` with Edit mode).
2. Edit an added line back to the old-side text so its hunk disappears or changes shape.

Before this change the editor stayed on the split fast-refresh path, which only patches row attributes — leaving stale added/deleted rows in the DOM.

**Changes**
- Detect when recomputing content hunks changes the rendered hunk shape, and use a full refresh (clearing the render cache) for that case instead of the in-place fast patch.
- Reset the editor's caret/selection geometry caches when a split content edit rebuilds rows, so the caret doesn't measure a detached row and jump.
- `fastRefreshDiffView` self-escalates to a full rebuild when a column's rendered row count diverges, instead of silently leaving stale rows.
- Guard the async editor-sync continuation so a highlighter promise from an older render can't resync a detached or replaced editor.
- Document `getDiffRenderShapeKey` (the fast-vs-full gate) and add regression coverage: split reshape that removes a hunk, a same-split-count reshape, and fast-path reachability.

**Scope note**
Rebased to drop the "preserve editor history across layout toggles" commit — that workaround is being handled via the cacheKey approach in #878. This PR is now only the split-reshape / async-sync correctness fix.
