### PR TITLE
fix(diffs): Preserve annotations across line edits

### DIFF
--- a/packages/diffs/src/editor/lineAnnotations.ts
+++ b/packages/diffs/src/editor/lineAnnotations.ts
@@ -1,55 +1,58 @@
 import type { DiffLineAnnotation } from '../types';
 import { getLineAnnotationName } from '../utils/getLineAnnotationName';
-import type { TextDocumentChange } from './textDocument';
+import type {
+  TextDocumentChange,
+  TextDocumentLineChange,
+} from './textDocument';
 import { getLineNumberAttr, h } from './utils';
 
 export function applyDocumentChangeToLineAnnotations<T>(
   change: TextDocumentChange,
   lineAnnotations: DiffLineAnnotation<T>[]
 ): DiffLineAnnotation<T>[] | undefined {
-  if (change.lineDelta === 0) {
+  const lineChanges = getLineChanges(change);
+  if (lineChanges.length === 0) {
     return undefined;
   }
 
-  const startCharacter = change.startCharacter;
-  const removedLineCount = Math.max(0, -change.lineDelta);
-  const deletedStartLine =
-    removedLineCount === 0
-      ? undefined
-      : change.startLine + (startCharacter === 0 ? 0 : 1);
-  const deletedEndLine =
-    deletedStartLine === undefined
-      ? undefined
-      : deletedStartLine + removedLineCount;
-  const shiftFromLine =
-    removedLineCount > 0
-      ? change.startLine + removedLineCount
-      : change.startLine + (startCharacter === 0 ? 0 : 1);
   const nextLineAnnotations: DiffLineAnnotation<T>[] = [];
-
   let changed = false;
   for (const annotation of lineAnnotations) {
-    if (annotation.side === 'deletions') {
+    if (annotation.side === 'deletions' || annotation.lineNumber <= 0) {
       nextLineAnnotations.push(annotation);
       continue;
     }
 
-    const line = annotation.lineNumber - 1;
-    if (
-      deletedStartLine !== undefined &&
-      deletedEndLine !== undefined &&
-      line >= deletedStartLine &&
-      line < deletedEndLine
-    ) {
-      changed = true;
-      continue;
+    let line = annotation.lineNumber - 1;
+    let lineCount = change.previousLineCount;
+    let annotationChanged = false;
+    for (const lineChange of lineChanges) {
+      const nextLineCount = Math.max(1, lineCount + lineChange.lineDelta);
+      const nextLine = mapLineThroughLineChange(
+        line,
+        lineChange,
+        nextLineCount
+      );
+      if (
+        nextLine !== line ||
+        lineChangeTouchesAnnotationLine(line, lineChange)
+      ) {
+        annotationChanged = true;
+      }
+      line = nextLine;
+      lineCount = nextLineCount;
     }
 
-    if (line >= shiftFromLine) {
-      nextLineAnnotations.push({
-        ...annotation,
-        lineNumber: line + change.lineDelta + 1,
-      });
+    const lineNumber = line + 1;
+    if (annotationChanged) {
+      nextLineAnnotations.push(
+        lineNumber === annotation.lineNumber
+          ? annotation
+          : {
+              ...annotation,
+              lineNumber,
+            }
+      );
       changed = true;
       continue;
     }
@@ -58,6 +61,86 @@ export function applyDocumentChangeToLineAnnotations<T>(
   }
 
   return changed ? nextLineAnnotations : undefined;
+}
+
+function getLineChanges(
+  change: TextDocumentChange
+): readonly TextDocumentLineChange[] {
+  if (change.lineChanges !== undefined) {
+    return change.lineChanges;
+  }
+  if (change.lineDelta === 0) {
+    return [];
+  }
+  const removedLineCount = Math.max(0, -change.lineDelta);
+  const startLine =
+    removedLineCount > 0 && change.startCharacter > 0
+      ? change.startLine + 1
+      : change.startLine;
+  return [
+    {
+      startLine,
+      startCharacter: change.startCharacter,
+      endLine: startLine + removedLineCount,
+      endCharacter: 0,
+      insertedLineBreaks: Math.max(0, change.lineDelta),
+      lineDelta: change.lineDelta,
+    },
+  ];
+}
+
+function mapLineThroughLineChange(
+  line: number,
+  lineChange: TextDocumentLineChange,
+  nextLineCount: number
+): number {
+  if (line < lineChange.startLine) {
+    return line;
+  }
+
+  if (
+    line > lineChange.endLine ||
+    (lineChange.endLine > lineChange.startLine &&
+      line === lineChange.endLine &&
+      lineChange.endCharacter === 0)
+  ) {
+    return line + lineChange.lineDelta;
+  }
+
+  if (lineChange.startLine === lineChange.endLine) {
+    if (lineChange.startCharacter === 0) {
+      return line + lineChange.insertedLineBreaks;
+    }
+    return line;
+  }
+
+  const replacementLineOffset = Math.min(
+    Math.max(0, line - lineChange.startLine),
+    lineChange.insertedLineBreaks
+  );
+  return clampLine(lineChange.startLine + replacementLineOffset, nextLineCount);
+}
+
+function lineChangeTouchesAnnotationLine(
+  line: number,
+  lineChange: TextDocumentLineChange
+): boolean {
+  if (
+    lineChange.lineDelta === 0 ||
+    line < lineChange.startLine ||
+    line > lineChange.endLine
+  ) {
+    return false;
+  }
+  return !(
+    lineChange.endLine > lineChange.startLine &&
+    line === lineChange.endLine &&
+    lineChange.endCharacter === 0
+  );
+}
+
+function clampLine(line: number, lineCount: number): number {
+  return Math.max(0, Math.min(line, Math.max(0, lineCount - 1)));
 }
 
 export function renderLineAnnotations<LAnnotation>(

--- a/packages/diffs/src/editor/textDocument.ts
+++ b/packages/diffs/src/editor/textDocument.ts
@@ -96,6 +96,21 @@ export interface ResolvedTextEdit {
   readonly text: string;
 }
 
+export interface TextDocumentLineChange {
+  /** Line where this edit starts, adjusted for previous edits in the batch. */
+  readonly startLine: number;
+  /** Character on the start line where this edit begins. */
+  readonly startCharacter: number;
+  /** Line where this edit ends, adjusted for previous edits in the batch. */
+  readonly endLine: number;
+  /** Character on the end line where this edit ends. */
+  readonly endCharacter: number;
+  /** Number of line breaks inserted by this edit's replacement text. */
+  readonly insertedLineBreaks: number;
+  /** Difference between old and new line counts for this edit. */
+  readonly lineDelta: number;
+}
+
 export interface TextDocumentChange {
   /** First line whose rendered content or tokenizer state may have changed. */
   readonly startLine: number;
@@ -111,6 +126,11 @@ export interface TextDocumentChange {
   readonly lineDelta: number;
   /** Exact rendered line ranges touched by each edit after the edit was applied. */
   readonly changedLineRanges: readonly [startLine: number, endLine: number][];
+  /**
+   * Per-edit line changes, stored non-enumerably by TextDocument so exact
+   * object assertions and public logging keep the compact change shape.
+   */
+  readonly lineChanges?: readonly TextDocumentLineChange[];
 }
 
 /**
@@ -421,6 +441,12 @@ export class TextDocument<LAnnotation> {
       lineDelta: lineCount - previousLineCount,
       changedLineRanges: changedLineRange.ranges,
     };
+    Object.defineProperty(change, 'lineChanges', {
+      value: changedLineRange.lineChanges,
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    });
     return change;
   }
 
@@ -431,20 +457,33 @@ export class TextDocument<LAnnotation> {
     startLine: number;
     endLine: number;
     ranges: [number, number][];
+    lineChanges: TextDocumentLineChange[];
   } {
     let startLine = Infinity;
     let endLine = 0;
     let lineDeltaBeforeEdit = 0;
     const ranges: [number, number][] = [];
+    const lineChanges: TextDocumentLineChange[] = [];
     for (let i = 0; i < edits.length; i++) {
       const edit = edits[i];
-      const editStartLine = editPositions[i * 2].line;
-      const editEndLine = editPositions[i * 2 + 1].line;
+      const editStart = editPositions[i * 2];
+      const editEnd = editPositions[i * 2 + 1];
+      const editStartLine = editStart.line;
+      const editEndLine = editEnd.line;
       const insertedLineSpan = countLineBreaks(edit.text);
       const changedStartLine = editStartLine + lineDeltaBeforeEdit;
       const changedEndLine = changedStartLine + insertedLineSpan;
+      const lineDelta = insertedLineSpan - (editEndLine - editStartLine);
       startLine = Math.min(startLine, editStartLine);
       endLine = Math.max(endLine, changedEndLine);
+      lineChanges.push({
+        startLine: changedStartLine,
+        startCharacter: editStart.character,
+        endLine: editEndLine + lineDeltaBeforeEdit,
+        endCharacter: editEnd.character,
+        insertedLineBreaks: insertedLineSpan,
+        lineDelta,
+      });
       const lastRange = ranges[ranges.length - 1];
       if (lastRange !== undefined && changedStartLine <= lastRange[1] + 1) {
         ranges[ranges.length - 1] = [
@@ -454,15 +493,16 @@ export class TextDocument<LAnnotation> {
       } else {
         ranges.push([changedStartLine, changedEndLine]);
       }
-      lineDeltaBeforeEdit += insertedLineSpan - (editEndLine - editStartLine);
+      lineDeltaBeforeEdit += lineDelta;
     }
     if (startLine === Infinity) {
       return {
         startLine: 0,
         endLine: 0,
         ranges: [[0, 0]],
+        lineChanges: [],
       };
     }
-    return { startLine, endLine, ranges };
+    return { startLine, endLine, ranges, lineChanges };
   }
 }

--- a/packages/diffs/test/editorLineAnnotations.test.ts
+++ b/packages/diffs/test/editorLineAnnotations.test.ts
@@ -5,7 +5,7 @@ import { TextDocument } from '../src/editor/textDocument';
 import type { DiffLineAnnotation } from '../src/types';
 
 describe('applyDocumentChangeToLineAnnotations', () => {
-  test('deletes annotations attached to deleted lines', () => {
+  test('keeps annotations attached to the nearest line when their line is deleted', () => {
     const textDocument = new TextDocument('inmemory://1', 'one\ntwo\nthree');
     const annotations: DiffLineAnnotation<string>[] = [
       { side: 'additions', lineNumber: 1, metadata: 'one' },
@@ -25,6 +25,56 @@ describe('applyDocumentChangeToLineAnnotations', () => {
 
     expect(applyDocumentChangeToLineAnnotations(change!, annotations)).toEqual([
       { side: 'additions', lineNumber: 1, metadata: 'one' },
+      { side: 'additions', lineNumber: 2, metadata: 'two' },
+      { side: 'additions', lineNumber: 2, metadata: 'three' },
+    ]);
+  });
+
+  test('returns a refreshed annotation list when a deleted line keeps the same line number', () => {
+    const textDocument = new TextDocument('inmemory://1', 'one\ntwo\nthree');
+    const annotations: DiffLineAnnotation<string>[] = [
+      { side: 'additions', lineNumber: 2, metadata: 'two' },
+    ];
+
+    const change = textDocument.applyEdits([
+      {
+        range: {
+          start: { line: 1, character: 0 },
+          end: { line: 2, character: 0 },
+        },
+        newText: '',
+      },
+    ]);
+    const nextAnnotations = applyDocumentChangeToLineAnnotations(
+      change!,
+      annotations
+    );
+
+    expect(nextAnnotations).not.toBe(annotations);
+    expect(nextAnnotations).toEqual([
+      { side: 'additions', lineNumber: 2, metadata: 'two' },
+    ]);
+  });
+
+  test('moves annotations on a merged line instead of deleting them', () => {
+    const textDocument = new TextDocument('inmemory://1', 'one\ntwo\nthree');
+    const annotations: DiffLineAnnotation<string>[] = [
+      { side: 'additions', lineNumber: 2, metadata: 'two' },
+      { side: 'additions', lineNumber: 3, metadata: 'three' },
+    ];
+
+    const change = textDocument.applyEdits([
+      {
+        range: {
+          start: { line: 0, character: 3 },
+          end: { line: 1, character: 0 },
+        },
+        newText: '',
+      },
+    ]);
+
+    expect(applyDocumentChangeToLineAnnotations(change!, annotations)).toEqual([
+      { side: 'additions', lineNumber: 1, metadata: 'two' },
       { side: 'additions', lineNumber: 2, metadata: 'three' },
     ]);
   });
@@ -73,5 +123,39 @@ describe('applyDocumentChangeToLineAnnotations', () => {
     expect(
       applyDocumentChangeToLineAnnotations(change!, annotations)
     ).toBeUndefined();
+  });
+
+  test('moves annotations through net-zero multi-edits', () => {
+    const textDocument = new TextDocument(
+      'inmemory://1',
+      'one\ntwo\nthree\nfour\nfive'
+    );
+    const annotations: DiffLineAnnotation<string>[] = [
+      { side: 'additions', lineNumber: 2, metadata: 'two' },
+      { side: 'additions', lineNumber: 3, metadata: 'three' },
+    ];
+
+    const change = textDocument.applyEdits([
+      {
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 0 },
+        },
+        newText: 'inserted\n',
+      },
+      {
+        range: {
+          start: { line: 3, character: 0 },
+          end: { line: 4, character: 0 },
+        },
+        newText: '',
+      },
+    ]);
+
+    expect(change?.lineDelta).toBe(0);
+    expect(applyDocumentChangeToLineAnnotations(change!, annotations)).toEqual([
+      { side: 'additions', lineNumber: 3, metadata: 'two' },
+      { side: 'additions', lineNumber: 4, metadata: 'three' },
+    ]);
   });
 });


### PR DESCRIPTION
1. Open a diff editor with an annotation on an added line.
2. Delete that line, or delete the newline immediately above it.
3. Undo and redo the edit, or insert another line above it.
4. The annotation disappears or fails to return with history.

The annotation mapper only used the aggregate line delta for an edit batch. That made it guess deleted ranges, drop annotations on deleted lines, and skip net-zero batches where one edit added lines and another removed them.

Record per-edit line changes on TextDocumentChange and map annotations through each line edit in order. Keep annotations by moving them to the nearest surviving line, and refresh touched annotation lists so undo and redo restore the right annotation state.