### PR TITLE
fix(diffs): Keep column-zero carets from matching prior brackets

### DIFF
--- a/packages/diffs/src/editor/matchBrackets.ts
+++ b/packages/diffs/src/editor/matchBrackets.ts
@@ -60,7 +60,7 @@ function findAdjacentBracket<LAnnotation>(
   tokenizer: EditorTokenizer,
   position: Position
 ): BracketPosition | undefined {
-  const previousPosition = getPreviousCharacterPosition(textDocument, position);
+  const previousPosition = getPreviousCharacterPosition(position);
   if (previousPosition !== undefined) {
     const previousBracket = getBracketAtPosition(
       textDocument,
@@ -74,22 +74,15 @@ function findAdjacentBracket<LAnnotation>(
   return getBracketAtPosition(textDocument, tokenizer, position);
 }
 
-function getPreviousCharacterPosition<LAnnotation>(
-  textDocument: TextDocument<LAnnotation>,
+function getPreviousCharacterPosition(
   position: Position
 ): Position | undefined {
   if (position.character > 0) {
     return { line: position.line, character: position.character - 1 };
   }
-  if (position.line <= 0) {
-    return undefined;
-  }
-  const previousLine = position.line - 1;
-  const previousLineLength = textDocument.getLineText(previousLine).length;
-  if (previousLineLength === 0) {
-    return undefined;
-  }
-  return { line: previousLine, character: previousLineLength - 1 };
+  // Bracket adjacency is line-local: column-zero carets are not visually next to
+  // the previous line's last character.
+  return undefined;
 }
 
 function getBracketAtPosition<LAnnotation>(

--- a/packages/diffs/test/editorBracketMatch.test.ts
+++ b/packages/diffs/test/editorBracketMatch.test.ts
@@ -255,6 +255,26 @@ describe('editor bracket matching', () => {
     ]);
   });
 
+  test('does not match a bracket before a column-zero caret', () => {
+    const textDocument = new TextDocument(
+      'inmemory://1',
+      'if (ok) {\nreturn ok;\n}',
+      'ts'
+    );
+    const tokenizer = {
+      getStringCommentRegexpRangesInLine() {
+        return null;
+      },
+    } as unknown as EditorTokenizer;
+
+    expect(
+      findBracketMatchRanges(textDocument, tokenizer, {
+        line: 1,
+        character: 0,
+      })
+    ).toBeUndefined();
+  });
+
   test('bounds forward scans for unmatched opening brackets', () => {
     const contents = ['(', ...Array.from({ length: 1_199 }, () => 'x')].join(
       '\n'


### PR DESCRIPTION
1. Open a diff file in the editor with a `{` at the end of one line and its matching `}` later in the file.
2. Place the caret at column 0 on the line immediately after the `{`.
3. The editor highlights the previous line's `{` and its matching `}`, even though the caret is not beside either bracket.

The matcher treated the previous line's last character as adjacent to column-zero carets. Keep the previous-character lookup line-local so column-zero carets can only match a bracket at the current position.
