### PR TITLE
fix(diffs): Stop structural edits scanning to EOF

### DIFF
--- a/packages/diffs/src/editor/tokenzier.ts
+++ b/packages/diffs/src/editor/tokenzier.ts
@@ -53,6 +53,7 @@ export class EditorTokenizer {
 
   // state
   #stateStack: StateStack[] = [INITIAL]; // cached state stack by line index
+  #comparisonStateStack: StateStack[] = [];
   #lastLine: number = -1;
   #isStopped: boolean = true;
   #isPaused: boolean = false;
@@ -197,6 +198,7 @@ export class EditorTokenizer {
     this.#setTheme(themeName);
     this.stopBackgroundTokenize();
     this.#stateStack = [INITIAL];
+    this.#comparisonStateStack = [];
     if (this.#grammar !== undefined && this.#textDocument.lineCount > 0) {
       this.#scheduleBackgroundTokenize(0);
     }
@@ -318,6 +320,7 @@ export class EditorTokenizer {
       dirtyStart >= viewStart;
     const changedLineRanges: readonly [number, number][] =
       change.changedLineRanges ?? [[dirtyStart, change.endLine]];
+    this.#comparisonStateStack = [];
     let offscreenSyncEnd = -1;
     if (dirtyStart < viewStart) {
       for (const [rangeStart, rangeEnd] of changedLineRanges) {
@@ -335,7 +338,7 @@ export class EditorTokenizer {
     if (canReuseCachedStates) {
       this.#buildStateStack(dirtyStart);
     } else {
-      this.#shiftCachedStateStack(change);
+      this.#shiftComparisonStateStack(change);
       if (renderRange === undefined || dirtyStart >= viewStart) {
         this.#buildStateStack(viewStart);
       }
@@ -479,6 +482,7 @@ export class EditorTokenizer {
     this.#lastLine = -1;
     this.#backgroundChangedLineRanges = undefined;
     this.#backgroundChangedRangeIndex = 0;
+    this.#comparisonStateStack = [];
     this.#detachMessageListener();
   }
 
@@ -620,14 +624,15 @@ export class EditorTokenizer {
     }
   }
 
-  // Preserve old end states past a line-count edit at their new indexes. Those
-  // shifted states let background tokenization stop once the grammar state
-  // matches the pre-edit tail again instead of scanning to EOF.
-  #shiftCachedStateStack(change: TextDocumentChange): void {
+  // Preserve old end states as comparison-only sentinels. They let background
+  // tokenization stop when grammar state reconverges without letting foreground
+  // tokenization seed from stale pre-edit states.
+  #shiftComparisonStateStack(change: TextDocumentChange): void {
     const lineChanges: readonly [number, number, number][] =
       change.changedLineChanges ?? [
         [change.startLine, change.endLine, change.lineDelta],
       ];
+    const comparisonStateStack = this.#stateStack.slice();
 
     for (const [startLine, endLine, lineDelta] of lineChanges) {
       if (lineDelta === 0) {
@@ -638,37 +643,53 @@ export class EditorTokenizer {
       const oldLineSpan = insertedLineSpan - lineDelta;
       const sourceStart = startLine + oldLineSpan + 1;
       const targetStart = startLine + insertedLineSpan + 1;
-      const originalLength = this.#stateStack.length;
+      const originalLength = comparisonStateStack.length;
 
       if (lineDelta > 0) {
         for (let line = originalLength - 1; line >= sourceStart; line--) {
           const targetLine = line + lineDelta;
-          if (line in this.#stateStack) {
-            this.#stateStack[targetLine] = this.#stateStack[line];
+          if (line in comparisonStateStack) {
+            comparisonStateStack[targetLine] = comparisonStateStack[line];
           } else {
-            Reflect.deleteProperty(this.#stateStack, targetLine);
+            Reflect.deleteProperty(comparisonStateStack, targetLine);
           }
         }
       } else {
         for (let line = sourceStart; line < originalLength; line++) {
           const targetLine = line + lineDelta;
-          if (line in this.#stateStack) {
-            this.#stateStack[targetLine] = this.#stateStack[line];
+          if (line in comparisonStateStack) {
+            comparisonStateStack[targetLine] = comparisonStateStack[line];
           } else {
-            Reflect.deleteProperty(this.#stateStack, targetLine);
+            Reflect.deleteProperty(comparisonStateStack, targetLine);
           }
         }
-        const retainedPrefixLength = Math.min(originalLength, startLine + 1);
-        this.#stateStack.length = Math.max(
-          retainedPrefixLength,
+        comparisonStateStack.length = Math.max(
+          Math.min(originalLength, startLine + 1),
           originalLength + lineDelta
         );
       }
 
       for (let line = startLine + 1; line < targetStart; line++) {
-        Reflect.deleteProperty(this.#stateStack, line);
+        Reflect.deleteProperty(comparisonStateStack, line);
       }
     }
+
+    this.#stateStack.length = Math.min(
+      this.#stateStack.length,
+      change.startLine + 1
+    );
+    comparisonStateStack.length = Math.min(
+      comparisonStateStack.length,
+      this.#textDocument.lineCount + 1
+    );
+    for (let line = 0; line <= change.startLine; line++) {
+      Reflect.deleteProperty(comparisonStateStack, line);
+    }
+    this.#comparisonStateStack = comparisonStateStack;
+  }
+
+  #getPreviousEndState(line: number): StateStack | undefined {
+    return this.#comparisonStateStack[line] ?? this.#stateStack[line];
   }
 
   #buildStateStack(endAt: number) {
@@ -731,7 +752,7 @@ export class EditorTokenizer {
 
       const previousNextState =
         currentChangedRangeEnd !== undefined
-          ? this.#stateStack[line + 1]
+          ? this.#getPreviousEndState(line + 1)
           : undefined;
       const lineText = this.#textDocument.getLineText(line);
       if (lineText.length > this.#tokenizeMaxLineLength) {

--- a/packages/diffs/src/editor/tokenzier.ts
+++ b/packages/diffs/src/editor/tokenzier.ts
@@ -316,9 +316,8 @@ export class EditorTokenizer {
       canReuseCachedStates ||
       renderRange === undefined ||
       dirtyStart >= viewStart;
-    const changedLineRanges: readonly [number, number][] = canReuseCachedStates
-      ? (change.changedLineRanges ?? [[dirtyStart, change.endLine]])
-      : [[dirtyStart, change.endLine]];
+    const changedLineRanges: readonly [number, number][] =
+      change.changedLineRanges ?? [[dirtyStart, change.endLine]];
     let offscreenSyncEnd = -1;
     if (dirtyStart < viewStart) {
       for (const [rangeStart, rangeEnd] of changedLineRanges) {
@@ -336,10 +335,7 @@ export class EditorTokenizer {
     if (canReuseCachedStates) {
       this.#buildStateStack(dirtyStart);
     } else {
-      this.#stateStack.length = Math.min(
-        this.#stateStack.length,
-        dirtyStart + 1
-      );
+      this.#shiftCachedStateStack(change);
       if (renderRange === undefined || dirtyStart >= viewStart) {
         this.#buildStateStack(viewStart);
       }
@@ -372,9 +368,7 @@ export class EditorTokenizer {
           offscreenState = resolved.state;
           offscreenDirtyLines.set(offscreenLine, resolved.resolvedTokens);
         }
-        if (canCacheTokenizedStates) {
-          this.#stateStack[offscreenEnd] = offscreenState;
-        }
+        this.#stateStack[offscreenEnd] = offscreenState;
       }
     }
     // Seed the loop's grammar state after the offscreen flush, not before it.
@@ -463,7 +457,7 @@ export class EditorTokenizer {
             : line;
       this.#scheduleBackgroundTokenize(
         backgroundLine,
-        canReuseCachedStates ? changedLineRanges : undefined,
+        changedLineRanges,
         changedRangeIndex
       );
     }
@@ -623,6 +617,57 @@ export class EditorTokenizer {
   ): void {
     if (this.#matchBrackets) {
       this.#bracketIgnoredRanges.set(line, ranges);
+    }
+  }
+
+  // Preserve old end states past a line-count edit at their new indexes. Those
+  // shifted states let background tokenization stop once the grammar state
+  // matches the pre-edit tail again instead of scanning to EOF.
+  #shiftCachedStateStack(change: TextDocumentChange): void {
+    const lineChanges: readonly [number, number, number][] =
+      change.changedLineChanges ?? [
+        [change.startLine, change.endLine, change.lineDelta],
+      ];
+
+    for (const [startLine, endLine, lineDelta] of lineChanges) {
+      if (lineDelta === 0) {
+        continue;
+      }
+
+      const insertedLineSpan = endLine - startLine;
+      const oldLineSpan = insertedLineSpan - lineDelta;
+      const sourceStart = startLine + oldLineSpan + 1;
+      const targetStart = startLine + insertedLineSpan + 1;
+      const originalLength = this.#stateStack.length;
+
+      if (lineDelta > 0) {
+        for (let line = originalLength - 1; line >= sourceStart; line--) {
+          const targetLine = line + lineDelta;
+          if (line in this.#stateStack) {
+            this.#stateStack[targetLine] = this.#stateStack[line];
+          } else {
+            Reflect.deleteProperty(this.#stateStack, targetLine);
+          }
+        }
+      } else {
+        for (let line = sourceStart; line < originalLength; line++) {
+          const targetLine = line + lineDelta;
+          if (line in this.#stateStack) {
+            this.#stateStack[targetLine] = this.#stateStack[line];
+          } else {
+            Reflect.deleteProperty(this.#stateStack, targetLine);
+          }
+        }
+        const retainedPrefixLength = Math.min(originalLength, startLine + 1);
+        this.#stateStack.length = Math.max(
+          retainedPrefixLength,
+          originalLength + lineDelta
+        );
+      }
+
+      for (let line = startLine + 1; line < targetStart; line++) {
+        Reflect.deleteProperty(this.#stateStack, line);
+      }
     }
   }
 

--- a/packages/diffs/test/editorTokenizer.test.ts
+++ b/packages/diffs/test/editorTokenizer.test.ts
@@ -585,6 +585,120 @@ describe('EditorTokenizer', () => {
     }
   });
 
+  test('settles background tokenization after newline insertions reconverge', () => {
+    const originalAddEventListener = globalThis.addEventListener;
+    const originalRemoveEventListener = globalThis.removeEventListener;
+    const originalPostMessage = globalThis.postMessage;
+    const originalPerformanceNow = performance.now;
+    let messageListener: ((event: MessageEvent) => void) | undefined;
+    const postedMessages: unknown[] = [];
+
+    globalThis.addEventListener = ((
+      type: string,
+      listener: EventListenerOrEventListenerObject
+    ) => {
+      if (type === 'message' && typeof listener === 'function') {
+        messageListener = listener as (event: MessageEvent) => void;
+      }
+    }) as typeof globalThis.addEventListener;
+    globalThis.removeEventListener = ((
+      type: string,
+      listener: EventListenerOrEventListenerObject
+    ) => {
+      if (type === 'message' && listener === messageListener) {
+        messageListener = undefined;
+      }
+    }) as typeof globalThis.removeEventListener;
+    globalThis.postMessage = ((message: unknown) => {
+      postedMessages.push(message);
+    }) as typeof globalThis.postMessage;
+    Object.defineProperty(performance, 'now', {
+      configurable: true,
+      value: () => 0,
+    });
+
+    try {
+      let tokenizeLineCount = 0;
+      const grammar = {
+        tokenizeLine2(lineText: string, ruleStack: StateStack) {
+          tokenizeLineCount++;
+          return {
+            tokens: new Uint32Array([0, 0]),
+            ruleStack,
+            stoppedEarly: false,
+            lineText,
+          };
+        },
+      } as unknown as IGrammar;
+      const textDocument = new TextDocument(
+        'test.ts',
+        Array.from({ length: 200 }, (_, i) => `line ${i}`).join('\n'),
+        'typescript'
+      );
+      const tokenizer = new EditorTokenizer({
+        highlighter: createTestHighlighter({
+          getLanguage: () => grammar,
+        }),
+        textDocument,
+        codeOptions: { theme: 'test-theme', themeType: 'dark' },
+        setStyle: noopSetStyle,
+        onDeferTokenize: () => {},
+      });
+
+      tokenizer.tokenize(
+        {
+          startLine: 0,
+          startCharacter: 0,
+          endLine: textDocument.lineCount - 1,
+          previousLineCount: textDocument.lineCount,
+          lineCount: textDocument.lineCount,
+          lineDelta: 0,
+          changedLineRanges: [[0, textDocument.lineCount - 1]],
+        },
+        {
+          startingLine: 0,
+          totalLines: textDocument.lineCount,
+          bufferBefore: 0,
+          bufferAfter: 0,
+        }
+      );
+      tokenizeLineCount = 0;
+      postedMessages.length = 0;
+
+      const change = textDocument.applyEdits([
+        {
+          range: {
+            start: { line: 0, character: 'line 0'.length },
+            end: { line: 0, character: 'line 0'.length },
+          },
+          newText: '\ninserted line',
+        },
+      ])!;
+      tokenizer.tokenize(change, {
+        startingLine: 0,
+        totalLines: 1,
+        bufferBefore: 0,
+        bufferAfter: 0,
+      });
+      const activeJobMessage = postedMessages.at(-1);
+      tokenizeLineCount = 0;
+
+      expect(activeJobMessage).toBeDefined();
+      messageListener?.({ data: activeJobMessage } as MessageEvent);
+
+      expect(tokenizeLineCount).toBe(1);
+      expect(messageListener).toBeUndefined();
+    } finally {
+      globalThis.addEventListener = originalAddEventListener;
+      globalThis.removeEventListener = originalRemoveEventListener;
+      globalThis.postMessage = originalPostMessage;
+      Object.defineProperty(performance, 'now', {
+        configurable: true,
+        value: originalPerformanceNow,
+      });
+    }
+  });
+
   test('registers global message listener only while background tokenization runs', () => {
     const originalAddEventListener = globalThis.addEventListener;
     const originalRemoveEventListener = globalThis.removeEventListener;

--- a/packages/diffs/test/editorTokenizer.test.ts
+++ b/packages/diffs/test/editorTokenizer.test.ts
@@ -699,6 +699,104 @@ describe('EditorTokenizer', () => {
     }
   });
 
+  test('does not seed foreground tokenization from shifted convergence states', () => {
+    const originalAddEventListener = globalThis.addEventListener;
+    const originalRemoveEventListener = globalThis.removeEventListener;
+    const originalPostMessage = globalThis.postMessage;
+    globalThis.addEventListener =
+      (() => {}) as typeof globalThis.addEventListener;
+    globalThis.removeEventListener =
+      (() => {}) as typeof globalThis.removeEventListener;
+    globalThis.postMessage = (() => {}) as typeof globalThis.postMessage;
+
+    try {
+      const insideComment = {
+        equals: (other: StateStack) => other === insideComment,
+      } as unknown as StateStack;
+      const grammar = {
+        tokenizeLine2(lineText: string, ruleStack: StateStack) {
+          const inside = ruleStack === insideComment;
+          const stillInside = inside
+            ? !lineText.includes('*/')
+            : lineText.includes('/*');
+          return {
+            tokens: new Uint32Array([0, inside ? 1 << 15 : 0]),
+            ruleStack: stillInside ? insideComment : INITIAL,
+            stoppedEarly: false,
+            lineText,
+          };
+        },
+      } as unknown as IGrammar;
+      const textDocument = new TextDocument(
+        'test.ts',
+        Array.from({ length: 150 }, (_, i) => `line ${i}`).join('\n'),
+        'typescript'
+      );
+      const tokenizer = new EditorTokenizer({
+        highlighter: createTestHighlighter({
+          getLanguage: () => grammar,
+          setTheme: () => ({ colorMap: ['#code', '#comment'] }),
+        }),
+        textDocument,
+        codeOptions: { theme: 'test-theme', themeType: 'dark' },
+        setStyle: noopSetStyle,
+        onDeferTokenize: () => {},
+      });
+
+      tokenizer.tokenize(
+        {
+          startLine: 0,
+          startCharacter: 0,
+          endLine: textDocument.lineCount - 1,
+          previousLineCount: textDocument.lineCount,
+          lineCount: textDocument.lineCount,
+          lineDelta: 0,
+          changedLineRanges: [[0, textDocument.lineCount - 1]],
+        },
+        { startingLine: 0, totalLines: 150, bufferBefore: 0, bufferAfter: 0 }
+      );
+
+      const insertComment = textDocument.applyEdits([
+        {
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+          },
+          newText: '/*\n',
+        },
+      ])!;
+      tokenizer.tokenize(insertComment, {
+        startingLine: 0,
+        totalLines: 1,
+        bufferBefore: 0,
+        bufferAfter: 0,
+      });
+
+      const lowerLineText = textDocument.getLineText(100);
+      const changeLowerLine = textDocument.applyEdits([
+        {
+          range: {
+            start: { line: 100, character: 0 },
+            end: { line: 100, character: lowerLineText.length },
+          },
+          newText: 'changed inside comment',
+        },
+      ])!;
+      const dirtyLines = tokenizer.tokenize(changeLowerLine, {
+        startingLine: 100,
+        totalLines: 1,
+        bufferBefore: 0,
+        bufferAfter: 0,
+      });
+
+      expect(dirtyLines.get(100)?.[0]?.[1]).toBe('#comment');
+    } finally {
+      globalThis.addEventListener = originalAddEventListener;
+      globalThis.removeEventListener = originalRemoveEventListener;
+      globalThis.postMessage = originalPostMessage;
+    }
+  });
+
   test('registers global message listener only while background tokenization runs', () => {
     const originalAddEventListener = globalThis.addEventListener;
     const originalRemoveEventListener = globalThis.removeEventListener;


### PR DESCRIPTION
1. Open a large TypeScript file in the diffs editor.
2. Let tokenization populate the file, then press Enter near the top.
3. Keep typing near that edit and observe each background pass restart and scan the tail instead of stopping after grammar state reconverges.

Line-count edits truncated cached grammar end states and scheduled the background job without changed ranges, leaving it no prior state to compare with. Shift cached end states across inserted or deleted lines and carry changed ranges into background tokenization so it settles once state matches the shifted tail again.
