### PR TITLE
Add playwright tests for diffs and edit mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         run: >-
           moon ci --include-relations --summary detailed :build demo:build
           diffshub:build docs:build docs:build-trees-site path-store:build-demo
-          :test :typecheck trees:test-e2e root:lint root:lint-css
+          :test :typecheck trees:test-e2e diffs:test-e2e root:lint root:lint-css
 
   actions-pinned:
     name: Actions pinned to SHA

--- a/packages/diffs/moon.yml
+++ b/packages/diffs/moon.yml
@@ -13,3 +13,31 @@ tasks:
     options:
       cache: false
       runInCI: 'always'
+
+  # Browser E2E for shadow-DOM rendering and contentEditable edit mode, which
+  # the jsdom unit suite cannot exercise. Mirrors the trees E2E setup: a Vite
+  # fixture server serves the built dist and Playwright drives real Chromium.
+  test-e2e:
+    script:
+      '(bun ./test/e2e/check-playwright-binary.ts || pnpm exec playwright
+      install chromium) && pnpm exec playwright test -c
+      test/e2e/playwright.config.ts'
+    deps:
+      - 'build'
+    inputs:
+      - 'src/**/*'
+      - 'test/e2e/**/*'
+    options:
+      envFile: '/.env.worktree'
+
+  # Spawned by playwright's webServer (also under CI); DIFFS_E2E_PORT is
+  # provided by the caller, with a worktree-offset default for manual runs.
+  test-e2e-server:
+    script:
+      'DIFFS_E2E_PORT=${DIFFS_E2E_PORT:-$(( ${PIERRE_PORT_OFFSET:-0} + 4175 ))}
+      vite --config test/e2e/vite.config.ts'
+    options:
+      cache: false
+      persistent: true
+      runInCI: 'always'
+      envFile: '/.env.worktree'

--- a/packages/diffs/package.json
+++ b/packages/diffs/package.json
@@ -75,6 +75,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/core": "catalog:",
+    "@playwright/test": "catalog:",
     "@tsdown/css": "catalog:",
     "@types/hast": "catalog:",
     "@types/jsdom": "catalog:",
@@ -89,7 +90,8 @@
     "react": "catalog:",
     "react-dom": "catalog:",
     "tsdown": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vite": "catalog:"
   },
   "peerDependencies": {
     "react": "^18.3.1 || ^19.0.0",

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -106,6 +106,32 @@ import {
   round,
 } from './utils';
 
+// ShadowRoot.getSelection is a non-standard Blink/WebKit method (predates the
+// spec'd Selection.getComposedRanges) and is missing from the DOM lib types.
+type ShadowRootWithSelection = ShadowRoot & {
+  getSelection?: () => Selection | null;
+};
+
+// Fallback for browsers without Selection.getComposedRanges: read the first
+// range from the shadow root's own selection so the editor can still map a
+// caret placed by a click inside its shadow tree. Normalized to a StaticRange
+// so it matches the getComposedRanges return shape the callers expect. Returns
+// undefined when the API or a live range is unavailable.
+function getShadowRootRange(shadowRoot: ShadowRoot): StaticRange | undefined {
+  const selection = (shadowRoot as ShadowRootWithSelection).getSelection?.();
+  if (selection == null || selection.rangeCount === 0) {
+    return undefined;
+  }
+  const range = selection.getRangeAt(0);
+  return {
+    collapsed: range.collapsed,
+    startContainer: range.startContainer,
+    startOffset: range.startOffset,
+    endContainer: range.endContainer,
+    endOffset: range.endOffset,
+  };
+}
+
 export interface EditorOptions<LAnnotation> {
   /** The maximum number of entries to keep in the undo stack. */
   historyMaxEntries?: number;
@@ -944,19 +970,23 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
           }
 
           const selectionRaw = document.getSelection();
-          // getComposedRanges is the only selection API that reads through the
-          // editor's shadow root, but it is newly available and missing on
-          // older browsers and embedded WebViews. Bail out instead of throwing
-          // out of this listener on every selectionchange when it is absent.
-          if (
-            selectionRaw == null ||
-            typeof selectionRaw.getComposedRanges !== 'function'
-          ) {
+          if (selectionRaw == null) {
             return;
           }
-          const composedRange = selectionRaw.getComposedRanges({
-            shadowRoots: [shadowRoot],
-          })?.[0];
+          // Read the caret/selection through the editor's shadow root.
+          // getComposedRanges is the standard, spec'd way to do this but is only
+          // available in newer browsers. When it is missing (older browsers,
+          // embedded WebViews, and the pinned CI Chromium), fall back to the
+          // older Blink/WebKit-specific ShadowRoot.getSelection(), which still
+          // reports the range inside the shadow tree. Only bail when neither API
+          // yields a range, so a click can still seed the caret rather than
+          // leaving the surface unusable.
+          const composedRange =
+            typeof selectionRaw.getComposedRanges === 'function'
+              ? selectionRaw.getComposedRanges({
+                  shadowRoots: [shadowRoot],
+                })?.[0]
+              : getShadowRootRange(shadowRoot);
           if (
             composedRange === undefined ||
             !this.#rangeBelongsToEditor(composedRange)

--- a/packages/diffs/test/annotations.test.ts
+++ b/packages/diffs/test/annotations.test.ts
@@ -114,37 +114,44 @@ describe('Annotation Rendering', () => {
       ]);
     });
 
-    test('render paired top rows in split style', async () => {
-      const annotations: DiffLineAnnotation<string>[] = [
-        { side: 'deletions', lineNumber: 0, metadata: 'old-file' },
-        { side: 'additions', lineNumber: 0, metadata: 'new-file' },
-      ];
-      const renderer = new DiffHunksRenderer<string>({
-        diffStyle: 'split',
-        expandUnchanged: true,
-      });
-      renderer.setLineAnnotations(annotations);
+    // Highlights every line of the ~700-line fixture on both sides
+    // (`expandUnchanged` split render), so it needs more than bun's default 5s
+    // per-test timeout to stay reliable under CI contention.
+    test(
+      'render paired top rows in split style',
+      async () => {
+        const annotations: DiffLineAnnotation<string>[] = [
+          { side: 'deletions', lineNumber: 0, metadata: 'old-file' },
+          { side: 'additions', lineNumber: 0, metadata: 'new-file' },
+        ];
+        const renderer = new DiffHunksRenderer<string>({
+          diffStyle: 'split',
+          expandUnchanged: true,
+        });
+        renderer.setLineAnnotations(annotations);
 
-      const { additionsContentAST, deletionsContentAST } =
-        await renderer.asyncRender(diff);
-      assertDefined(
-        additionsContentAST,
-        'additionsContentAST should be defined'
-      );
-      assertDefined(
-        deletionsContentAST,
-        'deletionsContentAST should be defined'
-      );
-      const firstAddition = additionsContentAST[0];
-      const firstDeletion = deletionsContentAST[0];
-      assertDefined(firstAddition, 'firstAddition should be defined');
-      assertDefined(firstDeletion, 'firstDeletion should be defined');
+        const { additionsContentAST, deletionsContentAST } =
+          await renderer.asyncRender(diff);
+        assertDefined(
+          additionsContentAST,
+          'additionsContentAST should be defined'
+        );
+        assertDefined(
+          deletionsContentAST,
+          'deletionsContentAST should be defined'
+        );
+        const firstAddition = additionsContentAST[0];
+        const firstDeletion = deletionsContentAST[0];
+        assertDefined(firstAddition, 'firstAddition should be defined');
+        assertDefined(firstDeletion, 'firstDeletion should be defined');
 
-      expect(getHastAnnotationIndex(firstAddition)).toBe('-1,-1');
-      expect(getHastAnnotationIndex(firstDeletion)).toBe('-1,-1');
-      expect(getSlotNames(firstAddition)).toEqual(['annotation-additions-0']);
-      expect(getSlotNames(firstDeletion)).toEqual(['annotation-deletions-0']);
-    });
+        expect(getHastAnnotationIndex(firstAddition)).toBe('-1,-1');
+        expect(getHastAnnotationIndex(firstDeletion)).toBe('-1,-1');
+        expect(getSlotNames(firstAddition)).toEqual(['annotation-additions-0']);
+        expect(getSlotNames(firstDeletion)).toEqual(['annotation-deletions-0']);
+      },
+      { timeout: 15000 }
+    );
 
     test('do not collide with first-row annotation keys in split style', async () => {
       const renderer = new DiffHunksRenderer<string>({ diffStyle: 'split' });

--- a/packages/diffs/test/e2e/annotations.pw.ts
+++ b/packages/diffs/test/e2e/annotations.pw.ts
@@ -1,0 +1,25 @@
+import { expect, type Page, test } from '@playwright/test';
+
+async function openFixture(page: Page): Promise<void> {
+  await page.goto('/test/e2e/fixtures/annotations.html');
+  await page.waitForFunction(() => window.__annotationsReady === true);
+}
+
+test.describe('line annotations', () => {
+  test('renders custom annotation content anchored to its line', async ({
+    page,
+  }) => {
+    await openFixture(page);
+
+    // The shadow DOM carries the annotation row + slot for line index 1.
+    await expect(page.locator('[data-line-annotation]')).toHaveCount(1);
+
+    // The custom content is projected through the light-DOM slot named for the
+    // annotation's line, and is visible to the user.
+    const slotted = page.locator('[data-annotation-slot][slot="annotation-2"]');
+    await expect(slotted).toHaveCount(1);
+    const content = slotted.locator('[data-test-annotation]');
+    await expect(content).toBeVisible();
+    await expect(content).toHaveText('note on line 2');
+  });
+});

--- a/packages/diffs/test/e2e/check-playwright-binary.ts
+++ b/packages/diffs/test/e2e/check-playwright-binary.ts
@@ -1,0 +1,13 @@
+import { chromium } from '@playwright/test';
+import { existsSync } from 'node:fs';
+
+const executablePath = chromium.executablePath();
+
+if (existsSync(executablePath)) {
+  process.exit(0);
+}
+
+console.error(
+  `[diffs:e2e] Missing Playwright Chromium binary at: ${executablePath}`
+);
+process.exit(1);

--- a/packages/diffs/test/e2e/conflict.pw.ts
+++ b/packages/diffs/test/e2e/conflict.pw.ts
@@ -1,0 +1,76 @@
+import { expect, type Page, test } from '@playwright/test';
+
+async function openFixture(page: Page): Promise<void> {
+  await page.goto('/test/e2e/fixtures/conflict.html');
+  await page.waitForFunction(() => window.__conflictReady === true);
+}
+
+const actionButton = (conflictIndex: number, resolution: string): string =>
+  `button[data-merge-conflict-action="${resolution}"][data-merge-conflict-conflict-index="${conflictIndex}"]`;
+
+const CONTENT = '[data-content]';
+const resolutions = (page: Page): Promise<string[]> =>
+  page.evaluate(() => window.__conflictResolutions ?? []);
+
+test.describe('merge conflict resolution', () => {
+  test('renders conflict markers and per-conflict action buttons', async ({
+    page,
+  }) => {
+    await openFixture(page);
+
+    // Each conflict offers current / incoming / both, for two conflicts.
+    await expect(page.locator('[data-merge-conflict-action]')).toHaveCount(6);
+    await expect(page.locator(actionButton(0, 'current'))).toBeVisible();
+    await expect(page.locator(actionButton(0, 'incoming'))).toBeVisible();
+    await expect(page.locator(actionButton(1, 'both'))).toBeVisible();
+
+    // Both sides of each conflict are present before resolution.
+    await expect(page.locator(CONTENT)).toContainText('const ttl = 12;');
+    await expect(page.locator(CONTENT)).toContainText('const ttl = 24;');
+    // Conflict marker rows are rendered (start / separator / end per conflict).
+    await expect(
+      page.locator('[data-merge-conflict-marker-row]').first()
+    ).toBeVisible();
+  });
+
+  test('accepting incoming resolves that conflict and keeps others interactive', async ({
+    page,
+  }) => {
+    await openFixture(page);
+
+    await page.locator(actionButton(0, 'incoming')).click();
+
+    // The resolved conflict drops its action buttons and its "current" side.
+    await expect(
+      page.locator('[data-merge-conflict-conflict-index="0"]')
+    ).toHaveCount(0);
+    await expect(page.locator(CONTENT)).not.toContainText('const ttl = 12;');
+    await expect(page.locator(CONTENT)).toContainText('const ttl = 24;');
+    await expect.poll(() => resolutions(page)).toEqual(['incoming']);
+
+    // The second, untouched conflict is still fully interactive.
+    await expect(page.locator(actionButton(1, 'current'))).toBeVisible();
+    await page.locator(actionButton(1, 'current')).click();
+
+    await expect(
+      page.locator('[data-merge-conflict-conflict-index="1"]')
+    ).toHaveCount(0);
+    await expect(page.locator(CONTENT)).toContainText('const max = 1;');
+    await expect(page.locator(CONTENT)).not.toContainText('const max = 2;');
+    await expect.poll(() => resolutions(page)).toEqual(['incoming', 'current']);
+  });
+
+  test('accepting both keeps current and incoming lines', async ({ page }) => {
+    await openFixture(page);
+
+    await page.locator(actionButton(0, 'both')).click();
+
+    await expect(page.locator(CONTENT)).toContainText('const ttl = 12;');
+    await expect(page.locator(CONTENT)).toContainText('const ttl = 24;');
+    // Conflict markers for the resolved region are gone.
+    await expect(
+      page.locator('[data-merge-conflict-conflict-index="0"]')
+    ).toHaveCount(0);
+    await expect.poll(() => resolutions(page)).toEqual(['both']);
+  });
+});

--- a/packages/diffs/test/e2e/diff-render.pw.ts
+++ b/packages/diffs/test/e2e/diff-render.pw.ts
@@ -1,0 +1,93 @@
+import { expect, type Page, test } from '@playwright/test';
+
+// Playwright CSS locators pierce the open shadow root, so all selectors below
+// resolve against the `diffs-container` shadow DOM without extra ceremony.
+const ADDITIONS = '[data-code][data-additions] [data-content]';
+const DELETIONS = '[data-code][data-deletions] [data-content]';
+
+async function openFixture(page: Page): Promise<void> {
+  await page.goto('/test/e2e/fixtures/diff-render.html');
+  await page.waitForFunction(() => window.__diffReady === true);
+}
+
+test.describe('diff rendering', () => {
+  test('renders additions and deletions with the expected line types', async ({
+    page,
+  }) => {
+    await openFixture(page);
+
+    const additions = page.locator(
+      `${ADDITIONS} [data-line-type="change-addition"]`
+    );
+    await expect(additions).toHaveCount(2);
+    await expect(additions.first()).toHaveText('  return `hi ${name}!`;');
+    await expect(additions.nth(1)).toHaveText('  return `bye ${name}!`;');
+
+    const deletions = page.locator(
+      `${DELETIONS} [data-line-type="change-deletion"]`
+    );
+    await expect(deletions).toHaveCount(2);
+    await expect(deletions.first()).toHaveText("  return 'hi ' + name;");
+
+    // Syntax highlighting splits a code line into multiple token spans; assert
+    // more than one so we know the highlighter actually ran in the browser.
+    expect(
+      await additions.first().evaluate((el) => el.childElementCount)
+    ).toBeGreaterThan(1);
+  });
+
+  test('toggling between split and unified changes the layout', async ({
+    page,
+  }) => {
+    await openFixture(page);
+
+    // Split view renders separate additions and deletions columns.
+    await expect(page.locator('[data-code][data-additions]')).toHaveCount(1);
+    await expect(page.locator('[data-code][data-deletions]')).toHaveCount(1);
+    await expect(page.locator('[data-code][data-unified]')).toHaveCount(0);
+
+    await page.locator('[data-toggle-style]').click();
+
+    // Unified view collapses to a single column.
+    await expect(page.locator('[data-current-style]')).toHaveText('unified');
+    await expect(page.locator('[data-code][data-unified]')).toHaveCount(1);
+    await expect(page.locator('[data-code][data-additions]')).toHaveCount(0);
+    await expect(page.locator('[data-code][data-deletions]')).toHaveCount(0);
+  });
+
+  test('clicking a hunk separator expands collapsed context', async ({
+    page,
+  }) => {
+    await openFixture(page);
+
+    const expanded = page.locator(
+      `${ADDITIONS} [data-line-type="context-expanded"]`
+    );
+    await expect(expanded).toHaveCount(0);
+    await expect(page.locator('[data-expand-button]').first()).toBeVisible();
+
+    await page.locator('[data-expand-button]').first().click();
+
+    // The previously hidden unchanged lines are revealed as expanded context
+    // and the separators that offered the expansion are consumed.
+    await expect(expanded.first()).toBeVisible();
+    await expect(page.locator('[data-expand-button]')).toHaveCount(0);
+  });
+
+  test('rejecting a hunk removes its addition from the diff', async ({
+    page,
+  }) => {
+    await openFixture(page);
+
+    const additions = page.locator(
+      `${ADDITIONS} [data-line-type="change-addition"]`
+    );
+    await expect(additions).toHaveCount(2);
+
+    await page.locator('[data-reject-hunk]').click();
+
+    // The first hunk's change is reverted, so only the second addition remains.
+    await expect(additions).toHaveCount(1);
+    await expect(additions.first()).toHaveText('  return `bye ${name}!`;');
+  });
+});

--- a/packages/diffs/test/e2e/e2e-globals.d.ts
+++ b/packages/diffs/test/e2e/e2e-globals.d.ts
@@ -1,0 +1,62 @@
+// Shared ambient globals for the diffs E2E fixtures.
+//
+// Each fixture stashes a ready flag (and sometimes an editor handle or an
+// interaction log) on `window` so the Playwright specs can await setup and read
+// state. TypeScript merges the `Window` interface across the whole program, so
+// declaring these per-file with `declare global` produced conflicting `__editor`
+// shapes that failed typecheck. Declaring them once here keeps every spec in
+// agreement.
+
+interface E2ELineRange {
+  start: number;
+  end: number;
+}
+
+interface E2ESelectionPoint {
+  line: number;
+  character: number;
+}
+
+interface E2ESelection {
+  start: E2ESelectionPoint;
+  end: E2ESelectionPoint;
+  direction?: 'none' | 'backward' | 'forward';
+}
+
+interface E2EEditorState {
+  file: { contents: string };
+  selections?: E2ESelection[];
+}
+
+// The subset of the real Editor surface the fixtures expose on `window`.
+interface E2EEditor {
+  canUndo: boolean;
+  canRedo: boolean;
+  getState: () => E2EEditorState;
+  setSelections: (selections: E2ESelection[]) => void;
+  focus: () => void;
+}
+
+interface Window {
+  // Fixture ready flags.
+  __diffReady?: boolean;
+  __editReady?: boolean;
+  __editableReady?: boolean;
+  __conflictReady?: boolean;
+  __fileStatesReady?: boolean;
+  __markersReady?: boolean;
+  __lineSelectReady?: boolean;
+  __annotationsReady?: boolean;
+  __themeReady?: boolean;
+  __selectionActionReady?: boolean;
+
+  // Interaction logs populated by fixture callbacks.
+  __editorEvents?: string[];
+  __conflictResolutions?: string[];
+  __selectionChanges?: (E2ELineRange | null)[];
+  __gutterClicks?: E2ELineRange[];
+  __actionClicks?: string[];
+
+  // Editor handle exposed by the editable fixtures.
+  __editor?: E2EEditor;
+}

--- a/packages/diffs/test/e2e/edit-rewrite.pw.ts
+++ b/packages/diffs/test/e2e/edit-rewrite.pw.ts
@@ -1,0 +1,39 @@
+import { expect, type Page, test } from '@playwright/test';
+
+const CONTENT = '[data-content]';
+
+async function openFixture(page: Page): Promise<void> {
+  await page.goto('/test/e2e/fixtures/editable.html');
+  await page.waitForFunction(() => window.__editableReady === true);
+}
+
+const contents = (page: Page): Promise<string> =>
+  page.evaluate(() => window.__editor?.getState().file.contents ?? '');
+const changeCount = (page: Page): Promise<number> =>
+  page.evaluate(() => window.__editorEvents?.length ?? 0);
+
+test.describe('rewrite the whole editable file', () => {
+  test('selecting all, deleting, and typing new code emits the new file', async ({
+    page,
+  }) => {
+    await openFixture(page);
+
+    // Select everything and clear it.
+    await page.locator(CONTENT).click();
+    await page.keyboard.press('ControlOrMeta+a');
+    await page.keyboard.press('Backspace');
+    await expect.poll(() => contents(page)).toBe('');
+
+    // Type a fresh multi-line file (Enter for the line break).
+    await page.keyboard.type('const rewritten = true;');
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('export default rewritten;');
+
+    await expect
+      .poll(() => contents(page))
+      .toBe('const rewritten = true;\nexport default rewritten;');
+    // None of the original content survives the rewrite.
+    await expect.poll(() => contents(page)).not.toContain('foo');
+    await expect.poll(() => changeCount(page)).toBeGreaterThan(0);
+  });
+});

--- a/packages/diffs/test/e2e/edit.pw.ts
+++ b/packages/diffs/test/e2e/edit.pw.ts
@@ -1,0 +1,98 @@
+import { expect, type Page, test } from '@playwright/test';
+
+const ADDITIONS = '[data-code][data-additions] [data-content]';
+const DELETIONS = '[data-code][data-deletions] [data-content]';
+
+async function openFixture(page: Page): Promise<void> {
+  await page.goto('/test/e2e/fixtures/edit.html');
+  await page.waitForFunction(() => window.__editReady === true);
+}
+
+const canUndo = (page: Page): Promise<boolean> =>
+  page.evaluate(() => window.__editor?.canUndo ?? false);
+const canRedo = (page: Page): Promise<boolean> =>
+  page.evaluate(() => window.__editor?.canRedo ?? false);
+const changeCount = (page: Page): Promise<number> =>
+  page.evaluate(() => window.__editorEvents?.length ?? 0);
+
+// Real user path: a plain click into the editable additions column places the
+// caret, then typing flows through the genuine keyboard -> beforeinput ->
+// onChange pipeline. This guards the shadow-selection fallback in
+// src/editor/editor.ts: the pinned Chromium here lacks
+// Selection.getComposedRanges, so the editor reads the caret via
+// ShadowRoot.getSelection() instead. Without that fallback a click left the
+// caret unseeded and every keystroke was silently dropped.
+async function clickIntoAdditions(page: Page): Promise<void> {
+  await page.locator(ADDITIONS).click();
+}
+
+test.describe('edit mode', () => {
+  test('a plain click seeds the caret so typing works (regression)', async ({
+    page,
+  }) => {
+    await openFixture(page);
+
+    await clickIntoAdditions(page);
+    await page.keyboard.type('Z');
+
+    await expect(page.locator(ADDITIONS)).toContainText('Z');
+    await expect.poll(() => changeCount(page)).toBeGreaterThan(0);
+  });
+
+  test('additions are editable while deletions stay read-only', async ({
+    page,
+  }) => {
+    await openFixture(page);
+
+    await expect(page.locator(ADDITIONS)).toHaveAttribute(
+      'contenteditable',
+      'true'
+    );
+    // The deleted (old-file) column is never editable.
+    await expect(page.locator(DELETIONS)).not.toHaveAttribute(
+      'contenteditable',
+      'true'
+    );
+
+    const deletionText = await page.locator(DELETIONS).textContent();
+
+    // Editing the additions column must not disturb the read-only deletions.
+    await clickIntoAdditions(page);
+    await page.keyboard.type('Z');
+    await expect(page.locator(ADDITIONS)).toContainText('Z');
+
+    await expect(page.locator(DELETIONS)).toHaveText(deletionText ?? '');
+  });
+
+  test('typing inserts text, fires onChange, and enables undo', async ({
+    page,
+  }) => {
+    await openFixture(page);
+
+    expect(await changeCount(page)).toBe(0);
+    expect(await canUndo(page)).toBe(false);
+
+    await clickIntoAdditions(page);
+    await page.keyboard.type('Z');
+
+    await expect(page.locator(ADDITIONS)).toContainText('Z');
+    await expect.poll(() => changeCount(page)).toBeGreaterThan(0);
+    await expect.poll(() => canUndo(page)).toBe(true);
+  });
+
+  test('undo and redo round-trip a typed edit', async ({ page }) => {
+    await openFixture(page);
+
+    await clickIntoAdditions(page);
+    await page.keyboard.type('Z');
+    await expect(page.locator(ADDITIONS)).toContainText('Z');
+    await expect.poll(() => canUndo(page)).toBe(true);
+
+    await page.keyboard.press('ControlOrMeta+z');
+    await expect(page.locator(ADDITIONS)).not.toContainText('Z');
+    await expect.poll(() => canRedo(page)).toBe(true);
+
+    await page.keyboard.press('ControlOrMeta+Shift+z');
+    await expect(page.locator(ADDITIONS)).toContainText('Z');
+  });
+});

--- a/packages/diffs/test/e2e/file-states.pw.ts
+++ b/packages/diffs/test/e2e/file-states.pw.ts
@@ -1,0 +1,44 @@
+import { expect, type Page, test } from '@playwright/test';
+
+async function openFixture(page: Page): Promise<void> {
+  await page.goto('/test/e2e/fixtures/file-states.html');
+  await page.waitForFunction(() => window.__fileStatesReady === true);
+}
+
+test.describe('file states', () => {
+  test('an added file renders only additions', async ({ page }) => {
+    await openFixture(page);
+
+    const added = page.locator('[data-added-mount]');
+    // Only the additions column exists for a newly added file.
+    await expect(added.locator('[data-code][data-additions]')).toHaveCount(1);
+    await expect(added.locator('[data-code][data-deletions]')).toHaveCount(0);
+    await expect(
+      added.locator('[data-line-type="change-deletion"]')
+    ).toHaveCount(0);
+    await expect(
+      added.locator('[data-line-type="change-addition"]').first()
+    ).toBeVisible();
+    await expect(added.locator('[data-content]')).toContainText(
+      'export const created = true;'
+    );
+  });
+
+  test('a deleted file renders only deletions', async ({ page }) => {
+    await openFixture(page);
+
+    const deleted = page.locator('[data-deleted-mount]');
+    // Only the deletions column exists for a removed file.
+    await expect(deleted.locator('[data-code][data-deletions]')).toHaveCount(1);
+    await expect(deleted.locator('[data-code][data-additions]')).toHaveCount(0);
+    await expect(
+      deleted.locator('[data-line-type="change-addition"]')
+    ).toHaveCount(0);
+    await expect(
+      deleted.locator('[data-line-type="change-deletion"]').first()
+    ).toBeVisible();
+    await expect(deleted.locator('[data-content]')).toContainText(
+      'export const removed = true;'
+    );
+  });
+});

--- a/packages/diffs/test/e2e/find-replace.pw.ts
+++ b/packages/diffs/test/e2e/find-replace.pw.ts
@@ -1,0 +1,69 @@
+import { expect, type Page, test } from '@playwright/test';
+
+const CONTENT = '[data-content]';
+const PANEL = '[data-search-panel]';
+const SEARCH_INPUT = '[data-search-panel] input[data-search]';
+const REPLACE_INPUT = '[data-search-panel] input[data-replace]';
+const MATCHES = '[data-search-panel] [data-matches]';
+
+async function openFixture(page: Page): Promise<void> {
+  await page.goto('/test/e2e/fixtures/editable.html');
+  await page.waitForFunction(() => window.__editableReady === true);
+}
+
+const contents = (page: Page): Promise<string> =>
+  page.evaluate(() => window.__editor?.getState().file.contents ?? '');
+
+// Focus the editor surface, then open the search panel with the real shortcut.
+// The panel container is a zero-height CSS grid wrapper (its cells are laid out
+// individually), so wait on the visible search input rather than the wrapper.
+async function openSearchPanel(page: Page): Promise<void> {
+  await page.locator(CONTENT).click();
+  await page.keyboard.press('ControlOrMeta+f');
+  await expect(page.locator(PANEL)).toHaveCount(1);
+  await expect(page.locator(SEARCH_INPUT)).toBeVisible();
+}
+
+test.describe('find and replace', () => {
+  test('Cmd/Ctrl+F opens the panel and reports match counts', async ({
+    page,
+  }) => {
+    await openFixture(page);
+    await openSearchPanel(page);
+
+    await page.locator(SEARCH_INPUT).fill('foo');
+
+    // "foo" appears four times across the three lines.
+    await expect(page.locator(MATCHES)).toContainText('4');
+    await expect(
+      page.locator('[data-search-panel] [data-no-matches]')
+    ).toHaveCount(0);
+
+    await page.locator(SEARCH_INPUT).fill('nope');
+    await expect(page.locator(MATCHES)).toContainText('No results');
+  });
+
+  test('switching to replace mode and Replace All rewrites every match', async ({
+    page,
+  }) => {
+    await openFixture(page);
+    await openSearchPanel(page);
+
+    await page.locator(SEARCH_INPUT).fill('foo');
+    // Cmd/Ctrl+Alt+F toggles the panel into find/replace mode in place.
+    await page.keyboard.press('ControlOrMeta+Alt+f');
+    await expect(page.locator('[data-search-grid]')).toHaveAttribute(
+      'data-mode',
+      'replace'
+    );
+
+    await page.locator(REPLACE_INPUT).fill('qux');
+    await page
+      .locator('[data-replace-actions] button[aria-label="Replace All"]')
+      .click();
+
+    await expect.poll(() => contents(page)).toContain('const qux = 1;');
+    await expect.poll(() => contents(page)).toContain('const bar = qux + qux;');
+    await expect.poll(() => contents(page)).not.toContain('foo');
+  });
+});

--- a/packages/diffs/test/e2e/fixtures/annotations.html
+++ b/packages/diffs/test/e2e/fixtures/annotations.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>diffs annotations fixture</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 16px;
+        font-family: system-ui, sans-serif;
+      }
+      [data-diff-mount] {
+        max-width: 900px;
+      }
+    </style>
+  </head>
+  <body>
+    <div data-diff-mount></div>
+
+    <script type="module">
+      import { File } from '/dist/index.js';
+
+      const mount = document.querySelector('[data-diff-mount]');
+      if (!(mount instanceof HTMLElement)) {
+        throw new Error('Missing annotations fixture mount.');
+      }
+
+      const file = {
+        name: 'annotated.ts',
+        contents: `function add(a, b) {
+  return a + b;
+}
+const sum = add(1, 2);
+`,
+      };
+
+      // A single inline annotation attached to line 2 (the return statement).
+      const lineAnnotations = [{ lineNumber: 2 }];
+
+      const instance = new File({
+        disableFileHeader: true,
+        theme: { dark: 'pierre-dark', light: 'pierre-light' },
+        themeType: 'dark',
+        renderAnnotation(annotation) {
+          const el = document.createElement('div');
+          el.dataset.testAnnotation = '';
+          el.textContent = `note on line ${annotation.lineNumber}`;
+          return el;
+        },
+      });
+      instance.render({ file, lineAnnotations, containerWrapper: mount });
+
+      const waitForAnnotation = async () => {
+        const started = performance.now();
+        while (true) {
+          const host = mount.querySelector('diffs-container');
+          const slotted = host?.querySelector('[data-annotation-slot]');
+          const row = host?.shadowRoot?.querySelector('[data-line-annotation]');
+          if (slotted != null && row != null) {
+            return;
+          }
+          if (performance.now() - started > 5000) {
+            throw new Error('Timed out waiting for annotation.');
+          }
+          await new Promise((resolve) => requestAnimationFrame(resolve));
+        }
+      };
+
+      await waitForAnnotation();
+      window.__annotationsReady = true;
+    </script>
+  </body>
+</html>

--- a/packages/diffs/test/e2e/fixtures/annotations.html
+++ b/packages/diffs/test/e2e/fixtures/annotations.html
@@ -16,6 +16,20 @@
     </style>
   </head>
   <body>
+    <a
+      data-fixtures-index
+      href="/test/e2e/fixtures/index.html"
+      style="
+        display: inline-block;
+        margin-bottom: 16px;
+        font-family: system-ui, sans-serif;
+        font-size: 14px;
+        font-weight: 600;
+        color: #0b62d6;
+        text-decoration: none;
+      "
+      >&larr; All fixtures</a
+    >
     <div data-diff-mount></div>
 
     <script type="module">

--- a/packages/diffs/test/e2e/fixtures/conflict.html
+++ b/packages/diffs/test/e2e/fixtures/conflict.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>diffs merge-conflict fixture</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 16px;
+        font-family: system-ui, sans-serif;
+      }
+      [data-diff-mount] {
+        max-width: 900px;
+      }
+      [data-log] {
+        margin-top: 16px;
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <div data-diff-mount></div>
+    <div data-log></div>
+
+    <script type="module">
+      import { UnresolvedFile } from '/dist/index.js';
+
+      const mount = document.querySelector('[data-diff-mount]');
+      const log = document.querySelector('[data-log]');
+      if (!(mount instanceof HTMLElement) || !(log instanceof HTMLElement)) {
+        throw new Error('Missing conflict fixture nodes.');
+      }
+
+      // Two independent conflicts so a test can resolve the first and confirm
+      // the second is still interactive. No base marker (2-way conflict).
+      const file = {
+        name: 'session.ts',
+        contents: [
+          'const start = true;',
+          '<<<<<<< HEAD',
+          'const ttl = 12;',
+          '=======',
+          'const ttl = 24;',
+          '>>>>>>> feature',
+          'const middle = true;',
+          '<<<<<<< HEAD',
+          'const max = 1;',
+          '=======',
+          'const max = 2;',
+          '>>>>>>> feature',
+          'const end = true;',
+          '',
+        ].join('\n'),
+      };
+
+      // Each resolution is recorded so tests can assert the callback fires with
+      // the chosen side rather than only inspecting the DOM.
+      const resolutions = [];
+      window.__conflictResolutions = resolutions;
+
+      // Uncontrolled mode: with no onMergeConflictAction, clicking an action
+      // button resolves the conflict and re-renders internally;
+      // onMergeConflictResolve is the post-resolution notification.
+      const instance = new UnresolvedFile({
+        disableFileHeader: true,
+        theme: { dark: 'pierre-dark', light: 'pierre-light' },
+        themeType: 'dark',
+        mergeConflictActionsType: 'default',
+        onMergeConflictResolve(_file, payload) {
+          resolutions.push(payload.resolution);
+        },
+      });
+
+      instance.render({ file, containerWrapper: mount });
+      window.__conflictInstance = instance;
+
+      // The diff renders asynchronously while the highlighter loads; wait until
+      // the first conflict's action button is committed to the shadow DOM.
+      const waitForActions = async () => {
+        const started = performance.now();
+        while (true) {
+          const host = mount.querySelector('diffs-container');
+          const button = host?.shadowRoot?.querySelector(
+            '[data-merge-conflict-action]'
+          );
+          if (button != null) {
+            return;
+          }
+          if (performance.now() - started > 5000) {
+            throw new Error('Timed out waiting for conflict actions.');
+          }
+          await new Promise((resolve) => requestAnimationFrame(resolve));
+        }
+      };
+
+      await waitForActions();
+      window.__conflictReady = true;
+    </script>
+  </body>
+</html>

--- a/packages/diffs/test/e2e/fixtures/conflict.html
+++ b/packages/diffs/test/e2e/fixtures/conflict.html
@@ -21,6 +21,20 @@
     </style>
   </head>
   <body>
+    <a
+      data-fixtures-index
+      href="/test/e2e/fixtures/index.html"
+      style="
+        display: inline-block;
+        margin-bottom: 16px;
+        font-family: system-ui, sans-serif;
+        font-size: 14px;
+        font-weight: 600;
+        color: #0b62d6;
+        text-decoration: none;
+      "
+      >&larr; All fixtures</a
+    >
     <div data-diff-mount></div>
     <div data-log></div>
 

--- a/packages/diffs/test/e2e/fixtures/diff-render.html
+++ b/packages/diffs/test/e2e/fixtures/diff-render.html
@@ -21,6 +21,20 @@
     </style>
   </head>
   <body>
+    <a
+      data-fixtures-index
+      href="/test/e2e/fixtures/index.html"
+      style="
+        display: inline-block;
+        margin-bottom: 16px;
+        font-family: system-ui, sans-serif;
+        font-size: 14px;
+        font-weight: 600;
+        color: #0b62d6;
+        text-decoration: none;
+      "
+      >&larr; All fixtures</a
+    >
     <div data-controls>
       <button type="button" data-toggle-style>Toggle split/unified</button>
       <button type="button" data-reject-hunk>Reject first hunk</button>

--- a/packages/diffs/test/e2e/fixtures/diff-render.html
+++ b/packages/diffs/test/e2e/fixtures/diff-render.html
@@ -1,0 +1,150 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>diffs render fixture</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 16px;
+        font-family: system-ui, sans-serif;
+      }
+      [data-controls] {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 16px;
+      }
+      [data-diff-mount] {
+        max-width: 900px;
+      }
+    </style>
+  </head>
+  <body>
+    <div data-controls>
+      <button type="button" data-toggle-style>Toggle split/unified</button>
+      <button type="button" data-reject-hunk>Reject first hunk</button>
+      <span data-current-style></span>
+    </div>
+    <div data-diff-mount></div>
+
+    <script type="module">
+      import { FileDiff, parseDiffFromFile } from '/dist/index.js';
+      import { diffAcceptRejectHunk } from '/dist/index.js';
+
+      const mount = document.querySelector('[data-diff-mount]');
+      const styleLabel = document.querySelector('[data-current-style]');
+      if (!(mount instanceof HTMLElement)) {
+        throw new Error('Missing diff mount.');
+      }
+
+      // Two changed regions separated by a block of unchanged lines. The
+      // unchanged middle is large enough to collapse into a clickable hunk
+      // separator so the expand-context interaction has something to reveal.
+      const oldFile = {
+        name: 'greetings.ts',
+        contents: `export function greet(name) {
+  return 'hi ' + name;
+}
+
+const a = 1;
+const b = 2;
+const c = 3;
+const d = 4;
+const e = 5;
+const f = 6;
+const g = 7;
+const h = 8;
+
+export function farewell(name) {
+  return 'bye ' + name;
+}
+`,
+      };
+
+      const newFile = {
+        name: 'greetings.ts',
+        contents: `export function greet(name) {
+  return \`hi \${name}!\`;
+}
+
+const a = 1;
+const b = 2;
+const c = 3;
+const d = 4;
+const e = 5;
+const f = 6;
+const g = 7;
+const h = 8;
+
+export function farewell(name) {
+  return \`bye \${name}!\`;
+}
+`,
+      };
+
+      let fileDiff = parseDiffFromFile(oldFile, newFile);
+
+      const instance = new FileDiff({
+        disableFileHeader: true,
+        theme: { dark: 'pierre-dark', light: 'pierre-light' },
+        themeType: 'dark',
+        diffStyle: 'split',
+      });
+
+      const renderDiff = () => {
+        instance.render({ fileDiff, containerWrapper: mount });
+        styleLabel.textContent = instance.options.diffStyle ?? 'split';
+      };
+
+      renderDiff();
+
+      // Wait until the shadow DOM has committed real diff rows before signalling
+      // readiness so tests never race the async highlighter's first paint.
+      const waitForRows = async () => {
+        const started = performance.now();
+        while (true) {
+          const host = mount.querySelector('diffs-container');
+          const row = host?.shadowRoot?.querySelector('[data-line-type]');
+          if (row != null) {
+            return;
+          }
+          if (performance.now() - started > 5000) {
+            throw new Error('Timed out waiting for diff rows.');
+          }
+          await new Promise((resolve) => requestAnimationFrame(resolve));
+        }
+      };
+
+      document
+        .querySelector('[data-toggle-style]')
+        .addEventListener('click', () => {
+          instance.setOptions({
+            ...instance.options,
+            diffStyle:
+              instance.options.diffStyle === 'split' ? 'unified' : 'split',
+          });
+          instance.rerender();
+          styleLabel.textContent = instance.options.diffStyle ?? 'split';
+        });
+
+      document
+        .querySelector('[data-reject-hunk]')
+        .addEventListener('click', () => {
+          fileDiff = diffAcceptRejectHunk(fileDiff, 0, 'reject');
+          renderDiff();
+        });
+
+      // Expose the instance for tests that need to assert on option state.
+      window.__diffFixture = {
+        instance,
+        get fileDiff() {
+          return fileDiff;
+        },
+      };
+
+      await waitForRows();
+      window.__diffReady = true;
+    </script>
+  </body>
+</html>

--- a/packages/diffs/test/e2e/fixtures/edit.html
+++ b/packages/diffs/test/e2e/fixtures/edit.html
@@ -21,6 +21,20 @@
     </style>
   </head>
   <body>
+    <a
+      data-fixtures-index
+      href="/test/e2e/fixtures/index.html"
+      style="
+        display: inline-block;
+        margin-bottom: 16px;
+        font-family: system-ui, sans-serif;
+        font-size: 14px;
+        font-weight: 600;
+        color: #0b62d6;
+        text-decoration: none;
+      "
+      >&larr; All fixtures</a
+    >
     <!--
       NOTE: clicking into the additions column to place the caret exercises a
       real cross-browser gap. The editor reads its selection through the shadow

--- a/packages/diffs/test/e2e/fixtures/edit.html
+++ b/packages/diffs/test/e2e/fixtures/edit.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>diffs edit-mode fixture</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 16px;
+        font-family: system-ui, sans-serif;
+      }
+      [data-diff-mount] {
+        max-width: 900px;
+      }
+      [data-editor-log] {
+        margin-top: 16px;
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <!--
+      NOTE: clicking into the additions column to place the caret exercises a
+      real cross-browser gap. The editor reads its selection through the shadow
+      root, and the pinned CI Chromium (and older browsers/WebViews) lack
+      Selection.getComposedRanges. That path now falls back to the older
+      ShadowRoot.getSelection() (see getShadowRootRange in src/editor/editor.ts),
+      so a plain click seeds the caret and typing works without a workaround.
+      edit.pw.ts intentionally clicks-then-types to guard this behavior.
+    -->
+    <div data-diff-mount></div>
+    <div data-editor-log></div>
+
+    <script type="module">
+      import { FileDiff } from '/dist/index.js';
+      import { Editor } from '/dist/editor/index.js';
+
+      const mount = document.querySelector('[data-diff-mount]');
+      const log = document.querySelector('[data-editor-log]');
+      if (!(mount instanceof HTMLElement) || !(log instanceof HTMLElement)) {
+        throw new Error('Missing edit fixture nodes.');
+      }
+
+      const oldFile = {
+        name: 'edit.ts',
+        contents: `const value = 1;
+const removed = 'old';
+export default value;
+`,
+      };
+
+      const newFile = {
+        name: 'edit.ts',
+        contents: `const value = 1;
+const added = 'new';
+export default value;
+`,
+      };
+
+      // Every onChange payload is recorded so tests can assert the editor emits
+      // the updated file contents rather than inspecting the DOM alone.
+      const events = [];
+      window.__editorEvents = events;
+
+      const editor = new Editor({
+        onChange(file) {
+          events.push(file.contents);
+          log.textContent = `changes: ${events.length}`;
+        },
+      });
+      window.__editor = editor;
+
+      const instance = new FileDiff({
+        disableFileHeader: true,
+        theme: { dark: 'pierre-dark', light: 'pierre-light' },
+        themeType: 'dark',
+        diffStyle: 'split',
+      });
+
+      instance.render({ oldFile, newFile, containerWrapper: mount });
+      editor.edit(instance);
+
+      const findAdditionsContent = () => {
+        const host = mount.querySelector('diffs-container');
+        const shadow = host?.shadowRoot;
+        if (shadow == null) {
+          return undefined;
+        }
+        for (const code of shadow.querySelectorAll('[data-code]')) {
+          if (code.dataset.deletions !== undefined) {
+            continue;
+          }
+          for (const child of code.children) {
+            if (child.dataset.content !== undefined) {
+              return child;
+            }
+          }
+        }
+        return undefined;
+      };
+
+      const waitForEditable = async () => {
+        const started = performance.now();
+        while (true) {
+          const content = findAdditionsContent();
+          if (
+            content != null &&
+            content.getAttribute('contenteditable') === 'true'
+          ) {
+            return;
+          }
+          if (performance.now() - started > 5000) {
+            throw new Error('Timed out waiting for editable additions column.');
+          }
+          await new Promise((resolve) => requestAnimationFrame(resolve));
+        }
+      };
+
+      await waitForEditable();
+      window.__editReady = true;
+    </script>
+  </body>
+</html>

--- a/packages/diffs/test/e2e/fixtures/editable.html
+++ b/packages/diffs/test/e2e/fixtures/editable.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>diffs editable-file fixture</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 16px;
+        font-family: system-ui, sans-serif;
+      }
+      [data-diff-mount] {
+        max-width: 900px;
+      }
+    </style>
+  </head>
+  <body>
+    <div data-diff-mount></div>
+
+    <script type="module">
+      import { File } from '/dist/index.js';
+      import { Editor } from '/dist/editor/index.js';
+
+      const mount = document.querySelector('[data-diff-mount]');
+      if (!(mount instanceof HTMLElement)) {
+        throw new Error('Missing editable fixture mount.');
+      }
+
+      const file = {
+        name: 'editable.ts',
+        contents: `const foo = 1;
+const bar = foo + foo;
+const baz = foo;
+`,
+      };
+
+      // Record every onChange so tests can assert the emitted file contents,
+      // which is more robust than scraping tokenized DOM text.
+      const events = [];
+      window.__editorEvents = events;
+
+      const editor = new Editor({
+        onChange(next) {
+          events.push(next.contents);
+        },
+      });
+      window.__editor = editor;
+
+      // Editable single-file surface: `useTokenTransformer` mirrors what the
+      // React <File contentEditable> path enables before attaching an editor.
+      const instance = new File({
+        disableFileHeader: true,
+        theme: { dark: 'pierre-dark', light: 'pierre-light' },
+        themeType: 'dark',
+        useTokenTransformer: true,
+      });
+      instance.render({ file, containerWrapper: mount });
+      editor.edit(instance);
+
+      const waitForEditable = async () => {
+        const started = performance.now();
+        while (true) {
+          const host = mount.querySelector('diffs-container');
+          const content = host?.shadowRoot?.querySelector('[data-content]');
+          if (content?.getAttribute('contenteditable') === 'true') {
+            return;
+          }
+          if (performance.now() - started > 5000) {
+            throw new Error('Timed out waiting for editable content.');
+          }
+          await new Promise((resolve) => requestAnimationFrame(resolve));
+        }
+      };
+
+      await waitForEditable();
+      window.__editableReady = true;
+    </script>
+  </body>
+</html>

--- a/packages/diffs/test/e2e/fixtures/editable.html
+++ b/packages/diffs/test/e2e/fixtures/editable.html
@@ -16,6 +16,20 @@
     </style>
   </head>
   <body>
+    <a
+      data-fixtures-index
+      href="/test/e2e/fixtures/index.html"
+      style="
+        display: inline-block;
+        margin-bottom: 16px;
+        font-family: system-ui, sans-serif;
+        font-size: 14px;
+        font-weight: 600;
+        color: #0b62d6;
+        text-decoration: none;
+      "
+      >&larr; All fixtures</a
+    >
     <div data-diff-mount></div>
 
     <script type="module">

--- a/packages/diffs/test/e2e/fixtures/file-states.html
+++ b/packages/diffs/test/e2e/fixtures/file-states.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>diffs file-states fixture</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 16px;
+        font-family: system-ui, sans-serif;
+      }
+      section {
+        max-width: 900px;
+        margin-bottom: 24px;
+      }
+    </style>
+  </head>
+  <body>
+    <section>
+      <h2>Added</h2>
+      <div data-added-mount></div>
+    </section>
+    <section>
+      <h2>Deleted</h2>
+      <div data-deleted-mount></div>
+    </section>
+
+    <script type="module">
+      import { FileDiff } from '/dist/index.js';
+
+      const addedMount = document.querySelector('[data-added-mount]');
+      const deletedMount = document.querySelector('[data-deleted-mount]');
+      if (
+        !(addedMount instanceof HTMLElement) ||
+        !(deletedMount instanceof HTMLElement)
+      ) {
+        throw new Error('Missing file-states fixture nodes.');
+      }
+
+      const theme = { dark: 'pierre-dark', light: 'pierre-light' };
+
+      const createdFile = {
+        name: 'created.ts',
+        contents: `export const created = true;
+export function hello() {
+  return 'world';
+}
+`,
+      };
+
+      const removedFile = {
+        name: 'removed.ts',
+        contents: `export const removed = true;
+export function goodbye() {
+  return 'world';
+}
+`,
+      };
+
+      // Added file: no old side. Deleted file: no new side. Both keys are
+      // required and the absent side must be explicit null.
+      const added = new FileDiff({
+        theme,
+        themeType: 'dark',
+        diffStyle: 'split',
+      });
+      added.render({
+        oldFile: null,
+        newFile: createdFile,
+        containerWrapper: addedMount,
+      });
+
+      const deleted = new FileDiff({
+        theme,
+        themeType: 'dark',
+        diffStyle: 'split',
+      });
+      deleted.render({
+        oldFile: removedFile,
+        newFile: null,
+        containerWrapper: deletedMount,
+      });
+
+      const waitForRows = async (mount) => {
+        const started = performance.now();
+        while (true) {
+          const host = mount.querySelector('diffs-container');
+          const row = host?.shadowRoot?.querySelector('[data-line-type]');
+          if (row != null) {
+            return;
+          }
+          if (performance.now() - started > 5000) {
+            throw new Error('Timed out waiting for diff rows.');
+          }
+          await new Promise((resolve) => requestAnimationFrame(resolve));
+        }
+      };
+
+      await Promise.all([waitForRows(addedMount), waitForRows(deletedMount)]);
+      window.__fileStatesReady = true;
+    </script>
+  </body>
+</html>

--- a/packages/diffs/test/e2e/fixtures/file-states.html
+++ b/packages/diffs/test/e2e/fixtures/file-states.html
@@ -17,6 +17,20 @@
     </style>
   </head>
   <body>
+    <a
+      data-fixtures-index
+      href="/test/e2e/fixtures/index.html"
+      style="
+        display: inline-block;
+        margin-bottom: 16px;
+        font-family: system-ui, sans-serif;
+        font-size: 14px;
+        font-weight: 600;
+        color: #0b62d6;
+        text-decoration: none;
+      "
+      >&larr; All fixtures</a
+    >
     <section>
       <h2>Added</h2>
       <div data-added-mount></div>

--- a/packages/diffs/test/e2e/fixtures/index.html
+++ b/packages/diffs/test/e2e/fixtures/index.html
@@ -1,0 +1,158 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>diffs E2E fixtures</title>
+    <style>
+      body {
+        margin: 0 auto;
+        padding: 32px 24px;
+        max-width: 720px;
+        font-family: system-ui, sans-serif;
+        line-height: 1.5;
+        color: #1a1a1a;
+      }
+      h1 {
+        font-size: 20px;
+      }
+      p {
+        color: #555;
+      }
+      ul {
+        list-style: none;
+        padding: 0;
+      }
+      li {
+        border: 1px solid #e0e0e0;
+        border-radius: 10px;
+        padding: 16px;
+        margin-bottom: 12px;
+      }
+      a {
+        font-size: 16px;
+        font-weight: 600;
+        text-decoration: none;
+        color: #0b62d6;
+      }
+      .desc {
+        margin: 6px 0 0;
+        font-size: 14px;
+      }
+      code {
+        font-family: ui-monospace, monospace;
+        background: #f2f2f2;
+        padding: 1px 5px;
+        border-radius: 4px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>@pierre/diffs — E2E fixtures</h1>
+    <p>
+      These are the standalone pages the Playwright suite drives against the
+      built <code>/dist</code>. Open one and interact with it exactly as a test
+      would. Each fixture sets a readiness flag on <code>window</code> once its
+      content has rendered.
+    </p>
+    <ul>
+      <li>
+        <a href="/test/e2e/fixtures/diff-render.html">diff-render.html</a>
+        <p class="desc">
+          A <code>FileDiff</code> (split view) with two changed regions and a
+          collapsed unchanged block. Buttons toggle split/unified and reject the
+          first hunk. Drives <code>diff-render.pw.ts</code> (rendering,
+          split/unified, expand context, accept/reject). Ready flag:
+          <code>window.__diffReady</code>.
+        </p>
+      </li>
+      <li>
+        <a href="/test/e2e/fixtures/edit.html">edit.html</a>
+        <p class="desc">
+          A <code>FileDiff</code> attached to the <code>Editor</code> (edit
+          mode). The additions column is editable; deletions are read-only.
+          Drives <code>edit.pw.ts</code> (typing, onChange, undo/redo). Ready
+          flag: <code>window.__editReady</code>; edits are logged to
+          <code>window.__editorEvents</code>.
+        </p>
+      </li>
+      <li>
+        <a href="/test/e2e/fixtures/conflict.html">conflict.html</a>
+        <p class="desc">
+          An <code>UnresolvedFile</code> with two merge conflicts. Clicking the
+          accept-current/incoming/both buttons resolves each conflict. Drives
+          <code>conflict.pw.ts</code>. Ready flag:
+          <code>window.__conflictReady</code>.
+        </p>
+      </li>
+      <li>
+        <a href="/test/e2e/fixtures/file-states.html">file-states.html</a>
+        <p class="desc">
+          An added file (<code>oldFile: null</code>) and a deleted file (<code
+            >newFile: null</code
+          >), showing additions-only and deletions-only rendering. Drives
+          <code>file-states.pw.ts</code>. Ready flag:
+          <code>window.__fileStatesReady</code>.
+        </p>
+      </li>
+      <li>
+        <a href="/test/e2e/fixtures/editable.html">editable.html</a>
+        <p class="desc">
+          A single editable <code>File</code> + <code>Editor</code>. Drives
+          <code>find-replace.pw.ts</code> (Cmd/Ctrl+F, Replace All),
+          <code>multi-edit.pw.ts</code> (multi-caret, Tab/Shift+Tab), and
+          <code>edit-rewrite.pw.ts</code> (select-all rewrite). Ready flag:
+          <code>window.__editableReady</code>.
+        </p>
+      </li>
+      <li>
+        <a href="/test/e2e/fixtures/markers.html">markers.html</a>
+        <p class="desc">
+          An editor with <code>setMarkers</code> squiggles (error/warning/info),
+          hover popups, and boundary containment. Drives
+          <code>markers.pw.ts</code>. Ready flag:
+          <code>window.__markersReady</code>.
+        </p>
+      </li>
+      <li>
+        <a href="/test/e2e/fixtures/line-select.html">line-select.html</a>
+        <p class="desc">
+          A read-only <code>File</code> with line selection and the gutter
+          utility button. Drives <code>line-select.pw.ts</code> (click/drag
+          selection, utility click). Ready flag:
+          <code>window.__lineSelectReady</code>.
+        </p>
+      </li>
+      <li>
+        <a href="/test/e2e/fixtures/annotations.html">annotations.html</a>
+        <p class="desc">
+          A <code>File</code> with a custom inline
+          <code>renderAnnotation</code> row anchored to a line. Drives
+          <code>annotations.pw.ts</code>. Ready flag:
+          <code>window.__annotationsReady</code>.
+        </p>
+      </li>
+      <li>
+        <a href="/test/e2e/fixtures/theme.html">theme.html</a>
+        <p class="desc">
+          An editor that toggles between the dark and light themes; verifies
+          token colors change and a selection survives the switch. Drives
+          <code>theme.pw.ts</code>. Ready flag:
+          <code>window.__themeReady</code>.
+        </p>
+      </li>
+      <li>
+        <a href="/test/e2e/fixtures/selection-action.html"
+          >selection-action.html</a
+        >
+        <p class="desc">
+          An editor with <code>enabledSelectionAction</code> and a custom
+          <code>renderSelectionAction</code> popover; verifies it appears on a
+          selection, stays in bounds, and reports the selected text. Drives
+          <code>selection-action.pw.ts</code>. Ready flag:
+          <code>window.__selectionActionReady</code>.
+        </p>
+      </li>
+    </ul>
+  </body>
+</html>

--- a/packages/diffs/test/e2e/fixtures/line-select.html
+++ b/packages/diffs/test/e2e/fixtures/line-select.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>diffs line-selection fixture</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 16px;
+        font-family: system-ui, sans-serif;
+      }
+      [data-diff-mount] {
+        max-width: 900px;
+      }
+    </style>
+  </head>
+  <body>
+    <div data-diff-mount></div>
+
+    <script type="module">
+      import { File } from '/dist/index.js';
+
+      const mount = document.querySelector('[data-diff-mount]');
+      if (!(mount instanceof HTMLElement)) {
+        throw new Error('Missing line-select fixture mount.');
+      }
+
+      const file = {
+        name: 'lines.ts',
+        contents: `const one = 1;
+const two = 2;
+const three = 3;
+const four = 4;
+const five = 5;
+const six = 6;
+`,
+      };
+
+      // Record interaction callbacks so tests can assert the exact line ranges
+      // the component reports, alongside the DOM state.
+      const lineNumberClicks = [];
+      const selectionChanges = [];
+      const gutterClicks = [];
+      window.__lineNumberClicks = lineNumberClicks;
+      window.__selectionChanges = selectionChanges;
+      window.__gutterClicks = gutterClicks;
+
+      const instance = new File({
+        disableFileHeader: true,
+        theme: { dark: 'pierre-dark', light: 'pierre-light' },
+        themeType: 'dark',
+        enableLineSelection: true,
+        enableGutterUtility: true,
+        onLineNumberClick(props) {
+          lineNumberClicks.push(props.lineNumber ?? props);
+        },
+        onLineSelectionChange(range) {
+          selectionChanges.push(range);
+        },
+        onGutterUtilityClick(range) {
+          gutterClicks.push(range);
+        },
+      });
+      instance.render({ file, containerWrapper: mount });
+
+      const waitForGutter = async () => {
+        const started = performance.now();
+        while (true) {
+          const host = mount.querySelector('diffs-container');
+          const row = host?.shadowRoot?.querySelector(
+            '[data-gutter] [data-column-number]'
+          );
+          if (row != null) {
+            return;
+          }
+          if (performance.now() - started > 5000) {
+            throw new Error('Timed out waiting for gutter rows.');
+          }
+          await new Promise((resolve) => requestAnimationFrame(resolve));
+        }
+      };
+
+      await waitForGutter();
+      window.__lineSelectReady = true;
+    </script>
+  </body>
+</html>

--- a/packages/diffs/test/e2e/fixtures/line-select.html
+++ b/packages/diffs/test/e2e/fixtures/line-select.html
@@ -16,6 +16,20 @@
     </style>
   </head>
   <body>
+    <a
+      data-fixtures-index
+      href="/test/e2e/fixtures/index.html"
+      style="
+        display: inline-block;
+        margin-bottom: 16px;
+        font-family: system-ui, sans-serif;
+        font-size: 14px;
+        font-weight: 600;
+        color: #0b62d6;
+        text-decoration: none;
+      "
+      >&larr; All fixtures</a
+    >
     <div data-diff-mount></div>
 
     <script type="module">

--- a/packages/diffs/test/e2e/fixtures/markers.html
+++ b/packages/diffs/test/e2e/fixtures/markers.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>diffs markers fixture</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 16px;
+        font-family: system-ui, sans-serif;
+      }
+      [data-diff-mount] {
+        max-width: 900px;
+      }
+    </style>
+  </head>
+  <body>
+    <div data-diff-mount></div>
+
+    <script type="module">
+      import { File } from '/dist/index.js';
+      import { Editor } from '/dist/editor/index.js';
+
+      const mount = document.querySelector('[data-diff-mount]');
+      if (!(mount instanceof HTMLElement)) {
+        throw new Error('Missing markers fixture mount.');
+      }
+
+      const file = {
+        name: 'markers.ts',
+        contents: `function total(items) {
+  const count = items.length;
+  return conut;
+}
+var label = 'x';
+`,
+      };
+
+      const editor = new Editor({});
+      window.__editor = editor;
+
+      const instance = new File({
+        disableFileHeader: true,
+        theme: { dark: 'pierre-dark', light: 'pierre-light' },
+        themeType: 'dark',
+        useTokenTransformer: true,
+      });
+      instance.render({ file, containerWrapper: mount });
+      editor.edit(instance);
+
+      // Ranges are 0-based line/character. One of each severity so the test can
+      // assert per-severity rendering.
+      const markers = [
+        {
+          severity: 'info',
+          message: 'count is never read',
+          start: { line: 1, character: 8 },
+          end: { line: 1, character: 13 },
+        },
+        {
+          severity: 'error',
+          message: 'Cannot find name conut',
+          start: { line: 2, character: 9 },
+          end: { line: 2, character: 14 },
+        },
+        {
+          severity: 'warning',
+          message: 'Unexpected var, use let or const',
+          start: { line: 4, character: 0 },
+          end: { line: 4, character: 3 },
+        },
+      ];
+
+      // setMarkers throws until the editor attaches to its surface (async), so
+      // retry each frame until it sticks and the squiggles are in the DOM.
+      const applyMarkers = async () => {
+        const started = performance.now();
+        while (true) {
+          try {
+            editor.setMarkers(markers);
+            const host = mount.querySelector('diffs-container');
+            const rendered = host?.shadowRoot?.querySelector(
+              '[data-marker-range]'
+            );
+            if (rendered != null) {
+              return;
+            }
+          } catch {
+            // editor not attached yet
+          }
+          if (performance.now() - started > 5000) {
+            throw new Error('Timed out waiting for markers.');
+          }
+          await new Promise((resolve) => requestAnimationFrame(resolve));
+        }
+      };
+
+      await applyMarkers();
+      window.__markersReady = true;
+    </script>
+  </body>
+</html>

--- a/packages/diffs/test/e2e/fixtures/markers.html
+++ b/packages/diffs/test/e2e/fixtures/markers.html
@@ -16,6 +16,20 @@
     </style>
   </head>
   <body>
+    <a
+      data-fixtures-index
+      href="/test/e2e/fixtures/index.html"
+      style="
+        display: inline-block;
+        margin-bottom: 16px;
+        font-family: system-ui, sans-serif;
+        font-size: 14px;
+        font-weight: 600;
+        color: #0b62d6;
+        text-decoration: none;
+      "
+      >&larr; All fixtures</a
+    >
     <div data-diff-mount></div>
 
     <script type="module">

--- a/packages/diffs/test/e2e/fixtures/selection-action.html
+++ b/packages/diffs/test/e2e/fixtures/selection-action.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>diffs selection-action fixture</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 16px;
+        font-family: system-ui, sans-serif;
+      }
+      [data-diff-mount] {
+        max-width: 900px;
+      }
+    </style>
+  </head>
+  <body>
+    <div data-diff-mount></div>
+
+    <script type="module">
+      import { File } from '/dist/index.js';
+      import { Editor } from '/dist/editor/index.js';
+
+      const mount = document.querySelector('[data-diff-mount]');
+      if (!(mount instanceof HTMLElement)) {
+        throw new Error('Missing selection-action fixture mount.');
+      }
+
+      const file = {
+        name: 'selection.ts',
+        contents: `const alpha = 'first';
+const beta = 'second';
+const gamma = 'third';
+`,
+      };
+
+      // Records the selected text captured when the custom action is clicked.
+      const actionClicks = [];
+      window.__actionClicks = actionClicks;
+
+      const editor = new Editor({
+        enabledSelectionAction: true,
+        renderSelectionAction({ getSelectionText, close }) {
+          const container = document.createElement('div');
+          container.dataset.testAction = '';
+          const button = document.createElement('button');
+          button.type = 'button';
+          button.dataset.testActionButton = '';
+          button.textContent = 'Capture';
+          // Prevent the mousedown from blurring the editor and collapsing the
+          // selection before the click handler reads it.
+          button.addEventListener('mousedown', (e) => e.preventDefault());
+          button.addEventListener('click', () => {
+            actionClicks.push(getSelectionText());
+            close();
+          });
+          container.appendChild(button);
+          return container;
+        },
+      });
+      window.__editor = editor;
+
+      const instance = new File({
+        disableFileHeader: true,
+        theme: { dark: 'pierre-dark', light: 'pierre-light' },
+        themeType: 'dark',
+        useTokenTransformer: true,
+      });
+      instance.render({ file, containerWrapper: mount });
+      editor.edit(instance);
+
+      const waitForEditable = async () => {
+        const started = performance.now();
+        while (true) {
+          const host = mount.querySelector('diffs-container');
+          const content = host?.shadowRoot?.querySelector('[data-content]');
+          if (content?.getAttribute('contenteditable') === 'true') {
+            return;
+          }
+          if (performance.now() - started > 5000) {
+            throw new Error('Timed out waiting for editable content.');
+          }
+          await new Promise((resolve) => requestAnimationFrame(resolve));
+        }
+      };
+
+      await waitForEditable();
+      window.__selectionActionReady = true;
+    </script>
+  </body>
+</html>

--- a/packages/diffs/test/e2e/fixtures/selection-action.html
+++ b/packages/diffs/test/e2e/fixtures/selection-action.html
@@ -16,6 +16,20 @@
     </style>
   </head>
   <body>
+    <a
+      data-fixtures-index
+      href="/test/e2e/fixtures/index.html"
+      style="
+        display: inline-block;
+        margin-bottom: 16px;
+        font-family: system-ui, sans-serif;
+        font-size: 14px;
+        font-weight: 600;
+        color: #0b62d6;
+        text-decoration: none;
+      "
+      >&larr; All fixtures</a
+    >
     <div data-diff-mount></div>
 
     <script type="module">

--- a/packages/diffs/test/e2e/fixtures/theme.html
+++ b/packages/diffs/test/e2e/fixtures/theme.html
@@ -16,6 +16,20 @@
     </style>
   </head>
   <body>
+    <a
+      data-fixtures-index
+      href="/test/e2e/fixtures/index.html"
+      style="
+        display: inline-block;
+        margin-bottom: 16px;
+        font-family: system-ui, sans-serif;
+        font-size: 14px;
+        font-weight: 600;
+        color: #0b62d6;
+        text-decoration: none;
+      "
+      >&larr; All fixtures</a
+    >
     <button type="button" data-toggle-theme>Toggle theme</button>
     <div data-diff-mount></div>
 

--- a/packages/diffs/test/e2e/fixtures/theme.html
+++ b/packages/diffs/test/e2e/fixtures/theme.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>diffs theme fixture</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 16px;
+        font-family: system-ui, sans-serif;
+      }
+      [data-diff-mount] {
+        max-width: 900px;
+      }
+    </style>
+  </head>
+  <body>
+    <button type="button" data-toggle-theme>Toggle theme</button>
+    <div data-diff-mount></div>
+
+    <script type="module">
+      import { File } from '/dist/index.js';
+      import { Editor } from '/dist/editor/index.js';
+
+      const mount = document.querySelector('[data-diff-mount]');
+      if (!(mount instanceof HTMLElement)) {
+        throw new Error('Missing theme fixture mount.');
+      }
+
+      const file = {
+        name: 'theme.ts',
+        contents: `const greeting = 'hello world';
+const count = 42;
+export { greeting, count };
+`,
+      };
+
+      const editor = new Editor({});
+      window.__editor = editor;
+
+      const instance = new File({
+        disableFileHeader: true,
+        theme: { dark: 'pierre-dark', light: 'pierre-light' },
+        themeType: 'dark',
+        useTokenTransformer: true,
+      });
+      instance.render({ file, containerWrapper: mount });
+      editor.edit(instance);
+
+      // Flip between the configured dark and light themes. setThemeType swaps
+      // the theme CSS in place without re-rendering the content, which is what
+      // lets an active selection survive the switch.
+      document
+        .querySelector('[data-toggle-theme]')
+        .addEventListener('click', () => {
+          const next = instance.options.themeType === 'dark' ? 'light' : 'dark';
+          instance.setThemeType(next);
+        });
+
+      const waitForEditable = async () => {
+        const started = performance.now();
+        while (true) {
+          const host = mount.querySelector('diffs-container');
+          const content = host?.shadowRoot?.querySelector('[data-content]');
+          if (content?.getAttribute('contenteditable') === 'true') {
+            return;
+          }
+          if (performance.now() - started > 5000) {
+            throw new Error('Timed out waiting for editable content.');
+          }
+          await new Promise((resolve) => requestAnimationFrame(resolve));
+        }
+      };
+
+      await waitForEditable();
+      window.__themeReady = true;
+    </script>
+  </body>
+</html>

--- a/packages/diffs/test/e2e/line-select.pw.ts
+++ b/packages/diffs/test/e2e/line-select.pw.ts
@@ -1,0 +1,76 @@
+import { expect, type Page, test } from '@playwright/test';
+
+const gutterRow = (lineNumber: number): string =>
+  `[data-gutter] [data-column-number="${lineNumber}"]`;
+
+async function openFixture(page: Page): Promise<void> {
+  await page.goto('/test/e2e/fixtures/line-select.html');
+  await page.waitForFunction(() => window.__lineSelectReady === true);
+}
+
+const selectionChanges = (page: Page): Promise<(E2ELineRange | null)[]> =>
+  page.evaluate(() => window.__selectionChanges ?? []);
+const gutterClicks = (page: Page): Promise<E2ELineRange[]> =>
+  page.evaluate(() => window.__gutterClicks ?? []);
+
+test.describe('line selection and gutter utility', () => {
+  test('clicking a gutter line number selects that line', async ({ page }) => {
+    await openFixture(page);
+
+    await page.locator(gutterRow(2)).click();
+
+    // A selected line marks both its gutter and content rows; scope to the
+    // gutter so the count is one per selected line, and confirm it is line 2.
+    await expect(
+      page.locator('[data-gutter] [data-selected-line]')
+    ).toHaveCount(1);
+    await expect(
+      page.locator(`[data-gutter] [data-column-number="2"][data-selected-line]`)
+    ).toHaveCount(1);
+  });
+
+  test('dragging down the gutter selects a range of lines', async ({
+    page,
+  }) => {
+    await openFixture(page);
+
+    const from = await page.locator(gutterRow(2)).boundingBox();
+    const to = await page.locator(gutterRow(4)).boundingBox();
+    if (from == null || to == null) {
+      throw new Error('missing gutter rows');
+    }
+
+    await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(to.x + to.width / 2, to.y + to.height / 2, {
+      steps: 5,
+    });
+    await page.mouse.up();
+
+    // Lines 2 through 4 end up selected (counted on the gutter side).
+    await expect(
+      page.locator('[data-gutter] [data-selected-line]')
+    ).toHaveCount(3);
+    await expect
+      .poll(() => selectionChanges(page))
+      .toContainEqual({ start: 2, end: 4 });
+  });
+
+  test('hovering a gutter row reveals a utility button that reports its line', async ({
+    page,
+  }) => {
+    await openFixture(page);
+
+    await page.locator(gutterRow(3)).hover();
+    const utility = page.locator('[data-utility-button]');
+    await expect(utility).toBeVisible();
+
+    await utility.click();
+    await expect
+      .poll(() => gutterClicks(page))
+      .toContainEqual({
+        start: 3,
+        end: 3,
+      });
+  });
+});

--- a/packages/diffs/test/e2e/markers.pw.ts
+++ b/packages/diffs/test/e2e/markers.pw.ts
@@ -1,0 +1,71 @@
+import { expect, type Page, test } from '@playwright/test';
+
+const RANGE = '[data-marker-range]';
+const CONTENT = '[data-content]';
+
+async function openFixture(page: Page): Promise<void> {
+  await page.goto('/test/e2e/fixtures/markers.html');
+  await page.waitForFunction(() => window.__markersReady === true);
+}
+
+// Returns true when every element matching `selector` is laid out inside the
+// editor's host element (with a 1px tolerance for sub-pixel rounding). Used to
+// prove marker squiggles and popups never render outside the editor boundary.
+function allWithinHost(page: Page, selector: string): Promise<boolean> {
+  return page.evaluate((sel) => {
+    const host = document.querySelector('diffs-container');
+    const root = host?.shadowRoot;
+    if (host == null || root == null) {
+      return false;
+    }
+    const hostRect = host.getBoundingClientRect();
+    const elements = [...root.querySelectorAll(sel)];
+    if (elements.length === 0) {
+      return false;
+    }
+    return elements.every((el) => {
+      const rect = el.getBoundingClientRect();
+      return (
+        rect.left >= hostRect.left - 1 &&
+        rect.top >= hostRect.top - 1 &&
+        rect.right <= hostRect.right + 1 &&
+        rect.bottom <= hostRect.bottom + 1
+      );
+    });
+  }, selector);
+}
+
+test.describe('editor markers', () => {
+  test('renders one squiggle per severity', async ({ page }) => {
+    await openFixture(page);
+
+    await expect(page.locator(RANGE)).toHaveCount(3);
+    await expect(page.locator('[data-marker-error]')).toHaveCount(1);
+    await expect(page.locator('[data-marker-warning]')).toHaveCount(1);
+    await expect(page.locator('[data-marker-info]')).toHaveCount(1);
+  });
+
+  test('hovering a squiggle shows its message popup', async ({ page }) => {
+    await openFixture(page);
+
+    // The popup is driven by a mouseover on the underlying text (hit-tested by
+    // line + char), not the overlay squiggle, which sits behind the content.
+    await page.locator(CONTENT).getByText('conut').hover();
+
+    const popup = page.locator('[data-marker-popup]');
+    await expect(popup).toBeVisible();
+    await expect(popup).toContainText('Cannot find name conut');
+  });
+
+  test('squiggles and popups stay within the editor bounds', async ({
+    page,
+  }) => {
+    await openFixture(page);
+
+    expect(await allWithinHost(page, RANGE)).toBe(true);
+
+    await page.locator(CONTENT).getByText('conut').hover();
+    await expect(page.locator('[data-marker-popup]')).toBeVisible();
+    expect(await allWithinHost(page, '[data-marker-popup]')).toBe(true);
+  });
+});

--- a/packages/diffs/test/e2e/multi-edit.pw.ts
+++ b/packages/diffs/test/e2e/multi-edit.pw.ts
@@ -1,0 +1,80 @@
+import { expect, type Page, test } from '@playwright/test';
+
+const CONTENT = '[data-content]';
+
+async function openFixture(page: Page): Promise<void> {
+  await page.goto('/test/e2e/fixtures/editable.html');
+  await page.waitForFunction(() => window.__editableReady === true);
+}
+
+const contents = (page: Page): Promise<string> =>
+  page.evaluate(() => window.__editor?.getState().file.contents ?? '');
+
+test.describe('multi-cursor and indentation', () => {
+  // Adding a caret with a modifier-click can't be simulated in the pinned
+  // headless Chromium: selectionchange fires before pointerdown there, so the
+  // editor can't reserve the prior caret before the new one lands. We instead
+  // seed two carets through the public setSelections API and drive real
+  // keyboard input, which exercises the multi-caret edit pipeline itself.
+  test('typing with multiple carets edits every caret', async ({ page }) => {
+    await openFixture(page);
+
+    await page.locator(CONTENT).click();
+    await page.evaluate(() => {
+      const editor = window.__editor;
+      if (editor == null) {
+        throw new Error('editor missing');
+      }
+      editor.focus();
+      editor.setSelections([
+        {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 0 },
+          direction: 'none',
+        },
+        {
+          start: { line: 2, character: 0 },
+          end: { line: 2, character: 0 },
+          direction: 'none',
+        },
+      ]);
+    });
+
+    await page.keyboard.type('Z');
+
+    // Both carets receive the keystroke, so two Z's are inserted.
+    await expect
+      .poll(async () => (await contents(page)).split('Z').length - 1)
+      .toBe(2);
+  });
+
+  test('Tab indents selected lines and Shift+Tab outdents them', async ({
+    page,
+  }) => {
+    await openFixture(page);
+    const original = await contents(page);
+
+    await page.locator(CONTENT).click();
+    await page.keyboard.press('ControlOrMeta+a');
+    await page.keyboard.press('Tab');
+
+    // Every non-empty line gains a leading indent unit (tab or spaces).
+    await expect
+      .poll(async () =>
+        (await contents(page))
+          .split('\n')
+          .filter((line) => line.length > 0)
+          .every((line) => /^(\t| {2,})/.test(line))
+      )
+      .toBe(true);
+
+    // Re-focus and re-select every line so the outdent applies to the whole
+    // file regardless of where the indent left the selection. The explicit click
+    // guarantees the content surface holds focus before the select-all, which
+    // otherwise races the async re-render under parallel worker pressure.
+    await page.locator(CONTENT).click();
+    await page.keyboard.press('ControlOrMeta+a');
+    await page.keyboard.press('Shift+Tab');
+    await expect.poll(() => contents(page)).toBe(original);
+  });
+});

--- a/packages/diffs/test/e2e/playwright.config.ts
+++ b/packages/diffs/test/e2e/playwright.config.ts
@@ -1,0 +1,51 @@
+import {
+  defineConfig,
+  devices,
+  type PlaywrightTestConfig,
+} from '@playwright/test';
+
+import { loadWorktreeEnv } from '../../../../scripts/load-worktree-env.mjs';
+
+// Pull `PIERRE_PORT_OFFSET` from `.env.worktree` when Playwright is launched
+// outside a moon task (e.g. `pnpm exec playwright test` from the package root).
+loadWorktreeEnv();
+
+const portOffset = Number(process.env.PIERRE_PORT_OFFSET ?? 0);
+const e2ePort = 4175 + portOffset;
+const e2eBaseUrl = `http://127.0.0.1:${e2ePort}`;
+const e2eOutputDir = `/tmp/pierre-diffs-playwright-results${portOffset > 0 ? `-${portOffset}` : ''}`;
+
+const config: PlaywrightTestConfig = defineConfig({
+  testDir: '.',
+  testMatch: ['**/*.pw.ts'],
+  outputDir: e2eOutputDir,
+  fullyParallel: true,
+  reporter: 'list',
+  timeout: 30_000,
+  // A single retry in CI absorbs the rare highlighter/tokenizer warm-up race
+  // when the first paint lands a frame late under parallel worker pressure.
+  // Local runs keep retries off so flakes stay visible during development.
+  retries: process.env.CI ? 1 : 0,
+  expect: {
+    timeout: 5_000,
+  },
+  use: {
+    baseURL: e2eBaseUrl,
+    headless: true,
+    viewport: { width: 1200, height: 800 },
+  },
+  webServer: {
+    command: `DIFFS_E2E_PORT=${e2ePort} moon run diffs:test-e2e-server`,
+    url: `${e2eBaseUrl}/test/e2e/fixtures/diff-render.html`,
+    reuseExistingServer: false,
+    timeout: 60_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});
+
+export default config;

--- a/packages/diffs/test/e2e/selection-action.pw.ts
+++ b/packages/diffs/test/e2e/selection-action.pw.ts
@@ -1,0 +1,69 @@
+import { expect, type Page, test } from '@playwright/test';
+
+const CONTENT = '[data-content]';
+const POPOVER = '[data-selection-action-popover]';
+
+async function openFixture(page: Page): Promise<void> {
+  await page.goto('/test/e2e/fixtures/selection-action.html');
+  await page.waitForFunction(() => window.__selectionActionReady === true);
+}
+
+const actionClicks = (page: Page): Promise<string[]> =>
+  page.evaluate(() => window.__actionClicks ?? []);
+
+function popoverWithinHost(page: Page): Promise<boolean> {
+  return page.evaluate((sel) => {
+    const host = document.querySelector('diffs-container');
+    const root = host?.shadowRoot;
+    const popover = root?.querySelector(sel);
+    if (host == null || popover == null) {
+      return false;
+    }
+    const hostRect = host.getBoundingClientRect();
+    const rect = popover.getBoundingClientRect();
+    return (
+      rect.left >= hostRect.left - 1 &&
+      rect.top >= hostRect.top - 1 &&
+      rect.right <= hostRect.right + 1 &&
+      rect.bottom <= hostRect.bottom + 1
+    );
+  }, POPOVER);
+}
+
+// Double-click a word to make a real, mouse-driven ranged selection. The
+// popover is (re)created on pointerup for enabledSelectionAction, so a mouse
+// gesture is what surfaces it.
+async function selectWord(page: Page): Promise<void> {
+  await page.locator(CONTENT).getByText('alpha').dblclick();
+}
+
+test.describe('selection action popover', () => {
+  test('appears with custom content on a ranged selection', async ({
+    page,
+  }) => {
+    await openFixture(page);
+    await selectWord(page);
+
+    const popover = page.locator(POPOVER);
+    await expect(popover).toBeVisible();
+    await expect(popover.locator('[data-test-action-button]')).toBeVisible();
+  });
+
+  test('stays within the editor bounds', async ({ page }) => {
+    await openFixture(page);
+    await selectWord(page);
+
+    await expect(page.locator(POPOVER)).toBeVisible();
+    expect(await popoverWithinHost(page)).toBe(true);
+  });
+
+  test('clicking the action receives the selected text', async ({ page }) => {
+    await openFixture(page);
+    await selectWord(page);
+
+    await expect(page.locator(POPOVER)).toBeVisible();
+    await page.locator('[data-test-action-button]').click();
+
+    await expect.poll(() => actionClicks(page)).toEqual(['alpha']);
+  });
+});

--- a/packages/diffs/test/e2e/theme.pw.ts
+++ b/packages/diffs/test/e2e/theme.pw.ts
@@ -1,0 +1,54 @@
+import { expect, type Page, test } from '@playwright/test';
+
+const CONTENT = '[data-content]';
+
+async function openFixture(page: Page): Promise<void> {
+  await page.goto('/test/e2e/fixtures/theme.html');
+  await page.waitForFunction(() => window.__themeReady === true);
+}
+
+const selections = (page: Page): Promise<E2ESelection[] | undefined> =>
+  page.evaluate(() => window.__editor?.getState().selections);
+
+// Reads the rendered text color of the first content token, which differs
+// between the dark and light themes.
+const tokenColor = (page: Page): Promise<string> =>
+  page.evaluate(() => {
+    const root = document.querySelector('diffs-container')?.shadowRoot;
+    const token = root?.querySelector('[data-content] [data-char]');
+    return token != null ? getComputedStyle(token).color : '';
+  });
+
+test.describe('theme switching', () => {
+  test('toggling the theme changes the rendered token colors', async ({
+    page,
+  }) => {
+    await openFixture(page);
+
+    const darkColor = await tokenColor(page);
+    await page.locator('[data-toggle-theme]').click();
+
+    await expect.poll(() => tokenColor(page)).not.toBe(darkColor);
+  });
+
+  test('a text selection is preserved across a theme switch', async ({
+    page,
+  }) => {
+    await openFixture(page);
+
+    // Build a real selection with the keyboard, then capture it.
+    await page.locator(CONTENT).click();
+    await page.keyboard.press('ControlOrMeta+ArrowLeft');
+    for (let i = 0; i < 5; i++) {
+      await page.keyboard.press('Shift+ArrowRight');
+    }
+    const before = await selections(page);
+    expect(before?.[0]).toBeDefined();
+    expect(before?.[0]?.start).not.toEqual(before?.[0]?.end);
+
+    await page.locator('[data-toggle-theme]').click();
+
+    // The selection must not move when only the theme changes.
+    await expect.poll(() => selections(page)).toEqual(before);
+  });
+});

--- a/packages/diffs/test/e2e/vite.config.ts
+++ b/packages/diffs/test/e2e/vite.config.ts
@@ -1,15 +1,36 @@
 import { resolve } from 'node:path';
-import { defineConfig, type UserConfig } from 'vite';
+import { defineConfig, type Plugin, type UserConfig } from 'vite';
 
 const defaultPort = 4175;
 const portFromEnv = Number(process.env.DIFFS_E2E_PORT);
 const port = Number.isFinite(portFromEnv) ? portFromEnv : defaultPort;
+
+const fixturesIndexPath = '/test/e2e/fixtures/index.html';
+
+// Vite's startup banner only prints the server root, but the useful entry point
+// is the fixture index that links to every fixture page. Append its full URL to
+// the printed URLs so `moon run diffs:test-e2e-server` surfaces it directly.
+function logFixturesIndex(): Plugin {
+  return {
+    name: 'diffs-e2e-fixtures-index-url',
+    configureServer(server) {
+      const printUrls = server.printUrls.bind(server);
+      server.printUrls = () => {
+        printUrls();
+        console.log(
+          `  \x1b[32m➜\x1b[0m  \x1b[1mFixtures:\x1b[0m http://127.0.0.1:${port}${fixturesIndexPath}`
+        );
+      };
+    },
+  };
+}
 
 // Serve the package root so fixtures can import the built library directly via
 // `/dist/index.js` and `/dist/editor/index.js`. Vite resolves the bundle's bare
 // dependency imports (shiki, etc.) from node_modules on the fly.
 const config: UserConfig = defineConfig({
   root: resolve(import.meta.dirname, '..', '..'),
+  plugins: [logFixturesIndex()],
   server: {
     host: '127.0.0.1',
     port,

--- a/packages/diffs/test/e2e/vite.config.ts
+++ b/packages/diffs/test/e2e/vite.config.ts
@@ -1,0 +1,20 @@
+import { resolve } from 'node:path';
+import { defineConfig, type UserConfig } from 'vite';
+
+const defaultPort = 4175;
+const portFromEnv = Number(process.env.DIFFS_E2E_PORT);
+const port = Number.isFinite(portFromEnv) ? portFromEnv : defaultPort;
+
+// Serve the package root so fixtures can import the built library directly via
+// `/dist/index.js` and `/dist/editor/index.js`. Vite resolves the bundle's bare
+// dependency imports (shiki, etc.) from node_modules on the fly.
+const config: UserConfig = defineConfig({
+  root: resolve(import.meta.dirname, '..', '..'),
+  server: {
+    host: '127.0.0.1',
+    port,
+    strictPort: true,
+  },
+});
+
+export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -611,6 +611,9 @@ importers:
       '@arethetypeswrong/core':
         specifier: 'catalog:'
         version: 0.18.2
+      '@playwright/test':
+        specifier: 'catalog:'
+        version: 1.51.1
       '@tsdown/css':
         specifier: 'catalog:'
         version: 0.22.3(jiti@2.7.0)(postcss-import@16.1.1(postcss@8.5.6))(postcss@8.5.6)(tsdown@0.22.3)(yaml@2.9.0)
@@ -656,6 +659,9 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.1.0(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0)
 
   packages/path-store:
     devDependencies:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -189,6 +189,7 @@ Each of our dev/test services has a **base port**:
 | `apps/docs` diffshub dev/prod | 3692      |
 | `apps/docs` E2E               | 4174      |
 | `packages/trees` E2E          | 4173      |
+| `packages/diffs` E2E          | 4175      |
 | `packages/path-store` E2E     | 4176      |
 | Chrome remote debug           | 9222      |
 

--- a/scripts/wt.ts
+++ b/scripts/wt.ts
@@ -37,6 +37,7 @@ const PORT_BASES = {
   docsDiffshub: 3692,
   docsE2E: 4174,
   treesE2E: 4173,
+  diffsE2E: 4175,
   pathStoreE2E: 4176,
   chrome: 9222,
 } as const;
@@ -366,6 +367,7 @@ function cmdPs(): number {
     ['docsDiffshub', 'diffshub'],
     ['docsE2E', 'docsE2E'],
     ['treesE2E', 'treesE2E'],
+    ['diffsE2E', 'diffsE2E'],
     ['pathStoreE2E', 'psE2E'],
     ['chrome', 'chrome'],
   ];
@@ -634,6 +636,7 @@ Worktree: ${slug} (offset ${offset})
   trees dev:    http://localhost:${ports.docsTrees}
   docs E2E:     http://localhost:${ports.docsE2E}
   trees E2E:    http://localhost:${ports.treesE2E}
+  diffs E2E:    http://localhost:${ports.diffsE2E}
   path-store:   http://localhost:${ports.pathStoreE2E}
   chrome debug: localhost:${ports.chrome} (user-data-dir /tmp/chrome-devtools-${slug})
 


### PR DESCRIPTION
## Add browser E2E tests for diffs & edit mode

Adds a Playwright E2E suite for `@pierre/diffs`, covering behavior the jsdom
unit tests can't reach: shadow-DOM rendering and real `contentEditable` editing.
Mirrors the existing `trees` E2E setup — a Vite server serves the built `dist`
and Playwright drives real Chromium against static HTML fixtures.

### Coverage
- **Diff rendering**: split/unified toggle, hunk expansion, accept/reject
- **Edit mode**: typing, `onChange`, undo/redo, additions-editable vs
  deletions-read-only, full-file rewrite
- **Find & replace**, **multi-cursor + indent/outdent**, **markers** (hover +
  bounds), **line selection + gutter utility**, **annotations**,
  **theme switching** (selection-stable), **selection actions** (in-bounds)
- **Merge conflicts** and **added/deleted file states**

### Notable fix
- Editor now falls back to `ShadowRoot.getSelection()` when
  `Selection.getComposedRanges` is unavailable (older browsers, WebViews, and
  the pinned CI Chromium), so a click reliably seeds the caret and typing works.

### Infra
- `diffs:test-e2e` + `diffs:test-e2e-server` moon tasks; `diffs:test-e2e` wired
  into CI
- Reserves worktree port `4175` (`scripts/wt.ts`, `scripts/README.md`)
- Shared `test/e2e/e2e-globals.d.ts` for fixture `window` globals

## Running the tests

Run the full suite: `moon run diffs:test-e2e`

View the fixtures in your own browser — start the server and open the index:

- `moon run diffs:test-e2e-server`
- Open http://127.0.0.1:4175/test/e2e/fixtures/

The index page lists every fixture with a description, its ready-flag, and the
spec that drives it.