### PR TITLE
fix(diffs): Clear match highlights when the search is dismissed

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -1262,7 +1262,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       addEventListener(contentEl, 'keydown', (e) => {
         if (e.key === 'Escape') {
           e.preventDefault();
-          this.#searchPanel?.cleanup();
+          this.#searchPanel?.close();
           this.#searchPanel = undefined;
           this.#retainSearchPanelFocus = false;
           this.#selectionAction?.cleanup();

--- a/packages/diffs/src/editor/searchPanel.ts
+++ b/packages/diffs/src/editor/searchPanel.ts
@@ -38,6 +38,7 @@ export class SearchPanelWidget {
   #updateMatches?: (options?: { syncSelection?: boolean }) => void;
   #applyMode?: (mode: SearchPanelMode) => void;
   #navigate?: (findPrevious: boolean) => void;
+  #close?: () => void;
 
   constructor(options: SearchPanelOptions) {
     const {
@@ -78,13 +79,10 @@ export class SearchPanelWidget {
       prevButton.disabled = noMatches;
       nextButton.disabled = noMatches;
 
-      if (searchParams.text === '') {
-        matchResultElement.textContent = 'No results';
-        matchResultElement.dataset.noMatches = '';
-        return;
-      }
-
-      if (matches.all.length === 0) {
+      // An empty query and a query with zero hits are the same "no results"
+      // state. Both push an empty match set through onUpdate so the editor
+      // drops #matches and clears the painted highlights.
+      if (noMatches) {
         matchResultElement.textContent = 'No results';
         matchResultElement.dataset.noMatches = '';
         matches.current = undefined;
@@ -217,6 +215,7 @@ export class SearchPanelWidget {
       this.cleanup();
       onClose();
     };
+    this.#close = close;
 
     // Shared builder for the panel's icon controls. Every clickable control is a
     // real <button> so it gets focus, keyboard activation, and native disabled
@@ -446,6 +445,16 @@ export class SearchPanelWidget {
     this.#applyMode?.(mode);
   }
 
+  // Tears the panel down the way the close button and Escape-in-input do:
+  // removes the DOM and runs onClose so the editor clears its match highlights.
+  // Prefer this over cleanup() for any user-initiated dismissal.
+  close(): void {
+    this.#close?.();
+  }
+
+  // DOM-only teardown. Does NOT run onClose, so it leaves the editor's match
+  // highlights in place; only use it when the caller clears that state itself
+  // (e.g. a full editor reset). User-initiated dismissals should call close().
   cleanup(): void {
     this.#container.remove();
   }

--- a/packages/diffs/test/e2e/find-replace.pw.ts
+++ b/packages/diffs/test/e2e/find-replace.pw.ts
@@ -5,6 +5,7 @@ const PANEL = '[data-search-panel]';
 const SEARCH_INPUT = '[data-search-panel] input[data-search]';
 const REPLACE_INPUT = '[data-search-panel] input[data-replace]';
 const MATCHES = '[data-search-panel] [data-matches]';
+const HIGHLIGHTS = '[data-match-range]';
 
 async function openFixture(page: Page): Promise<void> {
   await page.goto('/test/e2e/fixtures/editable.html');
@@ -65,5 +66,58 @@ test.describe('find and replace', () => {
     await expect.poll(() => contents(page)).toContain('const qux = 1;');
     await expect.poll(() => contents(page)).toContain('const bar = qux + qux;');
     await expect.poll(() => contents(page)).not.toContain('foo');
+  });
+
+  test('clearing the query removes the match highlights', async ({ page }) => {
+    await openFixture(page);
+    await openSearchPanel(page);
+
+    await page.locator(SEARCH_INPUT).fill('foo');
+    await expect(page.locator(MATCHES)).toContainText('4');
+    // "foo" is a single-line match, so each of the four hits paints one block.
+    await expect(page.locator(HIGHLIGHTS)).toHaveCount(4);
+
+    // Emptying the query returns the panel to its "No results" state; the
+    // highlights must clear with it rather than linger over an empty box.
+    await page.locator(SEARCH_INPUT).fill('');
+    await expect(page.locator(MATCHES)).toContainText('No results');
+    await expect(page.locator(HIGHLIGHTS)).toHaveCount(0);
+  });
+
+  test('Escape in the search input closes the panel and clears highlights', async ({
+    page,
+  }) => {
+    await openFixture(page);
+    await openSearchPanel(page);
+
+    await page.locator(SEARCH_INPUT).fill('foo');
+    await expect(page.locator(HIGHLIGHTS)).toHaveCount(4);
+
+    // Escape while the search input holds focus is the already-correct teardown
+    // path; keep it covered as the counterpart to the content-Escape case.
+    await page.locator(SEARCH_INPUT).press('Escape');
+
+    await expect(page.locator(PANEL)).toHaveCount(0);
+    await expect(page.locator(HIGHLIGHTS)).toHaveCount(0);
+  });
+
+  test('Escape from the editor content closes the panel and clears highlights', async ({
+    page,
+  }) => {
+    await openFixture(page);
+    await openSearchPanel(page);
+
+    await page.locator(SEARCH_INPUT).fill('foo');
+    await expect(page.locator(HIGHLIGHTS)).toHaveCount(4);
+
+    // Click into the editor text so focus leaves the search input, then press
+    // Escape. This is handled by the content-focused keydown handler, a
+    // separate teardown path that must clear the highlights too.
+    await page.locator(CONTENT).click();
+    await expect(page.locator(PANEL)).toHaveCount(1);
+    await page.keyboard.press('Escape');
+
+    await expect(page.locator(PANEL)).toHaveCount(0);
+    await expect(page.locator(HIGHLIGHTS)).toHaveCount(0);
   });
 });


### PR DESCRIPTION
Reproduce (empty query):

1. Open a file in the editor and press Cmd/Ctrl+F.
2. Type a matching term, e.g. "foo"; its matches highlight.
3. Delete the query so the search box is empty.

Wrong: the highlights stay painted over an empty box.

Reproduce (Escape from the content):

1. Press Cmd/Ctrl+F and search a term so its matches highlight.
2. Click into the editor text, then press Escape.

Wrong: the panel closes but the highlights stay painted.

Emptying the query returned from updateMatches before calling onUpdate([]), the only channel that clears the editor's #matches and repaints, so the highlights were never dropped. Fold the empty-query case into the existing zero-match branch, which already calls it.

The content-focused Escape handler tore the panel down with cleanup(), which removes the panel DOM but skips the onClose teardown. Add a close() method (cleanup plus onClose) and call it from that handler so #matches is cleared and the overlay repaints, matching the close button and the search input's own Escape.
