### PR TITLE
[diffs] CodeView / WorkerPool Init Race Fix

### DIFF
--- a/apps/demo/src/codeViewDemo.ts
+++ b/apps/demo/src/codeViewDemo.ts
@@ -94,6 +94,7 @@ export function renderDemoCodeView(
 
   const items = createCodeViewItems(parsedPatches);
   const options: CodeViewOptions<CodeViewCommentMetadata> = {
+    // __devOnlyValidateItemHeights: true,
     theme,
     themeType,
     diffStyle,

--- a/apps/demo/src/style.css
+++ b/apps/demo/src/style.css
@@ -211,11 +211,6 @@ code {
   flex-direction: row-reverse;
 }
 
-diffs-container {
-  /* content-visibility: auto; */
-  margin-top: 2px;
-}
-
 .header-filename-suffix-badge {
   display: inline-flex;
   align-items: center;

--- a/apps/demo/src/utils/createWorkerAPI.ts
+++ b/apps/demo/src/utils/createWorkerAPI.ts
@@ -6,12 +6,18 @@ import {
 // oxlint-disable-next-line import/default -- Vite worker URL provides a default export
 import WorkerUrl from '@pierre/diffs/worker/worker.js?worker&url';
 
+// HACK(debug): Quick way to test worker initialization failure cases if needed
+const FORCE_WORKER_POOL_FAILURE = false;
+
 export function createWorkerAPI(
   highlighterOptions: WorkerInitializationRenderOptions
 ): WorkerPoolManager {
   return getOrCreateWorkerPoolSingleton({
     poolOptions: {
       workerFactory() {
+        if (FORCE_WORKER_POOL_FAILURE) {
+          throw new Error('HACK: forced worker pool initialization failure');
+        }
         return new Worker(WorkerUrl, { type: 'module' });
       },
       poolSize: 3,

--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -2723,6 +2723,7 @@ export class CodeView<LAnnotation = undefined> {
     this.renderState.lastIndex = lastRenderedIndex;
 
     this.flushSlotCoordinator();
+    this.flushManagers(updatedItems);
     this.reconcileRenderedItems(updatedItems);
     this.syncContainerHeight();
     this.updateStickyPositioning();
@@ -2792,7 +2793,16 @@ export class CodeView<LAnnotation = undefined> {
     }
     this.renderState.scrollTop = roundToDevicePixel(syncedScrollTop);
 
-    this.flushManagers(updatedItems);
+    // The post-render scroll-correction block above can call applyScrollFix ->
+    // syncPagedScrollScaffolding -> applyStickyPositioning, which recomputes
+    // renderState.stickyHeight from getStickyBounds(windowSpecs) for the
+    // corrected scroll position. The rendered DOM slice was committed earlier in
+    // this frame for the pre-correction window and is not re-rendered here, so
+    // that windowSpecs-based value can diverge from the committed slice by the
+    // scroll-correction delta. Recompute sticky positioning from the committed
+    // renderRange (no-arg path) so renderState.stickyHeight matches the slice
+    // actually in the DOM before we validate it.
+    this.updateStickyPositioning();
 
     this.validateStickyContainerHeight();
     this.fixContainerFocus();

--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -1422,6 +1422,12 @@ export class CodeView<LAnnotation = undefined> {
         this.render(true);
       }
     );
+
+    // If the worker is awiting on initialization, we should attempt to
+    // initialize
+    if (workerManager.getStats().managerState === 'waiting') {
+      void workerManager.initialize().catch(() => {});
+    }
     return false;
   }
 

--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -1400,14 +1400,21 @@ export class CodeView<LAnnotation = undefined> {
 
   private isReady(): boolean {
     const { workerManager } = this;
-    if (workerManager == null || workerManager.isInitialized()) {
+    // A failed worker pool never reaches the 'initialized' state (it reverts to
+    // 'waiting' with workersFailed: true), so treat failure as ready and let
+    // the renderers fall back to synchronous highlighting.
+    if (
+      workerManager == null ||
+      workerManager.isInitialized() ||
+      workerManager.getStats().workersFailed
+    ) {
       this.clearReadySubscription();
       return true;
     }
 
     this.isReadySubscription ??= workerManager.subscribeToStatChanges(
       (stats) => {
-        if (stats.managerState !== 'initialized') {
+        if (stats.managerState !== 'initialized' && !stats.workersFailed) {
           return;
         }
 

--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -606,6 +606,7 @@ export class CodeView<LAnnotation = undefined> {
   private pendingElementPool: HTMLElement[] = [];
   private options: CodeViewOptions<LAnnotation>;
   private workerManager: WorkerPoolManager | undefined;
+  private isReadySubscription: (() => void) | undefined;
   private isContainerManaged: boolean;
 
   constructor(
@@ -887,6 +888,7 @@ export class CodeView<LAnnotation = undefined> {
   }
 
   public reset(): void {
+    this.clearReadySubscription();
     this.restoreScrollInteractions();
     this.cleanAllRenderedItems();
     this.selectedLines = null;
@@ -1394,6 +1396,34 @@ export class CodeView<LAnnotation = undefined> {
     } else {
       queueRender(this.computeRenderRangeAndEmit);
     }
+  }
+
+  private isReady(): boolean {
+    const { workerManager } = this;
+    if (workerManager == null || workerManager.isInitialized()) {
+      this.clearReadySubscription();
+      return true;
+    }
+
+    this.isReadySubscription ??= workerManager.subscribeToStatChanges(
+      (stats) => {
+        if (stats.managerState !== 'initialized') {
+          return;
+        }
+
+        this.clearReadySubscription();
+        this.render(true);
+      }
+    );
+    return false;
+  }
+
+  private clearReadySubscription(): void {
+    if (this.isReadySubscription == null) {
+      return;
+    }
+    this.isReadySubscription();
+    this.isReadySubscription = undefined;
   }
 
   public instanceChanged(
@@ -2524,6 +2554,9 @@ export class CodeView<LAnnotation = undefined> {
     timestamp: number = performance.now()
   ): void => {
     if (CodeView.__STOP || this.container == null) {
+      return;
+    }
+    if (!this.isReady()) {
       return;
     }
 

--- a/packages/diffs/test/CodeView.workerPoolReady.test.ts
+++ b/packages/diffs/test/CodeView.workerPoolReady.test.ts
@@ -7,10 +7,16 @@ import { createRoot, installDom, makeFileItem, wait } from './domHarness';
 class FakeWorkerPoolManager {
   private initialized = false;
   private failed = false;
+  private initializeCalls = 0;
+  private autoInitialize = false;
   private statSubscribers = new Set<(stats: WorkerStats) => unknown>();
 
   public get statSubscriberCount(): number {
     return this.statSubscribers.size;
+  }
+
+  public get initializeCallCount(): number {
+    return this.initializeCalls;
   }
 
   public isInitialized(): boolean {
@@ -21,8 +27,19 @@ class FakeWorkerPoolManager {
     return false;
   }
 
+  // Mirror the real manager: a waiting pool only leaves 'waiting' once
+  // initialize() runs. When auto-initialize is enabled, initialize() drives the
+  // pool to 'initialized' the way the real worker bootstrap eventually does.
   public initialize(): Promise<void> {
+    this.initializeCalls += 1;
+    if (this.autoInitialize) {
+      this.markInitialized();
+    }
     return Promise.resolve();
+  }
+
+  public enableAutoInitialize(): void {
+    this.autoInitialize = true;
   }
 
   public subscribeToStatChanges(
@@ -153,6 +170,40 @@ describe('CodeView worker pool readiness', () => {
       // A failed pool must trigger fallback rendering instead of staying blank.
       expect(viewer.getRenderedItems().map((item) => item.id)).toEqual([
         'file:failed-worker',
+      ]);
+      expect(workerManager.statSubscriberCount).toBe(0);
+      expect(consoleError).not.toHaveBeenCalled();
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+
+  test('kicks initialization for a waiting pool that has not auto-started', async () => {
+    const { cleanup } = installDom();
+    const consoleError = spyOn(console, 'error').mockImplementation(() => {});
+    const workerManager = new FakeWorkerPoolManager();
+    // Model a pool sitting idle in 'waiting' (e.g. after terminate()): it never
+    // reaches 'initialized' unless something calls initialize().
+    workerManager.enableAutoInitialize();
+    const viewer = new CodeView(
+      { disableFileHeader: true },
+      workerManager.asWorkerPoolManager()
+    );
+
+    try {
+      viewer.setup(createRoot({ height: 1000 }));
+      viewer.setItems([makeFileItem('file:waiting-pool', 3)]);
+
+      viewer.render(true);
+      await wait(0);
+
+      // Rendering must kick initialization rather than block forever, which
+      // then drives the pool to 'initialized' and lets the item render.
+      expect(workerManager.initializeCallCount).toBeGreaterThan(0);
+      expect(viewer.getRenderedItems().map((item) => item.id)).toEqual([
+        'file:waiting-pool',
       ]);
       expect(workerManager.statSubscriberCount).toBe(0);
       expect(consoleError).not.toHaveBeenCalled();

--- a/packages/diffs/test/CodeView.workerPoolReady.test.ts
+++ b/packages/diffs/test/CodeView.workerPoolReady.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+import { CodeView } from '../src/components/CodeView';
+import type { WorkerPoolManager, WorkerStats } from '../src/worker';
+import { createRoot, installDom, makeFileItem, wait } from './domHarness';
+
+class FakeWorkerPoolManager {
+  private initialized = false;
+  private statSubscribers = new Set<(stats: WorkerStats) => unknown>();
+
+  public get statSubscriberCount(): number {
+    return this.statSubscribers.size;
+  }
+
+  public isInitialized(): boolean {
+    return this.initialized;
+  }
+
+  public isWorkingPool(): boolean {
+    return false;
+  }
+
+  public subscribeToStatChanges(
+    callback: (stats: WorkerStats) => unknown
+  ): () => void {
+    this.statSubscribers.add(callback);
+    callback(this.getStats());
+    return () => {
+      this.statSubscribers.delete(callback);
+    };
+  }
+
+  public subscribeToThemeChanges(): () => void {
+    return () => {};
+  }
+
+  public unsubscribeToThemeChanges(): void {}
+
+  public cleanUpTasks(): void {}
+
+  public getFileResultCache(): undefined {
+    return undefined;
+  }
+
+  public markInitialized(): void {
+    this.initialized = true;
+    const stats = this.getStats();
+    for (const callback of Array.from(this.statSubscribers)) {
+      callback(stats);
+    }
+  }
+
+  private getStats(): WorkerStats {
+    return {
+      managerState: this.initialized ? 'initialized' : 'waiting',
+      workersFailed: false,
+      totalWorkers: 0,
+      busyWorkers: 0,
+      queuedTasks: 0,
+      activeTasks: 0,
+      themeSubscribers: 0,
+      fileCacheSize: 0,
+      diffCacheSize: 0,
+    };
+  }
+
+  public asWorkerPoolManager(): WorkerPoolManager {
+    return this as unknown as WorkerPoolManager;
+  }
+}
+
+describe('CodeView worker pool readiness', () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test('waits for worker pool initialization before rendering items', async () => {
+    const { cleanup } = installDom();
+    const consoleError = mock(() => {});
+    console.error = consoleError;
+    const workerManager = new FakeWorkerPoolManager();
+    const viewer = new CodeView(
+      { disableFileHeader: true },
+      workerManager.asWorkerPoolManager()
+    );
+
+    try {
+      viewer.setup(createRoot({ height: 1000 }));
+      viewer.setItems([makeFileItem('file:pending-worker', 3)]);
+
+      viewer.render(true);
+      await wait(0);
+
+      expect(viewer.getRenderedItems()).toHaveLength(0);
+      expect(workerManager.statSubscriberCount).toBe(1);
+
+      viewer.render(true);
+      await wait(0);
+
+      expect(viewer.getRenderedItems()).toHaveLength(0);
+      expect(workerManager.statSubscriberCount).toBe(1);
+
+      workerManager.markInitialized();
+
+      expect(viewer.getRenderedItems().map((item) => item.id)).toEqual([
+        'file:pending-worker',
+      ]);
+      expect(workerManager.statSubscriberCount).toBe(0);
+      expect(consoleError).not.toHaveBeenCalled();
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+});

--- a/packages/diffs/test/CodeView.workerPoolReady.test.ts
+++ b/packages/diffs/test/CodeView.workerPoolReady.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test';
 
 import { CodeView } from '../src/components/CodeView';
 import type { WorkerPoolManager, WorkerStats } from '../src/worker';
@@ -91,8 +91,7 @@ describe('CodeView worker pool readiness', () => {
 
   test('waits for worker pool initialization before rendering items', async () => {
     const { cleanup } = installDom();
-    const consoleError = mock(() => {});
-    console.error = consoleError;
+    const consoleError = spyOn(console, 'error').mockImplementation(() => {});
     const workerManager = new FakeWorkerPoolManager();
     const viewer = new CodeView(
       { disableFileHeader: true },
@@ -131,8 +130,7 @@ describe('CodeView worker pool readiness', () => {
 
   test('renders via fallback when the worker pool fails after subscribing', async () => {
     const { cleanup } = installDom();
-    const consoleError = mock(() => {});
-    console.error = consoleError;
+    const consoleError = spyOn(console, 'error').mockImplementation(() => {});
     const workerManager = new FakeWorkerPoolManager();
     const viewer = new CodeView(
       { disableFileHeader: true },
@@ -167,8 +165,7 @@ describe('CodeView worker pool readiness', () => {
 
   test('renders immediately when the worker pool has already failed', async () => {
     const { cleanup } = installDom();
-    const consoleError = mock(() => {});
-    console.error = consoleError;
+    const consoleError = spyOn(console, 'error').mockImplementation(() => {});
     const workerManager = new FakeWorkerPoolManager();
     workerManager.markFailed();
     const viewer = new CodeView(

--- a/packages/diffs/test/CodeView.workerPoolReady.test.ts
+++ b/packages/diffs/test/CodeView.workerPoolReady.test.ts
@@ -6,6 +6,7 @@ import { createRoot, installDom, makeFileItem, wait } from './domHarness';
 
 class FakeWorkerPoolManager {
   private initialized = false;
+  private failed = false;
   private statSubscribers = new Set<(stats: WorkerStats) => unknown>();
 
   public get statSubscriberCount(): number {
@@ -18,6 +19,10 @@ class FakeWorkerPoolManager {
 
   public isWorkingPool(): boolean {
     return false;
+  }
+
+  public initialize(): Promise<void> {
+    return Promise.resolve();
   }
 
   public subscribeToStatChanges(
@@ -50,10 +55,20 @@ class FakeWorkerPoolManager {
     }
   }
 
-  private getStats(): WorkerStats {
+  // Mirror WorkerPoolManager's init-failure state: it reverts to 'waiting' with
+  // workersFailed: true rather than ever reaching 'initialized'.
+  public markFailed(): void {
+    this.failed = true;
+    const stats = this.getStats();
+    for (const callback of Array.from(this.statSubscribers)) {
+      callback(stats);
+    }
+  }
+
+  public getStats(): WorkerStats {
     return {
       managerState: this.initialized ? 'initialized' : 'waiting',
-      workersFailed: false,
+      workersFailed: this.failed,
       totalWorkers: 0,
       busyWorkers: 0,
       queuedTasks: 0,
@@ -104,6 +119,73 @@ describe('CodeView worker pool readiness', () => {
 
       expect(viewer.getRenderedItems().map((item) => item.id)).toEqual([
         'file:pending-worker',
+      ]);
+      expect(workerManager.statSubscriberCount).toBe(0);
+      expect(consoleError).not.toHaveBeenCalled();
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+
+  test('renders via fallback when the worker pool fails after subscribing', async () => {
+    const { cleanup } = installDom();
+    const consoleError = mock(() => {});
+    console.error = consoleError;
+    const workerManager = new FakeWorkerPoolManager();
+    const viewer = new CodeView(
+      { disableFileHeader: true },
+      workerManager.asWorkerPoolManager()
+    );
+
+    try {
+      viewer.setup(createRoot({ height: 1000 }));
+      viewer.setItems([makeFileItem('file:failed-worker', 3)]);
+
+      viewer.render(true);
+      await wait(0);
+
+      // Still initializing: nothing rendered yet, one readiness subscriber.
+      expect(viewer.getRenderedItems()).toHaveLength(0);
+      expect(workerManager.statSubscriberCount).toBe(1);
+
+      workerManager.markFailed();
+
+      // A failed pool must trigger fallback rendering instead of staying blank.
+      expect(viewer.getRenderedItems().map((item) => item.id)).toEqual([
+        'file:failed-worker',
+      ]);
+      expect(workerManager.statSubscriberCount).toBe(0);
+      expect(consoleError).not.toHaveBeenCalled();
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+
+  test('renders immediately when the worker pool has already failed', async () => {
+    const { cleanup } = installDom();
+    const consoleError = mock(() => {});
+    console.error = consoleError;
+    const workerManager = new FakeWorkerPoolManager();
+    workerManager.markFailed();
+    const viewer = new CodeView(
+      { disableFileHeader: true },
+      workerManager.asWorkerPoolManager()
+    );
+
+    try {
+      viewer.setup(createRoot({ height: 1000 }));
+      viewer.setItems([makeFileItem('file:already-failed', 3)]);
+
+      viewer.render(true);
+      await wait(0);
+
+      // No readiness subscription is needed; render proceeds via fallback.
+      expect(viewer.getRenderedItems().map((item) => item.id)).toEqual([
+        'file:already-failed',
       ]);
       expect(workerManager.statSubscriberCount).toBe(0);
       expect(consoleError).not.toHaveBeenCalled();


### PR DESCRIPTION
Since the release of CodeView, there has been an issue on initialization where CodeView attempts to render before the WorkerPool is ready, which while generally harmless, does end up rendering some zero height containers and does cause some layout validation thrash.

I also found a few areas that I could tighten up with virtualization calculations being properly delayed by a tick (bad). So also potentially improved cases of scrolling into un-measured annotations above.

Fixes #786 