### PR TITLE
[diffs] CodeView: Custom header / footer support

### DIFF
--- a/apps/demo/src/codeViewDemo.ts
+++ b/apps/demo/src/codeViewDemo.ts
@@ -115,6 +115,22 @@ export function renderDemoCodeView(
     enableLineSelection: true,
     enableGutterUtility: true,
     stickyHeaders: true,
+    // renderCodeViewHeader() {
+    //   const el = document.createElement('div');
+    //   el.textContent = 'CodeView header — scrolls with the content';
+    //   el.style.padding = '20px';
+    //   el.style.textAlign = 'center';
+    //   el.style.borderBottom =
+    //     '1px solid var(--color-border, rgba(128, 128, 128, 0.3))';
+    //   return el;
+    // },
+    // renderCodeViewFooter() {
+    //   const el = document.createElement('div');
+    //   el.textContent = 'CodeView footer 🫶';
+    //   el.style.padding = '40px';
+    //   el.style.textAlign = 'center';
+    //   return el;
+    // },
     layout: { paddingTop: 10, paddingBottom: 24, gap: 12 },
     onGutterUtilityClick(range, context) {
       if (context.item.type !== 'diff') {

--- a/apps/docs/app/(diffs)/_docs/DocsPage.tsx
+++ b/apps/docs/app/(diffs)/_docs/DocsPage.tsx
@@ -9,6 +9,8 @@ import type { Metadata } from 'next';
 import { MERGE_CONFLICT_EXAMPLE } from '../_examples/MergeConflict/constants';
 import { MergeConflict } from '../_examples/MergeConflict/MergeConflict';
 import {
+  CODE_VIEW_HEADER_FOOTER_REACT_EXAMPLE,
+  CODE_VIEW_HEADER_FOOTER_VANILLA_EXAMPLE,
   CODE_VIEW_ITEM_METRICS_OPTIONS_EXAMPLE,
   CODE_VIEW_ITEM_TYPE_EXAMPLE,
   CODE_VIEW_LAYOUT_OPTIONS_EXAMPLE,
@@ -384,6 +386,8 @@ async function CodeViewSection() {
     codeViewReactExample,
     codeViewScrollTargetsExample,
     codeViewVanillaExample,
+    codeViewHeaderFooterReactExample,
+    codeViewHeaderFooterVanillaExample,
   ] = await Promise.all([
     preloadFile(CODE_VIEW_ITEM_TYPE_EXAMPLE),
     preloadFile(CODE_VIEW_LAYOUT_OPTIONS_EXAMPLE),
@@ -391,6 +395,8 @@ async function CodeViewSection() {
     preloadFile(CODE_VIEW_REACT_EXAMPLE),
     preloadFile(CODE_VIEW_SCROLL_TARGETS_EXAMPLE),
     preloadFile(CODE_VIEW_VANILLA_EXAMPLE),
+    preloadFile(CODE_VIEW_HEADER_FOOTER_REACT_EXAMPLE),
+    preloadFile(CODE_VIEW_HEADER_FOOTER_VANILLA_EXAMPLE),
   ]);
   const content = await renderMDX({
     filePath: '(diffs)/docs/CodeView/content.mdx',
@@ -401,6 +407,8 @@ async function CodeViewSection() {
       codeViewReactExample,
       codeViewScrollTargetsExample,
       codeViewVanillaExample,
+      codeViewHeaderFooterReactExample,
+      codeViewHeaderFooterVanillaExample,
     },
   });
   return <ProseWrapper>{content}</ProseWrapper>;

--- a/apps/docs/app/(diffs)/docs/CodeView/constants.ts
+++ b/apps/docs/app/(diffs)/docs/CodeView/constants.ts
@@ -396,7 +396,7 @@ viewer.addItems([
     type: 'file',
     file: {
       name: 'CHANGELOG.md',
-      contents: '# Changelog\n\n- Added personalized greetings.',
+      contents: '# Changelog\\n\\n- Added personalized greetings.',
     },
   },
 ]);
@@ -407,3 +407,162 @@ window.addEventListener('beforeunload', () => {
   },
   options,
 };
+
+export const CODE_VIEW_HEADER_FOOTER_REACT_EXAMPLE: PreloadFileOptions<undefined> =
+  {
+    file: {
+      name: 'code_view_header_footer.tsx',
+      contents: `import { parseDiffFromFile, type CodeViewItem } from '@pierre/diffs';
+import { CodeView } from '@pierre/diffs/react';
+import { useCallback, useMemo, useState } from 'react';
+
+const oldAppFile = {
+  name: 'src/app.ts',
+  contents: \`export function greet() {\n  return "hello";\n}\`,
+};
+
+const newAppFile = {
+  name: 'src/app.ts',
+  contents:
+    \`export function greet(name: string) {\n  return "hello " + name;\n}\`,
+};
+
+export function ReviewSurface() {
+  const [approved, setApproved] = useState(false);
+
+  const items = useMemo<CodeViewItem[]>(
+    () => [
+      {
+        id: 'diff:src/app.ts',
+        type: 'diff',
+        fileDiff: parseDiffFromFile(oldAppFile, newAppFile),
+      },
+    ],
+    []
+  );
+
+  // Rendered before the first item and portaled into a host element the
+  // viewer manages inside the scroll container. Not virtualized: always in
+  // the DOM. Memoize render callbacks so the viewer doesn't re-render the
+  // header on every parent render. (don't trust react compiler).
+  const renderHeader = useCallback(() => {
+    return (
+      <section className="pr-summary">
+        <h2>Add personalized greetings</h2>
+        <p>Threads a name through greet() so callers control the message.</p>
+        <span>1 file changed</span>
+      </section>
+    );
+  }, []);
+
+  // Rendered after the last item. Plain state-driven JSX: when it re-renders
+  // at a different height, the viewer re-measures automatically. List the
+  // state the callback reads in the deps so updates flow through. (don't trust
+  // react compiler).
+  const renderFooter = useCallback(() => {
+    return (
+      <div className="review-actions">
+        <span>{approved ? 'Approved' : 'Reviewed 1 of 1 files'}</span>
+        <button type="button" onClick={() => setApproved(true)}>
+          Approve changes
+        </button>
+      </div>
+    );
+  }, [approved]);
+
+  return (
+    <CodeView
+      items={items}
+      style={{ height: 600, overflow: 'auto' }}
+      options={{
+        theme: { dark: 'pierre-dark', light: 'pierre-light' },
+        stickyHeaders: true,
+        layout: { paddingTop: 16, paddingBottom: 16, gap: 12 },
+      }}
+      renderCodeViewHeader={renderHeader}
+      renderCodeViewFooter={renderFooter}
+    />
+  );
+}`,
+    },
+    options,
+  };
+
+export const CODE_VIEW_HEADER_FOOTER_VANILLA_EXAMPLE: PreloadFileOptions<undefined> =
+  {
+    file: {
+      name: 'code_view_header_footer.ts',
+      contents: `import { CodeView, parseDiffFromFile } from '@pierre/diffs';
+
+const root = document.getElementById('review-root');
+if (root == null) {
+  throw new Error('Expected #review-root to exist');
+}
+
+root.style.height = '600px';
+root.style.overflow = 'auto';
+
+// Create the header element once, outside the callback. To update it later,
+// mutate it in place: the viewer observes the host and re-measures height
+// changes automatically.
+const summaryCard = document.createElement('section');
+summaryCard.className = 'pr-summary';
+const summaryTitle = document.createElement('h2');
+summaryTitle.textContent = 'Add personalized greetings';
+const summaryBody = document.createElement('p');
+summaryBody.textContent =
+  'Threads a name through greet() so callers control the message.';
+summaryCard.append(summaryTitle, summaryBody);
+
+const approveBar = document.createElement('div');
+approveBar.className = 'review-actions';
+const approveButton = document.createElement('button');
+approveButton.type = 'button';
+approveButton.textContent = 'Approve changes';
+approveButton.addEventListener('click', () => {
+  // Mutating the existing element is the whole update model; no re-render
+  // call is needed, and the new height is measured automatically.
+  approveBar.textContent = 'Approved';
+});
+approveBar.append('Reviewed 1 of 1 files — ', approveButton);
+
+const viewer = new CodeView({
+  theme: { dark: 'pierre-dark', light: 'pierre-light' },
+  stickyHeaders: true,
+  layout: { paddingTop: 16, paddingBottom: 16, gap: 12 },
+  // Return the same element across calls. Returning undefined instead would
+  // empty the host; removing the callback removes the host entirely.
+  renderCodeViewHeader() {
+    return summaryCard;
+  },
+  renderCodeViewFooter() {
+    return approveBar;
+  },
+});
+
+viewer.setup(root);
+
+viewer.setItems([
+  {
+    id: 'diff:src/app.ts',
+    type: 'diff',
+    fileDiff: parseDiffFromFile(
+      {
+        name: 'src/app.ts',
+        contents: 'export function greet() {\\n  return "hello";\\n}',
+      },
+      {
+        name: 'src/app.ts',
+        contents:
+          'export function greet(name: string) {\\n  return "hello " + name;\\n}',
+      }
+    ),
+  },
+]);
+
+window.addEventListener('beforeunload', () => {
+  viewer.cleanUp();
+});`,
+    },
+    options,
+  };

--- a/apps/docs/app/(diffs)/docs/CodeView/content.mdx
+++ b/apps/docs/app/(diffs)/docs/CodeView/content.mdx
@@ -24,6 +24,9 @@ CodeView to avoid handling scaling yourself.
 - `scrollTo` APIs for items, line targets, and raw scroll positions.
 - Unified selection API, support for custom annotations, custom headers, and
   gutter utilities across the entire viewer.
+- Optional non-virtualized [header and footer regions](#codeview-header-footer)
+  rendered inside the scroll container — ideal for PR summary cards and approval
+  bars.
 
 ### Core Model
 
@@ -60,6 +63,40 @@ For controlling layout inside and between items in `CodeView`, you can use the
 and adjust the layout. You should not apply these values with CSS yourself.
 
 <DocsCodeExample {...codeViewLayoutOptionsExample} />
+
+### Header &amp; Footer
+
+Use the `renderCodeViewHeader` and `renderCodeViewFooter` options to render your
+own element at the start and end of the scroll content; before the first item
+and after the last one.
+
+- Headers and footers are not virtualized. Unlike items, they are always in the
+  DOM while the viewer is mounted.
+- They are rendered inside the scroll container, as part of the scrollable
+  content. `CodeView` doesn't apply any positioning of its own, and they don't
+  affect `stickyHeaders` behavior for item headers.
+- You never declare a height. `CodeView` measures the element on mount and
+  tracks later size changes with a `ResizeObserver`, so async content, font
+  loads, and late-arriving React portals stay coherent, and scroll position is
+  re-anchored when a header's height changes.
+- Both render even when the item list is empty, which makes them useful for
+  loading or empty states in review UIs.
+- In React, return plain JSX from the `renderCodeViewHeader` /
+  `renderCodeViewFooter` props. The node is portaled into a host element the
+  viewer manages, so state-driven updates just work. Memoize the callbacks with
+  `useCallback` (listing any state they read as deps) so the header and footer
+  don't re-render on every parent render (don't trust React Compiler).
+- In Vanilla JS, return the same element across calls and mutate it in place to
+  update; returning `undefined` empties the host. The callback's presence
+  controls whether the host element exists at all.
+- The host elements carry `data-diffs-code-view-header` and
+  `data-diffs-code-view-footer` attributes for styling, and are exposed via
+  `getHeaderElement()` / `getFooterElement()` on the instance.
+
+<CodeViewExampleTabs
+  reactExample={codeViewHeaderFooterReactExample}
+  vanillaExample={codeViewHeaderFooterVanillaExample}
+/>
 
 ### File &amp; Diff Size Estimation
 

--- a/apps/docs/app/(diffs)/docs/ReactAPI/content.mdx
+++ b/apps/docs/app/(diffs)/docs/ReactAPI/content.mdx
@@ -38,7 +38,7 @@ input and remount (for example, with a changing `key`) when you want to reset.
 
 The `CodeView` tab above is the quick-start version. For the full guide on
 controlled `items`, imperative `initialItems`, ids, `version`, selection, and
-`scrollTo`, see [CodeView](#code-view).
+`scrollTo`, see [CodeView](#codeview).
 
 ### Partial Diff Hydration
 
@@ -65,7 +65,7 @@ component has similar props, but uses `LineAnnotation` instead of
 
 `CodeView` reuses many of the same option names internally, but it has its own
 controlled `items` mode, imperative mode with optional `initialItems`, viewer
-ref, and mixed-item render props. See [CodeView](#code-view) for the dedicated
+ref, and mixed-item render props. See [CodeView](#codeview) for the dedicated
 guide.
 
 Header customization and collapsing behavior:

--- a/apps/docs/app/(diffs)/docs/VanillaAPI/constants.ts
+++ b/apps/docs/app/(diffs)/docs/VanillaAPI/constants.ts
@@ -293,7 +293,7 @@ viewer.addItems([
     type: 'file',
     file: {
       name: 'CHANGELOG.md',
-      contents: '# Changelog\n\n- Added personalized greetings.',
+      contents: '# Changelog\\n\\n- Added personalized greetings.',
     },
   },
 ]);

--- a/apps/docs/app/(diffs)/docs/VanillaAPI/content.mdx
+++ b/apps/docs/app/(diffs)/docs/VanillaAPI/content.mdx
@@ -30,7 +30,7 @@ highlighting, theming, and interactivity for you.
 
 The `CodeView` tab above is the quick-start version. For the deeper guide on
 `setup`, `setItems`, `addItems`, `getItem`, `updateItem`, selection, and
-`scrollTo`, see [CodeView](#code-view).
+`scrollTo`, see [CodeView](#codeview).
 
 ### Props
 
@@ -56,7 +56,7 @@ default; set `disableErrorHandling: true` when you want errors to rethrow.
 adding CodeView-specific controls like `layout`, `itemMetrics`, `stickyHeaders`,
 `pointerEventsOnScroll`, and `smoothScrollSettings`. Its class instance also
 exposes item-level methods such as `addItems`, `getItem`, and `updateItem`. See
-[CodeView](#code-view) for the dedicated guide.
+[CodeView](#codeview) for the dedicated guide.
 
 Header customization and collapsing behavior:
 

--- a/apps/docs/scripts/generate-llms-txt.ts
+++ b/apps/docs/scripts/generate-llms-txt.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'fs';
 import { dirname, extname, join } from 'path';
 import { pathToFileURL } from 'url';
 
@@ -42,17 +48,20 @@ const DIFFS_SECTIONS = [
   'CoreTypes',
   'ReactAPI',
   'VanillaAPI',
+  'CodeView',
   'Editor',
   'Virtualization',
   'CustomHunkSeparators',
   'Utilities',
   'Styling',
   'Theming',
+  'TokenHooks',
   'WorkerPool',
   'SSR',
 ] as const;
 
 const TREES_SECTIONS = [
+  'Overview',
   'Guides/ChooseYourIntegration',
   'Guides/GetStartedWithReact',
   'Guides/GetStartedWithVanilla',
@@ -82,6 +91,8 @@ const SECTION_DESCRIPTIONS: Record<string, Record<string, string>> = {
       'MultiFileDiff, PatchDiff, FileDiff, File components and shared props',
     VanillaAPI:
       'FileDiff and File classes, props, deprecated vanilla custom hunk separators, and low-level renderers',
+    CodeView:
+      'One virtualized scroll region for mixed file and diff lists, with scrollTo targeting, viewer-wide selection, sticky headers, and header/footer regions',
     Editor:
       'Pluggable editing for File surfaces, including text editing, native selections, history, search, selection action, and shortcuts',
     Virtualization: 'Virtual scrolling for large diffs and files',
@@ -92,11 +103,15 @@ const SECTION_DESCRIPTIONS: Record<string, Record<string, string>> = {
     Styling: 'CSS variables, inline styles, and unsafe CSS injection',
     Theming:
       'Pierre Light/Dark themes, custom theme creation, and registration',
+    TokenHooks:
+      'Experimental token-level enter/leave/click callbacks for hover UI and LSP integrations',
     WorkerPool:
       'Off-main-thread syntax highlighting with configurable worker pools',
     SSR: 'Server-side rendering with preload functions for instant first paint',
   },
   trees: {
+    Overview:
+      'What trees is, the path-first model, and the React, vanilla, and SSR entry points',
     'Guides/ChooseYourIntegration':
       'Choosing between React and vanilla, with the shared path-first model',
     'Guides/GetStartedWithReact':
@@ -290,10 +305,15 @@ function stripJsx(mdx: string): string {
 }
 
 function cleanMarkdown(md: string): string {
-  return md
-    .replace(/\s*\[toc-ignore\]/g, '')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim();
+  return (
+    md
+      .replace(/\s*\[toc-ignore\]/g, '')
+      // MDX headings escape `&` as an HTML entity; decode it so the plain-text
+      // output reads as markdown, not markup.
+      .replace(/&amp;/g, '&')
+      .replace(/\n{3,}/g, '\n\n')
+      .trim()
+  );
 }
 
 function processMdx(raw: string): string {
@@ -511,6 +531,86 @@ const LLMS_DOCS_URL: Record<ProductId, string> = {
   trees: 'https://trees.software/docs',
 };
 
+// A docs dir is a section when it contains its section MDX file (content.mdx,
+// or the MDX_FILENAME_OVERRIDES filename for that dir).
+function isSectionDir(docsPrefix: string, dirName: string): boolean {
+  const mdxFilename =
+    MDX_FILENAME_OVERRIDES[`${docsPrefix}/${dirName}`] ?? 'content.mdx';
+  return existsSync(join(ROOT, 'app', docsPrefix, dirName, mdxFilename));
+}
+
+// Discover a product's section dirs by scanning `app/<docsPrefix>`. A dir
+// containing its section MDX is a section; anything else is treated as a
+// grouping dir (trees' Guides/Reference) and its immediate children are
+// checked one level deep.
+function discoverSectionDirs(docsPrefix: string): string[] {
+  const base = join(ROOT, 'app', docsPrefix);
+  const discovered: string[] = [];
+  for (const entry of readdirSync(base, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    if (isSectionDir(docsPrefix, entry.name)) {
+      discovered.push(entry.name);
+      continue;
+    }
+    for (const child of readdirSync(join(base, entry.name), {
+      withFileTypes: true,
+    })) {
+      if (!child.isDirectory()) continue;
+      const nested = `${entry.name}/${child.name}`;
+      if (isSectionDir(docsPrefix, nested)) discovered.push(nested);
+    }
+  }
+  return discovered;
+}
+
+// Fail the build when the hardcoded section registries drift from the docs
+// dirs on disk. Section order must stay hand-maintained (it mirrors each
+// page's render order, which a filesystem scan cannot derive), so this guard
+// keeps the second source of truth honest: an unregistered dir, a stale
+// entry, or a missing description fails the very next build. Both products
+// are checked regardless of NEXT_PUBLIC_SITE, so a diffs build catches trees
+// drift too.
+function assertSectionRegistriesComplete(): void {
+  const problems: string[] = [];
+  for (const productId of ['diffs', 'trees'] as const) {
+    const listName =
+      productId === 'diffs' ? 'DIFFS_SECTIONS' : 'TREES_SECTIONS';
+    const registered = PRODUCT_SECTIONS[productId];
+    const registeredSet = new Set(registered);
+    const discovered = new Set(discoverSectionDirs(DOCS_PREFIX[productId]));
+
+    const missing = [...discovered].filter((dir) => !registeredSet.has(dir));
+    const stale = registered.filter((dir) => !discovered.has(dir));
+    const undescribed = registered.filter(
+      (dir) => SECTION_DESCRIPTIONS[productId]?.[dir] == null
+    );
+
+    if (missing.length > 0) {
+      problems.push(
+        `[${productId}] docs dirs not registered in ${listName}: ${missing.join(', ')}`
+      );
+    }
+    if (stale.length > 0) {
+      problems.push(
+        `[${productId}] ${listName} entries with no MDX on disk: ${stale.join(', ')}`
+      );
+    }
+    if (undescribed.length > 0) {
+      problems.push(
+        `[${productId}] sections missing SECTION_DESCRIPTIONS entries: ${undescribed.join(', ')}`
+      );
+    }
+  }
+
+  if (problems.length > 0) {
+    throw new Error(
+      'generate-llms-txt: section registries drifted from the docs dirs on disk.\n' +
+        problems.map((problem) => `  - ${problem}`).join('\n') +
+        '\nRegister each new docs dir in its section list (in page render order) and add a SECTION_DESCRIPTIONS entry.'
+    );
+  }
+}
+
 function resolveProductId(): ProductId {
   const site = process.env.NEXT_PUBLIC_SITE ?? 'diffs';
   if (site !== 'diffs' && site !== 'trees') {
@@ -522,6 +622,8 @@ function resolveProductId(): ProductId {
 }
 
 async function main() {
+  assertSectionRegistriesComplete();
+
   // Each Vercel deployment (diffs.com vs trees.software) builds from the same
   // codebase with NEXT_PUBLIC_SITE selecting the active product. Both sites
   // share `public/`, so we generate exactly one product's files per build and

--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -1,4 +1,6 @@
 import {
+  CODE_VIEW_FOOTER_ATTRIBUTE,
+  CODE_VIEW_HEADER_ATTRIBUTE,
   CORE_CSS_ATTRIBUTE,
   DEFAULT_CODE_VIEW_FILE_METRICS,
   DEFAULT_CODE_VIEW_LAYOUT,
@@ -854,7 +856,10 @@ export class CodeView<LAnnotation = undefined> {
   // hosts are always-rendered, non-virtualized siblings of `container`: the
   // header before it (scrolls away above the items) and the footer after it
   // (trails below them).
-  private reconcileHeaderFooterHosts(): void {
+  // Returns true when a host was newly mounted by this call, so the render cycle
+  // knows to take a synchronous height measurement in the following read phase.
+  private reconcileHeaderFooterHosts(): boolean {
+    const { headerHost: prevHeaderHost, footerHost: prevFooterHost } = this;
     this.headerHost = this.reconcileHost(
       'header',
       this.headerHost,
@@ -864,6 +869,10 @@ export class CodeView<LAnnotation = undefined> {
       'footer',
       this.footerHost,
       this.options.renderCodeViewFooter
+    );
+    return (
+      (prevHeaderHost == null && this.headerHost != null) ||
+      (prevFooterHost == null && this.footerHost != null)
     );
   }
 
@@ -884,6 +893,7 @@ export class CodeView<LAnnotation = undefined> {
     // drop its measured height back to the 0 no-op.
     if (render == null) {
       if (host != null) {
+        this.resizeObserver?.unobserve(host);
         host.remove();
         this.setHostHeight(kind, 0);
       }
@@ -901,20 +911,21 @@ export class CodeView<LAnnotation = undefined> {
     // empty host here and fill it via a portal, while vanilla callbacks return an
     // element to populate it directly.
     host = document.createElement('div');
+    // Establish a block formatting context so the content margins stay inside
+    // the host to ensure proper heights from measurements/ResizeObserver
+    host.style.display = 'flow-root';
     if (kind === 'header') {
+      host.setAttribute(CODE_VIEW_HEADER_ATTRIBUTE, '');
       this.root.insertBefore(host, this.container);
     } else {
+      host.setAttribute(CODE_VIEW_FOOTER_ATTRIBUTE, '');
       this.root.appendChild(host);
     }
     const content = render();
     if (content != null) {
       host.appendChild(content);
     }
-    // Inline-measure once, synchronously, on mount so the first frame lays out
-    // with the real height instead of waiting on the async ResizeObserver. This
-    // forces a reflow, but only on the (rare) mount frame — the per-frame hot
-    // path early-returns above once the host exists.
-    this.setHostHeight(kind, host.getBoundingClientRect().height);
+    this.resizeObserver?.observe(host);
     return host;
   }
 
@@ -934,6 +945,25 @@ export class CodeView<LAnnotation = undefined> {
       this.footerHeight = height;
     }
     this.scrollDirty = true;
+  }
+
+  // Read the mounted hosts' heights from the DOM. Called only in the render
+  // cycle's read phase (right before reconcileRenderedItems) on a mount frame, so
+  // these getBoundingClientRect reads batch into the same reflow as the item
+  // height reads instead of forcing a separate reflow during the write phase.
+  private measureMountedHosts(): void {
+    if (this.headerHost != null) {
+      this.setHostHeight(
+        'header',
+        this.headerHost.getBoundingClientRect().height
+      );
+    }
+    if (this.footerHost != null) {
+      this.setHostHeight(
+        'footer',
+        this.footerHost.getBoundingClientRect().height
+      );
+    }
   }
 
   public setup(root: HTMLElement): void {
@@ -2835,10 +2865,8 @@ export class CodeView<LAnnotation = undefined> {
 
     // Mount/unmount the header/footer hosts in the same DOM-mutation window as the
     // items, after the scroll anchor was captured above and before the post-render
-    // anchor resolve below. A header mount shifts layout above the viewport; the
-    // inline measure inside reconcileHost updates headerHeight, and the post-render
-    // resolve compensates the shift exactly as it does for item height changes.
-    this.reconcileHeaderFooterHosts();
+    // anchor resolve below.
+    const hostsMounted = this.reconcileHeaderFooterHosts();
 
     let prevElement: HTMLElement | undefined;
     const updatedItems = new Set<CodeViewContextItem<LAnnotation>>();
@@ -2886,6 +2914,9 @@ export class CodeView<LAnnotation = undefined> {
 
     this.flushSlotCoordinator();
     this.flushManagers(updatedItems);
+    if (hostsMounted) {
+      this.measureMountedHosts();
+    }
     this.reconcileRenderedItems(updatedItems);
     this.syncContainerHeight();
     this.updateStickyPositioning();
@@ -3189,6 +3220,51 @@ export class CodeView<LAnnotation = undefined> {
             this.pendingScrollTarget = undefined;
             this.scrollAnimation = undefined;
           }
+        }
+      }
+      // A header/footer host resized after mount (async content, fonts, a React
+      // portal filling in). Re-measure and, for a header — which lives above the
+      // items — re-anchor so the content under the user's eyes doesn't jump,
+      // mirroring the stickyContainer branch above. Items are untouched by a host
+      // resize, so we skip reconcileRenderedItems/updateStickyPositioning; the
+      // trailing render() reconciles the range and render window.
+      else if (
+        entry.target === this.headerHost ||
+        entry.target === this.footerHost
+      ) {
+        const kind = entry.target === this.headerHost ? 'header' : 'footer';
+        const blockSize = entry.borderBoxSize[0].blockSize;
+        const currentHeight =
+          kind === 'header' ? this.headerHeight : this.footerHeight;
+        if (blockSize !== currentHeight) {
+          // Capture the anchor with the OLD offset, apply the new height, then
+          // resolve with the NEW offset so the delta cancels the layout shift. A
+          // footer only changes the scroll range, so its anchor resolves to no
+          // change (or a clamp when it shrinks below the current scroll).
+          const currentScrollTop = this.getScrollTop();
+          const anchor = this.getScrollAnchor(currentScrollTop);
+          this.setHostHeight(kind, blockSize);
+          const anchoredScrollTop =
+            anchor != null ? this.resolveAnchoredScrollTop(anchor) : undefined;
+          if (anchoredScrollTop != null) {
+            const resizeAnchorDelta = anchoredScrollTop - currentScrollTop;
+            this.applyScrollFix(
+              anchoredScrollTop,
+              currentScrollTop,
+              this.windowSpecs
+            );
+            if (this.scrollAnimation != null) {
+              this.scrollAnimation.position += resizeAnchorDelta;
+            }
+          }
+          if (
+            this.pendingScrollTarget != null &&
+            this.isPendingTargetSettled(this.pendingScrollTarget)
+          ) {
+            this.pendingScrollTarget = undefined;
+            this.scrollAnimation = undefined;
+          }
+          this.render();
         }
       }
       // Root element resize (element-mode only)

--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -456,6 +456,16 @@ export interface CodeViewOptions<LAnnotation>
   onSelectedLinesChange?(selection: CodeViewLineSelection | null): void;
   layout?: CodeViewLayout;
 
+  /** Render a non-virtualized element at the very start of the scroll content,
+   * before the first item. It is always rendered and scrolls with the content.
+   * Return the same element across calls and mutate it in place to update;
+   * height changes are measured automatically. */
+  renderCodeViewHeader?(): HTMLElement | undefined;
+  /** Render a non-virtualized element at the very end of the scroll content,
+   * after the last item. Always rendered; height changes are measured
+   * automatically. */
+  renderCodeViewFooter?(): HTMLElement | undefined;
+
   /** Internal dev-only check to ensure your `itemMetrics` are correct.  Its
    * automatically disabled in a production build because it will hurt
    * performance fairly significantly */
@@ -596,6 +606,19 @@ export class CodeView<LAnnotation = undefined> {
   private container: HTMLDivElement | undefined = document.createElement('div');
   private stickyContainer = document.createElement('div');
   private stickyOffset = document.createElement('div');
+  // Always-rendered, non-virtualized header/footer hosts. They mount as normal-
+  // flow siblings of `container` inside `root` (header before it, footer after
+  // it), so the footer needs no special positioning. Created lazily, only when a
+  // renderCodeViewHeader/renderCodeViewFooter callback is provided. Never enter
+  // the element pool.
+  private headerHost: HTMLDivElement | undefined;
+  private footerHost: HTMLDivElement | undefined;
+  // Measured heights of the header/footer hosts, folded into the scroll-range
+  // and item-offset math. Default 0 (a no-op) so the math is coherent before a
+  // host exists; set by an inline measure on mount, then kept current by the
+  // ResizeObserver.
+  private headerHeight = 0;
+  private footerHeight = 0;
   private elementPool: HTMLElement[] = [];
   private elementPoolVersion = 0;
   private elementPoolTracker = new WeakMap<HTMLElement, number>();
@@ -632,6 +655,15 @@ export class CodeView<LAnnotation = undefined> {
 
   private getLayout(): CodeViewLayout {
     return this.options.layout ?? DEFAULT_CODE_VIEW_LAYOUT;
+  }
+
+  // Absolute offset (in scroll pixels) from the top of the scroll content to the
+  // first virtualized item. paddingTop is the container's top margin; headerHeight
+  // is the always-rendered header that sits before the items and pushes every item
+  // down by its measured height. Anchor/scroll-target math adds this to an item's
+  // local `top` to get its absolute scroll position.
+  private getItemTopOffset(): number {
+    return this.getLayout().paddingTop + this.headerHeight;
   }
 
   private computeMetricsCache(
@@ -815,6 +847,95 @@ export class CodeView<LAnnotation = undefined> {
     this.container?.style.setProperty('margin-bottom', `${paddingBottom}px`);
   }
 
+  // Mount or unmount the header/footer hosts so they match the current
+  // renderCodeViewHeader/renderCodeViewFooter options. This runs as part of the render cycle
+  // (see computeRenderRangeAndEmit), so the first render, later option
+  // changes, and content updates all converge on one insert/remove path. The
+  // hosts are always-rendered, non-virtualized siblings of `container`: the
+  // header before it (scrolls away above the items) and the footer after it
+  // (trails below them).
+  private reconcileHeaderFooterHosts(): void {
+    this.headerHost = this.reconcileHost(
+      'header',
+      this.headerHost,
+      this.options.renderCodeViewHeader
+    );
+    this.footerHost = this.reconcileHost(
+      'footer',
+      this.footerHost,
+      this.options.renderCodeViewFooter
+    );
+  }
+
+  // Reconcile a single header/footer host: create + position + populate it when
+  // its callback first appears, tear it down when the callback is removed, and
+  // otherwise leave the mounted host untouched (its content is owned by the
+  // caller, or by React via a portal). Returns the new host reference.
+  private reconcileHost(
+    kind: 'header' | 'footer',
+    host: HTMLDivElement | undefined,
+    render: (() => HTMLElement | undefined) | undefined
+  ): HTMLDivElement | undefined {
+    if (this.root == null || this.container == null) {
+      return host;
+    }
+
+    // No callback → the host should not exist; tear down any mounted host and
+    // drop its measured height back to the 0 no-op.
+    if (render == null) {
+      if (host != null) {
+        host.remove();
+        this.setHostHeight(kind, 0);
+      }
+      return undefined;
+    }
+
+    // Already mounted → nothing to do.
+    if (host != null) {
+      return host;
+    }
+
+    // Callback present but not yet mounted → create and position the host. We
+    // keep the host even when render() returns nothing: callback *presence* (not
+    // its return value) governs whether the host exists. This lets React mount an
+    // empty host here and fill it via a portal, while vanilla callbacks return an
+    // element to populate it directly.
+    host = document.createElement('div');
+    if (kind === 'header') {
+      this.root.insertBefore(host, this.container);
+    } else {
+      this.root.appendChild(host);
+    }
+    const content = render();
+    if (content != null) {
+      host.appendChild(content);
+    }
+    // Inline-measure once, synchronously, on mount so the first frame lays out
+    // with the real height instead of waiting on the async ResizeObserver. This
+    // forces a reflow, but only on the (rare) mount frame — the per-frame hot
+    // path early-returns above once the host exists.
+    this.setHostHeight(kind, host.getBoundingClientRect().height);
+    return host;
+  }
+
+  // Store a header/footer host's measured height, flagging the scroll state dirty
+  // when it actually changed so the surrounding render cycle re-derives the scroll
+  // range and re-anchors (the header offset shifts every item's position).
+  private setHostHeight(kind: 'header' | 'footer', height: number): void {
+    if (kind === 'header') {
+      if (this.headerHeight === height) {
+        return;
+      }
+      this.headerHeight = height;
+    } else {
+      if (this.footerHeight === height) {
+        return;
+      }
+      this.footerHeight = height;
+    }
+    this.scrollDirty = true;
+  }
+
   public setup(root: HTMLElement): void {
     if (this.root != null) {
       throw new Error('CodeView.setup: already setup');
@@ -936,6 +1057,10 @@ export class CodeView<LAnnotation = undefined> {
     this.stickyOffset.remove();
     this.stickyContainer.remove();
     this.stickyContainer.textContent = '';
+    this.headerHost?.remove();
+    this.footerHost?.remove();
+    this.headerHost = undefined;
+    this.footerHost = undefined;
     this.root = undefined;
     this.container = undefined;
   }
@@ -1369,7 +1494,15 @@ export class CodeView<LAnnotation = undefined> {
       this.renderOptionsRevision++;
     }
 
-    if (!this.isContainerManaged && this.items.length > 0) {
+    // Render when there are items, OR when the header/footer presence changed —
+    // an otherwise-empty CodeView still needs a render to mount/unmount its hosts.
+    const headerFooterChanged =
+      prevOptions.renderCodeViewHeader !== options.renderCodeViewHeader ||
+      prevOptions.renderCodeViewFooter !== options.renderCodeViewFooter;
+    if (
+      !this.isContainerManaged &&
+      (this.items.length > 0 || headerFooterChanged)
+    ) {
       this.render();
     }
   }
@@ -1548,7 +1681,7 @@ export class CodeView<LAnnotation = undefined> {
     if (item == null) {
       return undefined;
     }
-    return item.top + this.getLayout().paddingTop;
+    return item.top + this.getItemTopOffset();
   }
 
   private createItem(
@@ -2091,8 +2224,15 @@ export class CodeView<LAnnotation = undefined> {
 
   private getMaxScrollTopForHeight(scrollHeight: number): number {
     const { paddingBottom, paddingTop } = this.getLayout();
+    // The header/footer hosts live in `root` outside `container`, so they add to
+    // the real scrollable range on top of the items + padding.
     return Math.max(
-      paddingTop + scrollHeight + paddingBottom - this.getHeight(),
+      paddingTop +
+        this.headerHeight +
+        scrollHeight +
+        this.footerHeight +
+        paddingBottom -
+        this.getHeight(),
       0
     );
   }
@@ -2287,7 +2427,7 @@ export class CodeView<LAnnotation = undefined> {
     // Determine a stable scrollTo target for `nearest` alignment. This is to
     // ensure that we don't experience any scroll bouncing
     const offset = target.offset ?? 0;
-    const targetTop = this.getLayout().paddingTop + rect.top;
+    const targetTop = this.getItemTopOffset() + rect.top;
     const targetBottom = targetTop + rect.height;
     const currentTop = this.getScrollTop();
     const visibleTop =
@@ -2651,7 +2791,9 @@ export class CodeView<LAnnotation = undefined> {
     // Compute the projected logical window, then synchronize the paged scroll
     // scaffold before mutating rendered items.
     this.windowSpecs = createWindowFromScrollPosition({
-      scrollTop: targetScrollTop,
+      // The window is in item-space (0 = first item's top); subtract the header so
+      // a tall header can't desync which items fall inside the render window.
+      scrollTop: targetScrollTop - this.headerHeight,
       height: viewportHeight,
       scrollHeight: this.getScrollHeight(),
       fitPerfectly,
@@ -2690,6 +2832,13 @@ export class CodeView<LAnnotation = undefined> {
         }
       }
     }
+
+    // Mount/unmount the header/footer hosts in the same DOM-mutation window as the
+    // items, after the scroll anchor was captured above and before the post-render
+    // anchor resolve below. A header mount shifts layout above the viewport; the
+    // inline measure inside reconcileHost updates headerHeight, and the post-render
+    // resolve compensates the shift exactly as it does for item height changes.
+    this.reconcileHeaderFooterHosts();
 
     let prevElement: HTMLElement | undefined;
     const updatedItems = new Set<CodeViewContextItem<LAnnotation>>();
@@ -3094,7 +3243,7 @@ export class CodeView<LAnnotation = undefined> {
         continue;
       }
 
-      const absoluteItemTop = this.getLayout().paddingTop + item.top;
+      const absoluteItemTop = this.getItemTopOffset() + item.top;
       const absoluteItemBottom = absoluteItemTop + item.height;
       // Skip items entirely above the viewport since we can't see it
       if (absoluteItemBottom <= scrollTop) {
@@ -3149,9 +3298,9 @@ export class CodeView<LAnnotation = undefined> {
       return undefined;
     }
 
-    const { paddingTop } = this.getLayout();
+    const itemTopOffset = this.getItemTopOffset();
     if (anchor.type === 'item') {
-      const absoluteItemTop = paddingTop + item.top;
+      const absoluteItemTop = itemTopOffset + item.top;
       return this.clampScrollTop(absoluteItemTop - anchor.viewportOffset);
     }
 
@@ -3162,7 +3311,7 @@ export class CodeView<LAnnotation = undefined> {
     if (linePosition == null) {
       return undefined;
     }
-    const absoluteLineTop = paddingTop + item.top + linePosition.top;
+    const absoluteLineTop = itemTopOffset + item.top + linePosition.top;
     return this.clampScrollTop(absoluteLineTop - anchor.viewportOffset);
   }
 

--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -2620,7 +2620,10 @@ export class CodeView<LAnnotation = undefined> {
     offset = 0,
     stickyOffset = 0
   ): number {
-    targetTop += this.getLayout().paddingTop;
+    // targetTop is item-space (0 = first item's top); shift it into absolute
+    // scroll coordinates. getItemTopOffset includes the header height, so
+    // scrolling to an item/line lands correctly when a header is present.
+    targetTop += this.getItemTopOffset();
     const viewportHeight = this.getHeight();
     // If the item + offset is bigger than the viewport, we'll fall back to
     // 'start'
@@ -3345,6 +3348,14 @@ export class CodeView<LAnnotation = undefined> {
     // If we already have a pendingLayoutAnchor, let's use that.
     if (this.pendingLayoutAnchor != null) {
       return this.pendingLayoutAnchor;
+    }
+
+    // We shouldn't scroll anchor when at the top, this way if a custom header
+    // gets asynchronously added it won't be hidden when added.  Also like,
+    // logically it doesn't make sense to anchor at the top of the document,
+    // you probably want to see stuff added at the top...
+    if (scrollTop <= 0) {
+      return undefined;
     }
 
     const { firstIndex, lastIndex, stickyTop, stickyBottom } = this.renderState;

--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -34,6 +34,7 @@ import type {
   VirtualFileMetrics,
   VirtualWindowSpecs,
 } from '../types';
+import { areManagedSnapshotsEqual } from '../utils/areManagedSnapshotsEqual';
 import { areObjectsEqual } from '../utils/areObjectsEqual';
 import { areOptionsEqual } from '../utils/areOptionsEqual';
 import { areSelectionsEqual } from '../utils/areSelectionsEqual';
@@ -163,6 +164,21 @@ export type CodeViewRenderedItem<LAnnotation> =
   | CodeViewRenderedDiffItem<LAnnotation>
   | CodeViewRenderedFileItem<LAnnotation>;
 
+// Everything the React layer portals into, published together so a single store
+// subscription drives per-item slots AND the global header/footer.
+export interface CodeViewSlotSnapshot<LAnnotation> {
+  // Rendered items that need React-managed slot content (per-item headers,
+  // annotations, gutter utilities), or undefined when none.
+  items: CodeViewRenderedItem<LAnnotation>[] | undefined;
+  // The always-rendered header/footer host elements React portals into, or
+  // undefined when the corresponding renderCodeViewHeader/Footer callback is not
+  // set. Because these live in the snapshot, a host mounting/unmounting changes
+  // it and triggers a publish — which is how React learns about hosts that are
+  // created on a later (worker-ready) render.
+  header: HTMLElement | undefined;
+  footer: HTMLElement | undefined;
+}
+
 export interface CodeViewLineSelection {
   id: string;
   range: SelectedLineRange;
@@ -173,7 +189,7 @@ export interface CodeViewCoordinator<LAnnotation> {
   hasAnnotationRenderer: boolean;
   hasGutterRenderer: boolean;
   onSnapshotChange(
-    snapshot: CodeViewRenderedItem<LAnnotation>[] | undefined
+    snapshot: CodeViewSlotSnapshot<LAnnotation> | undefined
   ): void;
 }
 
@@ -567,7 +583,7 @@ export class CodeView<LAnnotation = undefined> {
   private pendingLayoutReset: PendingCodeViewLayoutReset | undefined;
   private renderOptionsRevision = 0;
   private slotCoordinator: CodeViewCoordinator<LAnnotation> | undefined;
-  private slotSnapshot: CodeViewRenderedItem<LAnnotation>[] | undefined;
+  private slotSnapshot: CodeViewSlotSnapshot<LAnnotation> | undefined;
   private scrollListeners: Set<CodeViewScrollListener<LAnnotation>> = new Set();
   private scrollHeight = 0;
   private containerHeight = -1;
@@ -1694,8 +1710,23 @@ export class CodeView<LAnnotation = undefined> {
 
   public getSlotSnapshot(
     coordinator: CodeViewCoordinator<LAnnotation>
-  ): CodeViewRenderedItem<LAnnotation>[] | undefined {
-    return getSlotSnapshot(this.getRenderedItems(), coordinator);
+  ): CodeViewSlotSnapshot<LAnnotation> | undefined {
+    return this.buildSlotSnapshot(coordinator);
+  }
+
+  // Combine the per-item slot items with the current header/footer host elements
+  // into a single snapshot. Returns undefined only when there is nothing for
+  // React to portal.
+  private buildSlotSnapshot(
+    coordinator: CodeViewCoordinator<LAnnotation>
+  ): CodeViewSlotSnapshot<LAnnotation> | undefined {
+    const items = getSlotItems(this.getRenderedItems(), coordinator);
+    const { element: header } = this.header;
+    const { element: footer } = this.footer;
+    if (items == null && header == null && footer == null) {
+      return undefined;
+    }
+    return { items, header, footer };
   }
 
   public subscribeToScroll(
@@ -3493,19 +3524,14 @@ export class CodeView<LAnnotation = undefined> {
     if (this.slotCoordinator == null) {
       return;
     }
-    const { onSnapshotChange } = this.slotCoordinator;
 
-    const slotSnapshot = getSlotSnapshot(
-      this.getRenderedItems(),
-      this.slotCoordinator
-    );
-
-    if (areSlotSnapshotsEqual(this.slotSnapshot, slotSnapshot)) {
+    const slotSnapshot = this.buildSlotSnapshot(this.slotCoordinator);
+    if (areManagedSnapshotsEqual(this.slotSnapshot, slotSnapshot)) {
       return;
     }
 
     this.slotSnapshot = slotSnapshot;
-    onSnapshotChange(slotSnapshot);
+    this.slotCoordinator.onSnapshotChange(slotSnapshot);
   }
 
   private notifyScroll(): void {
@@ -3819,7 +3845,7 @@ function hasAnnotations<LAnnotation>(item: CodeViewItem<LAnnotation>): boolean {
   return (item.annotations?.length ?? 0) > 0;
 }
 
-function getSlotSnapshot<LAnnotation>(
+function getSlotItems<LAnnotation>(
   renderedItems: CodeViewRenderedItem<LAnnotation>[],
   {
     hasHeaderRenderers,
@@ -3848,34 +3874,4 @@ function getSlotSnapshot<LAnnotation>(
   }
 
   return slotSnapshot.length > 0 ? slotSnapshot : undefined;
-}
-
-function areSlotSnapshotsEqual<LAnnotation>(
-  previous: CodeViewRenderedItem<LAnnotation>[] | undefined,
-  next: CodeViewRenderedItem<LAnnotation>[] | undefined
-): boolean {
-  if (previous == null || next == null) {
-    return previous === next;
-  }
-
-  if (previous.length !== next.length) {
-    return false;
-  }
-
-  for (let index = 0; index < previous.length; index++) {
-    const previousItem = previous[index];
-    const nextItem = next[index];
-    if (
-      previousItem == null ||
-      nextItem == null ||
-      previousItem.id !== nextItem.id ||
-      previousItem.type !== nextItem.type ||
-      previousItem.element !== nextItem.element ||
-      previousItem.version !== nextItem.version
-    ) {
-      return false;
-    }
-  }
-
-  return true;
 }

--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -1103,11 +1103,13 @@ export class CodeView<LAnnotation = undefined> {
     this.stickyContainer.remove();
     this.stickyContainer.textContent = '';
     this.header.element?.remove();
-    this.footer.element?.remove();
     this.header.element = undefined;
-    this.footer.element = undefined;
     this.header.render = undefined;
+    this.header.height = 0;
+    this.footer.element?.remove();
+    this.footer.element = undefined;
     this.footer.render = undefined;
+    this.footer.height = 0;
     this.root = undefined;
     this.container = undefined;
   }

--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -897,15 +897,15 @@ export class CodeView<LAnnotation = undefined> {
   // and tear it down when the callback is removed. Otherwise the mounted host is
   // left untouched (its content is owned by the caller, or by React via a portal).
   // Mutates the record in place and returns whether its content changed.
-  private reconcileHost(kind: 'header' | 'footer'): boolean {
+  private reconcileHost(type: 'header' | 'footer'): boolean {
     const { root, container } = this;
     if (root == null || container == null) {
       return false;
     }
 
-    const host = kind === 'header' ? this.header : this.footer;
+    const host = type === 'header' ? this.header : this.footer;
     const render =
-      kind === 'header'
+      type === 'header'
         ? this.options.renderCodeViewHeader
         : this.options.renderCodeViewFooter;
 
@@ -936,7 +936,7 @@ export class CodeView<LAnnotation = undefined> {
     const element =
       host.element ??
       createCodeViewHeaderFooterHostElement(
-        kind,
+        type,
         container,
         this.resizeObserver
       );

--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -1,6 +1,4 @@
 import {
-  CODE_VIEW_FOOTER_ATTRIBUTE,
-  CODE_VIEW_HEADER_ATTRIBUTE,
   CORE_CSS_ATTRIBUTE,
   DEFAULT_CODE_VIEW_FILE_METRICS,
   DEFAULT_CODE_VIEW_LAYOUT,
@@ -40,6 +38,7 @@ import { areObjectsEqual } from '../utils/areObjectsEqual';
 import { areOptionsEqual } from '../utils/areOptionsEqual';
 import { areSelectionsEqual } from '../utils/areSelectionsEqual';
 import { areThemesEqual } from '../utils/areThemesEqual';
+import { createCodeViewHeaderFooterHostElement } from '../utils/createCodeViewHeaderFooterHostElement';
 import { createWindowFromScrollPosition } from '../utils/createWindowFromScrollPosition';
 import { isStyleNode } from '../utils/isStyleNode';
 import { prefersReducedMotion } from '../utils/prefersReducedMotion';
@@ -81,6 +80,20 @@ interface LineScrollPosition {
 interface StickyBounds {
   stickyTop: number;
   stickyBottom: number;
+}
+
+// Per-record state for one of the always-rendered header/footer hosts, keeping
+// its element, the callback that last populated it, and its measured height in a
+// single place instead of parallel fields on the CodeView instance.
+interface HeaderFooterHost {
+  // The mounted host element, or undefined when the callback is absent.
+  element: HTMLDivElement | undefined;
+  // The renderCodeView{Header,Footer} callback that last populated `element`, so
+  // a swapped reference can be detected and the host re-populated in place.
+  render?(): HTMLElement | undefined;
+  // Measured height, folded into the scroll-range / item-offset math. Stays 0
+  // while the host is absent (a no-op) so the math is always coherent.
+  height: number;
 }
 
 interface PagedScrollPosition {
@@ -608,19 +621,21 @@ export class CodeView<LAnnotation = undefined> {
   private container: HTMLDivElement | undefined = document.createElement('div');
   private stickyContainer = document.createElement('div');
   private stickyOffset = document.createElement('div');
-  // Always-rendered, non-virtualized header/footer hosts. They mount as normal-
-  // flow siblings of `container` inside `root` (header before it, footer after
-  // it), so the footer needs no special positioning. Created lazily, only when a
-  // renderCodeViewHeader/renderCodeViewFooter callback is provided. Never enter
-  // the element pool.
-  private headerHost: HTMLDivElement | undefined;
-  private footerHost: HTMLDivElement | undefined;
-  // Measured heights of the header/footer hosts, folded into the scroll-range
-  // and item-offset math. Default 0 (a no-op) so the math is coherent before a
-  // host exists; set by an inline measure on mount, then kept current by the
-  // ResizeObserver.
-  private headerHeight = 0;
-  private footerHeight = 0;
+  // Always-rendered, non-virtualized header/footer hosts (element wrapper,
+  // last-used render callback, and the measured height). They mount as
+  // normal-flow siblings of `container` inside `root` — the header before it
+  // and the footer after it.  Created lazily, never virtualized, so no pool
+  // elements required
+  private header: HeaderFooterHost = {
+    element: undefined,
+    render: undefined,
+    height: 0,
+  };
+  private footer: HeaderFooterHost = {
+    element: undefined,
+    render: undefined,
+    height: 0,
+  };
   private elementPool: HTMLElement[] = [];
   private elementPoolVersion = 0;
   private elementPoolTracker = new WeakMap<HTMLElement, number>();
@@ -660,12 +675,12 @@ export class CodeView<LAnnotation = undefined> {
   }
 
   // Absolute offset (in scroll pixels) from the top of the scroll content to the
-  // first virtualized item. paddingTop is the container's top margin; headerHeight
-  // is the always-rendered header that sits before the items and pushes every item
-  // down by its measured height. Anchor/scroll-target math adds this to an item's
-  // local `top` to get its absolute scroll position.
+  // first virtualized item. paddingTop is the container's top margin; the header
+  // host height is the always-rendered header that sits before the items and
+  // pushes every item down by its measured height. Anchor/scroll-target math adds
+  // this to an item's local `top` to get its absolute scroll position.
   private getItemTopOffset(): number {
-    return this.getLayout().paddingTop + this.headerHeight;
+    return this.getLayout().paddingTop + this.header.height;
   }
 
   private computeMetricsCache(
@@ -849,119 +864,103 @@ export class CodeView<LAnnotation = undefined> {
     this.container?.style.setProperty('margin-bottom', `${paddingBottom}px`);
   }
 
-  // Mount or unmount the header/footer hosts so they match the current
-  // renderCodeViewHeader/renderCodeViewFooter options. This runs as part of the render cycle
-  // (see computeRenderRangeAndEmit), so the first render, later option
-  // changes, and content updates all converge on one insert/remove path. The
-  // hosts are always-rendered, non-virtualized siblings of `container`: the
-  // header before it (scrolls away above the items) and the footer after it
-  // (trails below them).
-  // Returns true when a host was newly mounted by this call, so the render cycle
-  // knows to take a synchronous height measurement in the following read phase.
+  // Mount/unmount/re-populate the header and footer hosts to match the current
+  // renderCodeViewHeader/renderCodeViewFooter options. Runs inside the render
+  // cycle (see computeRenderRangeAndEmit), so the first render, later option
+  // changes, and content updates all converge on one path. Returns true when a
+  // host's content changed (a fresh mount or a swapped callback) so the render
+  // cycle takes a synchronous height measurement in the following read phase.
   private reconcileHeaderFooterHosts(): boolean {
-    const { headerHost: prevHeaderHost, footerHost: prevFooterHost } = this;
-    this.headerHost = this.reconcileHost(
-      'header',
-      this.headerHost,
-      this.options.renderCodeViewHeader
-    );
-    this.footerHost = this.reconcileHost(
-      'footer',
-      this.footerHost,
-      this.options.renderCodeViewFooter
-    );
-    return (
-      (prevHeaderHost == null && this.headerHost != null) ||
-      (prevFooterHost == null && this.footerHost != null)
-    );
+    const headerChanged = this.reconcileHost('header');
+    const footerChanged = this.reconcileHost('footer');
+    return headerChanged || footerChanged;
   }
 
-  // Reconcile a single header/footer host: create + position + populate it when
-  // its callback first appears, tear it down when the callback is removed, and
-  // otherwise leave the mounted host untouched (its content is owned by the
-  // caller, or by React via a portal). Returns the new host reference.
-  private reconcileHost(
-    kind: 'header' | 'footer',
-    host: HTMLDivElement | undefined,
-    render: (() => HTMLElement | undefined) | undefined
-  ): HTMLDivElement | undefined {
-    if (this.root == null || this.container == null) {
-      return host;
+  // Reconcile a single host record: create + position + populate it when its
+  // callback first appears, re-populate it when the callback reference changes,
+  // and tear it down when the callback is removed. Otherwise the mounted host is
+  // left untouched (its content is owned by the caller, or by React via a portal).
+  // Mutates the record in place and returns whether its content changed.
+  private reconcileHost(kind: 'header' | 'footer'): boolean {
+    const { root, container } = this;
+    if (root == null || container == null) {
+      return false;
     }
 
-    // No callback → the host should not exist; tear down any mounted host and
-    // drop its measured height back to the 0 no-op.
+    const host = kind === 'header' ? this.header : this.footer;
+    const render =
+      kind === 'header'
+        ? this.options.renderCodeViewHeader
+        : this.options.renderCodeViewFooter;
+
+    // Callback removed → the host should not exist; tear it down and reset height.
     if (render == null) {
-      if (host != null) {
-        this.resizeObserver?.unobserve(host);
-        host.remove();
-        this.setHostHeight(kind, 0);
+      if (host.element == null) {
+        return false;
       }
-      return undefined;
+      this.resizeObserver?.unobserve(host.element);
+      host.element.remove();
+      host.element = undefined;
+      host.render = undefined;
+      this.setHostHeight(host, 0);
+      return false;
     }
 
-    // Already mounted → nothing to do.
-    if (host != null) {
-      return host;
+    // Same callback on a mounted host → its content is already current (the
+    // common per-frame path).
+    if (host.element != null && render === host.render) {
+      return false;
     }
 
-    // Callback present but not yet mounted → create and position the host. We
-    // keep the host even when render() returns nothing: callback *presence* (not
-    // its return value) governs whether the host exists. This lets React mount an
-    // empty host here and fill it via a portal, while vanilla callbacks return an
-    // element to populate it directly.
-    host = document.createElement('div');
-    // Establish a block formatting context so the content margins stay inside
-    // the host to ensure proper heights from measurements/ResizeObserver
-    host.style.display = 'flow-root';
-    if (kind === 'header') {
-      host.setAttribute(CODE_VIEW_HEADER_ATTRIBUTE, '');
-      this.root.insertBefore(host, this.container);
-    } else {
-      host.setAttribute(CODE_VIEW_FOOTER_ATTRIBUTE, '');
-      this.root.appendChild(host);
-    }
+    // Callback added or swapped → ensure the host exists, then repopulate it from
+    // the callback's latest output. A returned element replaces the content; a
+    // nullish return empties the host, EXCEPT in container-managed (React) mode
+    // where React owns the host's light DOM via a portal, so it is left untouched
+    // (mirroring how cleanElement guards item light DOM).
+    const element =
+      host.element ??
+      createCodeViewHeaderFooterHostElement(
+        kind,
+        container,
+        this.resizeObserver
+      );
+    host.element = element;
     const content = render();
     if (content != null) {
-      host.appendChild(content);
+      element.replaceChildren(content);
+    } else if (!this.isContainerManaged && element.children.length > 0) {
+      element.textContent = '';
     }
-    this.resizeObserver?.observe(host);
-    return host;
+    host.render = render;
+    return true;
   }
 
-  // Store a header/footer host's measured height, flagging the scroll state dirty
-  // when it actually changed so the surrounding render cycle re-derives the scroll
-  // range and re-anchors (the header offset shifts every item's position).
-  private setHostHeight(kind: 'header' | 'footer', height: number): void {
-    if (kind === 'header') {
-      if (this.headerHeight === height) {
-        return;
-      }
-      this.headerHeight = height;
-    } else {
-      if (this.footerHeight === height) {
-        return;
-      }
-      this.footerHeight = height;
+  // Store a host's measured height, flagging the scroll state dirty when it
+  // actually changed so the surrounding render cycle re-derives the scroll range
+  // and re-anchors (the header offset shifts every item's position).
+  private setHostHeight(host: HeaderFooterHost, height: number): void {
+    if (host.height === height) {
+      return;
     }
+    host.height = height;
     this.scrollDirty = true;
   }
 
   // Read the mounted hosts' heights from the DOM. Called only in the render
-  // cycle's read phase (right before reconcileRenderedItems) on a mount frame, so
+  // cycle's read phase (right before reconcileRenderedItems) on a change frame, so
   // these getBoundingClientRect reads batch into the same reflow as the item
   // height reads instead of forcing a separate reflow during the write phase.
   private measureMountedHosts(): void {
-    if (this.headerHost != null) {
+    if (this.header.element != null) {
       this.setHostHeight(
-        'header',
-        this.headerHost.getBoundingClientRect().height
+        this.header,
+        this.header.element.getBoundingClientRect().height
       );
     }
-    if (this.footerHost != null) {
+    if (this.footer.element != null) {
       this.setHostHeight(
-        'footer',
-        this.footerHost.getBoundingClientRect().height
+        this.footer,
+        this.footer.element.getBoundingClientRect().height
       );
     }
   }
@@ -1087,10 +1086,12 @@ export class CodeView<LAnnotation = undefined> {
     this.stickyOffset.remove();
     this.stickyContainer.remove();
     this.stickyContainer.textContent = '';
-    this.headerHost?.remove();
-    this.footerHost?.remove();
-    this.headerHost = undefined;
-    this.footerHost = undefined;
+    this.header.element?.remove();
+    this.footer.element?.remove();
+    this.header.element = undefined;
+    this.footer.element = undefined;
+    this.header.render = undefined;
+    this.footer.render = undefined;
     this.root = undefined;
     this.container = undefined;
   }
@@ -1628,6 +1629,18 @@ export class CodeView<LAnnotation = undefined> {
 
   public getContainerElement(): HTMLElement | undefined {
     return this.root;
+  }
+
+  // The always-rendered header/footer host elements, or undefined when the
+  // corresponding renderCodeViewHeader/renderCodeViewFooter callback is not
+  // set. React reads these to portal its header/footer nodes into the
+  // vanilla-managed hosts.
+  public getHeaderElement(): HTMLElement | undefined {
+    return this.header.element;
+  }
+
+  public getFooterElement(): HTMLElement | undefined {
+    return this.footer.element;
   }
 
   public getRenderedItems(): CodeViewRenderedItem<LAnnotation>[] {
@@ -2258,9 +2271,9 @@ export class CodeView<LAnnotation = undefined> {
     // the real scrollable range on top of the items + padding.
     return Math.max(
       paddingTop +
-        this.headerHeight +
+        this.header.height +
         scrollHeight +
-        this.footerHeight +
+        this.footer.height +
         paddingBottom -
         this.getHeight(),
       0
@@ -2823,7 +2836,7 @@ export class CodeView<LAnnotation = undefined> {
     this.windowSpecs = createWindowFromScrollPosition({
       // The window is in item-space (0 = first item's top); subtract the header so
       // a tall header can't desync which items fall inside the render window.
-      scrollTop: targetScrollTop - this.headerHeight,
+      scrollTop: targetScrollTop - this.header.height,
       height: viewportHeight,
       scrollHeight: this.getScrollHeight(),
       fitPerfectly,
@@ -2863,10 +2876,10 @@ export class CodeView<LAnnotation = undefined> {
       }
     }
 
-    // Mount/unmount the header/footer hosts in the same DOM-mutation window as the
-    // items, after the scroll anchor was captured above and before the post-render
-    // anchor resolve below.
-    const hostsMounted = this.reconcileHeaderFooterHosts();
+    // Mount/unmount/re-populate the header/footer hosts in the same DOM-mutation
+    // window as the items, after the scroll anchor was captured above and before
+    // the post-render anchor resolve below.
+    const hostsChanged = this.reconcileHeaderFooterHosts();
 
     let prevElement: HTMLElement | undefined;
     const updatedItems = new Set<CodeViewContextItem<LAnnotation>>();
@@ -2914,7 +2927,9 @@ export class CodeView<LAnnotation = undefined> {
 
     this.flushSlotCoordinator();
     this.flushManagers(updatedItems);
-    if (hostsMounted) {
+    // Read phase: measure a freshly mounted or re-populated host now so its
+    // getBoundingClientRect batches into the same reflow as the item height reads.
+    if (hostsChanged) {
       this.measureMountedHosts();
     }
     this.reconcileRenderedItems(updatedItems);
@@ -3229,21 +3244,20 @@ export class CodeView<LAnnotation = undefined> {
       // resize, so we skip reconcileRenderedItems/updateStickyPositioning; the
       // trailing render() reconciles the range and render window.
       else if (
-        entry.target === this.headerHost ||
-        entry.target === this.footerHost
+        entry.target === this.header.element ||
+        entry.target === this.footer.element
       ) {
-        const kind = entry.target === this.headerHost ? 'header' : 'footer';
+        const host =
+          entry.target === this.header.element ? this.header : this.footer;
         const blockSize = entry.borderBoxSize[0].blockSize;
-        const currentHeight =
-          kind === 'header' ? this.headerHeight : this.footerHeight;
-        if (blockSize !== currentHeight) {
+        if (blockSize !== host.height) {
           // Capture the anchor with the OLD offset, apply the new height, then
           // resolve with the NEW offset so the delta cancels the layout shift. A
           // footer only changes the scroll range, so its anchor resolves to no
           // change (or a clamp when it shrinks below the current scroll).
           const currentScrollTop = this.getScrollTop();
           const anchor = this.getScrollAnchor(currentScrollTop);
-          this.setHostHeight(kind, blockSize);
+          this.setHostHeight(host, blockSize);
           const anchoredScrollTop =
             anchor != null ? this.resolveAnchoredScrollTop(anchor) : undefined;
           if (anchoredScrollTop != null) {

--- a/packages/diffs/src/constants.ts
+++ b/packages/diffs/src/constants.ts
@@ -54,6 +54,8 @@ export const THEME_CSS_ATTRIBUTE = 'data-theme-css';
 export const UNSAFE_CSS_ATTRIBUTE = 'data-unsafe-css';
 export const CORE_CSS_ATTRIBUTE = 'data-core-css';
 export const DIFFS_SCROLLBAR_MEASURE_ATTRIBUTE = 'data-diffs-scrollbar-measure';
+export const CODE_VIEW_HEADER_ATTRIBUTE = 'data-diffs-code-view-header';
+export const CODE_VIEW_FOOTER_ATTRIBUTE = 'data-diffs-code-view-footer';
 export const DIFFS_SCROLLBAR_GUTTER_MEASURED_PROPERTY =
   '--diffs-scrollbar-gutter-measured';
 

--- a/packages/diffs/src/react/CodeView.tsx
+++ b/packages/diffs/src/react/CodeView.tsx
@@ -26,6 +26,7 @@ import {
   type CodeViewOptions,
   type CodeViewRenderedItem,
   type CodeViewScrollTarget,
+  type CodeViewSlotSnapshot,
   type DiffLineAnnotation,
   type GetHoveredLineResult,
   type LineAnnotation,
@@ -52,6 +53,12 @@ interface CodeViewBaseProps<LAnnotation> {
   selectedLines?: CodeViewLineSelection | null;
   onSelectedLinesChange?(selection: CodeViewLineSelection | null): void;
   onScroll?(scrollTop: number, viewer: CodeViewClass<LAnnotation>): void;
+  /** Render a non-virtualized node at the very start of the scroll content,
+   * before the first item. Always rendered; scrolls with the content. */
+  renderCodeViewHeader?(): ReactNode;
+  /** Render a non-virtualized node at the very end of the scroll content, after
+   * the last item. Always rendered; scrolls with the content. */
+  renderCodeViewFooter?(): ReactNode;
   renderCustomHeader?(item: CodeViewItem<LAnnotation>): ReactNode;
   renderHeaderPrefix?(item: CodeViewItem<LAnnotation>): ReactNode;
   renderHeaderFilenameSuffix?(item: CodeViewItem<LAnnotation>): ReactNode;
@@ -109,8 +116,8 @@ type SlotPortalsComponent = <LAnnotation = undefined>(
 ) => React.JSX.Element;
 
 interface ManagedContentStore<LAnnotation> {
-  getSnapshot(): CodeViewRenderedItem<LAnnotation>[] | undefined;
-  publish(snapshot: CodeViewRenderedItem<LAnnotation>[] | undefined): void;
+  getSnapshot(): CodeViewSlotSnapshot<LAnnotation> | undefined;
+  publish(snapshot: CodeViewSlotSnapshot<LAnnotation> | undefined): void;
   subscribe(listener: () => void): () => void;
 }
 
@@ -150,6 +157,8 @@ function CodeViewInner<LAnnotation = undefined>(
     onSelectedLinesChange,
     options,
     renderAnnotation,
+    renderCodeViewFooter,
+    renderCodeViewHeader,
     renderCustomHeader,
     renderGutterUtility,
     renderHeaderFilenameSuffix,
@@ -173,6 +182,8 @@ function CodeViewInner<LAnnotation = undefined>(
     renderHeaderMetadata != null;
   const hasRenderers =
     hasHeaderRenderers || hasAnnotationRenderer || hasGutterRenderer;
+  const hasCodeViewHeader = renderCodeViewHeader != null;
+  const hasCodeViewFooter = renderCodeViewFooter != null;
   const emitSelectedLinesChange = useStableCallback(
     (selection: CodeViewLineSelection | null) => {
       onSelectedLinesChange?.(selection);
@@ -186,6 +197,8 @@ function CodeViewInner<LAnnotation = undefined>(
         options,
         hasCustomHeader,
         hasGutterRenderer,
+        hasCodeViewHeader,
+        hasCodeViewFooter,
         onSelectedLinesChange:
           onSelectedLinesChange != null ? emitSelectedLinesChange : undefined,
         controlledSelection,
@@ -194,6 +207,8 @@ function CodeViewInner<LAnnotation = undefined>(
       options,
       hasCustomHeader,
       hasGutterRenderer,
+      hasCodeViewHeader,
+      hasCodeViewFooter,
       onSelectedLinesChange,
       emitSelectedLinesChange,
       controlledSelection,
@@ -243,7 +258,7 @@ function CodeViewInner<LAnnotation = undefined>(
   });
 
   const onSnapshotChange = useStableCallback(
-    (snapshot: CodeViewRenderedItem<LAnnotation>[] | undefined) => {
+    (snapshot: CodeViewSlotSnapshot<LAnnotation> | undefined) => {
       if (cachedDataRef.current.disableFlushSync) {
         slotContentStore.publish(snapshot);
       } else {
@@ -256,7 +271,15 @@ function CodeViewInner<LAnnotation = undefined>(
 
   const slotCoordinator: CodeViewCoordinator<LAnnotation> | undefined =
     useMemo(() => {
-      if (!hasHeaderRenderers && !hasAnnotationRenderer && !hasGutterRenderer) {
+      // A coordinator is needed whenever React portals anything — per-item
+      // slots and codeview header and footer
+      if (
+        !hasHeaderRenderers &&
+        !hasAnnotationRenderer &&
+        !hasGutterRenderer &&
+        !hasCodeViewHeader &&
+        !hasCodeViewFooter
+      ) {
         return undefined;
       } else {
         return {
@@ -271,6 +294,8 @@ function CodeViewInner<LAnnotation = undefined>(
       hasAnnotationRenderer,
       hasGutterRenderer,
       hasHeaderRenderers,
+      hasCodeViewHeader,
+      hasCodeViewFooter,
     ]);
 
   useIsometricEffect(() => {
@@ -471,7 +496,7 @@ function CodeViewInner<LAnnotation = undefined>(
   return (
     <>
       <div ref={nodeRef} className={className} style={style} />
-      {hasRenderers && (
+      {(hasRenderers || hasCodeViewHeader || hasCodeViewFooter) && (
         <SlotPortals<LAnnotation>
           managedContentStore={slotContentStore}
           renderCustomHeader={renderCustomHeader}
@@ -480,6 +505,8 @@ function CodeViewInner<LAnnotation = undefined>(
           renderHeaderMetadata={renderHeaderMetadata}
           renderAnnotation={renderAnnotation}
           renderGutterUtility={renderGutterUtility}
+          renderCodeViewHeader={renderCodeViewHeader}
+          renderCodeViewFooter={renderCodeViewFooter}
         />
       )}
     </>
@@ -543,7 +570,7 @@ function assertUncontrolledCodeViewAction(
 function createSlotContentStore<
   LAnnotation,
 >(): ManagedContentStore<LAnnotation> {
-  let snapshot: CodeViewRenderedItem<LAnnotation>[] | undefined;
+  let snapshot: CodeViewSlotSnapshot<LAnnotation> | undefined;
   const listeners = new Set<() => void>();
 
   return {
@@ -573,6 +600,8 @@ interface CreateManagedCodeViewOptionsProps<LAnnotation> {
   options: CodeViewOptions<LAnnotation> | undefined;
   hasCustomHeader: boolean;
   hasGutterRenderer: boolean;
+  hasCodeViewHeader: boolean;
+  hasCodeViewFooter: boolean;
   onSelectedLinesChange?(selection: CodeViewLineSelection | null): void;
   controlledSelection: boolean;
 }
@@ -581,6 +610,8 @@ function createManagedCodeViewOptions<LAnnotation>({
   options,
   hasCustomHeader,
   hasGutterRenderer,
+  hasCodeViewHeader,
+  hasCodeViewFooter,
   onSelectedLinesChange,
   controlledSelection,
 }: CreateManagedCodeViewOptionsProps<LAnnotation>):
@@ -589,6 +620,8 @@ function createManagedCodeViewOptions<LAnnotation>({
   if (
     !hasCustomHeader &&
     !hasGutterRenderer &&
+    !hasCodeViewHeader &&
+    !hasCodeViewFooter &&
     onSelectedLinesChange == null &&
     !controlledSelection
   ) {
@@ -609,6 +642,16 @@ function createManagedCodeViewOptions<LAnnotation>({
   // actual content, so this placeholder intentionally returns nothing.
   if (hasGutterRenderer) {
     options.renderGutterUtility = noopRender;
+  }
+
+  // The imperative CodeView adapters use these callbacks' presence to create the
+  // header/footer host elements. React portals the actual content into them (via
+  // the slot snapshot), so these placeholders intentionally return nothing.
+  if (hasCodeViewHeader) {
+    options.renderCodeViewHeader = noopRender;
+  }
+  if (hasCodeViewFooter) {
+    options.renderCodeViewFooter = noopRender;
   }
 
   return options;
@@ -632,6 +675,8 @@ interface SlotPortalsProps<LAnnotation> {
   renderHeaderMetadata: CodeViewBaseProps<LAnnotation>['renderHeaderMetadata'];
   renderAnnotation: CodeViewBaseProps<LAnnotation>['renderAnnotation'];
   renderGutterUtility: CodeViewBaseProps<LAnnotation>['renderGutterUtility'];
+  renderCodeViewHeader: CodeViewBaseProps<LAnnotation>['renderCodeViewHeader'];
+  renderCodeViewFooter: CodeViewBaseProps<LAnnotation>['renderCodeViewFooter'];
 }
 
 const SlotPortals = memo(function SlotPortals<LAnnotation>({
@@ -642,6 +687,8 @@ const SlotPortals = memo(function SlotPortals<LAnnotation>({
   renderHeaderMetadata,
   renderAnnotation,
   renderGutterUtility,
+  renderCodeViewHeader,
+  renderCodeViewFooter,
 }: SlotPortalsProps<LAnnotation>) {
   const subscribe = useStableCallback((listener: () => void) =>
     managedContentStore.subscribe(listener)
@@ -649,24 +696,34 @@ const SlotPortals = memo(function SlotPortals<LAnnotation>({
   const getSnapshot = useStableCallback(() =>
     managedContentStore.getSnapshot()
   );
-  const renderedItems = useSyncExternalStore<
-    CodeViewRenderedItem<LAnnotation>[] | undefined
+  const snapshot = useSyncExternalStore<
+    CodeViewSlotSnapshot<LAnnotation> | undefined
   >(subscribe, getSnapshot, getSnapshot);
-  return renderedItems?.map((renderedItem) => {
-    return createPortal(
-      renderCodeViewItemChildren({
-        renderedItem,
-        renderCustomHeader,
-        renderHeaderPrefix,
-        renderHeaderFilenameSuffix,
-        renderHeaderMetadata,
-        renderAnnotation,
-        renderGutterUtility,
-      }),
-      renderedItem.element,
-      renderedItem.id
-    );
-  });
+  return (
+    <>
+      {snapshot?.items?.map((renderedItem) =>
+        createPortal(
+          renderCodeViewItemChildren({
+            renderedItem,
+            renderCustomHeader,
+            renderHeaderPrefix,
+            renderHeaderFilenameSuffix,
+            renderHeaderMetadata,
+            renderAnnotation,
+            renderGutterUtility,
+          }),
+          renderedItem.element,
+          renderedItem.id
+        )
+      )}
+      {renderCodeViewHeader != null &&
+        snapshot?.header != null &&
+        createPortal(renderCodeViewHeader(), snapshot.header)}
+      {renderCodeViewFooter != null &&
+        snapshot?.footer != null &&
+        createPortal(renderCodeViewFooter(), snapshot.footer)}
+    </>
+  );
 }) as SlotPortalsComponent;
 
 function renderCodeViewItemChildren<LAnnotation>({

--- a/packages/diffs/src/react/CodeView.tsx
+++ b/packages/diffs/src/react/CodeView.tsx
@@ -690,6 +690,7 @@ const SlotPortals = memo(function SlotPortals<LAnnotation>({
   renderCodeViewHeader,
   renderCodeViewFooter,
 }: SlotPortalsProps<LAnnotation>) {
+  'use no memo';
   const subscribe = useStableCallback((listener: () => void) =>
     managedContentStore.subscribe(listener)
   );
@@ -699,9 +700,16 @@ const SlotPortals = memo(function SlotPortals<LAnnotation>({
   const snapshot = useSyncExternalStore<
     CodeViewSlotSnapshot<LAnnotation> | undefined
   >(subscribe, getSnapshot, getSnapshot);
-  return (
-    <>
-      {snapshot?.items?.map((renderedItem) =>
+  let itemKeys = '';
+  for (const item of snapshot?.items ?? []) {
+    itemKeys += `${item.id}:${item.version}`;
+  }
+  // NOTE(amadeus): And just like that, the react compiler do be failing us
+  // lol... we need to pre-render everything for items, headers and footers to
+  // not trigger needless renders while scrolling
+  const renderedItems = useMemo(
+    () => {
+      return snapshot?.items?.map((renderedItem) =>
         createPortal(
           renderCodeViewItemChildren({
             renderedItem,
@@ -715,13 +723,34 @@ const SlotPortals = memo(function SlotPortals<LAnnotation>({
           renderedItem.element,
           renderedItem.id
         )
-      )}
-      {renderCodeViewHeader != null &&
-        snapshot?.header != null &&
-        createPortal(renderCodeViewHeader(), snapshot.header)}
-      {renderCodeViewFooter != null &&
-        snapshot?.footer != null &&
-        createPortal(renderCodeViewFooter(), snapshot.footer)}
+      );
+    },
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+    [
+      renderCustomHeader,
+      renderHeaderPrefix,
+      renderHeaderFilenameSuffix,
+      renderHeaderMetadata,
+      renderAnnotation,
+      renderGutterUtility,
+      itemKeys,
+    ]
+  );
+  const renderedHeader = useMemo(() => {
+    return renderCodeViewHeader != null && snapshot?.header != null
+      ? createPortal(renderCodeViewHeader(), snapshot.header)
+      : null;
+  }, [renderCodeViewHeader, snapshot?.header]);
+  const renderedFooter = useMemo(() => {
+    return renderCodeViewFooter != null && snapshot?.footer != null
+      ? createPortal(renderCodeViewFooter(), snapshot.footer)
+      : null;
+  }, [renderCodeViewFooter, snapshot?.footer]);
+  return (
+    <>
+      {renderedItems}
+      {renderedHeader}
+      {renderedFooter}
     </>
   );
 }) as SlotPortalsComponent;

--- a/packages/diffs/src/react/CodeView.tsx
+++ b/packages/diffs/src/react/CodeView.tsx
@@ -625,7 +625,7 @@ function createManagedCodeViewOptions<LAnnotation>({
     onSelectedLinesChange == null &&
     !controlledSelection
   ) {
-    return options;
+    return options ?? {};
   }
   options = { ...options, controlledSelection, onSelectedLinesChange };
 
@@ -702,7 +702,7 @@ const SlotPortals = memo(function SlotPortals<LAnnotation>({
   >(subscribe, getSnapshot, getSnapshot);
   let itemKeys = '';
   for (const item of snapshot?.items ?? []) {
-    itemKeys += `${item.id}:${item.version}`;
+    itemKeys += `${item.id}:${item.version}:${item.type}`;
   }
   // NOTE(amadeus): And just like that, the react compiler do be failing us
   // lol... we need to pre-render everything for items, headers and footers to

--- a/packages/diffs/src/utils/areManagedSnapshotsEqual.ts
+++ b/packages/diffs/src/utils/areManagedSnapshotsEqual.ts
@@ -1,6 +1,24 @@
-import type { CodeViewRenderedItem } from '../components/CodeView';
+import type {
+  CodeViewRenderedItem,
+  CodeViewSlotSnapshot,
+} from '../components/CodeView';
 
 export function areManagedSnapshotsEqual<LAnnotation>(
+  previous: CodeViewSlotSnapshot<LAnnotation> | undefined,
+  next: CodeViewSlotSnapshot<LAnnotation> | undefined
+): boolean {
+  if (previous == null || next == null) {
+    return previous === next;
+  }
+
+  if (previous.header !== next.header || previous.footer !== next.footer) {
+    return false;
+  }
+
+  return areRenderedItemsEqual(previous.items, next.items);
+}
+
+function areRenderedItemsEqual<LAnnotation>(
   previous: CodeViewRenderedItem<LAnnotation>[] | undefined,
   next: CodeViewRenderedItem<LAnnotation>[] | undefined
 ): boolean {

--- a/packages/diffs/src/utils/createCodeViewHeaderFooterHostElement.ts
+++ b/packages/diffs/src/utils/createCodeViewHeaderFooterHostElement.ts
@@ -1,0 +1,25 @@
+import {
+  CODE_VIEW_FOOTER_ATTRIBUTE,
+  CODE_VIEW_HEADER_ATTRIBUTE,
+} from '../constants';
+
+// Create, style, position, and observe a header/footer host element. `flow-root`
+// gives it a block formatting context so the caller's content margins stay
+// inside it, keeping measurement / ResizeObserver heights accurate.
+export function createCodeViewHeaderFooterHostElement(
+  kind: 'header' | 'footer',
+  container: HTMLDivElement,
+  resizeObserver?: ResizeObserver
+): HTMLDivElement {
+  const element = document.createElement('div');
+  element.style.display = 'flow-root';
+  if (kind === 'header') {
+    element.setAttribute(CODE_VIEW_HEADER_ATTRIBUTE, '');
+    container.before(element);
+  } else {
+    element.setAttribute(CODE_VIEW_FOOTER_ATTRIBUTE, '');
+    container.after(element);
+  }
+  resizeObserver?.observe(element);
+  return element;
+}

--- a/packages/diffs/src/utils/createCodeViewHeaderFooterHostElement.ts
+++ b/packages/diffs/src/utils/createCodeViewHeaderFooterHostElement.ts
@@ -7,13 +7,13 @@ import {
 // gives it a block formatting context so the caller's content margins stay
 // inside it, keeping measurement / ResizeObserver heights accurate.
 export function createCodeViewHeaderFooterHostElement(
-  kind: 'header' | 'footer',
+  type: 'header' | 'footer',
   container: HTMLDivElement,
   resizeObserver?: ResizeObserver
 ): HTMLDivElement {
   const element = document.createElement('div');
   element.style.display = 'flow-root';
-  if (kind === 'header') {
+  if (type === 'header') {
     element.setAttribute(CODE_VIEW_HEADER_ATTRIBUTE, '');
     container.before(element);
   } else {

--- a/packages/diffs/test/CodeView.headerFooter.test.ts
+++ b/packages/diffs/test/CodeView.headerFooter.test.ts
@@ -1,0 +1,358 @@
+import { describe, expect, test } from 'bun:test';
+
+import { CodeView, type CodeViewOptions } from '../src/components/CodeView';
+import {
+  CODE_VIEW_FOOTER_ATTRIBUTE,
+  CODE_VIEW_HEADER_ATTRIBUTE,
+  DEFAULT_CODE_VIEW_LAYOUT,
+} from '../src/constants';
+import type { CodeViewItem } from '../src/types';
+import {
+  createRoot,
+  dispatchScroll,
+  installDom,
+  makeFileItem,
+  renderItems,
+  wait,
+} from './domHarness';
+
+const ROOT_HEIGHT = 800;
+const { paddingTop, paddingBottom } = DEFAULT_CODE_VIEW_LAYOUT;
+
+function makeItems(count = 12, lineCount = 20): CodeViewItem[] {
+  return Array.from({ length: count }, (_, index) =>
+    makeFileItem(`file:${index}`, lineCount)
+  );
+}
+
+function headerOption(): CodeViewOptions<undefined> {
+  return { renderCodeViewHeader: () => document.createElement('div') };
+}
+
+// Assert a host is mounted and narrow away the `undefined` so it can be compared
+// against `Element | null` DOM accessors.
+function mustGetHost(host: HTMLElement | undefined): HTMLElement {
+  if (!(host instanceof HTMLElement)) {
+    throw new Error('expected header/footer host element to be mounted');
+  }
+  return host;
+}
+
+// jsdom performs no layout and the harness ResizeObserver is a no-op, so drive a
+// host's height by invoking the private resize handler directly with a synthetic
+// entry — the same path the real ResizeObserver would trigger. Flushes the
+// re-anchor + queued render so callers can assert synchronously.
+function resizeHost(
+  viewer: CodeView,
+  host: HTMLElement | undefined,
+  blockSize: number
+): void {
+  if (host == null) {
+    throw new Error('resizeHost: host element is not mounted');
+  }
+  const entry = {
+    target: host,
+    borderBoxSize: [{ blockSize, inlineSize: 1000 }],
+    contentBoxSize: [{ blockSize, inlineSize: 1000 }],
+  } as unknown as ResizeObserverEntry;
+  (
+    viewer as unknown as {
+      handleResize(entries: ResizeObserverEntry[]): void;
+    }
+  ).handleResize([entry]);
+  viewer.render(true);
+}
+
+// jsdom returns a zero rect for unlaid-out elements; stub a host's rect so the
+// synchronous inline measure (measureMountedHosts) reads a real height.
+function stubRectHeight(element: HTMLElement, height: number): void {
+  Object.defineProperty(element, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => ({
+      height,
+      width: 1000,
+      top: 0,
+      left: 0,
+      right: 1000,
+      bottom: height,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }),
+  });
+}
+
+describe('CodeView header/footer', () => {
+  test('mounts header/footer hosts as flanking siblings of the container', async () => {
+    const { cleanup } = installDom();
+    const viewer = new CodeView({
+      renderCodeViewHeader: () => document.createElement('div'),
+      renderCodeViewFooter: () => document.createElement('div'),
+    });
+    const root = createRoot();
+
+    try {
+      viewer.setup(root);
+      await renderItems(viewer, makeItems());
+
+      const header = mustGetHost(viewer.getHeaderElement());
+      const footer = mustGetHost(viewer.getFooterElement());
+      // root children are [header, container, footer].
+      expect(root.children).toHaveLength(3);
+      expect(root.firstElementChild).toBe(header);
+      expect(root.lastElementChild).toBe(footer);
+      expect(header.getAttribute(CODE_VIEW_HEADER_ATTRIBUTE)).toBe('');
+      expect(footer.getAttribute(CODE_VIEW_FOOTER_ATTRIBUTE)).toBe('');
+      // Block formatting context so caller margins can't collapse out.
+      expect(header.style.display).toBe('flow-root');
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+
+  test('header height offsets an item absolute top by exactly the header height', async () => {
+    const { cleanup } = installDom();
+    const viewer = new CodeView(headerOption());
+    const root = createRoot();
+
+    try {
+      viewer.setup(root);
+      await renderItems(viewer, makeItems());
+
+      const before = viewer.getTopForItem('file:5') ?? 0;
+      resizeHost(viewer, viewer.getHeaderElement(), 140);
+      const after = viewer.getTopForItem('file:5') ?? 0;
+
+      expect(after - before).toBe(140);
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+
+  test('header + footer heights extend the max scroll range', async () => {
+    const { cleanup } = installDom();
+    const viewer = new CodeView({
+      renderCodeViewHeader: () => document.createElement('div'),
+      renderCodeViewFooter: () => document.createElement('div'),
+    });
+    const root = createRoot();
+
+    try {
+      viewer.setup(root);
+      await renderItems(viewer, makeItems());
+
+      resizeHost(viewer, viewer.getHeaderElement(), 150);
+      resizeHost(viewer, viewer.getFooterElement(), 250);
+
+      viewer.scrollTo({ type: 'position', position: 1e9, behavior: 'instant' });
+      viewer.render(true);
+
+      const expectedMax = Math.max(
+        paddingTop +
+          150 +
+          viewer.getScrollHeight() +
+          250 +
+          paddingBottom -
+          ROOT_HEIGHT,
+        0
+      );
+      expect(viewer.getScrollTop()).toBe(expectedMax);
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+
+  test('scrolls to an item at its header-inclusive absolute top', async () => {
+    const { cleanup } = installDom();
+    const viewer = new CodeView(headerOption());
+    const root = createRoot();
+
+    try {
+      viewer.setup(root);
+      await renderItems(viewer, makeItems());
+      resizeHost(viewer, viewer.getHeaderElement(), 120);
+
+      viewer.scrollTo({
+        type: 'item',
+        id: 'file:6',
+        align: 'start',
+        behavior: 'instant',
+      });
+      viewer.render(true);
+
+      // align 'start' lands the item's absolute top (which includes the header
+      // offset) at the viewport top.
+      const targetTop = viewer.getTopForItem('file:6') ?? 0;
+      expect(viewer.getScrollTop()).toBe(targetTop);
+      expect(
+        viewer.getRenderedItems().some((item) => item.id === 'file:6')
+      ).toBe(true);
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+
+  test('reveals a header that grows while scrolled to the top (no anti-jump)', async () => {
+    const { cleanup } = installDom();
+    const viewer = new CodeView(headerOption());
+    const root = createRoot();
+
+    try {
+      viewer.setup(root);
+      await renderItems(viewer, makeItems());
+      expect(viewer.getScrollTop()).toBe(0);
+
+      resizeHost(viewer, viewer.getHeaderElement(), 300);
+
+      // At the top there is nothing above the viewport to keep stable, so the
+      // header reveals (content shifts down) instead of being anchored away.
+      expect(viewer.getScrollTop()).toBe(0);
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+
+  test('re-anchors content when a header grows while scrolled into the list', async () => {
+    const { cleanup } = installDom();
+    const viewer = new CodeView(headerOption());
+    const root = createRoot();
+
+    try {
+      viewer.setup(root);
+      await renderItems(viewer, makeItems());
+
+      root.scrollTop = 300;
+      dispatchScroll(root);
+      viewer.render(true);
+      expect(viewer.getScrollTop()).toBe(300);
+
+      resizeHost(viewer, viewer.getHeaderElement(), 120);
+
+      // The anchored item's viewport offset is preserved: the whole list shifted
+      // down by the header height, so scrollTop grows by the same amount.
+      expect(viewer.getScrollTop()).toBe(420);
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+
+  test('measures the header height synchronously on mount', async () => {
+    const { cleanup } = installDom();
+    const viewer = new CodeView(headerOption());
+    const root = createRoot();
+
+    try {
+      viewer.setup(root);
+      await renderItems(viewer, makeItems());
+
+      const before = viewer.getTopForItem('file:2') ?? 0;
+      // Stub the host rect, then swap the callback to force a fresh inline
+      // measure via measureMountedHosts (getBoundingClientRect), not the RO.
+      const host = viewer.getHeaderElement();
+      expect(host).toBeInstanceOf(HTMLElement);
+      stubRectHeight(host as HTMLElement, 90);
+      viewer.setOptions({
+        renderCodeViewHeader: () => document.createElement('span'),
+      });
+      viewer.render(true);
+
+      const after = viewer.getTopForItem('file:2') ?? 0;
+      expect(after - before).toBe(90);
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+
+  test('removing the header callback tears down the host and zeroes the offset', async () => {
+    const { cleanup } = installDom();
+    const viewer = new CodeView(headerOption());
+    const root = createRoot();
+
+    try {
+      viewer.setup(root);
+      await renderItems(viewer, makeItems());
+      resizeHost(viewer, viewer.getHeaderElement(), 150);
+
+      const withHeader = viewer.getTopForItem('file:3') ?? 0;
+
+      viewer.setOptions({});
+      viewer.render(true);
+
+      expect(viewer.getHeaderElement()).toBeUndefined();
+      expect(root.querySelector(`[${CODE_VIEW_HEADER_ATTRIBUTE}]`)).toBeNull();
+
+      const withoutHeader = viewer.getTopForItem('file:3') ?? 0;
+      expect(withHeader - withoutHeader).toBe(150);
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+
+  test('mounts a header on an empty CodeView and stays within a valid scroll range', async () => {
+    const { cleanup } = installDom();
+    const viewer = new CodeView(headerOption());
+    const root = createRoot();
+
+    try {
+      viewer.setup(root);
+      await renderItems(viewer, []);
+
+      expect(viewer.getHeaderElement()).toBeInstanceOf(HTMLElement);
+
+      resizeHost(viewer, viewer.getHeaderElement(), 2000);
+      viewer.scrollTo({ type: 'position', position: 1e9, behavior: 'instant' });
+      viewer.render(true);
+
+      const expectedMax = Math.max(
+        paddingTop + 2000 + paddingBottom - ROOT_HEIGHT,
+        0
+      );
+      expect(viewer.getScrollTop()).toBe(expectedMax);
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+
+  test('cleanUp removes the header/footer hosts', async () => {
+    const { cleanup } = installDom();
+    const viewer = new CodeView({
+      renderCodeViewHeader: () => document.createElement('div'),
+      renderCodeViewFooter: () => document.createElement('div'),
+    });
+    const root = createRoot();
+
+    try {
+      viewer.setup(root);
+      await renderItems(viewer, makeItems());
+      expect(viewer.getHeaderElement()).toBeInstanceOf(HTMLElement);
+
+      viewer.cleanUp();
+
+      expect(viewer.getHeaderElement()).toBeUndefined();
+      expect(viewer.getFooterElement()).toBeUndefined();
+      expect(root.querySelector(`[${CODE_VIEW_HEADER_ATTRIBUTE}]`)).toBeNull();
+      expect(root.querySelector(`[${CODE_VIEW_FOOTER_ATTRIBUTE}]`)).toBeNull();
+    } finally {
+      await wait(0);
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
Add support for custom rendered header/footer content sections in `CodeView`

I figured out an API that shouldn't really depend on knowing how tall things are, the elements are intentionally not virtualized and should automatically be tracked by ResizeObservers.

I went for an implementation that would the lightest weight to start with to get a sense of how useful the API might be for people.

An example of it working in DiffsHub (although I don't think we'll ship this):

### Header Example:
<img width="2684" height="2578" alt="CleanShot 2026-07-01 at 14 39 36" src="https://github.com/user-attachments/assets/0cdd26b0-1cdd-4d0c-9b14-b9c97ef7a424" />

### Footer Example:
<img width="2684" height="2578" alt="CleanShot 2026-07-01 at 14 41 01" src="https://github.com/user-attachments/assets/3705cc0d-5cff-406a-bd9e-7f4dee8c6b86" />


Fixes #894 