### PR TITLE
fix(diffs): honor Shift+Enter in search input

### DIFF
--- a/packages/diffs/src/editor/searchPanel.ts
+++ b/packages/diffs/src/editor/searchPanel.ts
@@ -302,7 +302,7 @@ export class SearchPanelWidget {
           close();
         } else if (e.key === 'Enter') {
           e.preventDefault();
-          findNextMatch(false, true);
+          findNextMatch(e.shiftKey, true);
         } else if (findAgain !== undefined) {
           // Override the native browser find-again shortcut so cmd+g steps to
           // the next match and cmd+shift+g to the previous one.

--- a/packages/diffs/test/editorSearchPanel.test.ts
+++ b/packages/diffs/test/editorSearchPanel.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'bun:test';
+
+import { type MatchRange, SearchPanelWidget } from '../src/editor/searchPanel';
+import { TextDocument } from '../src/editor/textDocument';
+import { installDom, wait } from './domHarness';
+
+function setSearchQuery(input: HTMLInputElement, value: string): void {
+  input.value = value;
+  input.dispatchEvent(
+    new window.Event('input', {
+      bubbles: true,
+      cancelable: true,
+    })
+  );
+}
+
+function pressEnter(input: HTMLInputElement, shiftKey = false): KeyboardEvent {
+  const event = new window.KeyboardEvent('keydown', {
+    key: 'Enter',
+    shiftKey,
+    bubbles: true,
+    cancelable: true,
+  });
+  input.dispatchEvent(event);
+  return event;
+}
+
+describe('SearchPanelWidget', () => {
+  test('uses Shift+Enter in the find input to navigate to the previous match', async () => {
+    const { cleanup } = installDom();
+    const textDocument = new TextDocument<undefined>(
+      'inmemory://search-panel',
+      'foo foo foo'
+    );
+    const containerElement = document.createElement('div');
+    document.body.appendChild(containerElement);
+    const scrolledMatches: MatchRange[] = [];
+
+    const widget = new SearchPanelWidget({
+      textDocument,
+      containerElement,
+      defaultQuery: '',
+      scrollToMatch: (nextMatch) => {
+        scrolledMatches.push([...nextMatch]);
+      },
+      applyReplace: () => {},
+      onUpdate: (matches) => matches[0],
+      onClose: () => {},
+    });
+
+    try {
+      await wait(0);
+
+      const input = document.querySelector<HTMLInputElement>(
+        '[data-search-panel] input[data-search]'
+      );
+      expect(input).not.toBeNull();
+
+      setSearchQuery(input!, 'foo');
+      const forward = pressEnter(input!);
+      expect(forward.defaultPrevented).toBe(true);
+      expect(scrolledMatches.at(-1)).toEqual([4, 7]);
+
+      const backward = pressEnter(input!, true);
+      expect(backward.defaultPrevented).toBe(true);
+      expect(scrolledMatches.at(-1)).toEqual([0, 3]);
+    } finally {
+      widget.cleanup();
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
1. Open the diffs editor with at least three repeated matches.
2. Press Cmd/Ctrl+F, search for the repeated text, and press Enter once to move from the first match to the second.
3. Press Shift+Enter while focus remains in the find input.
4. The selection should move back to the first match; before this fix, it advanced to the third match instead.

The find input treated every Enter keydown as forward navigation. Pass the event's shiftKey into the existing search navigation helper so Shift+Enter uses the previous-match path, matching Cmd/Ctrl+Shift+G and the previous button.

Add a jsdom regression test for the panel that asserts Enter moves forward and Shift+Enter returns to the previous range.