### PR TITLE
Updated Playwright tests, modify edit mode popover flipping

### DIFF
--- a/packages/diffs/src/editor/popover.ts
+++ b/packages/diffs/src/editor/popover.ts
@@ -146,6 +146,15 @@ export class PopoverManager {
       topScreen = 0;
       bottomScreen = window.innerHeight;
     }
+    // The overlay that hosts the popover lives inside `[data-code]`, which uses
+    // `overflow-y: clip` (see style.css). A short file smaller than the
+    // scrollport therefore clips the popover at its own top/bottom even when the
+    // window/scroll container still has room beyond those edges. Intersect the
+    // scrollport with the code element's own box so a first/last-line popover
+    // flips to the side that actually fits within that clip, not just within the
+    // outer viewport.
+    topScreen = Math.max(topScreen, codeRect.top);
+    bottomScreen = Math.min(bottomScreen, codeRect.bottom);
     if (bottomScreen <= topScreen) {
       return undefined;
     }
@@ -161,13 +170,14 @@ export class PopoverManager {
   // file container so it is not re-resolved on every render.
   //
   // Known limitations: this only inspects light-DOM ancestors outside the
-  // shadow root, so it cannot see a clip boundary inside it (e.g. `[data-code]`
-  // itself uses `overflow-y: clip`, which also is not one of the values matched
-  // below) and cannot cross into an outer shadow root if the file container is
-  // itself nested in another web component. It also only considers the
-  // *nearest* scrollable ancestor, not the intersection of every clipping
-  // ancestor, so a popover could still be clipped by an outer scroll context
-  // even when it fits within this nearer one.
+  // shadow root, so it cannot see arbitrary clip boundaries inside it and cannot
+  // cross into an outer shadow root if the file container is itself nested in
+  // another web component. It also only considers the *nearest* scrollable
+  // ancestor, not the intersection of every clipping ancestor, so a popover
+  // could still be clipped by an outer scroll context even when it fits within
+  // this nearer one. The `[data-code]` element's own `overflow-y: clip` box is
+  // handled separately in getPlacementBounds, which intersects it with whatever
+  // scrollport this method resolves.
   #getScrollContainer(): HTMLElement | undefined {
     const fileContainer = this.#fileContainer;
     if (fileContainer === undefined) {

--- a/packages/diffs/test/e2e/e2e-globals.d.ts
+++ b/packages/diffs/test/e2e/e2e-globals.d.ts
@@ -49,6 +49,7 @@ interface Window {
   __annotationsReady?: boolean;
   __themeReady?: boolean;
   __selectionActionReady?: boolean;
+  __selectionActionEdgesReady?: boolean;
 
   // Interaction logs populated by fixture callbacks.
   __editorEvents?: string[];

--- a/packages/diffs/test/e2e/fixtures/index.html
+++ b/packages/diffs/test/e2e/fixtures/index.html
@@ -153,6 +153,19 @@
           <code>window.__selectionActionReady</code>.
         </p>
       </li>
+      <li>
+        <a href="/test/e2e/fixtures/selection-action-edges.html"
+          >selection-action-edges.html</a
+        >
+        <p class="desc">
+          A taller 16-line editor with <code>enabledSelectionAction</code> used
+          to drag forward/backward selections whose head sits mid-file or on the
+          first/last row; verifies the popover flips off the code element's own
+          clip box and never spills past the file component's edges. Drives
+          <code>selection-action.pw.ts</code>. Ready flag:
+          <code>window.__selectionActionEdgesReady</code>.
+        </p>
+      </li>
     </ul>
   </body>
 </html>

--- a/packages/diffs/test/e2e/fixtures/selection-action-edges.html
+++ b/packages/diffs/test/e2e/fixtures/selection-action-edges.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>diffs selection-action edges fixture</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 16px;
+        font-family: system-ui, sans-serif;
+      }
+      /* Push the editor down so there is window room above its top edge; this
+         lets the first-line placement tests prove the popover flips off the
+         code element's own clip box rather than merely the window edge. */
+      [data-spacer] {
+        height: 64px;
+      }
+      [data-diff-mount] {
+        max-width: 900px;
+      }
+    </style>
+  </head>
+  <body>
+    <a
+      data-fixtures-index
+      href="/test/e2e/fixtures/index.html"
+      style="
+        display: inline-block;
+        margin-bottom: 16px;
+        font-family: system-ui, sans-serif;
+        font-size: 14px;
+        font-weight: 600;
+        color: #0b62d6;
+        text-decoration: none;
+      "
+      >&larr; All fixtures</a
+    >
+    <div data-spacer></div>
+    <div data-diff-mount></div>
+
+    <script type="module">
+      import { File } from '/dist/index.js';
+      import { Editor } from '/dist/editor/index.js';
+
+      const mount = document.querySelector('[data-diff-mount]');
+      if (!(mount instanceof HTMLElement)) {
+        throw new Error('Missing selection-action-edges fixture mount.');
+      }
+
+      // A 16-line file (no trailing newline, so line16 is the last line). Each
+      // line carries a unique `lineNN` identifier the tests can target to drag a
+      // selection whose head sits mid-file or exactly on the first/last row.
+      const lineCount = 16;
+      const lines = Array.from(
+        { length: lineCount },
+        (_, index) =>
+          `const line${String(index + 1).padStart(2, '0')} = 'v${String(
+            index + 1
+          ).padStart(2, '0')}';`
+      );
+      const file = {
+        name: 'edges.ts',
+        contents: lines.join('\n'),
+      };
+
+      const editor = new Editor({
+        enabledSelectionAction: true,
+        renderSelectionAction({ getSelectionText, close }) {
+          const container = document.createElement('div');
+          container.dataset.testAction = '';
+          const button = document.createElement('button');
+          button.type = 'button';
+          button.dataset.testActionButton = '';
+          button.textContent = 'Capture';
+          // Prevent the mousedown from blurring the editor and collapsing the
+          // selection before the click handler reads it.
+          button.addEventListener('mousedown', (e) => e.preventDefault());
+          button.addEventListener('click', () => {
+            close();
+          });
+          container.appendChild(button);
+          return container;
+        },
+      });
+      window.__editor = editor;
+
+      const instance = new File({
+        disableFileHeader: true,
+        theme: { dark: 'pierre-dark', light: 'pierre-light' },
+        themeType: 'dark',
+        useTokenTransformer: true,
+      });
+      instance.render({ file, containerWrapper: mount });
+      editor.edit(instance);
+
+      const waitForEditable = async () => {
+        const started = performance.now();
+        while (true) {
+          const host = mount.querySelector('diffs-container');
+          const content = host?.shadowRoot?.querySelector('[data-content]');
+          if (content?.getAttribute('contenteditable') === 'true') {
+            return;
+          }
+          if (performance.now() - started > 5000) {
+            throw new Error('Timed out waiting for editable content.');
+          }
+          await new Promise((resolve) => requestAnimationFrame(resolve));
+        }
+      };
+
+      await waitForEditable();
+      window.__selectionActionEdgesReady = true;
+    </script>
+  </body>
+</html>

--- a/packages/diffs/test/e2e/selection-action.pw.ts
+++ b/packages/diffs/test/e2e/selection-action.pw.ts
@@ -67,3 +67,102 @@ test.describe('selection action popover', () => {
     await expect.poll(() => actionClicks(page)).toEqual(['alpha']);
   });
 });
+
+// Reads the popover's --popover-y-shift, which encodes the resolved side:
+// '0px' means placed below the anchor, '-100%' means lifted above it.
+function popoverShift(page: Page): Promise<string> {
+  return page.evaluate((sel) => {
+    const root = document.querySelector('diffs-container')?.shadowRoot;
+    const popover = root?.querySelector(sel);
+    if (!(popover instanceof HTMLElement)) {
+      return '';
+    }
+    return popover.style.getPropertyValue('--popover-y-shift').trim();
+  }, POPOVER);
+}
+
+// Drags a real mouse selection from the center of one line's identifier token to
+// another's. The drag direction sets the selection direction (and thus which
+// side the popover prefers): a downward drag is forward, an upward drag is
+// backward, with the head landing on the drag's end line.
+async function dragSelect(
+  page: Page,
+  fromToken: string,
+  toToken: string
+): Promise<void> {
+  const center = async (token: string): Promise<{ x: number; y: number }> => {
+    const box = await page
+      .locator(CONTENT)
+      .getByText(token, { exact: true })
+      .first()
+      .boundingBox();
+    if (box == null) {
+      throw new Error(`no bounding box for ${token}`);
+    }
+    return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+  };
+  const from = await center(fromToken);
+  const to = await center(toToken);
+  await page.mouse.move(from.x, from.y);
+  await page.mouse.down();
+  await page.mouse.move(to.x, to.y, { steps: 10 });
+  await page.mouse.up();
+}
+
+// The taller 16-line fixture exists so a selection's head can sit exactly on the
+// first or last row: cases where the popover's preferred side would be clipped
+// by [data-code]'s own `overflow-y: clip` even though the window still has room
+// beyond that edge. Each case asserts the popover stays within the file
+// component and, for the edge cases, that it flipped to the fitting side.
+test.describe('selection action popover placement (edges)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/test/e2e/fixtures/selection-action-edges.html');
+    await page.waitForFunction(
+      () => window.__selectionActionEdgesReady === true
+    );
+  });
+
+  test('forward selection mid-file places the popover below, within bounds', async ({
+    page,
+  }) => {
+    await dragSelect(page, 'line06', 'line09');
+
+    await expect(page.locator(POPOVER)).toBeVisible();
+    expect(await popoverShift(page)).toBe('0px');
+    expect(await popoverWithinHost(page)).toBe(true);
+  });
+
+  test('backward selection mid-file places the popover above, within bounds', async ({
+    page,
+  }) => {
+    await dragSelect(page, 'line11', 'line08');
+
+    await expect(page.locator(POPOVER)).toBeVisible();
+    expect(await popoverShift(page)).toBe('-100%');
+    expect(await popoverWithinHost(page)).toBe(true);
+  });
+
+  test('backward selection up to the first line flips below, within bounds', async ({
+    page,
+  }) => {
+    await dragSelect(page, 'line05', 'line01');
+
+    await expect(page.locator(POPOVER)).toBeVisible();
+    // Preferred (above the first row) would be clipped by the code box top, so
+    // it must flip below the selection's bottom edge instead of spilling out.
+    expect(await popoverShift(page)).toBe('0px');
+    expect(await popoverWithinHost(page)).toBe(true);
+  });
+
+  test('forward selection down to the last line flips above, within bounds', async ({
+    page,
+  }) => {
+    await dragSelect(page, 'line12', 'line16');
+
+    await expect(page.locator(POPOVER)).toBeVisible();
+    // Preferred (below the last row) would be clipped by the code box bottom, so
+    // it must flip above the selection's top edge instead of spilling out.
+    expect(await popoverShift(page)).toBe('-100%');
+    expect(await popoverWithinHost(page)).toBe(true);
+  });
+});


### PR DESCRIPTION
Follow up to #927.

- Refines selection action test
- Adds another selection action test to confirm flipping behaviors
- Modifies popover flipping detection for instances where short files cause placement issues