### PR TITLE
fix(diffs): Treat trailing tabs like spaces for word deletion

### DIFF
--- a/packages/diffs/src/editor/selection.ts
+++ b/packages/diffs/src/editor/selection.ts
@@ -1997,7 +1997,7 @@ function resolveDeleteWordBackwardRange(
     if (match !== undefined && nextMatch !== match) {
       break;
     }
-    if (nextChar !== ' ' || pos !== head) {
+    if (nextMatch !== 0 || pos !== head) {
       match = nextMatch;
     }
     pos = prev;

--- a/packages/diffs/test/editorSelection.test.ts
+++ b/packages/diffs/test/editorSelection.test.ts
@@ -2052,8 +2052,32 @@ describe('applyDeleteWordBackwardToSelections', () => {
     expect(nextSelections).toEqual([createSelection(0, 0, 0, 0)]);
   });
 
+  test('deletes the preceding word and single trailing tab', () => {
+    const textDocument = new TextDocument('inmemory://1', 'hello\tworld');
+    const selections = [createSelection(0, 6, 0, 6)];
+    const { nextSelections } = applyDeleteWordBackwardToSelections(
+      textDocument,
+      selections
+    );
+
+    expect(textDocument.getText()).toBe('world');
+    expect(nextSelections).toEqual([createSelection(0, 0, 0, 0)]);
+  });
+
   test('deletes a multi-space run as its own group', () => {
     const textDocument = new TextDocument('inmemory://1', 'hello  world');
+    const selections = [createSelection(0, 7, 0, 7)];
+    const { nextSelections } = applyDeleteWordBackwardToSelections(
+      textDocument,
+      selections
+    );
+
+    expect(textDocument.getText()).toBe('helloworld');
+    expect(nextSelections).toEqual([createSelection(0, 5, 0, 5)]);
+  });
+
+  test('deletes a multi-tab run as its own group', () => {
+    const textDocument = new TextDocument('inmemory://1', 'hello\t\tworld');
     const selections = [createSelection(0, 7, 0, 7)];
     const { nextSelections } = applyDeleteWordBackwardToSelections(
       textDocument,


### PR DESCRIPTION
1. Open a diffs editor document containing `hello<Tab>world`.
2. Put the caret immediately after the tab, before `world`.
3. Run deleteWordBackward.
4. Observe that the editor deletes only the tab and leaves `helloworld` instead of deleting `hello<Tab>` and leaving `world`.

The word-deletion scan skipped assigning the first trailing whitespace cluster only when that cluster was a literal space. Reuse the computed whitespace class so a single trailing tab follows the same path, while multi-tab whitespace runs still delete as their own group.
