### PR TITLE
fix(diffs): Normalize CRLF editor insertions

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -1647,7 +1647,14 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     const clipboard = this.#options.clipboard;
     if (clipboard !== undefined) {
       const text = await clipboard.readText();
-      this.#replaceSelectionText(text, undefined, true);
+      const textDocument = this.#textDocument;
+      if (textDocument !== undefined) {
+        this.#replaceSelectionText(
+          textDocument.normalizeEol(text),
+          undefined,
+          true
+        );
+      }
     }
   };
 
@@ -2265,10 +2272,10 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       case 'insertCompositionText':
         break;
       case 'insertLineBreak':
-      case 'insertParagraph':
-        // TODO(@ije): use document.EOF instead of '\n'
-        this.#replaceSelectionText('\n');
+      case 'insertParagraph': {
+        this.#replaceSelectionText(this.#textDocument?.eol ?? '\n');
         break;
+      }
       case 'deleteContentBackward':
         this.#deleteSelectionText();
         break;

--- a/packages/diffs/test/editorClipboard.test.ts
+++ b/packages/diffs/test/editorClipboard.test.ts
@@ -300,6 +300,23 @@ function dispatchPaste(target: HTMLElement, text: string): void {
   expect(event.defaultPrevented).toBe(true);
 }
 
+function dispatchBeforeInput(target: HTMLElement, inputType: string): void {
+  const view = target.ownerDocument.defaultView;
+  if (view == null) {
+    throw new Error('target element is not attached to a window');
+  }
+  const event = new view.InputEvent('beforeinput', {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    inputType,
+    data: null,
+  });
+
+  target.dispatchEvent(event);
+  expect(event.defaultPrevented).toBe(true);
+}
+
 function dispatchPasteShortcutKeydown(
   target: HTMLElement,
   repeat = false,
@@ -809,6 +826,46 @@ describe('Editor clipboard events', () => {
     }
   });
 
+  test('custom clipboard provider matches the document EOL when the file uses CRLF', async () => {
+    const { cleanup } = installDom();
+    let reads = 0;
+
+    const editor = new Editor<undefined>({
+      clipboard: {
+        readText: () => {
+          reads++;
+          return 'X\nY';
+        },
+      },
+    });
+    const component = new TestEditableComponent({
+      name: 'example.txt',
+      contents: 'alpha\r\nbravo',
+      lang: 'text',
+    });
+
+    try {
+      editor.edit(component);
+      editor.setSelections([
+        {
+          start: { line: 1, character: 5 },
+          end: { line: 1, character: 5 },
+          direction: 'none',
+        },
+      ]);
+
+      const keydown = dispatchPasteShortcutKeydown(component.contentElement);
+      await wait();
+
+      expect(keydown.defaultPrevented).toBe(true);
+      expect(reads).toBe(1);
+      expect(editor.getState().file.contents).toBe('alpha\r\nbravoX\r\nY');
+    } finally {
+      editor.cleanUp();
+      cleanup();
+    }
+  });
+
   test('matches the document EOL when the file uses lone CR', () => {
     const { cleanup } = installDom();
 
@@ -840,4 +897,37 @@ describe('Editor clipboard events', () => {
       cleanup();
     }
   });
+});
+
+describe('Editor line break input', () => {
+  for (const inputType of ['insertLineBreak', 'insertParagraph'] as const) {
+    test(`${inputType} inserts the document EOL when the file uses CRLF`, () => {
+      const { cleanup } = installDom();
+
+      const editor = new Editor<undefined>();
+      const component = new TestEditableComponent({
+        name: 'example.txt',
+        contents: 'alpha\r\nbravo',
+        lang: 'text',
+      });
+
+      try {
+        editor.edit(component);
+        editor.setSelections([
+          {
+            start: { line: 1, character: 5 },
+            end: { line: 1, character: 5 },
+            direction: 'none',
+          },
+        ]);
+
+        dispatchBeforeInput(component.contentElement, inputType);
+
+        expect(editor.getState().file.contents).toBe('alpha\r\nbravo\r\n');
+      } finally {
+        editor.cleanUp();
+        cleanup();
+      }
+    });
+  }
 });


### PR DESCRIPTION
Reproduce the bug:
1. Open an editable diffs document whose first line break is CRLF.
2. Configure EditorOptions.clipboard with a custom readText provider.
3. Paste custom clipboard text containing only Unix "\n" line breaks.
4. Press Enter in the same document.
5. The buffer now mixes the document's "\r\n" with raw "\n".

Native paste already normalized clipboard text through TextDocument.normalizeEol, but the custom clipboard handler passed raw text to the edit path. Enter also inserted a hardcoded "\n". Normalize custom clipboard text against the active document and use textDocument.eol for insertLineBreak and insertParagraph.