### PR TITLE
fix(diffs): Handle replace input command keys

### DIFF
--- a/packages/diffs/src/editor/searchPanel.ts
+++ b/packages/diffs/src/editor/searchPanel.ts
@@ -278,7 +278,13 @@ export class SearchPanelWidget {
       },
       onkeydown: (e: KeyboardEvent) => {
         const findAgain = resolveFindAgainShortcut(e);
-        if (findAgain !== undefined) {
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          close();
+        } else if (e.key === 'Enter') {
+          e.preventDefault();
+          replace();
+        } else if (findAgain !== undefined) {
           e.preventDefault();
           findNextMatch(findAgain === 'previous', true);
         }

--- a/packages/diffs/src/editor/searchPanel.ts
+++ b/packages/diffs/src/editor/searchPanel.ts
@@ -277,6 +277,9 @@ export class SearchPanelWidget {
         searchParams.replaceText = (e.target as HTMLInputElement).value;
       },
       onkeydown: (e: KeyboardEvent) => {
+        if (e.isComposing) {
+          return;
+        }
         const findAgain = resolveFindAgainShortcut(e);
         if (e.key === 'Escape') {
           e.preventDefault();

--- a/packages/diffs/test/editorComposition.test.ts
+++ b/packages/diffs/test/editorComposition.test.ts
@@ -133,6 +133,40 @@ function dispatchBackspace(
   return event;
 }
 
+async function openSearchReplacePanel({
+  content,
+  window,
+}: Pick<EditorFixture, 'content' | 'window'>): Promise<HTMLElement> {
+  dispatchKeydown(window, content, {
+    key: 'f',
+    code: 'KeyF',
+    metaKey: true,
+    altKey: true,
+  });
+  await wait(0);
+
+  const panel = (
+    content.getRootNode() as ParentNode
+  ).querySelector<HTMLElement>('[data-search-panel]');
+  if (panel == null) {
+    throw new Error('search replace panel did not open');
+  }
+  return panel;
+}
+
+function findReplaceInput(panel: HTMLElement): HTMLInputElement {
+  const input = panel.querySelector<HTMLInputElement>('input[data-replace]');
+  if (input == null) {
+    throw new Error('replace input was not rendered');
+  }
+  return input;
+}
+
+function updateInputValue(input: HTMLInputElement, value: string): void {
+  input.value = value;
+  input.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+}
+
 describe('Editor composition input', () => {
   test('lets the browser own IME preview before committing composition text', async () => {
     const { cleanup, content, editor, window } = await createEditorFixture();
@@ -292,6 +326,62 @@ describe('Editor keyboard editing', () => {
           '[data-search-panel]'
         )
       ).toBeInstanceOf(HTMLElement);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('replaces the current match on Enter from the replace input', async () => {
+    const { cleanup, content, editor, window } = await createEditorFixture({
+      contents: 'alpha beta alpha',
+      selections: [
+        {
+          start: { line: 0, character: 2 },
+          end: { line: 0, character: 2 },
+          direction: 'none',
+        },
+      ],
+    });
+
+    try {
+      const panel = await openSearchReplacePanel({ content, window });
+      const replaceInput = findReplaceInput(panel);
+      updateInputValue(replaceInput, 'omega');
+
+      const event = dispatchKeydown(window, replaceInput, { key: 'Enter' });
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(editor.getState().file.contents).toBe('omega beta alpha');
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('closes the search panel on Escape from the replace input', async () => {
+    const { cleanup, content, window } = await createEditorFixture({
+      contents: 'alpha beta',
+      selections: [
+        {
+          start: { line: 0, character: 2 },
+          end: { line: 0, character: 2 },
+          direction: 'none',
+        },
+      ],
+    });
+
+    try {
+      const panel = await openSearchReplacePanel({ content, window });
+      const replaceInput = findReplaceInput(panel);
+
+      const event = dispatchKeydown(window, replaceInput, { key: 'Escape' });
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(panel.isConnected).toBe(false);
+      expect(
+        (content.getRootNode() as ParentNode).querySelector(
+          '[data-search-panel]'
+        )
+      ).toBeNull();
     } finally {
       cleanup();
     }

--- a/packages/diffs/test/editorComposition.test.ts
+++ b/packages/diffs/test/editorComposition.test.ts
@@ -357,6 +357,36 @@ describe('Editor keyboard editing', () => {
     }
   });
 
+  test('lets composing Enter commit IME text in the replace input', async () => {
+    const { cleanup, content, editor, window } = await createEditorFixture({
+      contents: 'alpha beta',
+      selections: [
+        {
+          start: { line: 0, character: 2 },
+          end: { line: 0, character: 2 },
+          direction: 'none',
+        },
+      ],
+    });
+
+    try {
+      const panel = await openSearchReplacePanel({ content, window });
+      const replaceInput = findReplaceInput(panel);
+      updateInputValue(replaceInput, 'omega');
+
+      const event = dispatchKeydown(window, replaceInput, {
+        key: 'Enter',
+        isComposing: true,
+      });
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(panel.isConnected).toBe(true);
+      expect(editor.getState().file.contents).toBe('alpha beta');
+    } finally {
+      cleanup();
+    }
+  });
+
   test('closes the search panel on Escape from the replace input', async () => {
     const { cleanup, content, window } = await createEditorFixture({
       contents: 'alpha beta',


### PR DESCRIPTION
To reproduce:
1. Open an editable diff with matching text.
2. Press Cmd+Option+F or Ctrl+Alt+F to open find/replace.
3. Move focus to the Replace input and type replacement text.
4. Press Enter, then repeat and press Escape.

Before this change, Enter in Replace did nothing and Escape did not dismiss the panel because the replace input only handled find-again shortcuts.

Handle Enter by running the existing single-replace action and Escape by closing the panel through the same user-dismissal path as the find input. Add editor fixture coverage for both key paths.
