### PR TITLE
[diffs/editor] Support `moveLineUp` and `moveLineDown` commands

### DIFF
--- a/apps/docs/app/(diffs)/_edit/EditPage.tsx
+++ b/apps/docs/app/(diffs)/_edit/EditPage.tsx
@@ -130,7 +130,10 @@ export function EditPage({
                 <>
                   Edit mode ships with all the additional shortcuts your users
                   will need out of the box. Use the example <code>File</code>{' '}
-                  below to try the shortcuts you see in the table. Editing the
+                  below to try the shortcuts you see in the table, including
+                  moving selected lines with <code>Alt-↑</code> /{' '}
+                  <code>Alt-↓</code> or <code>Alt-Ctrl-P</code> /{' '}
+                  <code>Alt-Ctrl-N</code> on macOS and Linux. Editing the
                   example <code>File</code> will not update the table.
                 </>
               }

--- a/apps/docs/app/(diffs)/_edit/constants.ts
+++ b/apps/docs/app/(diffs)/_edit/constants.ts
@@ -274,6 +274,26 @@ export const EDITOR_SHORTCUT_GROUPS: readonly EditorShortcutGroup[] = [
         modifiers: ['Shift'],
         action: 'Outdent line or selection',
       },
+      {
+        keys: ['↑'],
+        modifiers: ['Alt'],
+        action: 'Move selected line(s) up',
+      },
+      {
+        keys: ['↓'],
+        modifiers: ['Alt'],
+        action: 'Move selected line(s) down',
+      },
+      {
+        keys: ['P'],
+        modifiers: ['Alt', 'Ctrl'],
+        action: 'Move selected line(s) up (macOS/Linux)',
+      },
+      {
+        keys: ['N'],
+        modifiers: ['Alt', 'Ctrl'],
+        action: 'Move selected line(s) down (macOS/Linux)',
+      },
       { keys: ['X'], action: 'Cut', mod: true },
       { keys: ['C'], action: 'Copy', mod: true },
       { keys: ['V'], action: 'Paste', mod: true },

--- a/apps/docs/app/(diffs)/docs/Editor/content.mdx
+++ b/apps/docs/app/(diffs)/docs/Editor/content.mdx
@@ -187,23 +187,27 @@ Shortcuts use <kbd>Cmd</kbd> on macOS and <kbd>Ctrl</kbd> on Windows and Linux.
 Jumping to the document start or end uses the modifier with the <kbd>Home</kbd>
 and <kbd>End</kbd> keys; on macOS, the modifier with ↑ and ↓ arrows works too.
 
-| Action                       | Shortcut                                                        |
-| ---------------------------- | --------------------------------------------------------------- |
-| Indent line or selection     | <Shortcut meta={false}>Tab</Shortcut>                           |
-| Outdent line or selection    | <Shortcut meta={false} modifiers={['Shift']}>Tab</Shortcut>     |
-| Cut                          | <Shortcut>X</Shortcut>                                          |
-| Copy                         | <Shortcut>C</Shortcut>                                          |
-| Paste                        | <Shortcut>V</Shortcut>                                          |
-| Move the cursor              | <Shortcut meta={false}>↑ ↓ ← →</Shortcut>                       |
-| Extend the selection         | <Shortcut meta={false} modifiers={['Shift']}>↑ ↓ ← →</Shortcut> |
-| Jump to line start / end     | <Shortcut>← →</Shortcut>                                        |
-| Jump to document start / end | <Shortcut>Home / End</Shortcut>                                 |
-| Add a cursor                 | <Shortcut>Click</Shortcut>                                      |
-| Collapse to a single cursor  | <Shortcut meta={false}>Esc</Shortcut>                           |
-| Select all                   | <Shortcut>A</Shortcut>                                          |
-| Open the search panel        | <Shortcut>F</Shortcut>                                          |
-| Go to next search match      | <Shortcut>G</Shortcut>                                          |
-| Go to previous search match  | <Shortcut modifiers={['Shift']}>G</Shortcut>                    |
-| Find next match of selection | <Shortcut>D</Shortcut>                                          |
-| Undo                         | <Shortcut>Z</Shortcut>                                          |
-| Redo                         | <Shortcut modifiers={['Shift']}>Z</Shortcut>                    |
+| Action                       | Shortcut                                                                      |
+| ---------------------------- | ----------------------------------------------------------------------------- |
+| Indent line or selection     | <Shortcut meta={false}>Tab</Shortcut>                                         |
+| Outdent line or selection    | <Shortcut meta={false} modifiers={['Shift']}>Tab</Shortcut>                   |
+| Move selected line(s) up     | <Shortcut meta={false} modifiers={['Alt']}>↑</Shortcut>                       |
+| Move selected line(s) down   | <Shortcut meta={false} modifiers={['Alt']}>↓</Shortcut>                       |
+| Move selected line(s) up     | <Shortcut meta={false} modifiers={['Alt', 'Ctrl']}>P</Shortcut> (macOS/Linux) |
+| Move selected line(s) down   | <Shortcut meta={false} modifiers={['Alt', 'Ctrl']}>N</Shortcut> (macOS/Linux) |
+| Cut                          | <Shortcut>X</Shortcut>                                                        |
+| Copy                         | <Shortcut>C</Shortcut>                                                        |
+| Paste                        | <Shortcut>V</Shortcut>                                                        |
+| Move the cursor              | <Shortcut meta={false}>↑ ↓ ← →</Shortcut>                                     |
+| Extend the selection         | <Shortcut meta={false} modifiers={['Shift']}>↑ ↓ ← →</Shortcut>               |
+| Jump to line start / end     | <Shortcut>← →</Shortcut>                                                      |
+| Jump to document start / end | <Shortcut>Home / End</Shortcut>                                               |
+| Add a cursor                 | <Shortcut>Click</Shortcut>                                                    |
+| Collapse to a single cursor  | <Shortcut meta={false}>Esc</Shortcut>                                         |
+| Select all                   | <Shortcut>A</Shortcut>                                                        |
+| Open the search panel        | <Shortcut>F</Shortcut>                                                        |
+| Go to next search match      | <Shortcut>G</Shortcut>                                                        |
+| Go to previous search match  | <Shortcut modifiers={['Shift']}>G</Shortcut>                                  |
+| Find next match of selection | <Shortcut>D</Shortcut>                                                        |
+| Undo                         | <Shortcut>Z</Shortcut>                                                        |
+| Redo                         | <Shortcut modifiers={['Shift']}>Z</Shortcut>                                  |

--- a/packages/diffs/src/editor/command.ts
+++ b/packages/diffs/src/editor/command.ts
@@ -9,6 +9,8 @@ export type EditorCommand =
   | 'findNextMatch'
   | 'openSearchPanel'
   | 'openSearchReplacePanel'
+  | 'moveLineUp'
+  | 'moveLineDown'
   | 'moveCursorToDocStart'
   | 'moveCursorToDocEnd'
   | 'expandSelectionDocStart'
@@ -27,6 +29,27 @@ export function resolveEditorCommandFromKeyboardEvent(
   const { shiftKey, altKey, key } = event;
 
   const normalizedKey = key.length === 1 ? key.toLowerCase() : key;
+
+  if (!event.metaKey && !shiftKey) {
+    if (!event.ctrlKey && altKey && normalizedKey === 'ArrowUp') {
+      return 'moveLineUp';
+    }
+    if (!event.ctrlKey && altKey && normalizedKey === 'ArrowDown') {
+      return 'moveLineDown';
+    }
+    if (
+      (isMac || navigator.platform.includes('Linux')) &&
+      event.ctrlKey &&
+      altKey
+    ) {
+      if (normalizedKey === 'p' || event.code === 'KeyP') {
+        return 'moveLineUp';
+      }
+      if (normalizedKey === 'n' || event.code === 'KeyN') {
+        return 'moveLineDown';
+      }
+    }
+  }
 
   // cmd/ctrl+f opens the search panel in find mode; adding alt opens it in
   // find/replace mode. macOS emits a dead key for Option+F (key === 'ƒ'), so

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -57,6 +57,7 @@ import {
   getCaretPosition,
   getDocumentBoundarySelection,
   getDocumentFullSelection,
+  getSelectedLineBlocks,
   getSelectionAnchor,
   getSelectionText,
   isCollapsedSelection,
@@ -68,6 +69,7 @@ import {
   resolveIndentEdits,
   resolveSelectionCut,
   selectionIntersects,
+  shiftSelectionLines,
 } from './selection';
 import {
   type SelectionActionContext,
@@ -1587,6 +1589,11 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         break;
       }
 
+      case 'moveLineUp':
+      case 'moveLineDown':
+        this.#moveSelectedLines(command === 'moveLineUp' ? -1 : 1);
+        break;
+
       case 'indent':
       case 'outdent':
         if (this.#selections !== undefined) {
@@ -1730,6 +1737,77 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
           }
         }
         break;
+    }
+  }
+
+  #moveSelectedLines(direction: -1 | 1): void {
+    const textDocument = this.#textDocument;
+    const selections = this.#selections;
+    if (textDocument === undefined || selections === undefined) {
+      return;
+    }
+
+    const blocks = getSelectedLineBlocks(selections);
+    if (
+      blocks.length === 0 ||
+      (direction < 0 && blocks[0].startLine === 0) ||
+      (direction > 0 && blocks.at(-1)!.endLine >= textDocument.lineCount - 1)
+    ) {
+      return;
+    }
+
+    const lines: string[] = [];
+    for (let line = 0; line < textDocument.lineCount; line++) {
+      lines.push(textDocument.getLineText(line));
+    }
+
+    if (direction < 0) {
+      for (const block of blocks) {
+        const previous = lines[block.startLine - 1];
+        lines.splice(
+          block.startLine - 1,
+          block.endLine - block.startLine + 2,
+          ...lines.slice(block.startLine, block.endLine + 1),
+          previous
+        );
+      }
+    } else {
+      for (let index = blocks.length - 1; index >= 0; index--) {
+        const block = blocks[index];
+        const next = lines[block.endLine + 1];
+        lines.splice(
+          block.startLine,
+          block.endLine - block.startLine + 2,
+          next,
+          ...lines.slice(block.startLine, block.endLine + 1)
+        );
+      }
+    }
+
+    const nextSelections = selections.map((selection) =>
+      shiftSelectionLines(selection, direction)
+    );
+    const lastLine = textDocument.lineCount - 1;
+    const change = textDocument.applyEdits(
+      [
+        {
+          range: {
+            start: { line: 0, character: 0 },
+            end: {
+              line: lastLine,
+              character: textDocument.getLineLength(lastLine),
+            },
+          },
+          newText: lines.join(textDocument.eol),
+        },
+      ],
+      true,
+      selections,
+      nextSelections,
+      true
+    );
+    if (change !== undefined) {
+      this.#applyChange(change, nextSelections);
     }
   }
 

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -1785,7 +1785,12 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     }
 
     const nextSelections = selections.map((selection) =>
-      shiftSelectionLines(selection, direction)
+      shiftSelectionLines(
+        selection,
+        direction,
+        lines.length,
+        (line) => lines[line]?.length ?? 0
+      )
     );
     const lastLine = textDocument.lineCount - 1;
     const change = textDocument.applyEdits(

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -1756,56 +1756,75 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       return;
     }
 
-    const lines: string[] = [];
-    for (let line = 0; line < textDocument.lineCount; line++) {
-      lines.push(textDocument.getLineText(line));
-    }
+    const lineCount = textDocument.lineCount;
+    const lineRangeEnd = (line: number): Position =>
+      line < lineCount - 1
+        ? { line: line + 1, character: 0 }
+        : { line, character: textDocument.getLineLength(line) };
+    const getLinesText = (
+      lines: number[],
+      appendFinalLineBreak: boolean
+    ): string => {
+      const text = lines
+        .map((line) => textDocument.getLineText(line))
+        .join(textDocument.eol);
+      return appendFinalLineBreak ? text + textDocument.eol : text;
+    };
 
+    const edits: TextEdit[] = [];
     if (direction < 0) {
       for (const block of blocks) {
-        const previous = lines[block.startLine - 1];
-        lines.splice(
-          block.startLine - 1,
-          block.endLine - block.startLine + 2,
-          ...lines.slice(block.startLine, block.endLine + 1),
-          previous
-        );
+        const previousLine = block.startLine - 1;
+        const blockLines: number[] = [];
+        for (let line = block.startLine; line <= block.endLine; line++) {
+          blockLines.push(line);
+        }
+        edits.push({
+          range: {
+            start: { line: previousLine, character: 0 },
+            end: lineRangeEnd(block.endLine),
+          },
+          newText: getLinesText(
+            [...blockLines, previousLine],
+            block.endLine < lineCount - 1
+          ),
+        });
       }
     } else {
       for (let index = blocks.length - 1; index >= 0; index--) {
         const block = blocks[index];
-        const next = lines[block.endLine + 1];
-        lines.splice(
-          block.startLine,
-          block.endLine - block.startLine + 2,
-          next,
-          ...lines.slice(block.startLine, block.endLine + 1)
-        );
+        const nextLine = block.endLine + 1;
+        const blockLines: number[] = [];
+        for (let line = block.startLine; line <= block.endLine; line++) {
+          blockLines.push(line);
+        }
+        edits.push({
+          range: {
+            start: { line: block.startLine, character: 0 },
+            end: lineRangeEnd(nextLine),
+          },
+          newText: getLinesText(
+            [nextLine, ...blockLines],
+            nextLine < lineCount - 1
+          ),
+        });
       }
     }
 
+    const lastBlock = blocks.at(-1)!;
+    const lastLineLengthAfterMove =
+      direction > 0 && lastBlock.endLine === lineCount - 2
+        ? textDocument.getLineLength(lastBlock.endLine)
+        : textDocument.getLineLength(lineCount - 1);
     const nextSelections = selections.map((selection) =>
-      shiftSelectionLines(
-        selection,
-        direction,
-        lines.length,
-        (line) => lines[line]?.length ?? 0
+      shiftSelectionLines(selection, direction, lineCount, (line) =>
+        line === lineCount - 1
+          ? lastLineLengthAfterMove
+          : textDocument.getLineLength(line)
       )
     );
-    const lastLine = textDocument.lineCount - 1;
     const change = textDocument.applyEdits(
-      [
-        {
-          range: {
-            start: { line: 0, character: 0 },
-            end: {
-              line: lastLine,
-              character: textDocument.getLineLength(lastLine),
-            },
-          },
-          newText: lines.join(textDocument.eol),
-        },
-      ],
+      edits,
       true,
       selections,
       nextSelections,

--- a/packages/diffs/src/editor/selection.ts
+++ b/packages/diffs/src/editor/selection.ts
@@ -1326,6 +1326,63 @@ export function mergeOverlappingSelections(
 }
 
 /**
+ * Converts selections into merged line blocks for line-based commands.
+ */
+export function getSelectedLineBlocks(
+  selections: EditorSelection[]
+): { startLine: number; endLine: number }[] {
+  const blocks = selections
+    .map((selection) => {
+      let endLine = selection.end.line;
+      if (
+        selection.end.character === 0 &&
+        comparePosition(selection.start, selection.end) !== 0
+      ) {
+        endLine--;
+      }
+      return {
+        startLine: selection.start.line,
+        endLine: Math.max(selection.start.line, endLine),
+      };
+    })
+    .sort((a, b) => {
+      const startOrder = a.startLine - b.startLine;
+      return startOrder !== 0 ? startOrder : a.endLine - b.endLine;
+    });
+
+  const merged: { startLine: number; endLine: number }[] = [];
+  for (const block of blocks) {
+    const previous = merged.at(-1);
+    if (previous !== undefined && block.startLine <= previous.endLine + 1) {
+      previous.endLine = Math.max(previous.endLine, block.endLine);
+    } else {
+      merged.push({ ...block });
+    }
+  }
+  return merged;
+}
+
+/**
+ * Moves a selection's line positions after its lines are shifted.
+ */
+export function shiftSelectionLines(
+  selection: EditorSelection,
+  direction: -1 | 1
+): EditorSelection {
+  return {
+    start: {
+      line: selection.start.line + direction,
+      character: selection.start.character,
+    },
+    end: {
+      line: selection.end.line + direction,
+      character: selection.end.character,
+    },
+    direction: selection.direction,
+  };
+}
+
+/**
  * Finds the next matching word and updates the selections.
  */
 export function findNexMatch(

--- a/packages/diffs/src/editor/selection.ts
+++ b/packages/diffs/src/editor/selection.ts
@@ -1363,21 +1363,36 @@ export function getSelectedLineBlocks(
 }
 
 /**
- * Moves a selection's line positions after its lines are shifted.
+ * Moves a selection's line positions after its lines are shifted, clamping to
+ * the target document bounds.
  */
 export function shiftSelectionLines(
   selection: EditorSelection,
-  direction: -1 | 1
+  direction: -1 | 1,
+  lineCount: number,
+  getLineLength: (line: number) => number
 ): EditorSelection {
+  const shiftPosition = (position: Position): Position => {
+    const line = position.line + direction;
+    if (line >= lineCount) {
+      const lastLine = Math.max(0, lineCount - 1);
+      return {
+        line: lastLine,
+        character: getLineLength(lastLine),
+      };
+    }
+    if (line < 0) {
+      return { line: 0, character: 0 };
+    }
+    return {
+      line,
+      character: position.character,
+    };
+  };
+
   return {
-    start: {
-      line: selection.start.line + direction,
-      character: selection.start.character,
-    },
-    end: {
-      line: selection.end.line + direction,
-      character: selection.end.character,
-    },
+    start: shiftPosition(selection.start),
+    end: shiftPosition(selection.end),
     direction: selection.direction,
   };
 }

--- a/packages/diffs/test/editorApplyEdits.test.ts
+++ b/packages/diffs/test/editorApplyEdits.test.ts
@@ -681,6 +681,34 @@ describe('Editor move line commands', () => {
     }
   });
 
+  test('clamps an exclusive selection end when moving to EOF', async () => {
+    const { cleanup, content, editor, window } = await createEditorFixture(
+      'alpha\nbravo\ncharlie'
+    );
+
+    try {
+      editor.setSelections([
+        {
+          start: { line: 1, character: 0 },
+          end: { line: 2, character: 0 },
+          direction: 'forward',
+        },
+      ]);
+
+      pressMoveLine(window, content, 'down');
+      expect(editor.getState().file.contents).toBe('alpha\ncharlie\nbravo');
+      expect(editor.getState().selections).toEqual([
+        {
+          start: { line: 2, character: 0 },
+          end: { line: 2, character: 5 },
+          direction: 1,
+        },
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+
   test('moves multiple selections as separate line blocks', async () => {
     const { cleanup, content, editor, window } =
       await createEditorFixture('a\nb\nc\nd\ne\nf');

--- a/packages/diffs/test/editorApplyEdits.test.ts
+++ b/packages/diffs/test/editorApplyEdits.test.ts
@@ -651,6 +651,34 @@ describe('Editor move line commands', () => {
     }
   });
 
+  test('moves the final line up without adding a trailing newline', async () => {
+    const { cleanup, content, editor, window } = await createEditorFixture(
+      'alpha\nbravo\ncharlie'
+    );
+
+    try {
+      editor.setSelections([
+        {
+          start: { line: 2, character: 3 },
+          end: { line: 2, character: 3 },
+          direction: 'none',
+        },
+      ]);
+
+      pressMoveLine(window, content, 'up');
+      expect(editor.getState().file.contents).toBe('alpha\ncharlie\nbravo');
+      expect(editor.getState().selections).toEqual([
+        {
+          start: { line: 1, character: 3 },
+          end: { line: 1, character: 3 },
+          direction: 0,
+        },
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+
   test('moves every selected line in a range', async () => {
     const { cleanup, content, editor, window } = await createEditorFixture(
       'zero\none\ntwo\nthree\nfour'

--- a/packages/diffs/test/editorApplyEdits.test.ts
+++ b/packages/diffs/test/editorApplyEdits.test.ts
@@ -96,6 +96,22 @@ function pressUndoRedo(
   );
 }
 
+function pressMoveLine(
+  window: EditorTestWindow,
+  content: HTMLElement,
+  direction: 'up' | 'down'
+): void {
+  content.dispatchEvent(
+    new window.KeyboardEvent('keydown', {
+      key: direction === 'up' ? 'ArrowUp' : 'ArrowDown',
+      altKey: true,
+      bubbles: true,
+      composed: true,
+      cancelable: true,
+    })
+  );
+}
+
 describe('Editor.applyEdits selection sync', () => {
   test('shifts the caret down when an edit inserts lines above it', async () => {
     const { cleanup, editor } = await createEditorFixture(
@@ -591,6 +607,113 @@ describe('Editor.applyEdits selection sync', () => {
       expect(setBaseAndExtent).not.toHaveBeenCalled();
     } finally {
       getSelectionStub.mockRestore();
+      cleanup();
+    }
+  });
+});
+
+describe('Editor move line commands', () => {
+  test('moves the current line up and down', async () => {
+    const { cleanup, content, editor, window } = await createEditorFixture(
+      'alpha\nbravo\ncharlie'
+    );
+
+    try {
+      editor.setSelections([
+        {
+          start: { line: 1, character: 2 },
+          end: { line: 1, character: 2 },
+          direction: 'none',
+        },
+      ]);
+
+      pressMoveLine(window, content, 'up');
+      expect(editor.getState().file.contents).toBe('bravo\nalpha\ncharlie');
+      expect(editor.getState().selections).toEqual([
+        {
+          start: { line: 0, character: 2 },
+          end: { line: 0, character: 2 },
+          direction: 0,
+        },
+      ]);
+
+      pressMoveLine(window, content, 'down');
+      expect(editor.getState().file.contents).toBe('alpha\nbravo\ncharlie');
+      expect(editor.getState().selections).toEqual([
+        {
+          start: { line: 1, character: 2 },
+          end: { line: 1, character: 2 },
+          direction: 0,
+        },
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('moves every selected line in a range', async () => {
+    const { cleanup, content, editor, window } = await createEditorFixture(
+      'zero\none\ntwo\nthree\nfour'
+    );
+
+    try {
+      editor.setSelections([
+        {
+          start: { line: 1, character: 1 },
+          end: { line: 3, character: 2 },
+          direction: 'forward',
+        },
+      ]);
+
+      pressMoveLine(window, content, 'down');
+      expect(editor.getState().file.contents).toBe(
+        'zero\nfour\none\ntwo\nthree'
+      );
+      expect(editor.getState().selections).toEqual([
+        {
+          start: { line: 2, character: 1 },
+          end: { line: 4, character: 2 },
+          direction: 1,
+        },
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('moves multiple selections as separate line blocks', async () => {
+    const { cleanup, content, editor, window } =
+      await createEditorFixture('a\nb\nc\nd\ne\nf');
+
+    try {
+      editor.setSelections([
+        {
+          start: { line: 1, character: 0 },
+          end: { line: 1, character: 1 },
+          direction: 'forward',
+        },
+        {
+          start: { line: 4, character: 0 },
+          end: { line: 4, character: 1 },
+          direction: 'forward',
+        },
+      ]);
+
+      pressMoveLine(window, content, 'up');
+      expect(editor.getState().file.contents).toBe('b\na\nc\ne\nd\nf');
+      expect(editor.getState().selections).toEqual([
+        {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 1 },
+          direction: 1,
+        },
+        {
+          start: { line: 3, character: 0 },
+          end: { line: 3, character: 1 },
+          direction: 1,
+        },
+      ]);
+    } finally {
       cleanup();
     }
   });

--- a/packages/diffs/test/editorCommand.test.ts
+++ b/packages/diffs/test/editorCommand.test.ts
@@ -8,7 +8,7 @@ import {
 
 type ShortcutKeyboardEvent = Pick<
   KeyboardEvent,
-  'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey' | 'key'
+  'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey' | 'key' | 'code'
 >;
 type ShortcutCase = {
   event: Partial<ShortcutKeyboardEvent> & Pick<ShortcutKeyboardEvent, 'key'>;
@@ -73,6 +73,24 @@ describe('resolveEditorShortcutCommand', () => {
         event: { key: 'ArrowDown', metaKey: true },
         expected: 'moveCursorToDocEnd',
       },
+      { event: { key: 'ArrowUp', altKey: true }, expected: 'moveLineUp' },
+      { event: { key: 'ArrowDown', altKey: true }, expected: 'moveLineDown' },
+      {
+        event: { key: 'p', altKey: true, ctrlKey: true },
+        expected: 'moveLineUp',
+      },
+      {
+        event: { key: 'π', code: 'KeyP', altKey: true, ctrlKey: true },
+        expected: 'moveLineUp',
+      },
+      {
+        event: { key: 'n', altKey: true, ctrlKey: true },
+        expected: 'moveLineDown',
+      },
+      {
+        event: { key: '~', code: 'KeyN', altKey: true, ctrlKey: true },
+        expected: 'moveLineDown',
+      },
     ]);
   });
 
@@ -87,6 +105,34 @@ describe('resolveEditorShortcutCommand', () => {
         expected: 'moveCursorToDocStart',
       },
       { event: { key: 'End', ctrlKey: true }, expected: 'moveCursorToDocEnd' },
+      { event: { key: 'ArrowUp', altKey: true }, expected: 'moveLineUp' },
+      { event: { key: 'ArrowDown', altKey: true }, expected: 'moveLineDown' },
+      {
+        event: { key: 'p', altKey: true, ctrlKey: true },
+        expected: 'moveLineUp',
+      },
+      {
+        event: {
+          key: 'Unidentified',
+          code: 'KeyP',
+          altKey: true,
+          ctrlKey: true,
+        },
+        expected: 'moveLineUp',
+      },
+      {
+        event: { key: 'n', altKey: true, ctrlKey: true },
+        expected: 'moveLineDown',
+      },
+      {
+        event: {
+          key: 'Unidentified',
+          code: 'KeyN',
+          altKey: true,
+          ctrlKey: true,
+        },
+        expected: 'moveLineDown',
+      },
     ]);
   });
 


### PR DESCRIPTION
- Add `moveLineUp` and `moveLineDown` editor commands
- Shortcuts:
  - `Alt + ↑` / `Alt +↓`
  - `Alt + Ctrl + P` / `Alt + Ctrl + N` on macOS and Linux