### PR TITLE
[diffs/edit] impove preformance by removing `TextDocument.getText()` calls

### DIFF
--- a/packages/diffs/src/editor/selection.ts
+++ b/packages/diffs/src/editor/selection.ts
@@ -397,7 +397,7 @@ function getNextSelectionOffsetPairAfterReplace(
   const insertEnd = insertStart + newText.length;
   const originalLength = entry.end - entry.start;
   if (originalLength > 0) {
-    const originalText = textDocument.getText().slice(entry.start, entry.end);
+    const originalText = textDocument.getTextSlice(entry.start, entry.end);
     const preservedOffset = newText.indexOf(originalText);
     if (
       preservedOffset !== -1 &&
@@ -660,7 +660,6 @@ export function applyTransposeToSelections<LAnnotation>(
   nextSelections: EditorSelection[];
   change?: TextDocumentChange;
 } {
-  const text = textDocument.getText();
   const edits: ResolvedTextEdit[] = [];
   const nextOffsetPairs: Array<[number, number]> = [];
 
@@ -736,7 +735,7 @@ export function applyTransposeToSelections<LAnnotation>(
       const prevStart = prevEnd - (prevLength - prevGraphemeStart);
       const newText =
         lineText.slice(0, firstEnd) +
-        text.slice(prevEnd, offset) +
+        textDocument.getTextSlice(prevEnd, offset) +
         prevLineText.slice(prevGraphemeStart, prevLength);
       edit = {
         start: prevStart,

--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -73,7 +73,6 @@ import type { DiffLineMetadata } from '../utils/iterateOverDiff';
 import { iterateOverDiff } from '../utils/iterateOverDiff';
 import { renderDiffWithHighlighter } from '../utils/renderDiffWithHighlighter';
 import { shouldUseTokenTransformer } from '../utils/shouldUseTokenTransformer';
-import { splitFileContents } from '../utils/splitFileContents';
 import {
   recomputeDiffHunksForEdit,
   recomputeEmptyDocumentDiff,
@@ -430,21 +429,10 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
 
     // updateRenderCache may already have extended diff.additionLines for the
     // same edit pass, so never bail out purely on matching lengths here.
-    const documentText = textDocument.getText();
-    if (documentText.trim().length === 0) {
-      // Blank documents need the editor's logical line count: `"\n"` is two
-      // editable rows even though the diff parser sees one newline token.
-      diff.additionLines = getEditorDocumentLines(textDocument);
-    } else {
-      const parsedLines = splitFileContents(documentText);
-      // A non-empty document ending in a line break has a final logical empty
-      // line in the editor. Patch-style splitting drops that row, but edit mode
-      // still needs it as a caret host after pressing Enter.
-      diff.additionLines =
-        parsedLines.length < textDocument.lineCount
-          ? getEditorDocumentLines(textDocument)
-          : parsedLines;
-    }
+    // Read line-by-line from the editor document instead of materializing the
+    // entire text. This preserves blank documents and the final editable empty
+    // row after a trailing line break.
+    diff.additionLines = getEditorDocumentLines(textDocument);
 
     const newLength = diff.additionLines.length;
     const additionHastLines = result.code.additionLines;

--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -432,7 +432,10 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
     // Read line-by-line from the editor document instead of materializing the
     // entire text. This preserves blank documents and the final editable empty
     // row after a trailing line break.
-    diff.additionLines = getEditorDocumentLines(textDocument);
+    diff.additionLines = getEditorDocumentLines(
+      textDocument,
+      diff.additionLines
+    );
 
     const newLength = diff.additionLines.length;
     const additionHastLines = result.code.additionLines;
@@ -1994,12 +1997,40 @@ function createPlainAdditionLineElement(
   };
 }
 
-function getEditorDocumentLines(textDocument: DiffsTextDocument): string[] {
+function getEditorDocumentLines(
+  textDocument: DiffsTextDocument,
+  previousLines: string[]
+): string[] {
   const lines: string[] = [];
+  const fallbackLineBreak = getFallbackLineBreak(previousLines);
   for (let line = 0; line < textDocument.lineCount; line++) {
-    lines.push(textDocument.getLineText(line, true));
+    const lineText = textDocument.getLineText(line, true);
+    lines.push(
+      line < textDocument.lineCount - 1 && !hasLineBreakSuffix(lineText)
+        ? lineText + fallbackLineBreak
+        : lineText
+    );
   }
   return lines;
+}
+
+function hasLineBreakSuffix(line: string): boolean {
+  return line.endsWith('\n') || line.endsWith('\r');
+}
+
+function getFallbackLineBreak(lines: string[]): string {
+  for (const line of lines) {
+    if (line.endsWith('\r\n')) {
+      return '\r\n';
+    }
+    if (line.endsWith('\n')) {
+      return '\n';
+    }
+    if (line.endsWith('\r')) {
+      return '\r';
+    }
+  }
+  return '\n';
 }
 
 // Host line text omits line endings; diff line arrays keep the suffix from parsing.

--- a/packages/diffs/test/DiffHunksRendererRecompute.test.ts
+++ b/packages/diffs/test/DiffHunksRendererRecompute.test.ts
@@ -170,6 +170,30 @@ describe('DiffHunksRenderer content-edit recompute split', () => {
       additionLineNumber: 1,
     });
   });
+
+  test('line-count edits preserve line breaks from legacy host documents', async () => {
+    const renderer = await createPrimedRenderer('split');
+
+    renderer.applyDocumentChange({
+      ...makeTextDocument(EDITED_LINES),
+      getText: () => {
+        throw new Error('getText should not be called for line-count edits');
+      },
+    });
+
+    const rendered = renderer.diffCache;
+    expect(rendered).toBeDefined();
+    if (rendered == null) return;
+
+    expect(rendered.additionLines).toEqual([
+      'function greet(name) {\n',
+      '  console.log(\n',
+      'msg);\n',
+      '  return msg;\n',
+      '}\n',
+    ]);
+    expect(rendered.additionLines.join('')).toBe(EDITED_LINES.join('\n'));
+  });
 });
 
 // Deleting every character empties the editor's document, whose text is "".

--- a/packages/diffs/test/FileDiff.unifiedEditSeparators.test.ts
+++ b/packages/diffs/test/FileDiff.unifiedEditSeparators.test.ts
@@ -38,7 +38,10 @@ function makeTextDocument(lines: string[]): DiffsTextDocument {
   return {
     lineCount: lines.length,
     getText: () => text,
-    getLineText: (lineNumber: number) => lines[lineNumber] ?? '',
+    getLineText: (lineNumber: number, includeLineBreak = false) => {
+      const line = lines[lineNumber] ?? '';
+      return includeLineBreak ? line : line.replace(/\r?\n$/, '');
+    },
   };
 }
 
@@ -88,13 +91,7 @@ describe('FileDiff unified edit separators', () => {
 
       expect(countSeparatorSlots(fileContainer)).toBeGreaterThan(0);
 
-      const editedLines = [...fileDiff.additionLines];
-      const line = editedLines[40];
-      if (line == null) {
-        throw new Error('Expected a line to split');
-      }
-      editedLines.splice(40, 1, line.slice(0, 5), line.slice(5));
-      instance.applyDocumentChange(makeTextDocument(editedLines));
+      instance.applyDocumentChange(makeTextDocument(fileDiff.deletionLines));
 
       expect(countSeparatorSlots(fileContainer)).toBe(0);
     } finally {


### PR DESCRIPTION
Calling `getText()` of a text document without giving range is expensive on a large file, the pr fixes that