### PR TITLE
[diffs/editor] Fix diff re-render bug in edit mode

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -2225,14 +2225,9 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         this.#fileContainer?.shadowRoot?.appendChild(virtualCaret);
         virtualCaret.scrollIntoView({ block: 'center', inline: 'nearest' });
 
-        if (this.#scrollingToLine === line && yFix === 0) {
-          this.#scrollingToLine = undefined;
-          this.#scrollingToLineChar = undefined;
-          this.#scrollingToLineFixed = false;
-          this.#scrollingToLineNoFocus = false;
-        } else if (
+        if (
           this.#scrollingToLine === line &&
-          this.#scrollingToLineFixed
+          (yFix === 0 || this.#scrollingToLineFixed)
         ) {
           this.#scrollingToLine = undefined;
           this.#scrollingToLineChar = undefined;

--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -1215,10 +1215,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
               pendingSplitContext.side != null &&
               pendingSplitContext.side !== missingSide
             ) {
-              // NOTE(amadeus): If we see this error, we might need to bring back: flushSplitSpan();
-              throw new Error(
-                'DiffHunksRenderer.processDiffResult: iterateOverDiff, invalid pending splits'
-              );
+              pendingSplitContext.flush();
             }
             pendingSplitContext.side = missingSide;
             pendingSplitContext.increment();

--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -434,13 +434,16 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
     if (documentText.trim().length === 0) {
       // Blank documents need the editor's logical line count: `"\n"` is two
       // editable rows even though the diff parser sees one newline token.
-      const lines: string[] = [];
-      for (let line = 0; line < textDocument.lineCount; line++) {
-        lines.push(textDocument.getLineText(line, true));
-      }
-      diff.additionLines = lines;
+      diff.additionLines = getEditorDocumentLines(textDocument);
     } else {
-      diff.additionLines = splitFileContents(documentText);
+      const parsedLines = splitFileContents(documentText);
+      // A non-empty document ending in a line break has a final logical empty
+      // line in the editor. Patch-style splitting drops that row, but edit mode
+      // still needs it as a caret host after pressing Enter.
+      diff.additionLines =
+        parsedLines.length < textDocument.lineCount
+          ? getEditorDocumentLines(textDocument)
+          : parsedLines;
     }
 
     const newLength = diff.additionLines.length;
@@ -2004,6 +2007,14 @@ function createPlainAdditionLineElement(
       },
     ],
   };
+}
+
+function getEditorDocumentLines(textDocument: DiffsTextDocument): string[] {
+  const lines: string[] = [];
+  for (let line = 0; line < textDocument.lineCount; line++) {
+    lines.push(textDocument.getLineText(line, true));
+  }
+  return lines;
 }
 
 // Host line text omits line endings; diff line arrays keep the suffix from parsing.

--- a/packages/diffs/src/utils/updateDiffHunks.ts
+++ b/packages/diffs/src/utils/updateDiffHunks.ts
@@ -87,13 +87,8 @@ export function shouldTopAlignAdditionRecompute(
   return (
     additionLines.length > 0 &&
     additionLines.length < diff.deletionLines.length &&
-    (hasOnlyBlankAdditionContents(additionLines) ||
-      hasTrailingEditorBlankLine(additionLines))
+    hasOnlyBlankAdditionContents(additionLines)
   );
-}
-
-function hasTrailingEditorBlankLine(additionLines: string[]): boolean {
-  return additionLines.length > 1 && additionLines.at(-1) === '';
 }
 
 // Rebuilds hunk metadata while keeping the editable addition rows top-aligned in
@@ -159,7 +154,55 @@ export function recomputeDiffHunksForEdit(
       parseDiffOptions
     );
   }
-  return recomputeDiffHunks(diff, parseDiffOptions);
+  const additionLines = diff.additionLines;
+  const recomputed = recomputeDiffHunks(diff, parseDiffOptions);
+  if (
+    additionLines.length > recomputed.additionLines.length &&
+    hasTrailingEditorBlankLine(additionLines)
+  ) {
+    preserveTrailingEditorBlankLine(recomputed, additionLines);
+  }
+  return recomputed;
+}
+
+function hasTrailingEditorBlankLine(additionLines: string[]): boolean {
+  return additionLines.length > 1 && additionLines.at(-1) === '';
+}
+
+function preserveTrailingEditorBlankLine(
+  recomputed: FullDiffHunkUpdate,
+  additionLines: string[]
+): void {
+  const extraLineCount = additionLines.length - recomputed.additionLines.length;
+  if (extraLineCount <= 0) {
+    return;
+  }
+  const extraAdditionLineIndex = recomputed.additionLines.length;
+  recomputed.additionLines = additionLines;
+
+  const lastHunk = recomputed.hunks.at(-1);
+  if (lastHunk == null) {
+    recomputeDiffRenderLineCounts(recomputed);
+    return;
+  }
+
+  const lastHunkAdditionEnd =
+    lastHunk.additionLineIndex + lastHunk.additionCount;
+  if (lastHunkAdditionEnd !== extraAdditionLineIndex) {
+    recomputeDiffRenderLineCounts(recomputed);
+    return;
+  }
+
+  lastHunk.hunkContent.push({
+    type: 'change',
+    additions: extraLineCount,
+    deletions: 0,
+    additionLineIndex: extraAdditionLineIndex,
+    deletionLineIndex: lastHunk.deletionLineIndex + lastHunk.deletionCount,
+  });
+  lastHunk.additionCount += extraLineCount;
+  lastHunk.additionLines += extraLineCount;
+  recomputeDiffRenderLineCounts(recomputed);
 }
 
 /** Updates hunk metadata after addition lines change; re-parses affected hunks only. */
@@ -403,7 +446,9 @@ function recomputeHunkRenderLineCounts(hunk: Hunk): void {
   hunk.unifiedLineCount = unifiedLineCount;
 }
 
-function recomputeDiffRenderLineCounts(diff: FileDiffMetadata): void {
+function recomputeDiffRenderLineCounts(
+  diff: HunkMetadataUpdate & Pick<FileDiffMetadata, 'additionLines'>
+): void {
   let splitTotal = 0;
   let unifiedTotal = 0;
   let lastHunkAdditionEnd = 0;

--- a/packages/diffs/src/utils/updateDiffHunks.ts
+++ b/packages/diffs/src/utils/updateDiffHunks.ts
@@ -87,8 +87,13 @@ export function shouldTopAlignAdditionRecompute(
   return (
     additionLines.length > 0 &&
     additionLines.length < diff.deletionLines.length &&
-    hasOnlyBlankAdditionContents(additionLines)
+    (hasOnlyBlankAdditionContents(additionLines) ||
+      hasTrailingEditorBlankLine(additionLines))
   );
+}
+
+function hasTrailingEditorBlankLine(additionLines: string[]): boolean {
+  return additionLines.length > 1 && additionLines.at(-1) === '';
 }
 
 // Rebuilds hunk metadata while keeping the editable addition rows top-aligned in

--- a/packages/diffs/src/utils/updateDiffHunks.ts
+++ b/packages/diffs/src/utils/updateDiffHunks.ts
@@ -196,9 +196,8 @@ function preserveTrailingEditorBlankLine(
   for (const content of lastHunk.hunkContent) {
     if (
       content.type === 'change' &&
-      content.additions === 0 &&
-      content.deletions > 0 &&
-      content.additionLineIndex === extraAdditionLineIndex
+      content.additions < content.deletions &&
+      content.additionLineIndex + content.additions === extraAdditionLineIndex
     ) {
       content.additions += extraLineCount;
       lastHunk.additionCount += extraLineCount;

--- a/packages/diffs/src/utils/updateDiffHunks.ts
+++ b/packages/diffs/src/utils/updateDiffHunks.ts
@@ -193,6 +193,21 @@ function preserveTrailingEditorBlankLine(
     return;
   }
 
+  for (const content of lastHunk.hunkContent) {
+    if (
+      content.type === 'change' &&
+      content.additions === 0 &&
+      content.deletions > 0 &&
+      content.additionLineIndex === extraAdditionLineIndex
+    ) {
+      content.additions += extraLineCount;
+      lastHunk.additionCount += extraLineCount;
+      lastHunk.additionLines += extraLineCount;
+      recomputeDiffRenderLineCounts(recomputed);
+      return;
+    }
+  }
+
   lastHunk.hunkContent.push({
     type: 'change',
     additions: extraLineCount,

--- a/packages/diffs/src/utils/updateDiffHunks.ts
+++ b/packages/diffs/src/utils/updateDiffHunks.ts
@@ -178,18 +178,15 @@ function preserveTrailingEditorBlankLine(
     return;
   }
   const extraAdditionLineIndex = recomputed.additionLines.length;
-  recomputed.additionLines = additionLines;
 
   const lastHunk = recomputed.hunks.at(-1);
   if (lastHunk == null) {
-    recomputeDiffRenderLineCounts(recomputed);
     return;
   }
 
   const lastHunkAdditionEnd =
     lastHunk.additionLineIndex + lastHunk.additionCount;
   if (lastHunkAdditionEnd !== extraAdditionLineIndex) {
-    recomputeDiffRenderLineCounts(recomputed);
     return;
   }
 
@@ -199,6 +196,7 @@ function preserveTrailingEditorBlankLine(
       content.additions < content.deletions &&
       content.additionLineIndex + content.additions === extraAdditionLineIndex
     ) {
+      recomputed.additionLines = additionLines;
       content.additions += extraLineCount;
       lastHunk.additionCount += extraLineCount;
       lastHunk.additionLines += extraLineCount;
@@ -206,17 +204,6 @@ function preserveTrailingEditorBlankLine(
       return;
     }
   }
-
-  lastHunk.hunkContent.push({
-    type: 'change',
-    additions: extraLineCount,
-    deletions: 0,
-    additionLineIndex: extraAdditionLineIndex,
-    deletionLineIndex: lastHunk.deletionLineIndex + lastHunk.deletionCount,
-  });
-  lastHunk.additionCount += extraLineCount;
-  lastHunk.additionLines += extraLineCount;
-  recomputeDiffRenderLineCounts(recomputed);
 }
 
 /** Updates hunk metadata after addition lines change; re-parses affected hunks only. */

--- a/packages/diffs/test/editorDiffEmptyDocument.test.ts
+++ b/packages/diffs/test/editorDiffEmptyDocument.test.ts
@@ -248,6 +248,89 @@ describe('diff editor: select-all then delete', () => {
         await fixture.cleanup();
       }
     });
+
+    test(`keeps the trailing blank line and caret after typing text then Enter (${diffStyle})`, async () => {
+      const oldContents =
+        Array.from({ length: 8 }, (_, index) => `old ${index + 1}`).join('\n') +
+        '\n';
+      const newContents = [
+        'old 1\n',
+        'old 2\n',
+        'old 3 changed\n',
+        'old 4\n',
+        'inserted\n',
+        'old 5\n',
+        'old 6\n',
+        'old 7\n',
+        'old 8\n',
+        'appended\n',
+      ].join('');
+      const fixture = await createDiffEditorFixture(
+        diffStyle,
+        oldContents,
+        newContents
+      );
+      const { editor, container } = fixture;
+
+      try {
+        replaceAll(editor, '');
+        await wait(0);
+        expect(editor.getState().file.contents).toBe('');
+
+        editor.setSelections([
+          {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+            direction: 'none',
+          },
+        ]);
+        editor.applyEdits(
+          [
+            {
+              range: {
+                start: { line: 0, character: 0 },
+                end: { line: 0, character: 0 },
+              },
+              newText: 'a',
+            },
+          ],
+          true
+        );
+        await wait(0);
+
+        const content = findAdditionContent(container);
+        expect(content).toBeDefined();
+        if (content == null) return;
+        dispatchBeforeInput(content, 'insertLineBreak');
+
+        for (let attempt = 0; attempt < 40; attempt++) {
+          const hasLine2 = [...content.children].some(
+            (child) => (child as HTMLElement).dataset.line === '2'
+          );
+          const hasCaret =
+            container.shadowRoot?.querySelector('[data-caret]') != null;
+          if (hasLine2 && hasCaret) {
+            break;
+          }
+          await wait(10);
+        }
+
+        expect(editor.getState().file.contents).toBe('a\n');
+        const freshContent = findAdditionContent(container);
+        expect(freshContent).toBeDefined();
+        if (freshContent == null) return;
+        expect(
+          [...freshContent.children].some(
+            (child) => (child as HTMLElement).dataset.line === '2'
+          )
+        ).toBe(true);
+        expect(
+          container.shadowRoot?.querySelector('[data-caret]') != null
+        ).toBe(true);
+      } finally {
+        await fixture.cleanup();
+      }
+    });
   }
 });
 

--- a/packages/diffs/test/updateDiffHunks.test.ts
+++ b/packages/diffs/test/updateDiffHunks.test.ts
@@ -345,6 +345,58 @@ describe('updateDiffHunks', () => {
     ]);
   });
 
+  test('top-aligns an editor-only trailing blank line after replacing a longer file', () => {
+    const oldContents = ['old 1', 'old 2', 'old 3', 'old 4', ''].join('\n');
+    const diff = parseDiffFromFile(
+      { name: 'example.ts', contents: oldContents },
+      { name: 'example.ts', contents: 'a\n' },
+      { context: 3 }
+    );
+
+    // Mirrors select-all, type "a", then press Enter: the editor has a second
+    // logical row for the trailing blank line before tokenization sees content
+    // on that row.
+    diff.additionLines = ['a\n', ''];
+
+    const recomputed = recomputeDiffHunksForEdit(diff, { context: 3 });
+
+    expect(recomputed.additionLines).toEqual(['a\n', '']);
+    expect(recomputed.splitLineCount).toBe(4);
+    expect(recomputed.unifiedLineCount).toBe(6);
+    expect(recomputed.hunks[0]?.hunkContent).toEqual([
+      {
+        type: 'change',
+        additions: 2,
+        deletions: 4,
+        additionLineIndex: 0,
+        deletionLineIndex: 0,
+      },
+    ]);
+
+    Object.assign(diff, recomputed);
+    const splitRows: Array<{
+      deletionLineIndex: number | undefined;
+      additionLineIndex: number | undefined;
+    }> = [];
+    iterateOverDiff({
+      diff,
+      diffStyle: 'split',
+      callback(row) {
+        splitRows.push({
+          deletionLineIndex: row.deletionLine?.lineIndex,
+          additionLineIndex: row.additionLine?.lineIndex,
+        });
+      },
+    });
+
+    expect(splitRows).toEqual([
+      { deletionLineIndex: 0, additionLineIndex: 0 },
+      { deletionLineIndex: 1, additionLineIndex: 1 },
+      { deletionLineIndex: 2, additionLineIndex: undefined },
+      { deletionLineIndex: 3, additionLineIndex: undefined },
+    ]);
+  });
+
   test('translates reparsed hunk coordinates when context lines become changes', () => {
     const oldContents = [
       'ctx01',

--- a/packages/diffs/test/updateDiffHunks.test.ts
+++ b/packages/diffs/test/updateDiffHunks.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import type { FileDiffMetadata, Hunk } from '../src/types';
 import { cleanLastNewline } from '../src/utils/cleanLastNewline';
+import { iterateOverDiff } from '../src/utils/iterateOverDiff';
 import { parseDiffFromFile } from '../src/utils/parseDiffFromFile';
 import {
   recomputeDiffHunks,
@@ -296,7 +297,7 @@ describe('updateDiffHunks', () => {
     const recomputed = recomputeDiffHunksForEdit(diff, { context: 3 });
 
     expect(recomputed.additionLines).toEqual(['kept\n', '']);
-    expect(recomputed.splitLineCount).toBe(4);
+    expect(recomputed.splitLineCount).toBe(3);
     expect(recomputed.unifiedLineCount).toBe(4);
     expect(recomputed.hunks[0]?.hunkContent).toEqual([
       {
@@ -314,18 +315,33 @@ describe('updateDiffHunks', () => {
       },
       {
         type: 'change',
-        additions: 0,
+        additions: 1,
         deletions: 1,
         additionLineIndex: 1,
         deletionLineIndex: 2,
       },
-      {
-        type: 'change',
-        additions: 1,
-        deletions: 0,
-        additionLineIndex: 1,
-        deletionLineIndex: 3,
+    ]);
+
+    Object.assign(diff, recomputed);
+    const splitRows: Array<{
+      deletionLineIndex: number | undefined;
+      additionLineIndex: number | undefined;
+    }> = [];
+    iterateOverDiff({
+      diff,
+      diffStyle: 'split',
+      callback(row) {
+        splitRows.push({
+          deletionLineIndex: row.deletionLine?.lineIndex,
+          additionLineIndex: row.additionLine?.lineIndex,
+        });
       },
+    });
+
+    expect(splitRows).toEqual([
+      { deletionLineIndex: 0, additionLineIndex: undefined },
+      { deletionLineIndex: 1, additionLineIndex: 0 },
+      { deletionLineIndex: 2, additionLineIndex: 1 },
     ]);
   });
 

--- a/packages/diffs/test/updateDiffHunks.test.ts
+++ b/packages/diffs/test/updateDiffHunks.test.ts
@@ -5,6 +5,7 @@ import { cleanLastNewline } from '../src/utils/cleanLastNewline';
 import { parseDiffFromFile } from '../src/utils/parseDiffFromFile';
 import {
   recomputeDiffHunks,
+  recomputeDiffHunksForEdit,
   updateDiffHunks,
 } from '../src/utils/updateDiffHunks';
 import { hasTrailingContextMismatch } from '../src/utils/virtualDiffLayout';
@@ -277,6 +278,55 @@ describe('updateDiffHunks', () => {
       diff,
       runFullRecomputeEdit(base, line, 'line 10 replace newer')
     );
+  });
+
+  test('preserves context when a contentful edit has an editor-only trailing blank line', () => {
+    const oldContents = ['drop 1', 'kept', 'drop 2', ''].join('\n');
+    const diff = parseDiffFromFile(
+      { name: 'example.ts', contents: oldContents },
+      { name: 'example.ts', contents: 'kept\n' },
+      { context: 3 }
+    );
+
+    // Mirrors edit mode after deleting all but one matching line in a longer
+    // file and pressing Enter: the editor has a final logical empty line that
+    // patch-style splitting would normally drop.
+    diff.additionLines = ['kept\n', ''];
+
+    const recomputed = recomputeDiffHunksForEdit(diff, { context: 3 });
+
+    expect(recomputed.additionLines).toEqual(['kept\n', '']);
+    expect(recomputed.splitLineCount).toBe(4);
+    expect(recomputed.unifiedLineCount).toBe(4);
+    expect(recomputed.hunks[0]?.hunkContent).toEqual([
+      {
+        type: 'change',
+        additions: 0,
+        deletions: 1,
+        additionLineIndex: 0,
+        deletionLineIndex: 0,
+      },
+      {
+        type: 'context',
+        lines: 1,
+        additionLineIndex: 0,
+        deletionLineIndex: 1,
+      },
+      {
+        type: 'change',
+        additions: 0,
+        deletions: 1,
+        additionLineIndex: 1,
+        deletionLineIndex: 2,
+      },
+      {
+        type: 'change',
+        additions: 1,
+        deletions: 0,
+        additionLineIndex: 1,
+        deletionLineIndex: 3,
+      },
+    ]);
   });
 
   test('translates reparsed hunk coordinates when context lines become changes', () => {

--- a/packages/diffs/test/updateDiffHunks.test.ts
+++ b/packages/diffs/test/updateDiffHunks.test.ts
@@ -397,6 +397,79 @@ describe('updateDiffHunks', () => {
     ]);
   });
 
+  test('does not append an editor-only trailing blank line as an EOF change addition', () => {
+    const oldContents = ['line 1', 'remove me', 'line 3', ''].join('\n');
+    const diff = parseDiffFromFile(
+      { name: 'example.ts', contents: oldContents },
+      {
+        name: 'example.ts',
+        contents: ['line 1', 'add me', 'line 3', ''].join('\n'),
+      },
+      { context: 3 }
+    );
+
+    // The editor exposes the final logical empty row for a file ending in a
+    // newline. That row belongs to document state, not to diff hunk metadata.
+    diff.additionLines = ['line 1\n', 'add me\n', 'line 3\n', ''];
+
+    const recomputed = recomputeDiffHunksForEdit(diff, { context: 3 });
+
+    expect(recomputed.additionLines).toEqual([
+      'line 1\n',
+      'add me\n',
+      'line 3\n',
+    ]);
+    expect(recomputed.hunks[0]?.hunkContent).toEqual([
+      {
+        type: 'context',
+        lines: 1,
+        additionLineIndex: 0,
+        deletionLineIndex: 0,
+      },
+      {
+        type: 'change',
+        additions: 1,
+        deletions: 1,
+        additionLineIndex: 1,
+        deletionLineIndex: 1,
+      },
+      {
+        type: 'context',
+        lines: 1,
+        additionLineIndex: 2,
+        deletionLineIndex: 2,
+      },
+    ]);
+
+    Object.assign(diff, recomputed);
+    const rows: Array<{
+      type: string;
+      deletionLineIndex: number | undefined;
+      additionLineIndex: number | undefined;
+    }> = [];
+    iterateOverDiff({
+      diff,
+      diffStyle: 'both',
+      expandedHunks: true,
+      callback(row) {
+        rows.push({
+          type: row.type,
+          deletionLineIndex: row.deletionLine?.lineIndex,
+          additionLineIndex: row.additionLine?.lineIndex,
+        });
+      },
+    });
+
+    expect(
+      rows.some(
+        (row) =>
+          row.type === 'change' &&
+          row.deletionLineIndex == null &&
+          row.additionLineIndex === 3
+      )
+    ).toBe(false);
+  });
+
   test('translates reparsed hunk coordinates when context lines become changes', () => {
     const oldContents = [
       'ctx01',


### PR DESCRIPTION
reproduct steps:
1. render diff in edit mode
2. delete all lines of the new file (select all + delete)
3. type 'a'
4. stroke 'enter' to create a new line
5. [bug] no new line rendered, the editor selection/caret disappear