### PR TITLE
fix(diffs): Clear web font text width cache

### DIFF
--- a/packages/diffs/src/editor/textMeasure.ts
+++ b/packages/diffs/src/editor/textMeasure.ts
@@ -74,15 +74,18 @@ export class Metrics {
 
   /**
    * Re-measure the '0' character width against the font that is loaded right
-   * now, returning true when it changed.
+   * now, returning true when measurement-dependent UI should refresh.
    *
    * A custom web font can finish loading after the editor first renders.
    * Until then canvas measureText reports the fallback font's width, and
    * getComputedStyle returns the same font-family string before and after the
    * file arrives, so init()'s font guard never re-measures on its own. Call
    * this once fonts have settled (e.g. on document.fonts.ready) to replace a
-   * width measured against the fallback font with the real glyph width. The
-   * boolean return lets the caller skip re-rendering when nothing changed.
+   * width measured against the fallback font with the real glyph width. Font
+   * completion can also change DOM-measured emoji/ZWJ widths while leaving the
+   * ASCII width unchanged, and the computed font string stays the same in both
+   * cases. The boolean return lets the caller skip re-rendering when there is no
+   * measured state to refresh.
    */
   remeasureCharacterWidth(): boolean {
     if (this.#canvasCtx === undefined || this.#font === undefined) {
@@ -90,11 +93,12 @@ export class Metrics {
     }
     this.#canvasCtx.font = this.#font;
     const ch = this.canvasMeasureTextWidth('0');
-    if (ch === this.ch) {
-      return false;
+    const characterWidthChanged = ch !== this.ch;
+    if (characterWidthChanged) {
+      this.ch = ch;
     }
-    this.ch = ch;
-    return true;
+    const textWidthCacheCleared = this.#clearTextWidthCache();
+    return characterWidthChanged || textWidthCacheCleared;
   }
 
   /** measure the width of the text */
@@ -169,7 +173,13 @@ export class Metrics {
    * init(), e.g. on a layout reflow, so stale widths are not reused
    */
   clearTextWidthCache(): void {
+    this.#clearTextWidthCache();
+  }
+
+  #clearTextWidthCache(): boolean {
+    const hadCachedTextWidths = this.#textWidthCache.size > 0;
     this.#textWidthCache.clear();
+    return hadCachedTextWidths;
   }
 }
 

--- a/packages/diffs/test/editorTextMeasure.test.ts
+++ b/packages/diffs/test/editorTextMeasure.test.ts
@@ -12,11 +12,11 @@ import { round } from '../src/editor/utils';
 import { type DomHandle, installDom } from './domHarness';
 
 // Replaces HTMLElement.prototype.getBoundingClientRect with a stub that counts
-// invocations and reports a fixed sub-pixel width. domMeasureTextWidth() is the
-// only code under test that calls getBoundingClientRect, so the count equals the
+// invocations and reports a controlled width. domMeasureTextWidth() is the only
+// code under test that calls getBoundingClientRect, so the count equals the
 // number of forced layouts it performed. Returns the call counter and a restore
 // function.
-function stubBoundingClientRectWidth(width: number): {
+function stubBoundingClientRectWidth(width: number | (() => number)): {
   getCallCount: () => number;
   restore: () => void;
 } {
@@ -26,12 +26,13 @@ function stubBoundingClientRectWidth(width: number): {
     configurable: true,
     value(): DOMRect {
       calls++;
+      const measuredWidth = typeof width === 'function' ? width() : width;
       return {
-        width,
+        width: measuredWidth,
         height: 0,
         top: 0,
         left: 0,
-        right: width,
+        right: measuredWidth,
         bottom: 0,
         x: 0,
         y: 0,
@@ -252,6 +253,55 @@ describe('Metrics.remeasureCharacterWidth', () => {
     glyphWidth = 11;
     expect(metrics.remeasureCharacterWidth()).toBe(true);
     expect(metrics.ch).toBe(11);
+  });
+
+  test('clears cached DOM widths when ch changes after the font loads', () => {
+    let domWidth = 24;
+    const rect = stubBoundingClientRectWidth(() => domWidth);
+    try {
+      const metrics = initMetrics();
+      const emoji = '😀';
+
+      expect(metrics.measureTextWidth(emoji)).toBe(round(24));
+      expect(metrics.measureTextWidth(emoji)).toBe(round(24));
+      expect(rect.getCallCount()).toBe(1);
+
+      // The loaded font changes both the ASCII ch width and the DOM-measured
+      // emoji width while getComputedStyle(root).fontFamily stays the same.
+      glyphWidth = 11;
+      domWidth = 31;
+      expect(metrics.remeasureCharacterWidth()).toBe(true);
+
+      expect(metrics.measureTextWidth(emoji)).toBe(round(31));
+      expect(rect.getCallCount()).toBe(2);
+    } finally {
+      rect.restore();
+    }
+  });
+
+  test('clears cached DOM widths when ch is unchanged after the font loads', () => {
+    let domWidth = 24;
+    const rect = stubBoundingClientRectWidth(() => domWidth);
+    try {
+      const metrics = initMetrics();
+      const emoji = '😀';
+
+      expect(metrics.measureTextWidth(emoji)).toBe(round(24));
+      expect(metrics.measureTextWidth(emoji)).toBe(round(24));
+      expect(rect.getCallCount()).toBe(1);
+
+      // Some fonts keep the same ASCII advance as the fallback font while
+      // changing DOM-measured emoji widths. The stale cache still has to be
+      // cleared and reported so the editor repaints selection/caret overlays.
+      domWidth = 31;
+      expect(metrics.remeasureCharacterWidth()).toBe(true);
+      expect(metrics.ch).toBe(8);
+
+      expect(metrics.measureTextWidth(emoji)).toBe(round(31));
+      expect(rect.getCallCount()).toBe(2);
+    } finally {
+      rect.restore();
+    }
   });
 
   test('reports no change when the measured width is stable', () => {


### PR DESCRIPTION
1. Render the diffs editor with a custom monospace web font that uses font-display: swap.
2. Before the font file finishes loading, move the caret or make a selection on a line containing emoji.
3. Let the web font finish loading without resizing the editor.
4. Notice the caret and selection x positions still use fallback-font DOM widths until an unrelated resize.

Metrics.remeasureCharacterWidth only reported a refresh when ch changed, so font-load completion with the same ASCII advance skipped both cache invalidation and repaint. Clear cached DOM widths when present and return true for that invalidation too, so DOM-measured runs are remeasured with the loaded font.