### PR TITLE
fix(diffs): Move wrapped carets by visual rows

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -1306,7 +1306,11 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
           mvShortcut !== undefined &&
           textDocument !== undefined
         ) {
-          const cursorMoveOptions = this.#getCursorMoveOptions();
+          const cursorMoveOptions: CursorMoveOptions | undefined = this.#isWrap
+            ? {
+                getSoftLineOffsets: (line) => this.#wrapLineText(line),
+              }
+            : undefined;
           if (e.shiftKey) {
             this.#updateSelections(
               mapSelectionShift(
@@ -3709,15 +3713,6 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         this.#applyChangeToLineAnnotations(change)
       );
     }
-  }
-
-  #getCursorMoveOptions(): CursorMoveOptions | undefined {
-    if (!this.#isWrap) {
-      return undefined;
-    }
-    return {
-      getSoftLineOffsets: (line) => this.#wrapLineText(line),
-    };
   }
 
   #deleteSoftLineBackward() {

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -42,7 +42,11 @@ import {
   type SearchPanelMode,
   SearchPanelWidget,
 } from './searchPanel';
-import type { AutoSurround, EditorSelection } from './selection';
+import type {
+  AutoSurround,
+  CursorMoveOptions,
+  EditorSelection,
+} from './selection';
 import {
   applyDeleteCharacterToSelections,
   applyDeleteHardLineForwardToSelections,
@@ -1302,13 +1306,24 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
           mvShortcut !== undefined &&
           textDocument !== undefined
         ) {
+          const cursorMoveOptions = this.#getCursorMoveOptions();
           if (e.shiftKey) {
             this.#updateSelections(
-              mapSelectionShift(textDocument, this.#selections, mvShortcut)
+              mapSelectionShift(
+                textDocument,
+                this.#selections,
+                mvShortcut,
+                cursorMoveOptions
+              )
             );
           } else {
             this.#updateSelections(
-              mapCursorMove(textDocument, this.#selections, mvShortcut)
+              mapCursorMove(
+                textDocument,
+                this.#selections,
+                mvShortcut,
+                cursorMoveOptions
+              )
             );
           }
           this.#scrollToPrimaryCaret();
@@ -3694,6 +3709,15 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         this.#applyChangeToLineAnnotations(change)
       );
     }
+  }
+
+  #getCursorMoveOptions(): CursorMoveOptions | undefined {
+    if (!this.#isWrap) {
+      return undefined;
+    }
+    return {
+      getSoftLineOffsets: (line) => this.#wrapLineText(line),
+    };
   }
 
   #deleteSoftLineBackward() {

--- a/packages/diffs/src/editor/platform.ts
+++ b/packages/diffs/src/editor/platform.ts
@@ -75,6 +75,10 @@ export function isMoveCursorShortcut(
       return 'left';
     } else if (e.key === 'ArrowRight') {
       return 'right';
+    } else if (e.key === 'Home') {
+      return 'start';
+    } else if (e.key === 'End') {
+      return 'end';
     }
   }
 

--- a/packages/diffs/src/editor/selection.ts
+++ b/packages/diffs/src/editor/selection.ts
@@ -27,6 +27,17 @@ export interface EditorSelection extends Range {
   direction: SelectionDirection;
 }
 
+export interface CursorMoveOptions {
+  getSoftLineOffsets?: (line: number) => ArrayLike<number> | undefined;
+}
+
+interface SoftLineInfo {
+  start: number;
+  end: number;
+  index: number;
+  count: number;
+}
+
 /**
  * Converts a selection from a web selection to an editor selection.
  */
@@ -122,7 +133,8 @@ export function resolveIndentEdits(
 export function mapCursorMove(
   textDocument: TextDocument<unknown>,
   selections: EditorSelection[],
-  shortcut: 'textStart' | 'start' | 'end' | 'up' | 'down' | 'left' | 'right'
+  shortcut: 'textStart' | 'start' | 'end' | 'up' | 'down' | 'left' | 'right',
+  options: CursorMoveOptions = {}
 ): EditorSelection[] {
   const lineCount = textDocument.lineCount;
   return selections.map((selection) => {
@@ -138,16 +150,32 @@ export function mapCursorMove(
       const caret = getCaretPosition(selection);
       line = caret.line;
       character = caret.character;
+      const softLine = getSoftLineInfo(textDocument, line, character, options);
       if (shortcut === 'textStart') {
-        const indent = getLeadingSpaces(textDocument.getLineText(line));
-        character = character === indent ? 0 : indent;
+        const softLineText = textDocument
+          .getLineText(line)
+          .slice(softLine.start, softLine.end);
+        const indent = softLine.start + getLeadingSpaces(softLineText);
+        character = character === indent ? softLine.start : indent;
       } else {
-        character = shortcut === 'start' ? 0 : textDocument.getLineLength(line);
+        character = shortcut === 'start' ? softLine.start : softLine.end;
       }
     } else if (shortcut === 'up') {
-      line = Math.max(0, line - 1);
+      const moved = moveBySoftLine(textDocument, line, character, -1, options);
+      if (moved !== undefined) {
+        line = moved.line;
+        character = moved.character;
+      } else {
+        line = Math.max(0, line - 1);
+      }
     } else if (shortcut === 'down') {
-      line = Math.min(Math.max(lineCount - 1, 0), line + 1);
+      const moved = moveBySoftLine(textDocument, line, character, 1, options);
+      if (moved !== undefined) {
+        line = moved.line;
+        character = moved.character;
+      } else {
+        line = Math.min(Math.max(lineCount - 1, 0), line + 1);
+      }
     } else if (isCollapsedSelection(selection)) {
       const lineLength = textDocument.getLineLength(line);
       character = Math.min(character, lineLength);
@@ -186,13 +214,122 @@ export function mapCursorMove(
   });
 }
 
+function moveBySoftLine(
+  textDocument: TextDocument<unknown>,
+  line: number,
+  character: number,
+  direction: -1 | 1,
+  options: CursorMoveOptions
+): Position | undefined {
+  if (options.getSoftLineOffsets === undefined) {
+    return undefined;
+  }
+
+  const current = getSoftLineInfo(textDocument, line, character, options);
+  const targetIndex = current.index + direction;
+  let targetLine = line;
+  let target: SoftLineInfo;
+
+  if (targetIndex >= 0 && targetIndex < current.count) {
+    target = getSoftLineInfoAtIndex(
+      textDocument,
+      targetLine,
+      targetIndex,
+      options
+    );
+  } else {
+    const nextLine = line + direction;
+    if (nextLine < 0 || nextLine >= textDocument.lineCount) {
+      return { line, character };
+    }
+
+    targetLine = nextLine;
+    const targetCount = getSoftLineCount(textDocument, targetLine, options);
+    target = getSoftLineInfoAtIndex(
+      textDocument,
+      targetLine,
+      direction < 0 ? targetCount - 1 : 0,
+      options
+    );
+  }
+
+  const column = Math.max(0, character - current.start);
+  const targetCharacter = target.start + column;
+  return {
+    line: targetLine,
+    character:
+      target.index === target.count - 1
+        ? targetCharacter
+        : Math.min(targetCharacter, target.end),
+  };
+}
+
+function getSoftLineInfo(
+  textDocument: TextDocument<unknown>,
+  line: number,
+  character: number,
+  options: CursorMoveOptions
+): SoftLineInfo {
+  const lineLength = textDocument.getLineLength(line);
+  const offsets = options.getSoftLineOffsets?.(line);
+  if (offsets === undefined || offsets.length < 2) {
+    return { start: 0, end: lineLength, index: 0, count: 1 };
+  }
+
+  for (let index = 0; index + 1 < offsets.length; index++) {
+    const softLine = getSoftLineInfoAtIndex(textDocument, line, index, options);
+    if (character >= softLine.start && character <= softLine.end) {
+      return softLine;
+    }
+  }
+
+  return getSoftLineInfoAtIndex(
+    textDocument,
+    line,
+    character < (offsets[0] ?? 0) ? 0 : offsets.length - 2,
+    options
+  );
+}
+
+function getSoftLineCount(
+  textDocument: TextDocument<unknown>,
+  line: number,
+  options: CursorMoveOptions
+): number {
+  const offsets = options.getSoftLineOffsets?.(line);
+  return offsets === undefined || offsets.length < 2 ? 1 : offsets.length - 1;
+}
+
+function getSoftLineInfoAtIndex(
+  textDocument: TextDocument<unknown>,
+  line: number,
+  index: number,
+  options: CursorMoveOptions
+): SoftLineInfo {
+  const lineLength = textDocument.getLineLength(line);
+  const offsets = options.getSoftLineOffsets?.(line);
+  if (offsets === undefined || offsets.length < 2) {
+    return { start: 0, end: lineLength, index: 0, count: 1 };
+  }
+
+  const count = offsets.length - 1;
+  const boundedIndex = Math.max(0, Math.min(index, count - 1));
+  const start = Math.max(0, Math.min(lineLength, offsets[boundedIndex] ?? 0));
+  const end = Math.max(
+    start,
+    Math.min(lineLength, offsets[boundedIndex + 1] ?? lineLength)
+  );
+  return { start, end, index: boundedIndex, count };
+}
+
 /**
  * Same as mapCursorMove, but with shift key pressed.
  */
 export function mapSelectionShift(
   textDocument: TextDocument<unknown>,
   selections: EditorSelection[],
-  shortcut: 'textStart' | 'start' | 'end' | 'up' | 'down' | 'left' | 'right'
+  shortcut: 'textStart' | 'start' | 'end' | 'up' | 'down' | 'left' | 'right',
+  options: CursorMoveOptions = {}
 ): EditorSelection[] {
   return selections.map((selection) => {
     const focusPosition =
@@ -208,7 +345,8 @@ export function mapSelectionShift(
           direction: DirectionNone,
         },
       ],
-      shortcut
+      shortcut,
+      options
     );
     return createSelectionFrom(selection, movedFocusSelection);
   });

--- a/packages/diffs/test/editorSelection.test.ts
+++ b/packages/diffs/test/editorSelection.test.ts
@@ -10,6 +10,7 @@ import {
   applyTransposeToSelections,
   convertSelection,
   createSelectionFrom,
+  type CursorMoveOptions,
   DirectionForward,
   DirectionNone,
   type EditorSelection,
@@ -1443,6 +1444,80 @@ describe('mapSelectionMove', () => {
     expect(mapCursorMove(textDocument, lineEnd, 'left')).toEqual([
       createSelection(0, 1, 0, 1),
     ]);
+  });
+
+  test('moves vertically by wrapped visual rows', () => {
+    const textDocument = new TextDocument(
+      'inmemory://1',
+      '012345678901234567890123456789\nshort'
+    );
+    const wrapOptions: CursorMoveOptions = {
+      getSoftLineOffsets: (line) =>
+        line === 0 ? new Uint32Array([0, 10, 20, 30]) : undefined,
+    };
+    const middleVisualRow = [createSelection(0, 15, 0, 15)];
+
+    expect(
+      mapCursorMove(textDocument, middleVisualRow, 'down', wrapOptions)
+    ).toEqual([createSelection(0, 25, 0, 25)]);
+    expect(
+      mapCursorMove(textDocument, middleVisualRow, 'up', wrapOptions)
+    ).toEqual([createSelection(0, 5, 0, 5)]);
+    expect(
+      mapCursorMove(
+        textDocument,
+        [createSelection(0, 25, 0, 25)],
+        'down',
+        wrapOptions
+      )
+    ).toEqual([createSelection(1, 5, 1, 5)]);
+  });
+
+  test('moves to wrapped visual row boundaries', () => {
+    const textDocument = new TextDocument(
+      'inmemory://1',
+      '  abcdefghij  klmnop'
+    );
+    const wrapOptions: CursorMoveOptions = {
+      getSoftLineOffsets: () => new Uint32Array([0, 12, 20]),
+    };
+    const continuationRow = [createSelection(0, 16, 0, 16)];
+    const textStart = mapCursorMove(
+      textDocument,
+      continuationRow,
+      'textStart',
+      wrapOptions
+    );
+
+    expect(
+      mapCursorMove(textDocument, continuationRow, 'start', wrapOptions)
+    ).toEqual([createSelection(0, 12, 0, 12)]);
+    expect(
+      mapCursorMove(textDocument, continuationRow, 'end', wrapOptions)
+    ).toEqual([createSelection(0, 20, 0, 20)]);
+    expect(textStart).toEqual([createSelection(0, 14, 0, 14)]);
+    expect(
+      mapCursorMove(textDocument, textStart, 'textStart', wrapOptions)
+    ).toEqual([createSelection(0, 12, 0, 12)]);
+  });
+
+  test('extends selections by wrapped visual rows', () => {
+    const textDocument = new TextDocument(
+      'inmemory://1',
+      '012345678901234567890123456789'
+    );
+    const wrapOptions: CursorMoveOptions = {
+      getSoftLineOffsets: () => new Uint32Array([0, 10, 20, 30]),
+    };
+
+    expect(
+      mapSelectionShift(
+        textDocument,
+        [createSelection(0, 15, 0, 15)],
+        'down',
+        wrapOptions
+      )
+    ).toEqual([createSelection(0, 15, 0, 25, DirectionForward)]);
   });
 });
 

--- a/packages/diffs/test/editorWrapCaretPosition.test.ts
+++ b/packages/diffs/test/editorWrapCaretPosition.test.ts
@@ -29,11 +29,33 @@ async function waitForEditableContent(
   throw new Error('editor content did not become editable');
 }
 
+interface EditorTestWindow extends Window {
+  KeyboardEvent: {
+    new (type: string, eventInitDict?: KeyboardEventInit): KeyboardEvent;
+  };
+}
+
 // Height the test uses for a single visual row. Deliberately not the editor's
 // default 20px line height: the caret's y must come from the measured line
 // offsetTop, so a distinct value proves it is not coincidentally matching a
 // fixed lineHeight multiple.
 const ROW = 23;
+
+function rect(left: number, top: number, width = 1, height = 1): DOMRect {
+  return {
+    bottom: top + height,
+    height,
+    left,
+    right: left + width,
+    top,
+    width,
+    x: left,
+    y: top,
+    toJSON() {
+      return {};
+    },
+  } as DOMRect;
+}
 
 // jsdom performs no layout, so every element.offsetTop is 0 and the wrap-induced
 // vertical shift this test exercises would be invisible. Install a getter that
@@ -77,6 +99,63 @@ function installLineLayout(): {
   };
 }
 
+function restorePrototypeProperty(
+  proto: object,
+  property: string,
+  descriptor: PropertyDescriptor | undefined
+): void {
+  if (descriptor !== undefined) {
+    Object.defineProperty(proto, property, descriptor);
+  } else {
+    Reflect.deleteProperty(proto, property);
+  }
+}
+
+// #wrapLineText detects visual row starts by checking when a Range's top moves
+// downward. jsdom does not measure ranges, so this harness reports a new top
+// every `columns` UTF-16 offsets, making wrap offsets deterministic.
+function installWrapMeasurement(columns: number): { restore(): void } {
+  const rangeProto = Object.getPrototypeOf(document.createRange()) as object;
+  const elementProto = HTMLElement.prototype;
+  const originalRangeRect = Object.getOwnPropertyDescriptor(
+    rangeProto,
+    'getBoundingClientRect'
+  );
+  const originalElementRect = Object.getOwnPropertyDescriptor(
+    elementProto,
+    'getBoundingClientRect'
+  );
+
+  Object.defineProperty(rangeProto, 'getBoundingClientRect', {
+    configurable: true,
+    value(this: Range): DOMRect {
+      const offset = this.startOffset;
+      return rect((offset % columns) * 8, Math.floor(offset / columns) * ROW);
+    },
+  });
+  Object.defineProperty(elementProto, 'getBoundingClientRect', {
+    configurable: true,
+    value(): DOMRect {
+      return rect(0, 0, columns * 8, ROW);
+    },
+  });
+
+  return {
+    restore(): void {
+      restorePrototypeProperty(
+        rangeProto,
+        'getBoundingClientRect',
+        originalRangeRect
+      );
+      restorePrototypeProperty(
+        elementProto,
+        'getBoundingClientRect',
+        originalElementRect
+      );
+    },
+  };
+}
+
 function caretTranslateY(container: HTMLElement): number {
   const caret = container.shadowRoot?.querySelector('[data-caret]');
   if (!(caret instanceof HTMLElement)) {
@@ -99,7 +178,159 @@ function caretAt(line: number) {
   ];
 }
 
+async function createWrapEditor(
+  contents: string,
+  wrapColumns: number
+): Promise<{
+  cleanup(): void;
+  content: HTMLElement;
+  editor: Editor<undefined>;
+  window: EditorTestWindow;
+}> {
+  const dom = installDom();
+  const wrapMeasurement = installWrapMeasurement(wrapColumns);
+  const fileContainer = document.createElement('div');
+  document.body.appendChild(fileContainer);
+
+  const file = new File<undefined>({
+    disableFileHeader: true,
+    theme: DEFAULT_THEMES,
+    overflow: 'wrap',
+  });
+  const editor = new Editor<undefined>();
+  const initialFile: FileContents = {
+    name: 'wrap.ts',
+    contents,
+  };
+
+  file.render({ file: initialFile, fileContainer, forceRender: true });
+  editor.edit(file);
+  const content = await waitForEditableContent(fileContainer);
+
+  return {
+    cleanup(): void {
+      wrapMeasurement.restore();
+      editor.cleanUp();
+      file.cleanUp();
+      dom.cleanup();
+    },
+    content,
+    editor,
+    window: dom.window as unknown as EditorTestWindow,
+  };
+}
+
+function dispatchMovementKey(
+  window: EditorTestWindow,
+  content: HTMLElement,
+  init: KeyboardEventInit & { key: string }
+): KeyboardEvent {
+  const event = new window.KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    ...init,
+  });
+  content.dispatchEvent(event);
+  return event;
+}
+
+function setCaret(editor: Editor<undefined>, line: number, character: number) {
+  editor.setSelections([
+    {
+      start: { line, character },
+      end: { line, character },
+      direction: 'none',
+    },
+  ]);
+}
+
+function expectCaret(
+  editor: Editor<undefined>,
+  line: number,
+  character: number
+): void {
+  const selection = editor.getState().selections?.at(-1);
+  expect(selection?.start).toEqual({ line, character });
+  expect(selection?.end).toEqual({ line, character });
+}
+
 describe('editor wrap caret position', () => {
+  test('arrow keys move through wrapped visual rows before changing logical lines', async () => {
+    const { cleanup, content, editor, window } = await createWrapEditor(
+      '012345678901234567890123456789\nshort',
+      10
+    );
+
+    try {
+      setCaret(editor, 0, 15);
+
+      const downWithinLine = dispatchMovementKey(window, content, {
+        key: 'ArrowDown',
+      });
+      expect(downWithinLine.defaultPrevented).toBe(true);
+      expectCaret(editor, 0, 25);
+
+      dispatchMovementKey(window, content, { key: 'ArrowUp' });
+      expectCaret(editor, 0, 15);
+
+      setCaret(editor, 0, 25);
+      dispatchMovementKey(window, content, { key: 'ArrowDown' });
+      expectCaret(editor, 1, 5);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('line-boundary shortcuts use wrapped visual row boundaries', async () => {
+    const { cleanup, content, editor, window } = await createWrapEditor(
+      '  abcdefghij  klmnop',
+      12
+    );
+
+    try {
+      setCaret(editor, 0, 16);
+
+      const commandLeft = dispatchMovementKey(window, content, {
+        key: 'ArrowLeft',
+        metaKey: true,
+      });
+      expect(commandLeft.defaultPrevented).toBe(true);
+      expectCaret(editor, 0, 14);
+
+      dispatchMovementKey(window, content, {
+        key: 'ArrowLeft',
+        metaKey: true,
+      });
+      expectCaret(editor, 0, 12);
+
+      setCaret(editor, 0, 16);
+      dispatchMovementKey(window, content, {
+        key: 'ArrowRight',
+        metaKey: true,
+      });
+      expectCaret(editor, 0, 20);
+
+      setCaret(editor, 0, 16);
+      dispatchMovementKey(window, content, { key: 'a', ctrlKey: true });
+      expectCaret(editor, 0, 12);
+
+      setCaret(editor, 0, 16);
+      dispatchMovementKey(window, content, { key: 'e', ctrlKey: true });
+      expectCaret(editor, 0, 20);
+
+      setCaret(editor, 0, 16);
+      dispatchMovementKey(window, content, { key: 'Home' });
+      expectCaret(editor, 0, 12);
+
+      setCaret(editor, 0, 16);
+      dispatchMovementKey(window, content, { key: 'End' });
+      expectCaret(editor, 0, 20);
+    } finally {
+      cleanup();
+    }
+  });
+
   // When word wrap is on, growing a line until it wraps onto a second visual
   // row keeps the logical line count unchanged (change.lineDelta === 0) but
   // pushes every following line down by a row. The cached line-Y positions of


### PR DESCRIPTION
Reproduce the bug:
1. Open the diffs editor with word wrap enabled.
2. Put the caret on the middle visual row of one long logical line that wraps onto at least three rows.
3. Press ArrowDown.
4. The caret jumps to the next logical line instead of the next wrapped visual row. Cmd+Left, Cmd+Right, Ctrl+A, Ctrl+E, Home, and End also use logical line boundaries instead of the current visual row.

The editor already measured wrap offsets for caret rendering and soft-line deletion, but cursor movement did not receive those offsets. Pass wrap offsets into the selection movement mapper when wrap mode is active, and use them for vertical moves and line-boundary shortcuts.