### PR TITLE
fix(diffs): drop annotations deleted through EOF

### DIFF
--- a/packages/diffs/src/editor/lineAnnotations.ts
+++ b/packages/diffs/src/editor/lineAnnotations.ts
@@ -123,10 +123,8 @@ function getLineAnnotationChanges(
   }
   const removedLineCount = Math.max(0, -change.lineDelta);
   const deletedToDocumentEnd =
-    change.startLine === 0 &&
-    change.startCharacter === 0 &&
-    change.lineCount === 1 &&
-    change.lineDelta === 1 - change.previousLineCount;
+    change.endedAtDocumentEnd &&
+    change.startLine + removedLineCount === change.previousLineCount - 1;
   return [
     {
       startLine: change.startLine,

--- a/packages/diffs/src/editor/lineAnnotations.ts
+++ b/packages/diffs/src/editor/lineAnnotations.ts
@@ -82,28 +82,36 @@ export function applyDocumentChangeToLineAnnotations<T>(
 function getLineAnnotationChanges(
   change: TextDocumentChange
 ): readonly LineAnnotationChange[] {
-  if (change.lineDelta === 0) {
-    if (change.changedLineChanges !== undefined) {
-      return change.changedLineChanges.flatMap(
-        ([startLine, _endLine, lineDelta]) => {
-          if (lineDelta === 0) {
-            return [];
-          }
-          const removedLineCount = Math.max(0, -lineDelta);
-          return [
-            {
-              startLine,
-              startCharacter: 0,
-              endLine: startLine + removedLineCount,
-              deletesEndLine: false,
-              insertedLineBreaks: Math.max(0, lineDelta),
-              lineDelta,
-            },
-          ];
+  if (change.changedLineChanges !== undefined) {
+    return change.changedLineChanges.flatMap(
+      ([
+        startLine,
+        changedEndLine,
+        lineDelta,
+        startCharacter = 0,
+        _endCharacter = 0,
+        endedAtDocumentEnd = false,
+      ]) => {
+        if (lineDelta === 0) {
+          return [];
         }
-      );
-    }
+        const insertedLineBreaks = Math.max(0, changedEndLine - startLine);
+        const removedLineCount = Math.max(0, insertedLineBreaks - lineDelta);
+        return [
+          {
+            startLine,
+            startCharacter,
+            endLine: startLine + removedLineCount,
+            deletesEndLine: lineDelta < 0 && endedAtDocumentEnd,
+            insertedLineBreaks,
+            lineDelta,
+          },
+        ];
+      }
+    );
+  }
 
+  if (change.lineDelta === 0) {
     return change.changedLineRanges.flatMap(([startLine, endLine]) => {
       const insertedLineBreaks = endLine - startLine;
       if (insertedLineBreaks <= 0) {

--- a/packages/diffs/src/editor/textDocument.ts
+++ b/packages/diffs/src/editor/textDocument.ts
@@ -101,8 +101,12 @@ export interface TextDocumentChange {
   readonly startLine: number;
   /** Character on the first changed line where the edit began. */
   readonly startCharacter: number;
+  /** Character on the original last changed line where the edit ended. */
+  readonly endCharacter: number;
   /** Last line whose rendered content may have changed after the edit. */
   readonly endLine: number;
+  /** Whether the original edit range ended at the previous document EOF. */
+  readonly endedAtDocumentEnd: boolean;
   /** Line count before the edit was applied. */
   readonly previousLineCount: number;
   /** Line count after the edit was applied. */
@@ -416,12 +420,19 @@ export class TextDocument<LAnnotation> {
       editPositions
     );
     const startPosition = editPositions[0];
+    const endPosition = editPositions[editPositions.length - 1];
+    const endedAtDocumentEnd =
+      endPosition.line === previousLineCount - 1 &&
+      endPosition.character ===
+        this.#pieceTable.getLineLength(endPosition.line);
     this.#pieceTable.applyEdits(edits);
     const lineCount = this.#pieceTable.lineCount;
     const change: TextDocumentChange = {
       startLine: changedLineRange.startLine,
       startCharacter: startPosition.character,
+      endCharacter: endPosition.character,
       endLine: Math.min(changedLineRange.endLine, Math.max(0, lineCount - 1)),
+      endedAtDocumentEnd,
       previousLineCount,
       lineCount,
       lineDelta: lineCount - previousLineCount,

--- a/packages/diffs/src/editor/textDocument.ts
+++ b/packages/diffs/src/editor/textDocument.ts
@@ -120,6 +120,9 @@ export interface TextDocumentChange {
     startLine: number,
     endLine: number,
     lineDelta: number,
+    startCharacter?: number,
+    endCharacter?: number,
+    endedAtDocumentEnd?: boolean,
   ][];
 }
 
@@ -449,14 +452,30 @@ export class TextDocument<LAnnotation> {
     startLine: number;
     endLine: number;
     ranges: [number, number][];
-    changes: [startLine: number, endLine: number, lineDelta: number][];
+    changes: [
+      startLine: number,
+      endLine: number,
+      lineDelta: number,
+      startCharacter: number,
+      endCharacter: number,
+      endedAtDocumentEnd: boolean,
+    ][];
   } {
     let startLine = Infinity;
     let endLine = 0;
     let lineDeltaBeforeEdit = 0;
     const ranges: [number, number][] = [];
-    const changes: [startLine: number, endLine: number, lineDelta: number][] =
-      [];
+    const changes: [
+      startLine: number,
+      endLine: number,
+      lineDelta: number,
+      startCharacter: number,
+      endCharacter: number,
+      endedAtDocumentEnd: boolean,
+    ][] = [];
+    const previousLastLine = this.#pieceTable.lineCount - 1;
+    const previousLastLineLength =
+      this.#pieceTable.getLineLength(previousLastLine);
     for (let i = 0; i < edits.length; i++) {
       const edit = edits[i];
       const editStart = editPositions[i * 2];
@@ -478,7 +497,15 @@ export class TextDocument<LAnnotation> {
       } else {
         ranges.push([changedStartLine, changedEndLine]);
       }
-      changes.push([changedStartLine, changedEndLine, lineDelta]);
+      changes.push([
+        changedStartLine,
+        changedEndLine,
+        lineDelta,
+        editStart.character,
+        editEnd.character,
+        editEndLine === previousLastLine &&
+          editEnd.character === previousLastLineLength,
+      ]);
       lineDeltaBeforeEdit += lineDelta;
     }
     if (startLine === Infinity) {
@@ -486,7 +513,7 @@ export class TextDocument<LAnnotation> {
         startLine: 0,
         endLine: 0,
         ranges: [[0, 0]],
-        changes: [[0, 0, 0]],
+        changes: [[0, 0, 0, 0, 0, false]],
       };
     }
     return { startLine, endLine, ranges, changes };

--- a/packages/diffs/test/editorLineAnnotations.test.ts
+++ b/packages/diffs/test/editorLineAnnotations.test.ts
@@ -129,6 +129,35 @@ describe('applyDocumentChangeToLineAnnotations', () => {
     ]);
   });
 
+  test('does not borrow EOF from a later insertion when remapping deleted lines', () => {
+    const textDocument = new TextDocument('inmemory://1', 'l0\nl1\nl2\nl3');
+    const annotations: DiffLineAnnotation<string>[] = [
+      { side: 'additions', lineNumber: 4, metadata: 'l3' },
+    ];
+
+    const change = textDocument.applyEdits([
+      {
+        range: {
+          start: { line: 1, character: 0 },
+          end: { line: 3, character: 0 },
+        },
+        newText: '',
+      },
+      {
+        range: {
+          start: { line: 3, character: 2 },
+          end: { line: 3, character: 2 },
+        },
+        newText: '!',
+      },
+    ]);
+
+    expect(textDocument.getText()).toBe('l0\nl3!');
+    expect(applyDocumentChangeToLineAnnotations(change!, annotations)).toEqual([
+      { side: 'additions', lineNumber: 2, metadata: 'l3' },
+    ]);
+  });
+
   test('does not restore deleted addition annotations when new lines are inserted', () => {
     const textDocument = new TextDocument('inmemory://1', 'one\ntwo\nthree');
     const annotations: DiffLineAnnotation<string>[] = [

--- a/packages/diffs/test/editorLineAnnotations.test.ts
+++ b/packages/diffs/test/editorLineAnnotations.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from 'bun:test';
 
-import { applyDocumentChangeToLineAnnotations } from '../src/editor/lineAnnotations';
+import {
+  applyDocumentChangeToLineAnnotations,
+  renderLineAnnotations,
+} from '../src/editor/lineAnnotations';
 import { TextDocument } from '../src/editor/textDocument';
 import type { DiffLineAnnotation } from '../src/types';
+import { installDom, wait } from './domHarness';
 
 describe('applyDocumentChangeToLineAnnotations', () => {
   test('drops annotations attached to deleted lines', () => {
@@ -75,6 +79,53 @@ describe('applyDocumentChangeToLineAnnotations', () => {
     expect(textDocument.getText()).toBe('');
     expect(applyDocumentChangeToLineAnnotations(change!, annotations)).toEqual([
       { side: 'deletions', lineNumber: 1, metadata: 'old one' },
+    ]);
+  });
+
+  test('drops annotations on lines deleted through the end of the document', () => {
+    const textDocument = new TextDocument('inmemory://1', 'l0\nl1\nl2\nl3');
+    const annotations: DiffLineAnnotation<string>[] = [
+      { side: 'additions', lineNumber: 1, metadata: 'l0' },
+      { side: 'additions', lineNumber: 2, metadata: 'l1' },
+      { side: 'additions', lineNumber: 3, metadata: 'l2' },
+      { side: 'additions', lineNumber: 4, metadata: 'l3' },
+    ];
+
+    const change = textDocument.applyEdits([
+      {
+        range: {
+          start: { line: 1, character: 0 },
+          end: { line: 3, character: 2 },
+        },
+        newText: '',
+      },
+    ]);
+
+    expect(textDocument.getText()).toBe('l0\n');
+    expect(applyDocumentChangeToLineAnnotations(change!, annotations)).toEqual([
+      { side: 'additions', lineNumber: 1, metadata: 'l0' },
+    ]);
+  });
+
+  test('keeps final-line annotations when part of that line survives', () => {
+    const textDocument = new TextDocument('inmemory://1', 'l0\nl1\nl2\nl3');
+    const annotations: DiffLineAnnotation<string>[] = [
+      { side: 'additions', lineNumber: 4, metadata: 'l3' },
+    ];
+
+    const change = textDocument.applyEdits([
+      {
+        range: {
+          start: { line: 1, character: 0 },
+          end: { line: 3, character: 1 },
+        },
+        newText: '',
+      },
+    ]);
+
+    expect(textDocument.getText()).toBe('l0\n3');
+    expect(applyDocumentChangeToLineAnnotations(change!, annotations)).toEqual([
+      { side: 'additions', lineNumber: 2, metadata: 'l3' },
     ]);
   });
 
@@ -259,3 +310,107 @@ describe('applyDocumentChangeToLineAnnotations', () => {
     ]);
   });
 });
+
+describe('renderLineAnnotations', () => {
+  test('renders paired addition and deletion annotations', async () => {
+    const { cleanup } = installDom();
+    try {
+      const { content, gutter, leftContent, leftGutter } =
+        createSplitAnnotationHost(3);
+      const staleContent = document.createElement('div');
+      staleContent.dataset.lineAnnotation = 'stale';
+      content.children[0].after(staleContent);
+      const staleGutter = document.createElement('div');
+      staleGutter.dataset.gutterBuffer = 'annotation';
+      staleGutter.dataset.stale = '';
+      gutter.children[0].after(staleGutter);
+
+      renderLineAnnotations(
+        [
+          { side: 'additions', lineNumber: 2, metadata: 'new' },
+          { side: 'deletions', lineNumber: 1, metadata: 'old' },
+        ],
+        content,
+        gutter
+      );
+      await wait();
+
+      expect(
+        content.querySelector('[data-line-annotation="stale"]')
+      ).toBeNull();
+      expect(
+        gutter.querySelector('[data-gutter-buffer="annotation"][data-stale]')
+      ).toBeNull();
+      expect(
+        content.querySelector(
+          '[data-line-annotation="0,1"] slot[name="annotation-additions-2"]'
+        )
+      ).not.toBeNull();
+      expect(
+        leftContent.querySelector(
+          '[data-line-annotation="0,0"] slot[name="annotation-deletions-1"]'
+        )
+      ).not.toBeNull();
+      expect(content.querySelectorAll('[data-line-annotation]')).toHaveLength(
+        2
+      );
+      expect(
+        leftContent.querySelectorAll('[data-line-annotation]')
+      ).toHaveLength(2);
+      expect(
+        gutter.querySelectorAll('[data-gutter-buffer="annotation"]')
+      ).toHaveLength(2);
+      expect(
+        leftGutter.querySelectorAll('[data-gutter-buffer="annotation"]')
+      ).toHaveLength(2);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+function createSplitAnnotationHost(lineCount: number): {
+  content: HTMLElement;
+  gutter: HTMLElement;
+  leftContent: HTMLElement;
+  leftGutter: HTMLElement;
+} {
+  const root = document.createElement('div');
+  const leftCode = document.createElement('div');
+  leftCode.dataset.deletions = '';
+  const leftGutter = document.createElement('div');
+  leftGutter.dataset.gutter = '';
+  const leftContent = document.createElement('div');
+  leftContent.dataset.content = '';
+  leftCode.append(leftGutter, leftContent);
+
+  const code = document.createElement('div');
+  const gutter = document.createElement('div');
+  gutter.dataset.gutter = '';
+  const content = document.createElement('div');
+  content.dataset.content = '';
+  code.append(gutter, content);
+  root.append(leftCode, code);
+  document.body.append(root);
+
+  for (let lineNumber = 1; lineNumber <= lineCount; lineNumber++) {
+    appendRenderedLine(leftContent, leftGutter, lineNumber);
+    appendRenderedLine(content, gutter, lineNumber);
+  }
+
+  return { content, gutter, leftContent, leftGutter };
+}
+
+function appendRenderedLine(
+  content: HTMLElement,
+  gutter: HTMLElement,
+  lineNumber: number
+): void {
+  const contentLine = document.createElement('div');
+  contentLine.dataset.line = String(lineNumber);
+  content.append(contentLine);
+
+  const gutterLine = document.createElement('div');
+  gutterLine.dataset.columnNumber = String(lineNumber);
+  gutter.append(gutterLine);
+}

--- a/packages/diffs/test/editorTextDocument.test.ts
+++ b/packages/diffs/test/editorTextDocument.test.ts
@@ -89,7 +89,9 @@ describe('TextDocument', () => {
     expect(change).toEqual({
       startLine: 0,
       startCharacter: 0,
+      endCharacter: 5,
       endLine: 0,
+      endedAtDocumentEnd: true,
       previousLineCount: 2,
       lineCount: 1,
       lineDelta: -1,
@@ -194,7 +196,9 @@ describe('TextDocument', () => {
     expect(change).toEqual({
       startLine: 0,
       startCharacter: 6,
+      endCharacter: 11,
       endLine: 0,
+      endedAtDocumentEnd: true,
       previousLineCount: 1,
       lineCount: 1,
       lineDelta: 0,
@@ -255,7 +259,9 @@ describe('TextDocument', () => {
     expect(change).toEqual({
       startLine: 1,
       startCharacter: 0,
+      endCharacter: 1,
       endLine: 1,
+      endedAtDocumentEnd: false,
       previousLineCount: 3,
       lineCount: 3,
       lineDelta: 0,
@@ -279,7 +285,9 @@ describe('TextDocument', () => {
     expect(change).toEqual({
       startLine: 0,
       startCharacter: 1,
+      endCharacter: 1,
       endLine: 1,
+      endedAtDocumentEnd: true,
       previousLineCount: 1,
       lineCount: 2,
       lineDelta: 1,
@@ -303,7 +311,9 @@ describe('TextDocument', () => {
     expect(change).toEqual({
       startLine: 0,
       startCharacter: 1,
+      endCharacter: 0,
       endLine: 0,
+      endedAtDocumentEnd: false,
       previousLineCount: 3,
       lineCount: 1,
       lineDelta: -2,
@@ -342,7 +352,9 @@ describe('TextDocument', () => {
     expect(change).toEqual({
       startLine: 0,
       startCharacter: 1,
+      endCharacter: 1,
       endLine: 1,
+      endedAtDocumentEnd: true,
       previousLineCount: 1,
       lineCount: 2,
       lineDelta: 1,
@@ -367,7 +379,9 @@ describe('TextDocument', () => {
     expect(change).toEqual({
       startLine: 0,
       startCharacter: 5,
+      endCharacter: 5,
       endLine: 2,
+      endedAtDocumentEnd: true,
       previousLineCount: 1,
       lineCount: 3,
       lineDelta: 2,
@@ -1054,7 +1068,9 @@ describe('TextDocument', () => {
     expect(undoResult?.[0]).toEqual({
       startLine: 0,
       startCharacter: 1,
+      endCharacter: 2,
       endLine: 0,
+      endedAtDocumentEnd: true,
       previousLineCount: 1,
       lineCount: 1,
       lineDelta: 0,
@@ -1069,7 +1085,9 @@ describe('TextDocument', () => {
     expect(redoResult?.[0]).toEqual({
       startLine: 0,
       startCharacter: 1,
+      endCharacter: 1,
       endLine: 0,
+      endedAtDocumentEnd: true,
       previousLineCount: 1,
       lineCount: 1,
       lineDelta: 0,

--- a/packages/diffs/test/editorTextDocument.test.ts
+++ b/packages/diffs/test/editorTextDocument.test.ts
@@ -96,7 +96,7 @@ describe('TextDocument', () => {
       lineCount: 1,
       lineDelta: -1,
       changedLineRanges: [[0, 0]],
-      changedLineChanges: [[0, 0, -1]],
+      changedLineChanges: [[0, 0, -1, 0, 5, true]],
     });
   });
 
@@ -203,7 +203,7 @@ describe('TextDocument', () => {
       lineCount: 1,
       lineDelta: 0,
       changedLineRanges: [[0, 0]],
-      changedLineChanges: [[0, 0, 0]],
+      changedLineChanges: [[0, 0, 0, 6, 11, true]],
     });
   });
 
@@ -266,7 +266,7 @@ describe('TextDocument', () => {
       lineCount: 3,
       lineDelta: 0,
       changedLineRanges: [[1, 1]],
-      changedLineChanges: [[1, 1, 0]],
+      changedLineChanges: [[1, 1, 0, 0, 1, false]],
     });
   });
 
@@ -292,7 +292,7 @@ describe('TextDocument', () => {
       lineCount: 2,
       lineDelta: 1,
       changedLineRanges: [[0, 1]],
-      changedLineChanges: [[0, 1, 1]],
+      changedLineChanges: [[0, 1, 1, 1, 1, true]],
     });
   });
 
@@ -318,7 +318,7 @@ describe('TextDocument', () => {
       lineCount: 1,
       lineDelta: -2,
       changedLineRanges: [[0, 0]],
-      changedLineChanges: [[0, 0, -2]],
+      changedLineChanges: [[0, 0, -2, 1, 0, false]],
     });
   });
 
@@ -359,7 +359,7 @@ describe('TextDocument', () => {
       lineCount: 2,
       lineDelta: 1,
       changedLineRanges: [[0, 1]],
-      changedLineChanges: [[0, 1, 1]],
+      changedLineChanges: [[0, 1, 1, 1, 1, true]],
     });
   });
 
@@ -386,7 +386,7 @@ describe('TextDocument', () => {
       lineCount: 3,
       lineDelta: 2,
       changedLineRanges: [[0, 2]],
-      changedLineChanges: [[0, 2, 2]],
+      changedLineChanges: [[0, 2, 2, 5, 5, true]],
     });
   });
 
@@ -1075,7 +1075,7 @@ describe('TextDocument', () => {
       lineCount: 1,
       lineDelta: 0,
       changedLineRanges: [[0, 0]],
-      changedLineChanges: [[0, 0, 0]],
+      changedLineChanges: [[0, 0, 0, 1, 2, true]],
     });
     expect(d.canUndo).toBe(false);
     expect(d.canRedo).toBe(true);
@@ -1092,7 +1092,7 @@ describe('TextDocument', () => {
       lineCount: 1,
       lineDelta: 0,
       changedLineRanges: [[0, 0]],
-      changedLineChanges: [[0, 0, 0]],
+      changedLineChanges: [[0, 0, 0, 1, 1, true]],
     });
     expect(d.canUndo).toBe(true);
     expect(d.canRedo).toBe(false);

--- a/packages/diffs/test/editorTokenizer.test.ts
+++ b/packages/diffs/test/editorTokenizer.test.ts
@@ -97,7 +97,9 @@ describe('EditorTokenizer', () => {
         {
           startLine: 0,
           startCharacter: 0,
+          endCharacter: 0,
           endLine: 19,
+          endedAtDocumentEnd: false,
           previousLineCount: textDocument.lineCount,
           lineCount: textDocument.lineCount,
           lineDelta: 0,
@@ -144,7 +146,9 @@ describe('EditorTokenizer', () => {
     const change: TextDocumentChange = {
       startLine: 0,
       startCharacter: 0,
+      endCharacter: 0,
       endLine: 0,
+      endedAtDocumentEnd: false,
       previousLineCount: textDocument.lineCount,
       lineCount: textDocument.lineCount,
       lineDelta: 0,
@@ -223,7 +227,9 @@ describe('EditorTokenizer', () => {
       tokenizer.tokenize({
         startLine: 0,
         startCharacter: 0,
+        endCharacter: 0,
         endLine: 0,
+        endedAtDocumentEnd: false,
         previousLineCount: textDocument.lineCount,
         lineCount: textDocument.lineCount,
         lineDelta: 0,
@@ -289,7 +295,9 @@ describe('EditorTokenizer', () => {
         {
           startLine: 0,
           startCharacter: 0,
+          endCharacter: 0,
           endLine: 999,
+          endedAtDocumentEnd: false,
           previousLineCount: textDocument.lineCount,
           lineCount: textDocument.lineCount,
           lineDelta: 1,
@@ -362,7 +370,9 @@ describe('EditorTokenizer', () => {
       {
         startLine: 0,
         startCharacter: 0,
+        endCharacter: 0,
         endLine: 109,
+        endedAtDocumentEnd: false,
         previousLineCount: textDocument.lineCount,
         lineCount: textDocument.lineCount,
         lineDelta: 0,
@@ -445,7 +455,9 @@ describe('EditorTokenizer', () => {
         {
           startLine: 0,
           startCharacter: 0,
+          endCharacter: 0,
           endLine: textDocument.lineCount - 1,
+          endedAtDocumentEnd: false,
           previousLineCount: textDocument.lineCount,
           lineCount: textDocument.lineCount,
           lineDelta: 0,
@@ -551,7 +563,9 @@ describe('EditorTokenizer', () => {
         {
           startLine: 0,
           startCharacter: 0,
+          endCharacter: 0,
           endLine: 19,
+          endedAtDocumentEnd: false,
           previousLineCount: textDocument.lineCount,
           lineCount: textDocument.lineCount,
           lineDelta: 0,
@@ -641,7 +655,9 @@ describe('EditorTokenizer', () => {
         {
           startLine: 0,
           startCharacter: 0,
+          endCharacter: 0,
           endLine: 0,
+          endedAtDocumentEnd: false,
           previousLineCount: textDocument.lineCount,
           lineCount: textDocument.lineCount,
           lineDelta: 0,
@@ -700,7 +716,9 @@ describe('EditorTokenizer', () => {
       {
         startLine: 0,
         startCharacter: 0,
+        endCharacter: 0,
         endLine: 0,
+        endedAtDocumentEnd: false,
         previousLineCount: textDocument.lineCount,
         lineCount: textDocument.lineCount,
         lineDelta: 0,
@@ -788,7 +806,9 @@ describe('EditorTokenizer', () => {
       const change: TextDocumentChange = {
         startLine: 0,
         startCharacter: 0,
+        endCharacter: 0,
         endLine: 0,
+        endedAtDocumentEnd: false,
         previousLineCount: textDocument.lineCount,
         lineCount: textDocument.lineCount,
         lineDelta: 0,
@@ -877,7 +897,9 @@ describe('EditorTokenizer', () => {
       const change: TextDocumentChange = {
         startLine: 0,
         startCharacter: 0,
+        endCharacter: 0,
         endLine: 0,
+        endedAtDocumentEnd: false,
         previousLineCount: textDocument.lineCount,
         lineCount: textDocument.lineCount,
         lineDelta: 0,
@@ -965,7 +987,9 @@ describe('EditorTokenizer', () => {
         {
           startLine: 0,
           startCharacter: 0,
+          endCharacter: 0,
           endLine: 0,
+          endedAtDocumentEnd: false,
           previousLineCount: textDocument.lineCount,
           lineCount: textDocument.lineCount,
           lineDelta: 0,
@@ -1020,7 +1044,9 @@ describe('EditorTokenizer', () => {
       {
         startLine: 0,
         startCharacter: 0,
+        endCharacter: 0,
         endLine: 799,
+        endedAtDocumentEnd: false,
         previousLineCount: textDocument.lineCount,
         lineCount: textDocument.lineCount,
         lineDelta: 1,


### PR DESCRIPTION
1. Open an editable diff document with text `l0\nl1\nl2\nl3` and no trailing newline.
2. Add line annotations on all four addition lines.
3. Delete from zero-based line 1, column 0 through zero-based line 3, column 2.
4. Observe that the line 3 annotation survives on the empty trailing line instead of being removed.

TextDocumentChange only exposed the edit start character, so line annotation mapping could not tell a delete that reached EOF from a delete that merged into surviving final-line text. Record the original edit end character and whether the range ended at the previous document EOF, then use that EOF fact when deciding whether the end line was deleted.

Add coverage for the delete-to-EOF case, the partial-final-line guard, and renderLineAnnotations pairing and cleanup.