### PR TITLE
fix(diffs): Suppress repeated paste shortcuts

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -1209,15 +1209,21 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
           return;
         }
 
-        // Handle the 'paste' event manually with the custom clipboard API.
-        if (
-          e.key === 'v' &&
-          isPrimaryModifier(e) &&
-          this.#options.clipboard !== undefined
-        ) {
-          e.preventDefault();
-          queueRender(this.#handleCustomPasteEvent);
-          return;
+        const normalizedKey = e.key.length === 1 ? e.key.toLowerCase() : e.key;
+        if (normalizedKey === 'v' && isPrimaryModifier(e)) {
+          // Holding paste can enqueue a costly full diff recompute for every
+          // keyboard repeat. Accept the first paste and suppress repeats.
+          if (e.repeat) {
+            e.preventDefault();
+            return;
+          }
+
+          // Handle the 'paste' event manually with the custom clipboard API.
+          if (this.#options.clipboard !== undefined) {
+            e.preventDefault();
+            queueRender(this.#handleCustomPasteEvent);
+            return;
+          }
         }
 
         // Only hijack the native find-again shortcut while the panel is open

--- a/packages/diffs/test/editorClipboard.test.ts
+++ b/packages/diffs/test/editorClipboard.test.ts
@@ -12,7 +12,7 @@ import type {
   HighlightedToken,
   RenderRange,
 } from '../src/types';
-import { installDom } from './domHarness';
+import { installDom, wait } from './domHarness';
 
 function createTestHighlighter(): DiffsHighlighter {
   return {
@@ -217,6 +217,25 @@ function dispatchPaste(target: HTMLElement, text: string): void {
 
   target.dispatchEvent(event);
   expect(event.defaultPrevented).toBe(true);
+}
+
+function dispatchPasteShortcutKeydown(
+  target: HTMLElement,
+  repeat = false,
+  init: Partial<KeyboardEventInit> = {}
+): KeyboardEvent {
+  const event = new window.KeyboardEvent('keydown', {
+    key: init.key ?? 'v',
+    code: init.code ?? 'KeyV',
+    metaKey: true,
+    repeat,
+    ...init,
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+  });
+  target.dispatchEvent(event);
+  return event;
 }
 
 describe('Editor clipboard events', () => {
@@ -489,6 +508,131 @@ describe('Editor clipboard events', () => {
       const writes = dispatchCopy(component.contentElement);
 
       expect(writes).toEqual([['text', 'charlie']]);
+    } finally {
+      editor.cleanUp();
+      cleanup();
+    }
+  });
+
+  test('allows the first browser paste shortcut and suppresses repeat paste', () => {
+    const { cleanup } = installDom();
+
+    const editor = new Editor<undefined>();
+    const component = new TestEditableComponent({
+      name: 'example.txt',
+      contents: 'alpha',
+      lang: 'text',
+    });
+
+    try {
+      editor.edit(component);
+      editor.setSelections([
+        {
+          start: { line: 0, character: 5 },
+          end: { line: 0, character: 5 },
+          direction: 'none',
+        },
+      ]);
+
+      const firstKeydown = dispatchPasteShortcutKeydown(
+        component.contentElement,
+        false,
+        { key: 'V', shiftKey: true }
+      );
+      expect(firstKeydown.defaultPrevented).toBe(false);
+      dispatchPaste(component.contentElement, ' bravo');
+      expect(editor.getState().file.contents).toBe('alpha bravo');
+
+      const repeatKeydown = dispatchPasteShortcutKeydown(
+        component.contentElement,
+        true,
+        { key: 'V', shiftKey: true }
+      );
+      expect(repeatKeydown.defaultPrevented).toBe(true);
+      expect(editor.getState().file.contents).toBe('alpha bravo');
+    } finally {
+      editor.cleanUp();
+      cleanup();
+    }
+  });
+
+  test('does not read from a custom clipboard provider on repeat paste', async () => {
+    const { cleanup } = installDom();
+    let reads = 0;
+
+    const editor = new Editor<undefined>({
+      clipboard: {
+        readText: () => {
+          reads++;
+          return ' bravo';
+        },
+      },
+    });
+    const component = new TestEditableComponent({
+      name: 'example.txt',
+      contents: 'alpha',
+      lang: 'text',
+    });
+
+    try {
+      editor.edit(component);
+      editor.setSelections([
+        {
+          start: { line: 0, character: 5 },
+          end: { line: 0, character: 5 },
+          direction: 'none',
+        },
+      ]);
+
+      const repeatKeydown = dispatchPasteShortcutKeydown(
+        component.contentElement,
+        true
+      );
+      await wait();
+
+      expect(repeatKeydown.defaultPrevented).toBe(true);
+      expect(reads).toBe(0);
+      expect(editor.getState().file.contents).toBe('alpha');
+    } finally {
+      editor.cleanUp();
+      cleanup();
+    }
+  });
+
+  test('reads from a custom clipboard provider on first paste shortcut', async () => {
+    const { cleanup } = installDom();
+    let reads = 0;
+
+    const editor = new Editor<undefined>({
+      clipboard: {
+        readText: () => {
+          reads++;
+          return ' bravo';
+        },
+      },
+    });
+    const component = new TestEditableComponent({
+      name: 'example.txt',
+      contents: 'alpha',
+      lang: 'text',
+    });
+
+    try {
+      editor.edit(component);
+      editor.setSelections([
+        {
+          start: { line: 0, character: 5 },
+          end: { line: 0, character: 5 },
+          direction: 'none',
+        },
+      ]);
+
+      const keydown = dispatchPasteShortcutKeydown(component.contentElement);
+      await wait();
+
+      expect(keydown.defaultPrevented).toBe(true);
+      expect(reads).toBe(1);
+      expect(editor.getState().file.contents).toBe('alpha bravo');
     } finally {
       editor.cleanUp();
       cleanup();


### PR DESCRIPTION
A user can trigger the lag like this:
1. Focus an editable diff.
2. Hold Cmd+V or Ctrl+V with text on the clipboard.
3. The editor accepts each repeated paste keydown.
4. Each paste can add lines and make the page fall behind.

The root cause is that a held paste key produces repeat keydown events. Each accepted repeat can lead to another paste and another expensive diff update. For multi-line text, that update can recompute diff state from the full edited document.

Suppress repeated paste keydowns and let the first keydown keep the existing behavior. This keeps normal paste, including custom clipboard providers, while blocking the runaway repeat path.
