### PR TITLE
[diff/editor] Add stale async editor-sync guards

### DIFF
--- a/apps/docs/app/(diffs)/_examples/LiveEditing/LiveEditing.tsx
+++ b/apps/docs/app/(diffs)/_examples/LiveEditing/LiveEditing.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { cloneFileDiffMetadata } from '@pierre/diffs';
 import { Editor } from '@pierre/diffs/editor';
 import { EditorProvider, File, FileDiff } from '@pierre/diffs/react';
 import type {
@@ -56,6 +57,21 @@ export function LiveEditing({
   // Bumping this value remounts the editable surface, which is how Reset works
   // (see `handleReset`).
   const [resetKey, setResetKey] = useState(0);
+  // Editing a FileDiff updates the diff metadata it renders from so the live
+  // hunks stay in sync. Keep an untouched baseline and hand FileDiff a fresh
+  // clone for each remount; Reset must rebuild from the original additions, not
+  // a previously edited object.
+  const pristineFileDiff = useMemo(
+    () => cloneFileDiffMetadata(prerenderedDiff.fileDiff),
+    [prerenderedDiff.fileDiff]
+  );
+  const liveFileDiff = useMemo(
+    () => ({
+      ...cloneFileDiffMetadata(pristineFileDiff),
+      cacheKey: pristineFileDiff.name + resetKey,
+    }),
+    [pristineFileDiff, resetKey]
+  );
   // Edits emit through the editor's debounced `onChange`. After a remount (reset
   // or a control change) a change scheduled just before can still fire ~500ms
   // later carrying the pre-remount (edited) contents, which would flip
@@ -232,10 +248,7 @@ export function LiveEditing({
             <FileDiff
               key={resetKey}
               {...prerenderedDiff}
-              fileDiff={{
-                ...prerenderedDiff.fileDiff,
-                cacheKey: prerenderedDiff.fileDiff.name + resetKey,
-              }}
+              fileDiff={liveFileDiff}
               options={{ ...prerenderedDiff.options, diffStyle: diffLayout }}
               className="diff-container"
               renderHeaderMetadata={headerMetadata}

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -487,22 +487,16 @@ export class File<
     const editor = this.editor;
     const fileContainer = this.fileContainer;
     const file = this.file;
+    const lineAnnotations = this.lineAnnotations;
+    const renderRange = this.renderRange;
     if (editor != null && fileContainer != null && file != null) {
       void this.fileRenderer.initializeHighlighter().then((highlighter) => {
-        if (
-          !this.enabled ||
-          this.editor !== editor ||
-          this.fileContainer !== fileContainer ||
-          this.file !== file
-        ) {
-          return;
-        }
         editor.__syncRenderView(
           highlighter,
           fileContainer,
           file,
-          this.lineAnnotations,
-          this.renderRange
+          lineAnnotations,
+          renderRange
         );
       });
     }

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -491,6 +491,14 @@ export class File<
     const renderRange = this.renderRange;
     if (editor != null && fileContainer != null && file != null) {
       void this.fileRenderer.initializeHighlighter().then((highlighter) => {
+        if (
+          !this.enabled ||
+          this.editor !== editor ||
+          this.fileContainer !== fileContainer ||
+          this.file !== file
+        ) {
+          return;
+        }
         editor.__syncRenderView(
           highlighter,
           fileContainer,

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -489,6 +489,14 @@ export class File<
     const file = this.file;
     if (editor != null && fileContainer != null && file != null) {
       void this.fileRenderer.initializeHighlighter().then((highlighter) => {
+        if (
+          !this.enabled ||
+          this.editor !== editor ||
+          this.fileContainer !== fileContainer ||
+          this.file !== file
+        ) {
+          return;
+        }
         editor.__syncRenderView(
           highlighter,
           fileContainer,

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -318,7 +318,7 @@ export class FileDiff<
   ) => {
     // use the fileDiff from the hunksRenderer if it exists, it maybe updated
     // by the host
-    const fileDiff = this.hunksRenderer.getDiffCache() ?? this.fileDiff;
+    const fileDiff = this.fileDiffCache;
     if (fileDiff == null) {
       return undefined;
     }
@@ -1134,10 +1134,14 @@ export class FileDiff<
     onPostRender?.(fileContainer, this, phase);
   }
 
+  private get fileDiffCache(): FileDiffMetadata | undefined {
+    return this.hunksRenderer.diffCache ?? this.fileDiff;
+  }
+
   private syncRenderViewToEditor(): void {
     const editor = this.editor;
     const fileContainer = this.fileContainer;
-    const fileDiff = this.hunksRenderer.getDiffCache() ?? this.fileDiff;
+    const fileDiff = this.fileDiffCache;
     const lineAnnotations = this.lineAnnotations;
     const renderRange = this.renderRange;
     if (
@@ -1147,6 +1151,14 @@ export class FileDiff<
       !fileDiff.isPartial
     ) {
       void this.hunksRenderer.initializeHighlighter().then((highlighter) => {
+        if (
+          !this.enabled ||
+          this.editor !== editor ||
+          this.fileContainer !== fileContainer ||
+          this.fileDiffCache !== fileDiff
+        ) {
+          return;
+        }
         editor.__syncRenderView(
           highlighter,
           fileContainer,
@@ -1175,7 +1187,7 @@ export class FileDiff<
     newLineAnnotations?: DiffLineAnnotation<LAnnotation>[]
   ): void {
     this.hunksRenderer.applyDocumentChange(textDocument);
-    const fileDiff = this.hunksRenderer.getDiffCache();
+    const fileDiff = this.hunksRenderer.diffCache;
     if (fileDiff != null) {
       const cacheKey = this.fileDiff?.cacheKey;
       if (cacheKey != null && fileDiff.cacheKey == null) {

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -1145,6 +1145,14 @@ export class FileDiff<
       !fileDiff.isPartial
     ) {
       void this.hunksRenderer.initializeHighlighter().then((highlighter) => {
+        if (
+          !this.enabled ||
+          this.editor !== editor ||
+          this.fileContainer !== fileContainer ||
+          (this.hunksRenderer.getDiffCache() ?? this.fileDiff) !== fileDiff
+        ) {
+          return;
+        }
         editor.__syncRenderView(
           highlighter,
           fileContainer,

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -1138,6 +1138,8 @@ export class FileDiff<
     const editor = this.editor;
     const fileContainer = this.fileContainer;
     const fileDiff = this.hunksRenderer.getDiffCache() ?? this.fileDiff;
+    const lineAnnotations = this.lineAnnotations;
+    const renderRange = this.renderRange;
     if (
       editor != null &&
       fileContainer != null &&
@@ -1145,20 +1147,12 @@ export class FileDiff<
       !fileDiff.isPartial
     ) {
       void this.hunksRenderer.initializeHighlighter().then((highlighter) => {
-        if (
-          !this.enabled ||
-          this.editor !== editor ||
-          this.fileContainer !== fileContainer ||
-          (this.hunksRenderer.getDiffCache() ?? this.fileDiff) !== fileDiff
-        ) {
-          return;
-        }
         editor.__syncRenderView(
           highlighter,
           fileContainer,
           fileDiff,
-          this.lineAnnotations,
-          this.renderRange
+          lineAnnotations,
+          renderRange
         );
       });
     }

--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -257,7 +257,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
     this.workerManager?.cleanUpTasks(this);
   }
 
-  public getDiffCache(): FileDiffMetadata | undefined {
+  public get diffCache(): FileDiffMetadata | undefined {
     return this.renderCache?.diff ?? this.diff;
   }
 

--- a/packages/diffs/test/DiffHunksRendererRecompute.test.ts
+++ b/packages/diffs/test/DiffHunksRendererRecompute.test.ts
@@ -84,17 +84,17 @@ async function createPrimedRenderer(
 describe('DiffHunksRenderer content-edit recompute split', () => {
   test('updateRenderCache recomputes hunk metadata for changed addition lines', async () => {
     const renderer = await createPrimedRenderer();
-    const cacheDiff = renderer.getDiffCache();
-    expect(cacheDiff).toBeDefined();
-    if (cacheDiff == null) return;
+    const diffCache = renderer.diffCache;
+    expect(diffCache).toBeDefined();
+    if (diffCache == null) return;
 
-    const hunksBefore = cacheDiff.hunks;
+    const hunksBefore = diffCache.hunks;
     // In-place edit of an existing line (no line-count change).
     renderer.updateRenderCache(
       makeDirtyLines([[1, '  console.log(msg) // edited']]),
       'light'
     );
-    expect(cacheDiff.hunks).not.toBe(hunksBefore);
+    expect(diffCache.hunks).not.toBe(hunksBefore);
   });
 
   test('updateRenderCache matches a full recompute for a content-only edit', async () => {
@@ -103,7 +103,7 @@ describe('DiffHunksRenderer content-edit recompute split', () => {
       makeDirtyLines([[1, '  console.log(msg) // edited']]),
       'light'
     );
-    const incremental = split.getDiffCache();
+    const incremental = split.diffCache;
 
     // Expected result: a full re-parse of the same edited content from scratch.
     const full = parseDiffFromFile(
@@ -135,7 +135,7 @@ describe('DiffHunksRenderer content-edit recompute split', () => {
       makeTextDocumentFromText(EDITED_LINES.join('\n'))
     );
 
-    const rendered = renderer.getDiffCache();
+    const rendered = renderer.diffCache;
     expect(rendered).toBeDefined();
     if (rendered == null) return;
 
@@ -189,7 +189,7 @@ describe('DiffHunksRenderer.applyDocumentChange empty document', () => {
       const renderer = await createPrimedRenderer(diffStyle);
       renderer.applyDocumentChange(EMPTY_DOCUMENT);
 
-      const diff = renderer.getDiffCache();
+      const diff = renderer.diffCache;
       expect(diff).toBeDefined();
       if (diff == null) return;
 
@@ -228,7 +228,7 @@ describe('DiffHunksRenderer.applyDocumentChange empty document', () => {
       renderer.renderDiff(diff);
       renderer.applyDocumentChange(EMPTY_DOCUMENT);
 
-      const rendered = renderer.getDiffCache();
+      const rendered = renderer.diffCache;
       expect(rendered).toBeDefined();
       if (rendered == null) return;
 
@@ -275,7 +275,7 @@ describe('DiffHunksRenderer.applyDocumentChange empty document', () => {
       renderer.applyDocumentChange(EMPTY_DOCUMENT);
       renderer.applyDocumentChange(makeTextDocumentFromText('\n'));
 
-      const rendered = renderer.getDiffCache();
+      const rendered = renderer.diffCache;
       expect(rendered).toBeDefined();
       if (rendered == null) return;
 
@@ -322,7 +322,7 @@ describe('DiffHunksRenderer.applyDocumentChange empty document', () => {
       renderer.applyDocumentChange(EMPTY_DOCUMENT);
       renderer.applyDocumentChange(makeTextDocumentFromText('\n\n'));
 
-      const rendered = renderer.getDiffCache();
+      const rendered = renderer.diffCache;
       expect(rendered).toBeDefined();
       if (rendered == null) return;
 
@@ -369,7 +369,7 @@ describe('DiffHunksRenderer.applyDocumentChange empty document', () => {
       renderer.applyDocumentChange(EMPTY_DOCUMENT);
       renderer.applyDocumentChange(makeTextDocumentFromText('\n'));
 
-      const rendered = renderer.getDiffCache();
+      const rendered = renderer.diffCache;
       expect(rendered).toBeDefined();
       if (rendered == null) return;
       expect(rendered.additionLines).toEqual(['\n', '']);
@@ -404,7 +404,7 @@ describe('DiffHunksRenderer.applyDocumentChange empty document', () => {
 
       renderer.applyDocumentChange(EMPTY_DOCUMENT);
 
-      const rendered = renderer.getDiffCache();
+      const rendered = renderer.diffCache;
       expect(rendered).toBeDefined();
       if (rendered == null) return;
       expect(rendered.additionLines).toEqual(['']);

--- a/packages/diffs/test/editorDisplayOptionResync.test.ts
+++ b/packages/diffs/test/editorDisplayOptionResync.test.ts
@@ -4,7 +4,7 @@ import { FileDiff } from '../src/components/FileDiff';
 import { DEFAULT_THEMES } from '../src/constants';
 import { Editor } from '../src/editor/editor';
 import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
-import type { FileContents } from '../src/types';
+import type { DiffsHighlighter, FileContents } from '../src/types';
 import { parseDiffFromFile } from '../src/utils/parseDiffFromFile';
 import { installDom, wait } from './domHarness';
 
@@ -382,6 +382,109 @@ describe('diff editor: detach then re-attach', () => {
       expect(lineText(container, 2)).toBe('QCHANGED');
     } finally {
       await fixture.cleanup();
+    }
+  });
+
+  test('ignores a stale async editor sync after reset remounts the diff', async () => {
+    const dom = installDom();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const editor = new Editor<undefined>();
+    const oldFile: FileContents = {
+      name: 'edit.ts',
+      contents: 'alpha\nbravo\n',
+      cacheKey: 'old:initial',
+    };
+    const newFile: FileContents = {
+      name: 'edit.ts',
+      contents: 'alpha\nCHANGED\n',
+      cacheKey: 'new:initial',
+    };
+    const fileDiff = new FileDiff<undefined>(
+      {
+        disableFileHeader: true,
+        theme: DEFAULT_THEMES,
+        diffStyle: 'split',
+      },
+      undefined,
+      true
+    );
+
+    let remountedFileDiff: FileDiff<undefined> | undefined;
+
+    try {
+      fileDiff.render({
+        oldFile,
+        newFile,
+        fileContainer: container,
+        forceRender: true,
+      });
+      editor.edit(fileDiff);
+      await waitForEditable(container);
+
+      typeAt(editor, 0, 5, 'X');
+      await wait(0);
+      expect(lineText(container, 1)).toBe('alphaX');
+
+      const renderer = (
+        fileDiff as unknown as {
+          hunksRenderer: {
+            initializeHighlighter(): Promise<DiffsHighlighter>;
+          };
+          syncRenderViewToEditor(): void;
+        }
+      ).hunksRenderer;
+      const highlighter = await renderer.initializeHighlighter();
+      let resolveStaleSync:
+        | ((highlighter: DiffsHighlighter) => void)
+        | undefined;
+      renderer.initializeHighlighter = () =>
+        new Promise<DiffsHighlighter>((resolve) => {
+          resolveStaleSync = resolve;
+        });
+
+      // Queue an editor sync from the edited instance, then reset by unmounting
+      // that instance and mounting a fresh diff with the original contents.
+      (
+        fileDiff as unknown as { syncRenderViewToEditor(): void }
+      ).syncRenderViewToEditor();
+      fileDiff.cleanUp();
+
+      const remountedContainer = document.createElement('div');
+      document.body.appendChild(remountedContainer);
+      remountedFileDiff = new FileDiff<undefined>(
+        {
+          disableFileHeader: true,
+          theme: DEFAULT_THEMES,
+          diffStyle: 'split',
+        },
+        undefined,
+        true
+      );
+      remountedFileDiff.render({
+        oldFile: { ...oldFile, cacheKey: 'old:reset' },
+        newFile: { ...newFile, cacheKey: 'new:reset' },
+        fileContainer: remountedContainer,
+        forceRender: true,
+      });
+      editor.edit(remountedFileDiff);
+      await waitForEditable(remountedContainer);
+      expect(lineText(remountedContainer, 1)).toBe('alpha');
+
+      resolveStaleSync?.(highlighter);
+      await wait(0);
+
+      typeAt(editor, 1, 0, 'Q');
+      await wait(0);
+
+      expect(editor.getState().file.contents).toBe('alpha\nQCHANGED\n');
+      expect(lineText(remountedContainer, 1)).toBe('alpha');
+      expect(lineText(remountedContainer, 2)).toBe('QCHANGED');
+    } finally {
+      editor.cleanUp();
+      remountedFileDiff?.cleanUp();
+      dom.cleanup();
     }
   });
 });


### PR DESCRIPTION
- fix live editing in `/edit`: keeps a pristine cloned `FileDiffMetadat`a baseline and passes a fresh clone to `FileDiff` on reset/remount, so prior edits cannot leak back in.
- add stale async editor-sync guards