### PR TITLE
fix(diffs): Keep NFD graphemes intact in editor measurement

### DIFF
--- a/packages/diffs/src/editor/textMeasure.ts
+++ b/packages/diffs/src/editor/textMeasure.ts
@@ -1,10 +1,12 @@
 import { getGraphemeSegmenter, h, round } from './utils';
 
 // Upper bound on cached DOM text-width measurements. The cache only holds
-// non-ASCII runs (emoji, ZWJ sequences, variation selectors), so it stays
-// small for ordinary code, but capping it prevents unbounded growth on
-// emoji-heavy documents. Past the cap the oldest entry is evicted.
+// non-ASCII runs (emoji, ZWJ sequences, variation selectors, combining marks),
+// so it stays small for ordinary code, but capping it prevents unbounded growth
+// on emoji-heavy documents. Past the cap the oldest entry is evicted.
 const TEXT_WIDTH_CACHE_LIMIT = 4096;
+
+const COMBINING_MARK_PATTERN = /\p{Mark}/u;
 
 export class Metrics {
   #root?: HTMLElement;
@@ -191,7 +193,8 @@ export function needsDomTextMeasurement(text: string): boolean {
       (code >= 0xd800 && code <= 0xdfff) ||
       code === 0x200d ||
       code === 0xfe0e ||
-      code === 0xfe0f
+      code === 0xfe0f ||
+      (code > 0x7f && COMBINING_MARK_PATTERN.test(text.charAt(i)))
     ) {
       return true;
     }

--- a/packages/diffs/test/editorTextMeasure.test.ts
+++ b/packages/diffs/test/editorTextMeasure.test.ts
@@ -69,6 +69,11 @@ describe('needsDomTextMeasurement', () => {
     expect(needsDomTextMeasurement('\uFE0F')).toBe(true);
     expect(needsDomTextMeasurement('1\uFE0F\u20E3')).toBe(true);
   });
+
+  test('returns true for NFD combining marks', () => {
+    expect(needsDomTextMeasurement('e\u0301')).toBe(true);
+    expect(needsDomTextMeasurement('Cafe\u0301')).toBe(true);
+  });
 });
 
 describe('snapTextOffsetToUnicodeBoundary', () => {
@@ -114,6 +119,13 @@ describe('snapTextOffsetToUnicodeBoundary', () => {
       );
     }
   });
+
+  test('snaps offsets inside NFD combining-mark graphemes', () => {
+    const nfd = 'e\u0301x';
+    expect(needsDomTextMeasurement(nfd)).toBe(true);
+    expect(snapTextOffsetToUnicodeBoundary(nfd, 1)).toBe(2);
+    expect(snapTextOffsetToUnicodeBoundary(nfd, 2)).toBe(2);
+  });
 });
 
 describe('getUnicodeMeasurementOffsets', () => {
@@ -137,6 +149,10 @@ describe('getUnicodeMeasurementOffsets', () => {
   test('returns one offset per grapheme for ZWJ sequences', () => {
     const family = '👨‍👩‍👧‍👦';
     expect(getUnicodeMeasurementOffsets(family)).toEqual([0, family.length]);
+  });
+
+  test('returns one offset per grapheme for NFD combining marks', () => {
+    expect(getUnicodeMeasurementOffsets('e\u0301x')).toEqual([0, 2, 3]);
   });
 });
 

--- a/packages/diffs/test/editorWrapCaretPosition.test.ts
+++ b/packages/diffs/test/editorWrapCaretPosition.test.ts
@@ -331,6 +331,22 @@ describe('editor wrap caret position', () => {
     }
   });
 
+  test('wrap navigation keeps NFD combining marks with their base character', async () => {
+    const { cleanup, content, editor, window } = await createWrapEditor(
+      'e\u0301x',
+      1
+    );
+
+    try {
+      setCaret(editor, 0, 0);
+
+      dispatchMovementKey(window, content, { key: 'ArrowDown' });
+      expectCaret(editor, 0, 2);
+    } finally {
+      cleanup();
+    }
+  });
+
   // When word wrap is on, growing a line until it wraps onto a second visual
   // row keeps the logical line count unchanged (change.lineDelta === 0) but
   // pushes every following line down by a row. The cached line-Y positions of


### PR DESCRIPTION
To reproduce:
1. Open a diffs editor with line wrapping enabled in a narrow pane.
2. Add a long line containing decomposed text, such as repeated `Café` (or `Cafe\u0301`) words where the accent is U+0301.
3. Resize the pane until a soft wrap falls inside one `e\u0301` grapheme (e.g., `é` is the first symbol on the wrapped line), then move the caret vertically across that wrap.

The caret can land between `e` and the combining accent, and the wrapped line can split that grapheme across visual rows.

Detect Unicode combining marks in needsDomTextMeasurement so the existing grapheme segmenter drives caret snapping and wrap offset measurement for NFD text. Add predicate, snapping, measurement-offset, and wrapped navigation regressions.
