### PR TITLE
[docs/diffs]: Update agent UI component

### DIFF
--- a/apps/docs/app/(diffs)/_edit/EditPage.tsx
+++ b/apps/docs/app/(diffs)/_edit/EditPage.tsx
@@ -93,8 +93,9 @@ export function EditPage({
                 <>
                   Find strings across files with <code>Cmd/Ctrl-F</code> on any{' '}
                   <code>File</code> or <code>FileDiff</code>. Find and replace
-                  with <code>Cmd/Ctrl-Shift-F</code>. The search panel below is
-                  open—type a query to highlight matches, jump between them with{' '}
+                  with <code>Cmd-option-F</code>(Mac) or <code>Ctrl-Alt-F</code>
+                  (Linux/Windows). The search panel below is open—type a query
+                  to highlight matches, jump between them with{' '}
                   <code>Enter</code> or its arrows, and toggle case, whole-word,
                   or regex as you go.
                 </>

--- a/apps/docs/app/(diffs)/_edit/EditPage.tsx
+++ b/apps/docs/app/(diffs)/_edit/EditPage.tsx
@@ -93,7 +93,7 @@ export function EditPage({
                 <>
                   Find strings across files with <code>Cmd/Ctrl-F</code> on any{' '}
                   <code>File</code> or <code>FileDiff</code>. Find and replace
-                  with <code>Cmd-option-F</code>(Mac) or <code>Ctrl-Alt-F</code>
+                  with <code>Cmd-Opt-F</code>(Mac) or <code>Ctrl-Alt-F</code>
                   (Linux/Windows). The search panel below is open—type a query
                   to highlight matches, jump between them with{' '}
                   <code>Enter</code> or its arrows, and toggle case, whole-word,

--- a/apps/docs/app/(diffs)/_edit/SelectionDemo.tsx
+++ b/apps/docs/app/(diffs)/_edit/SelectionDemo.tsx
@@ -81,6 +81,14 @@ function getSelectionLineRange(selection: ChatSnippetSource['selection']): {
   return { lineEnd, lineStart };
 }
 
+function formatSelectionLineLabel(
+  snippet: Pick<ChatSnippet, 'lineEnd' | 'lineStart'>
+): string {
+  return snippet.lineStart === snippet.lineEnd
+    ? `(${String(snippet.lineStart)})`
+    : `(${String(snippet.lineStart)}-${String(snippet.lineEnd)})`;
+}
+
 // Demo of the editor's opt-in Selection Action: with `enabledSelectionAction`,
 // selecting text immediately reveals a floating popover (anchored below the
 // selection) whose contents come from `renderSelectionAction`. Here it mimics an
@@ -211,7 +219,7 @@ export function SelectionDemo({ prerenderedFile }: SelectionDemoProps) {
                         {snippet.fileName}
                       </span>
                       <span className="shrink-0">
-                        ({snippet.lineStart}-{snippet.lineEnd})
+                        {formatSelectionLineLabel(snippet)}
                       </span>
                     </div>
                     <File

--- a/apps/docs/app/(diffs)/_edit/SelectionDemo.tsx
+++ b/apps/docs/app/(diffs)/_edit/SelectionDemo.tsx
@@ -8,6 +8,7 @@ import {
   IconArrow,
   IconChevronSm,
   IconCommentFill,
+  IconFileCode,
   IconSparkle,
   IconX,
 } from '@pierre/icons';
@@ -47,24 +48,71 @@ const CHAT_SNIPPET_STYLE = {
   '--diffs-line-height': '18px',
 } as CSSProperties;
 
+interface ChatSnippet {
+  fileName: string;
+  id: number;
+  lineEnd: number;
+  lineStart: number;
+  text: string;
+}
+
+interface ChatSnippetSource {
+  selection: {
+    end: {
+      character: number;
+      line: number;
+    };
+    start: {
+      line: number;
+    };
+  };
+}
+
+function getSelectionLineRange(selection: ChatSnippetSource['selection']): {
+  lineEnd: number;
+  lineStart: number;
+} {
+  const endLine =
+    selection.end.character === 0 && selection.end.line > selection.start.line
+      ? selection.end.line - 1
+      : selection.end.line;
+  const lineStart = Math.min(selection.start.line, endLine) + 1;
+  const lineEnd = Math.max(selection.start.line, endLine) + 1;
+  return { lineEnd, lineStart };
+}
+
 // Demo of the editor's opt-in Selection Action: with `enabledSelectionAction`,
 // selecting text immediately reveals a floating popover (anchored below the
 // selection) whose contents come from `renderSelectionAction`. Here it mimics an
 // editor's "Add to chat": the primary action sends the selected snippet to a
 // mock chat panel beside the surface, and a secondary action copies it.
 export function SelectionDemo({ prerenderedFile }: SelectionDemoProps) {
-  const [snippets, setSnippets] = useState<string[]>([]);
+  const [snippets, setSnippets] = useState<ChatSnippet[]>([]);
+  const snippetIdRef = useRef(0);
 
   // The popover lives inside the editor instance, which is created once. Route
   // its "Add to chat" click through a ref so it always calls the latest setter
   // without recreating the editor.
-  const addSnippet = useCallback((text: string) => {
-    const trimmed = text.trim();
-    if (trimmed === '') {
-      return;
-    }
-    setSnippets((prev) => [...prev, trimmed]);
-  }, []);
+  const addSnippet = useCallback(
+    (text: string, source: ChatSnippetSource) => {
+      const trimmed = text.trim();
+      if (trimmed === '') {
+        return;
+      }
+      snippetIdRef.current += 1;
+      const id = snippetIdRef.current;
+      setSnippets((prev) => [
+        ...prev,
+        {
+          id,
+          fileName: prerenderedFile.file.name,
+          ...getSelectionLineRange(source.selection),
+          text: trimmed,
+        },
+      ]);
+    },
+    [prerenderedFile.file.name]
+  );
   const addSnippetRef = useRef(addSnippet);
   addSnippetRef.current = addSnippet;
 
@@ -72,7 +120,7 @@ export function SelectionDemo({ prerenderedFile }: SelectionDemoProps) {
     () =>
       new Editor<undefined>({
         enabledSelectionAction: true,
-        renderSelectionAction({ close, getSelectionText }) {
+        renderSelectionAction(selectionAction) {
           const container = document.createElement('div');
           container.style.cssText = 'display: flex; gap: 4px;';
 
@@ -86,8 +134,10 @@ export function SelectionDemo({ prerenderedFile }: SelectionDemoProps) {
             event.preventDefault()
           );
           addToChat.addEventListener('click', () => {
-            addSnippetRef.current(getSelectionText());
-            close();
+            addSnippetRef.current(selectionAction.getSelectionText(), {
+              selection: selectionAction.selection,
+            });
+            selectionAction.close();
           });
 
           const copy = document.createElement('button');
@@ -96,8 +146,10 @@ export function SelectionDemo({ prerenderedFile }: SelectionDemoProps) {
           copy.style.cssText = SECONDARY_BUTTON_STYLE;
           copy.addEventListener('mousedown', (event) => event.preventDefault());
           copy.addEventListener('click', () => {
-            void navigator.clipboard?.writeText(getSelectionText());
-            close();
+            void navigator.clipboard?.writeText(
+              selectionAction.getSelectionText()
+            );
+            selectionAction.close();
           });
 
           container.append(addToChat, copy);
@@ -148,15 +200,24 @@ export function SelectionDemo({ prerenderedFile }: SelectionDemoProps) {
               </p>
             ) : (
               <ul className="flex flex-col gap-2 p-3">
-                {snippets.map((snippet, index) => (
+                {snippets.map((snippet) => (
                   <li
-                    key={index}
+                    key={snippet.id}
                     className="overflow-hidden rounded-md border border-neutral-800"
                   >
+                    <div className="flex h-7 min-w-0 items-center gap-1.5 border-b border-neutral-800 px-2 pr-3 text-xs leading-none text-neutral-400">
+                      <IconFileCode className="size-3.5 shrink-0" />
+                      <span className="min-w-0 truncate font-medium text-neutral-200">
+                        {snippet.fileName}
+                      </span>
+                      <span className="shrink-0">
+                        ({snippet.lineStart}-{snippet.lineEnd})
+                      </span>
+                    </div>
                     <File
                       file={{
-                        name: `chat-snippet-${index}.ts`,
-                        contents: snippet,
+                        name: snippet.fileName,
+                        contents: snippet.text,
                       }}
                       options={{
                         theme: DEFAULT_THEMES,
@@ -168,7 +229,7 @@ export function SelectionDemo({ prerenderedFile }: SelectionDemoProps) {
                       // editor surface; a dynamically mounted read-only File isn't
                       // highlighted through it, so highlight on the main thread.
                       disableWorkerPool
-                      className="overflow-x-auto"
+                      className="max-h-32 overflow-auto"
                       style={CHAT_SNIPPET_STYLE}
                     />
                   </li>

--- a/apps/docs/app/(diffs)/_home/AgentUi.tsx
+++ b/apps/docs/app/(diffs)/_home/AgentUi.tsx
@@ -6,6 +6,7 @@ import { EditorProvider, File, FileDiff } from '@pierre/diffs/react';
 import {
   IconArrow,
   IconChevronSm,
+  IconFileCode,
   IconFilePlus,
   IconFolderPlus,
   IconSearch,
@@ -111,7 +112,40 @@ const SNIPPET_STYLE = {
 
 interface AuiSnippet {
   id: number;
+  fileName: string;
+  lineEnd: number;
+  lineStart: number;
   text: string;
+}
+
+interface AuiSnippetSource {
+  path: string;
+  selection: {
+    end: {
+      character: number;
+      line: number;
+    };
+    start: {
+      line: number;
+    };
+  };
+}
+
+function getFileName(path: string): string {
+  return path.split('/').at(-1) ?? path;
+}
+
+function getSelectionLineRange(selection: AuiSnippetSource['selection']): {
+  lineEnd: number;
+  lineStart: number;
+} {
+  const endLine =
+    selection.end.character === 0 && selection.end.line > selection.start.line
+      ? selection.end.line - 1
+      : selection.end.line;
+  const lineStart = Math.min(selection.start.line, endLine) + 1;
+  const lineEnd = Math.max(selection.start.line, endLine) + 1;
+  return { lineEnd, lineStart };
 }
 
 // Renders the active session's changed files as a @pierre/trees FileTree, with
@@ -909,14 +943,22 @@ export function AgentUi({
   // through a ref keeps the latest setter without depending on that lifecycle.
   const [snippets, setSnippets] = useState<AuiSnippet[]>([]);
   const snippetIdRef = useRef(0);
-  const addSnippet = useCallback((text: string) => {
+  const addSnippet = useCallback((text: string, source: AuiSnippetSource) => {
     const trimmed = text.trim();
     if (trimmed === '') {
       return;
     }
     snippetIdRef.current += 1;
     const id = snippetIdRef.current;
-    setSnippets((prev) => [...prev, { id, text: trimmed }]);
+    setSnippets((prev) => [
+      ...prev,
+      {
+        id,
+        fileName: getFileName(source.path),
+        ...getSelectionLineRange(source.selection),
+        text: trimmed,
+      },
+    ]);
   }, []);
   const addSnippetRef = useRef(addSnippet);
   addSnippetRef.current = addSnippet;
@@ -1028,7 +1070,7 @@ export function AgentUi({
     () =>
       new Editor({
         enabledSelectionAction: true,
-        renderSelectionAction({ close, getSelectionText }) {
+        renderSelectionAction(selectionAction) {
           const container = document.createElement('div');
           container.style.cssText = 'display: flex; gap: 4px;';
 
@@ -1042,8 +1084,14 @@ export function AgentUi({
             event.preventDefault()
           );
           addToChat.addEventListener('click', () => {
-            addSnippetRef.current(getSelectionText());
-            close();
+            const target = activeTargetRef.current;
+            if (target != null) {
+              addSnippetRef.current(selectionAction.getSelectionText(), {
+                path: target,
+                selection: selectionAction.selection,
+              });
+            }
+            selectionAction.close();
           });
 
           const copy = document.createElement('button');
@@ -1052,8 +1100,10 @@ export function AgentUi({
           copy.style.cssText = SELECTION_SECONDARY_BUTTON_STYLE;
           copy.addEventListener('mousedown', (event) => event.preventDefault());
           copy.addEventListener('click', () => {
-            void navigator.clipboard?.writeText(getSelectionText());
-            close();
+            void navigator.clipboard?.writeText(
+              selectionAction.getSelectionText()
+            );
+            selectionAction.close();
           });
 
           container.append(addToChat, copy);
@@ -1270,9 +1320,18 @@ export function AgentUi({
                 <ul className="aui-composer-attachments">
                   {snippets.map((snippet) => (
                     <li key={snippet.id} className="aui-attachment">
+                      <div className="aui-attachment-header">
+                        <IconFileCode aria-hidden="true" />
+                        <span className="aui-attachment-file">
+                          {snippet.fileName}
+                        </span>
+                        <span className="aui-attachment-lines">
+                          ({snippet.lineStart}-{snippet.lineEnd})
+                        </span>
+                      </div>
                       <File
                         file={{
-                          name: 'snippet.ts',
+                          name: snippet.fileName,
                           contents: snippet.text,
                         }}
                         options={{

--- a/apps/docs/app/(diffs)/_home/AgentUi.tsx
+++ b/apps/docs/app/(diffs)/_home/AgentUi.tsx
@@ -148,6 +148,14 @@ function getSelectionLineRange(selection: AuiSnippetSource['selection']): {
   return { lineEnd, lineStart };
 }
 
+function formatSelectionLineLabel(
+  snippet: Pick<AuiSnippet, 'lineEnd' | 'lineStart'>
+): string {
+  return snippet.lineStart === snippet.lineEnd
+    ? `(${String(snippet.lineStart)})`
+    : `(${String(snippet.lineStart)}-${String(snippet.lineEnd)})`;
+}
+
 // Renders the active session's changed files as a @pierre/trees FileTree, with
 // git-status colours and per-row +/- decorations. The tree is an imperative web
 // component, so it's created in an effect and torn down on session change.
@@ -1326,7 +1334,7 @@ export function AgentUi({
                           {snippet.fileName}
                         </span>
                         <span className="aui-attachment-lines">
-                          ({snippet.lineStart}-{snippet.lineEnd})
+                          {formatSelectionLineLabel(snippet)}
                         </span>
                       </div>
                       <File

--- a/apps/docs/app/(diffs)/_home/agent-ui.css
+++ b/apps/docs/app/(diffs)/_home/agent-ui.css
@@ -249,9 +249,42 @@ button.aui-dot.is-zoom:hover {
   background-color: var(--ide-surface);
 }
 
+.aui-attachment-header {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  height: 28px;
+  padding: 0 32px 0 8px;
+  border-bottom: 1px solid var(--ide-border);
+  color: var(--ide-fg-muted);
+  font-size: 12px;
+  line-height: 1;
+}
+
+.aui-attachment-header svg {
+  flex: 0 0 auto;
+  width: 14px;
+  height: 14px;
+}
+
+.aui-attachment-file {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--ide-fg);
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.aui-attachment-lines {
+  flex: 0 0 auto;
+}
+
 .aui-attachment-code {
   display: block;
-  overflow-x: auto;
+  max-height: 132px;
+  overflow: auto;
 }
 
 .aui-attachment-remove {


### PR DESCRIPTION
- “Add to chat” captures the live editor selection when clicked, then renders an attachment header like filename (start-end) with a file icon.
- Large snippet attachments are scrollable inside their code block.