### PR TITLE
fix(diffs): Keep redo correct after typing at an insert's left edge

### DIFF
--- a/packages/diffs/src/editor/editStack.ts
+++ b/packages/diffs/src/editor/editStack.ts
@@ -212,10 +212,14 @@ export function shouldCoalesceEditStackEntry<LAnnotation>(
       !nextForward.text.includes('\n') &&
       nextInverse.text.length === 0;
     if (previousWasInsert && nextIsInsert) {
-      const expectedMappedNextStart = previousForward.end;
-      // Allow continuing typing after replacing a selection (e.g. "hello" -> "w")
-      // while still requiring that the cursor extension maps inside the same base range.
-      if (mappedNextStart !== expectedMappedNextStart) {
+      // Merge only when the next insert starts exactly where the previous
+      // inserted text ends, in after-edit offsets. `previousInverse.end` marks
+      // that point, since undo replaces exactly the inserted range. A
+      // base-offset check can't tell this apart from a caret that jumped to the
+      // left edge: both edges of a pure insert map back to the same base offset,
+      // so typing "a" then "b" at the left edge would merge as "ab" while the
+      // buffer holds "ba", corrupting redo.
+      if (nextForward.start !== previousInverse.end) {
         return false;
       }
       mode ??= 'insert';

--- a/packages/diffs/test/editorEditStack.test.ts
+++ b/packages/diffs/test/editorEditStack.test.ts
@@ -207,4 +207,46 @@ describe('shouldCoalesceEditStackEntry', () => {
     const next = stackEntry('a', [{ start: 1, end: 1, text: '\n' }], 1, 2);
     expect(shouldCoalesceEditStackEntry(previous, next)).toBe(false);
   });
+
+  // Both edges of a pure insert map back to the same base offset, so the
+  // left-edge case is rejected by after-edit position, not base offset.
+  test('does not coalesce an insert typed at the left edge of the previous insert', () => {
+    const previous = stackEntry('', [{ start: 0, end: 0, text: 'a' }], 0, 1);
+    const next = stackEntry('a', [{ start: 0, end: 0, text: 'b' }], 1, 2);
+    expect(shouldCoalesceEditStackEntry(previous, next)).toBe(false);
+  });
+
+  test('does not coalesce an insert typed inside a previous multi-character insert', () => {
+    const previous = stackEntry('', [{ start: 0, end: 0, text: 'ab' }], 0, 1);
+    const next = stackEntry('ab', [{ start: 1, end: 1, text: 'c' }], 1, 2);
+    expect(shouldCoalesceEditStackEntry(previous, next)).toBe(false);
+  });
+
+  test('coalesces an insert that continues at the end of a multi-character insert run', () => {
+    const previous = stackEntry('', [{ start: 0, end: 0, text: 'ab' }], 0, 1);
+    const next = stackEntry('ab', [{ start: 2, end: 2, text: 'c' }], 1, 2);
+    expect(shouldCoalesceEditStackEntry(previous, next)).toBe(true);
+  });
+
+  test('does not coalesce typing before a just-replaced selection', () => {
+    const previous = stackEntry(
+      'hello',
+      [{ start: 0, end: 5, text: 'w' }],
+      0,
+      1
+    );
+    const next = stackEntry('w', [{ start: 0, end: 0, text: 'o' }], 1, 2);
+    expect(shouldCoalesceEditStackEntry(previous, next)).toBe(false);
+  });
+
+  test('coalesces typing after a just-replaced selection', () => {
+    const previous = stackEntry(
+      'hello',
+      [{ start: 0, end: 5, text: 'w' }],
+      0,
+      1
+    );
+    const next = stackEntry('w', [{ start: 1, end: 1, text: 'o' }], 1, 2);
+    expect(shouldCoalesceEditStackEntry(previous, next)).toBe(true);
+  });
 });

--- a/packages/diffs/test/editorTextDocument.test.ts
+++ b/packages/diffs/test/editorTextDocument.test.ts
@@ -18,6 +18,46 @@ function caret(line: number, character: number) {
   } satisfies EditorSelection;
 }
 
+// Inserts `text` at `character` on line 0 with history recording enabled, like a
+// single keystroke. `caretCharacter` is where the caret sits before the insert
+// (defaults to the insert position); pass a different value to model a caret
+// that moved away from the previous edit before typing.
+function typeAt(
+  d: ReturnType<typeof doc>,
+  character: number,
+  text: string,
+  caretCharacter = character
+) {
+  d.applyEdits(
+    [
+      {
+        range: {
+          start: { line: 0, character },
+          end: { line: 0, character },
+        },
+        newText: text,
+      },
+    ],
+    true,
+    [caret(0, caretCharacter)]
+  );
+}
+
+// Runs undo (or redo) to exhaustion. The number of history steps depends on how
+// edits coalesced, so tests that only care about the end-to-end result use these
+// instead of asserting a fixed step count.
+function undoAll(d: ReturnType<typeof doc>) {
+  while (d.canUndo) {
+    d.undo();
+  }
+}
+
+function redoAll(d: ReturnType<typeof doc>) {
+  while (d.canRedo) {
+    d.redo();
+  }
+}
+
 describe('TextDocument', () => {
   test('lang and lineCount', () => {
     const d = doc('a\nb\nc');
@@ -590,6 +630,49 @@ describe('TextDocument', () => {
 
     d.undo();
     expect(d.getText()).toBe('hello');
+  });
+
+  test('redo restores buffer order after typing at the left edge of an insert', () => {
+    const d = doc('');
+    typeAt(d, 0, 'a'); // "a", caret now after it
+    typeAt(d, 0, 'b', 0); // caret moved to the far left, type "b" -> "ba"
+
+    expect(d.getText()).toBe('ba');
+
+    undoAll(d);
+    expect(d.getText()).toBe('');
+
+    redoAll(d);
+    expect(d.getText()).toBe('ba');
+  });
+
+  test('redo restores buffer order after typing inside a coalesced insert run', () => {
+    const d = doc('');
+    typeAt(d, 0, 'a'); // "a"
+    typeAt(d, 1, 'b'); // "ab" (normal contiguous typing, coalesces)
+    typeAt(d, 1, 'c', 1); // caret moved between a and b, type "c" -> "acb"
+
+    expect(d.getText()).toBe('acb');
+
+    undoAll(d);
+    expect(d.getText()).toBe('');
+
+    redoAll(d);
+    expect(d.getText()).toBe('acb');
+  });
+
+  test('redo restores buffer after typing at the end of an insert run', () => {
+    const d = doc('');
+    typeAt(d, 0, 'a'); // "a"
+    typeAt(d, 1, 'b'); // "ab", continuing at the end
+
+    expect(d.getText()).toBe('ab');
+
+    undoAll(d);
+    expect(d.getText()).toBe('');
+
+    redoAll(d);
+    expect(d.getText()).toBe('ab');
   });
 
   test('paste does not coalesce into the preceding typed character', () => {


### PR DESCRIPTION
Type a character, move the caret to the far left with an arrow key, then type another character. The buffer shows the right result (for example "ba"), and undo clears it, but redo puts the characters back in the wrong order ("ab"). Any consumer reading the document contents then sees the corrupted text.

Consecutive inserts merge into one undo step so a run of typing undoes at once. The merge test only checked that the new insert mapped back to the same base offset as the previous one. For a pure insert both edges of the inserted text map back to that single offset, so typing before the previous character looked identical to continuing after it; the two inserts merged as if appended, but the buffer held them reversed, and redo replayed the merged run in append order.

Require the next insert to begin exactly at the end of the previously inserted text in after-edit offsets (the end of the previous inverse edit) before merging, so a caret that jumped left starts a new undo step instead.
