### PR TITLE
fix(diffs): delete to line start on Safari cmd+backspace

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -2083,6 +2083,12 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         this.#deleteSelectionText(true);
         break;
       case 'deleteSoftLineBackward':
+      // Safari emits deleteHardLineBackward for cmd+backspace where Chrome emits
+      // deleteSoftLineBackward; treat them the same so cmd+backspace deletes to
+      // the line start in both. They differ only on a wrapped line (hard goes to
+      // the logical line start, soft to the visual one), and Chrome's soft
+      // behavior is what we match.
+      case 'deleteHardLineBackward':
         this.#deleteSoftLineBackward();
         break;
       case 'deleteHardLineForward':

--- a/packages/diffs/test/editorDiffEmptyDocument.test.ts
+++ b/packages/diffs/test/editorDiffEmptyDocument.test.ts
@@ -164,3 +164,58 @@ describe('diff editor: select-all then delete', () => {
     });
   }
 });
+
+// Fires the beforeinput the browser would send, so the editor's own handler
+// runs (it reads e.inputType and edits #selections). cancelable lets the
+// handler preventDefault as it does in the browser. InputEvent lives on the
+// jsdom window rather than globalThis, so reach it through the element.
+function dispatchBeforeInput(content: HTMLElement, inputType: string): void {
+  const view = content.ownerDocument.defaultView;
+  if (view == null) {
+    throw new Error('content element is not attached to a window');
+  }
+  content.dispatchEvent(
+    new view.InputEvent('beforeinput', {
+      inputType,
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      data: null,
+    })
+  );
+}
+
+// cmd+backspace deletes to the start of the line. Chrome reports it as
+// deleteSoftLineBackward, but Safari reports deleteHardLineBackward; the editor
+// must treat both the same or Safari's cmd+backspace silently does nothing.
+describe('diff editor: cmd+backspace (deleteHardLineBackward) deletes to line start', () => {
+  for (const diffStyle of ['split', 'unified'] as const) {
+    test(`Safari's deleteHardLineBackward matches Chrome's deleteSoftLineBackward (${diffStyle})`, async () => {
+      const fixture = await createDiffEditorFixture(
+        diffStyle,
+        'a\nb\n',
+        'hello world\nfoo\n'
+      );
+      const { editor, container } = fixture;
+      try {
+        const content = findAdditionContent(container);
+        expect(content).toBeDefined();
+        if (content == null) return;
+
+        // Caret at the end of "hello world", then Safari's cmd+backspace.
+        editor.setSelections([
+          {
+            start: { line: 0, character: 11 },
+            end: { line: 0, character: 11 },
+            direction: 'none',
+          },
+        ]);
+        dispatchBeforeInput(content, 'deleteHardLineBackward');
+        await wait(0);
+        expect(editor.getState().file.contents).toBe('\nfoo\n');
+      } finally {
+        await fixture.cleanup();
+      }
+    });
+  }
+});


### PR DESCRIPTION
To reproduce, in the diff editor on Safari:

1. Click into the additions side and type text on a line.
2. Press cmd+Backspace.

Nothing is deleted, though cmd+Backspace deletes to the line start in Chrome.

Safari reports cmd+Backspace as the deleteHardLineBackward input type where Chrome reports deleteSoftLineBackward; the editor only handled the latter, so Safari's cmd+Backspace was dropped. Route both to the same handler. They differ only on a wrapped line (hard deletes to the logical line start, soft to the visual one), and Chrome's soft behavior is the one we match.