### PR TITLE
[diffs/editor] fix lineAnnotations rendering

### DIFF
--- a/packages/diffs/src/editor/lineAnnotations.ts
+++ b/packages/diffs/src/editor/lineAnnotations.ts
@@ -1,17 +1,23 @@
 import type { DiffLineAnnotation } from '../types';
 import { getLineAnnotationName } from '../utils/getLineAnnotationName';
-import type {
-  TextDocumentChange,
-  TextDocumentLineChange,
-} from './textDocument';
+import type { TextDocumentChange } from './textDocument';
 import { getLineNumberAttr, h } from './utils';
+
+interface LineAnnotationChange {
+  readonly startLine: number;
+  readonly startCharacter: number;
+  readonly endLine: number;
+  readonly deletesEndLine: boolean;
+  readonly insertedLineBreaks: number;
+  readonly lineDelta: number;
+}
 
 export function applyDocumentChangeToLineAnnotations<T>(
   change: TextDocumentChange,
   lineAnnotations: DiffLineAnnotation<T>[]
 ): DiffLineAnnotation<T>[] | undefined {
-  const lineChanges = getLineChanges(change);
-  if (lineChanges.length === 0) {
+  const annotationChanges = getLineAnnotationChanges(change);
+  if (annotationChanges.length === 0) {
     return undefined;
   }
 
@@ -23,16 +29,21 @@ export function applyDocumentChangeToLineAnnotations<T>(
       continue;
     }
 
-    let line = annotation.lineNumber - 1;
+    let line: number | undefined = annotation.lineNumber - 1;
     let lineCount = change.previousLineCount;
     let annotationChanged = false;
-    for (const lineChange of lineChanges) {
+    for (const lineChange of annotationChanges) {
       const nextLineCount = Math.max(1, lineCount + lineChange.lineDelta);
       const nextLine = mapLineThroughLineChange(
         line,
         lineChange,
         nextLineCount
       );
+      if (nextLine === undefined) {
+        annotationChanged = true;
+        line = undefined;
+        break;
+      }
       if (
         nextLine !== line ||
         lineChangeTouchesAnnotationLine(line, lineChange)
@@ -41,6 +52,11 @@ export function applyDocumentChangeToLineAnnotations<T>(
       }
       line = nextLine;
       lineCount = nextLineCount;
+    }
+
+    if (line === undefined) {
+      changed = true;
+      continue;
     }
 
     const lineNumber = line + 1;
@@ -63,26 +79,39 @@ export function applyDocumentChangeToLineAnnotations<T>(
   return changed ? nextLineAnnotations : undefined;
 }
 
-function getLineChanges(
+function getLineAnnotationChanges(
   change: TextDocumentChange
-): readonly TextDocumentLineChange[] {
-  if (change.lineChanges !== undefined) {
-    return change.lineChanges;
-  }
+): readonly LineAnnotationChange[] {
   if (change.lineDelta === 0) {
-    return [];
+    return change.changedLineRanges.flatMap(([startLine, endLine]) => {
+      const insertedLineBreaks = endLine - startLine;
+      if (insertedLineBreaks <= 0) {
+        return [];
+      }
+      return [
+        {
+          startLine,
+          startCharacter: 0,
+          endLine: startLine,
+          deletesEndLine: false,
+          insertedLineBreaks,
+          lineDelta: insertedLineBreaks,
+        },
+      ];
+    });
   }
   const removedLineCount = Math.max(0, -change.lineDelta);
-  const startLine =
-    removedLineCount > 0 && change.startCharacter > 0
-      ? change.startLine + 1
-      : change.startLine;
+  const deletedToDocumentEnd =
+    change.startLine === 0 &&
+    change.startCharacter === 0 &&
+    change.lineCount === 1 &&
+    change.lineDelta === 1 - change.previousLineCount;
   return [
     {
-      startLine,
+      startLine: change.startLine,
       startCharacter: change.startCharacter,
-      endLine: startLine + removedLineCount,
-      endCharacter: 0,
+      endLine: change.startLine + removedLineCount,
+      deletesEndLine: deletedToDocumentEnd,
       insertedLineBreaks: Math.max(0, change.lineDelta),
       lineDelta: change.lineDelta,
     },
@@ -91,9 +120,9 @@ function getLineChanges(
 
 function mapLineThroughLineChange(
   line: number,
-  lineChange: TextDocumentLineChange,
+  lineChange: LineAnnotationChange,
   nextLineCount: number
-): number {
+): number | undefined {
   if (line < lineChange.startLine) {
     return line;
   }
@@ -102,7 +131,7 @@ function mapLineThroughLineChange(
     line > lineChange.endLine ||
     (lineChange.endLine > lineChange.startLine &&
       line === lineChange.endLine &&
-      lineChange.endCharacter === 0)
+      !lineChange.deletesEndLine)
   ) {
     return line + lineChange.lineDelta;
   }
@@ -114,6 +143,10 @@ function mapLineThroughLineChange(
     return line;
   }
 
+  if (lineChangeDeletesAnnotationLine(line, lineChange)) {
+    return undefined;
+  }
+
   const replacementLineOffset = Math.min(
     Math.max(0, line - lineChange.startLine),
     lineChange.insertedLineBreaks
@@ -121,9 +154,29 @@ function mapLineThroughLineChange(
   return clampLine(lineChange.startLine + replacementLineOffset, nextLineCount);
 }
 
+function lineChangeDeletesAnnotationLine(
+  line: number,
+  lineChange: LineAnnotationChange
+): boolean {
+  if (
+    lineChange.lineDelta >= 0 ||
+    line < lineChange.startLine ||
+    line > lineChange.endLine
+  ) {
+    return false;
+  }
+  if (line === lineChange.startLine && lineChange.startCharacter > 0) {
+    return false;
+  }
+  if (line === lineChange.endLine && !lineChange.deletesEndLine) {
+    return false;
+  }
+  return true;
+}
+
 function lineChangeTouchesAnnotationLine(
   line: number,
-  lineChange: TextDocumentLineChange
+  lineChange: LineAnnotationChange
 ): boolean {
   if (
     lineChange.lineDelta === 0 ||
@@ -135,7 +188,7 @@ function lineChangeTouchesAnnotationLine(
   return !(
     lineChange.endLine > lineChange.startLine &&
     line === lineChange.endLine &&
-    lineChange.endCharacter === 0
+    !lineChange.deletesEndLine
   );
 }
 

--- a/packages/diffs/src/editor/lineAnnotations.ts
+++ b/packages/diffs/src/editor/lineAnnotations.ts
@@ -83,6 +83,27 @@ function getLineAnnotationChanges(
   change: TextDocumentChange
 ): readonly LineAnnotationChange[] {
   if (change.lineDelta === 0) {
+    if (change.changedLineChanges !== undefined) {
+      return change.changedLineChanges.flatMap(
+        ([startLine, _endLine, lineDelta]) => {
+          if (lineDelta === 0) {
+            return [];
+          }
+          const removedLineCount = Math.max(0, -lineDelta);
+          return [
+            {
+              startLine,
+              startCharacter: 0,
+              endLine: startLine + removedLineCount,
+              deletesEndLine: false,
+              insertedLineBreaks: Math.max(0, lineDelta),
+              lineDelta,
+            },
+          ];
+        }
+      );
+    }
+
     return change.changedLineRanges.flatMap(([startLine, endLine]) => {
       const insertedLineBreaks = endLine - startLine;
       if (insertedLineBreaks <= 0) {

--- a/packages/diffs/src/editor/textDocument.ts
+++ b/packages/diffs/src/editor/textDocument.ts
@@ -111,6 +111,12 @@ export interface TextDocumentChange {
   readonly lineDelta: number;
   /** Exact rendered line ranges touched by each edit after the edit was applied. */
   readonly changedLineRanges: readonly [startLine: number, endLine: number][];
+  /** Per-edit rendered line ranges before adjacent ranges are coalesced. */
+  readonly changedLineChanges?: readonly [
+    startLine: number,
+    endLine: number,
+    lineDelta: number,
+  ][];
 }
 
 /**
@@ -420,6 +426,7 @@ export class TextDocument<LAnnotation> {
       lineCount,
       lineDelta: lineCount - previousLineCount,
       changedLineRanges: changedLineRange.ranges,
+      changedLineChanges: changedLineRange.changes,
     };
     return change;
   }
@@ -431,11 +438,14 @@ export class TextDocument<LAnnotation> {
     startLine: number;
     endLine: number;
     ranges: [number, number][];
+    changes: [startLine: number, endLine: number, lineDelta: number][];
   } {
     let startLine = Infinity;
     let endLine = 0;
     let lineDeltaBeforeEdit = 0;
     const ranges: [number, number][] = [];
+    const changes: [startLine: number, endLine: number, lineDelta: number][] =
+      [];
     for (let i = 0; i < edits.length; i++) {
       const edit = edits[i];
       const editStart = editPositions[i * 2];
@@ -457,6 +467,7 @@ export class TextDocument<LAnnotation> {
       } else {
         ranges.push([changedStartLine, changedEndLine]);
       }
+      changes.push([changedStartLine, changedEndLine, lineDelta]);
       lineDeltaBeforeEdit += lineDelta;
     }
     if (startLine === Infinity) {
@@ -464,8 +475,9 @@ export class TextDocument<LAnnotation> {
         startLine: 0,
         endLine: 0,
         ranges: [[0, 0]],
+        changes: [[0, 0, 0]],
       };
     }
-    return { startLine, endLine, ranges };
+    return { startLine, endLine, ranges, changes };
   }
 }

--- a/packages/diffs/src/editor/textDocument.ts
+++ b/packages/diffs/src/editor/textDocument.ts
@@ -96,21 +96,6 @@ export interface ResolvedTextEdit {
   readonly text: string;
 }
 
-export interface TextDocumentLineChange {
-  /** Line where this edit starts, adjusted for previous edits in the batch. */
-  readonly startLine: number;
-  /** Character on the start line where this edit begins. */
-  readonly startCharacter: number;
-  /** Line where this edit ends, adjusted for previous edits in the batch. */
-  readonly endLine: number;
-  /** Character on the end line where this edit ends. */
-  readonly endCharacter: number;
-  /** Number of line breaks inserted by this edit's replacement text. */
-  readonly insertedLineBreaks: number;
-  /** Difference between old and new line counts for this edit. */
-  readonly lineDelta: number;
-}
-
 export interface TextDocumentChange {
   /** First line whose rendered content or tokenizer state may have changed. */
   readonly startLine: number;
@@ -126,11 +111,6 @@ export interface TextDocumentChange {
   readonly lineDelta: number;
   /** Exact rendered line ranges touched by each edit after the edit was applied. */
   readonly changedLineRanges: readonly [startLine: number, endLine: number][];
-  /**
-   * Per-edit line changes, stored non-enumerably by TextDocument so exact
-   * object assertions and public logging keep the compact change shape.
-   */
-  readonly lineChanges?: readonly TextDocumentLineChange[];
 }
 
 /**
@@ -441,12 +421,6 @@ export class TextDocument<LAnnotation> {
       lineDelta: lineCount - previousLineCount,
       changedLineRanges: changedLineRange.ranges,
     };
-    Object.defineProperty(change, 'lineChanges', {
-      value: changedLineRange.lineChanges,
-      enumerable: false,
-      configurable: false,
-      writable: false,
-    });
     return change;
   }
 
@@ -457,13 +431,11 @@ export class TextDocument<LAnnotation> {
     startLine: number;
     endLine: number;
     ranges: [number, number][];
-    lineChanges: TextDocumentLineChange[];
   } {
     let startLine = Infinity;
     let endLine = 0;
     let lineDeltaBeforeEdit = 0;
     const ranges: [number, number][] = [];
-    const lineChanges: TextDocumentLineChange[] = [];
     for (let i = 0; i < edits.length; i++) {
       const edit = edits[i];
       const editStart = editPositions[i * 2];
@@ -476,14 +448,6 @@ export class TextDocument<LAnnotation> {
       const lineDelta = insertedLineSpan - (editEndLine - editStartLine);
       startLine = Math.min(startLine, editStartLine);
       endLine = Math.max(endLine, changedEndLine);
-      lineChanges.push({
-        startLine: changedStartLine,
-        startCharacter: editStart.character,
-        endLine: editEndLine + lineDeltaBeforeEdit,
-        endCharacter: editEnd.character,
-        insertedLineBreaks: insertedLineSpan,
-        lineDelta,
-      });
       const lastRange = ranges[ranges.length - 1];
       if (lastRange !== undefined && changedStartLine <= lastRange[1] + 1) {
         ranges[ranges.length - 1] = [
@@ -500,9 +464,8 @@ export class TextDocument<LAnnotation> {
         startLine: 0,
         endLine: 0,
         ranges: [[0, 0]],
-        lineChanges: [],
       };
     }
-    return { startLine, endLine, ranges, lineChanges };
+    return { startLine, endLine, ranges };
   }
 }

--- a/packages/diffs/test/editorLineAnnotations.test.ts
+++ b/packages/diffs/test/editorLineAnnotations.test.ts
@@ -194,6 +194,8 @@ describe('applyDocumentChangeToLineAnnotations', () => {
     const annotations: DiffLineAnnotation<string>[] = [
       { side: 'additions', lineNumber: 2, metadata: 'two' },
       { side: 'additions', lineNumber: 3, metadata: 'three' },
+      { side: 'additions', lineNumber: 4, metadata: 'four' },
+      { side: 'additions', lineNumber: 5, metadata: 'five' },
     ];
 
     const change = textDocument.applyEdits([
@@ -217,6 +219,43 @@ describe('applyDocumentChangeToLineAnnotations', () => {
     expect(applyDocumentChangeToLineAnnotations(change!, annotations)).toEqual([
       { side: 'additions', lineNumber: 3, metadata: 'two' },
       { side: 'additions', lineNumber: 4, metadata: 'three' },
+      { side: 'additions', lineNumber: 5, metadata: 'five' },
+    ]);
+  });
+
+  test('preserves deletions in coalesced net-zero multi-edits', () => {
+    const textDocument = new TextDocument(
+      'inmemory://1',
+      'one\ntwo\nthree\nfour'
+    );
+    const annotations: DiffLineAnnotation<string>[] = [
+      { side: 'additions', lineNumber: 2, metadata: 'two' },
+      { side: 'additions', lineNumber: 3, metadata: 'three' },
+      { side: 'additions', lineNumber: 4, metadata: 'four' },
+    ];
+
+    const change = textDocument.applyEdits([
+      {
+        range: {
+          start: { line: 1, character: 0 },
+          end: { line: 1, character: 0 },
+        },
+        newText: 'inserted\n',
+      },
+      {
+        range: {
+          start: { line: 2, character: 0 },
+          end: { line: 3, character: 0 },
+        },
+        newText: '',
+      },
+    ]);
+
+    expect(change?.lineDelta).toBe(0);
+    expect(change?.changedLineRanges).toEqual([[1, 3]]);
+    expect(applyDocumentChangeToLineAnnotations(change!, annotations)).toEqual([
+      { side: 'additions', lineNumber: 3, metadata: 'two' },
+      { side: 'additions', lineNumber: 4, metadata: 'four' },
     ]);
   });
 });

--- a/packages/diffs/test/editorLineAnnotations.test.ts
+++ b/packages/diffs/test/editorLineAnnotations.test.ts
@@ -5,7 +5,7 @@ import { TextDocument } from '../src/editor/textDocument';
 import type { DiffLineAnnotation } from '../src/types';
 
 describe('applyDocumentChangeToLineAnnotations', () => {
-  test('keeps annotations attached to the nearest line when their line is deleted', () => {
+  test('drops annotations attached to deleted lines', () => {
     const textDocument = new TextDocument('inmemory://1', 'one\ntwo\nthree');
     const annotations: DiffLineAnnotation<string>[] = [
       { side: 'additions', lineNumber: 1, metadata: 'one' },
@@ -25,12 +25,11 @@ describe('applyDocumentChangeToLineAnnotations', () => {
 
     expect(applyDocumentChangeToLineAnnotations(change!, annotations)).toEqual([
       { side: 'additions', lineNumber: 1, metadata: 'one' },
-      { side: 'additions', lineNumber: 2, metadata: 'two' },
       { side: 'additions', lineNumber: 2, metadata: 'three' },
     ]);
   });
 
-  test('returns a refreshed annotation list when a deleted line keeps the same line number', () => {
+  test('drops a deleted line annotation when later lines keep its line number', () => {
     const textDocument = new TextDocument('inmemory://1', 'one\ntwo\nthree');
     const annotations: DiffLineAnnotation<string>[] = [
       { side: 'additions', lineNumber: 2, metadata: 'two' },
@@ -51,9 +50,71 @@ describe('applyDocumentChangeToLineAnnotations', () => {
     );
 
     expect(nextAnnotations).not.toBe(annotations);
-    expect(nextAnnotations).toEqual([
+    expect(nextAnnotations).toEqual([]);
+  });
+
+  test('drops all addition annotations when all document text is deleted', () => {
+    const textDocument = new TextDocument('inmemory://1', 'one\ntwo\nthree');
+    const annotations: DiffLineAnnotation<string>[] = [
+      { side: 'additions', lineNumber: 1, metadata: 'one' },
       { side: 'additions', lineNumber: 2, metadata: 'two' },
+      { side: 'additions', lineNumber: 3, metadata: 'three' },
+      { side: 'deletions', lineNumber: 1, metadata: 'old one' },
+    ];
+
+    const change = textDocument.applyEdits([
+      {
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 2, character: 5 },
+        },
+        newText: '',
+      },
     ]);
+
+    expect(textDocument.getText()).toBe('');
+    expect(applyDocumentChangeToLineAnnotations(change!, annotations)).toEqual([
+      { side: 'deletions', lineNumber: 1, metadata: 'old one' },
+    ]);
+  });
+
+  test('does not restore deleted addition annotations when new lines are inserted', () => {
+    const textDocument = new TextDocument('inmemory://1', 'one\ntwo\nthree');
+    const annotations: DiffLineAnnotation<string>[] = [
+      { side: 'additions', lineNumber: 1, metadata: 'one' },
+      { side: 'additions', lineNumber: 2, metadata: 'two' },
+      { side: 'additions', lineNumber: 3, metadata: 'three' },
+      { side: 'deletions', lineNumber: 1, metadata: 'old one' },
+    ];
+
+    const deleteChange = textDocument.applyEdits([
+      {
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 2, character: 5 },
+        },
+        newText: '',
+      },
+    ]);
+    const afterDelete = applyDocumentChangeToLineAnnotations(
+      deleteChange!,
+      annotations
+    )!;
+
+    const insertChange = textDocument.applyEdits([
+      {
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 0 },
+        },
+        newText: 'new one\nnew two',
+      },
+    ]);
+
+    expect(
+      applyDocumentChangeToLineAnnotations(insertChange!, afterDelete) ??
+        afterDelete
+    ).toEqual([{ side: 'deletions', lineNumber: 1, metadata: 'old one' }]);
   });
 
   test('moves annotations on a merged line instead of deleting them', () => {

--- a/packages/diffs/test/editorTextDocument.test.ts
+++ b/packages/diffs/test/editorTextDocument.test.ts
@@ -54,6 +54,7 @@ describe('TextDocument', () => {
       lineCount: 1,
       lineDelta: -1,
       changedLineRanges: [[0, 0]],
+      changedLineChanges: [[0, 0, -1]],
     });
   });
 
@@ -158,6 +159,7 @@ describe('TextDocument', () => {
       lineCount: 1,
       lineDelta: 0,
       changedLineRanges: [[0, 0]],
+      changedLineChanges: [[0, 0, 0]],
     });
   });
 
@@ -218,6 +220,7 @@ describe('TextDocument', () => {
       lineCount: 3,
       lineDelta: 0,
       changedLineRanges: [[1, 1]],
+      changedLineChanges: [[1, 1, 0]],
     });
   });
 
@@ -241,6 +244,7 @@ describe('TextDocument', () => {
       lineCount: 2,
       lineDelta: 1,
       changedLineRanges: [[0, 1]],
+      changedLineChanges: [[0, 1, 1]],
     });
   });
 
@@ -264,6 +268,7 @@ describe('TextDocument', () => {
       lineCount: 1,
       lineDelta: -2,
       changedLineRanges: [[0, 0]],
+      changedLineChanges: [[0, 0, -2]],
     });
   });
 
@@ -302,6 +307,7 @@ describe('TextDocument', () => {
       lineCount: 2,
       lineDelta: 1,
       changedLineRanges: [[0, 1]],
+      changedLineChanges: [[0, 1, 1]],
     });
   });
 
@@ -326,6 +332,7 @@ describe('TextDocument', () => {
       lineCount: 3,
       lineDelta: 2,
       changedLineRanges: [[0, 2]],
+      changedLineChanges: [[0, 2, 2]],
     });
   });
 
@@ -969,6 +976,7 @@ describe('TextDocument', () => {
       lineCount: 1,
       lineDelta: 0,
       changedLineRanges: [[0, 0]],
+      changedLineChanges: [[0, 0, 0]],
     });
     expect(d.canUndo).toBe(false);
     expect(d.canRedo).toBe(true);
@@ -983,6 +991,7 @@ describe('TextDocument', () => {
       lineCount: 1,
       lineDelta: 0,
       changedLineRanges: [[0, 0]],
+      changedLineChanges: [[0, 0, 0]],
     });
     expect(d.canUndo).toBe(true);
     expect(d.canRedo).toBe(false);


### PR DESCRIPTION
Reproducing steps：

1. go to /playground page, switch to edit mode in split layout
2. select all and delete
3. add new lines
4. [bug] the deleted line annotations restored


https://github.com/user-attachments/assets/ac6e9435-aaf7-4d87-95ff-ab2c0f95b8a3

