### PR TITLE
fix(diffs): Measure tab stops after CJK glyphs by pixels

### DIFF
--- a/packages/diffs/src/editor/textMeasure.ts
+++ b/packages/diffs/src/editor/textMeasure.ts
@@ -103,11 +103,48 @@ export class Metrics {
 
   /** measure the width of the text */
   measureTextWidth(text: string): number {
-    const textWithExpandedTabs = expandTabsToSpaces(text, this.tabSize);
-    if (needsDomTextMeasurement(textWithExpandedTabs)) {
-      return this.domMeasureTextWidth(textWithExpandedTabs);
+    if (!text.includes('\t')) {
+      return this.#measureTextWidthWithoutTabs(text);
     }
-    return this.canvasMeasureTextWidth(textWithExpandedTabs);
+    if (this.#canvasCtx === undefined) {
+      throw new Error('Metrics not initialized');
+    }
+    const asciiColumns = getExpandedAsciiTextColumns(text, this.tabSize);
+    if (asciiColumns !== -1) {
+      return asciiColumns * this.ch;
+    }
+
+    let width = 0;
+    let runStart = 0;
+    const tabStopWidth = this.tabSize * this.ch;
+    for (let i = 0; i < text.length; i++) {
+      if (text.charCodeAt(i) !== /* '\t' */ 9) {
+        continue;
+      }
+
+      if (i > runStart) {
+        width += this.#measureTextWidthWithoutTabs(text.slice(runStart, i));
+      }
+      // CSS tab stops are pixel positions, so wide glyphs before a tab must
+      // contribute their measured width rather than one logical column.
+      if (tabStopWidth > 0) {
+        const remainder = width % tabStopWidth;
+        width += remainder === 0 ? tabStopWidth : tabStopWidth - remainder;
+      }
+      runStart = i + 1;
+    }
+
+    if (runStart < text.length) {
+      width += this.#measureTextWidthWithoutTabs(text.slice(runStart));
+    }
+    return round(width);
+  }
+
+  #measureTextWidthWithoutTabs(text: string): number {
+    if (needsDomTextMeasurement(text)) {
+      return this.domMeasureTextWidth(text);
+    }
+    return this.canvasMeasureTextWidth(text);
   }
 
   /** measure the width of the text using the canvas measureText API */
@@ -268,32 +305,6 @@ export function getUnicodeMeasurementOffsets(
     offsets.push(offset);
   }
   return offsets;
-}
-
-/**
- * Expand tab characters to spaces using fixed tab stops: each tab advances to
- * the next multiple of tabSize from its running column, matching how the
- * rendered text expands tabs via CSS `tab-size`. Expanding every tab to a flat
- * tabSize would mis-measure tabs that follow other characters on the same line
- * (e.g. an alignment tab in `foo\tbar`).
- */
-export function expandTabsToSpaces(text: string, tabSize: number): string {
-  if (!text.includes('\t')) {
-    return text;
-  }
-  let result = '';
-  let column = 0;
-  for (let i = 0; i < text.length; i++) {
-    if (text.charCodeAt(i) === /* '\t' */ 9) {
-      const advance = tabSize - (column % tabSize);
-      result += ' '.repeat(advance);
-      column += advance;
-    } else {
-      result += text[i];
-      column += 1;
-    }
-  }
-  return result;
 }
 
 /**

--- a/packages/diffs/test/editorTextMeasure.test.ts
+++ b/packages/diffs/test/editorTextMeasure.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 
 import {
-  expandTabsToSpaces,
   getExpandedAsciiTextColumns,
   getUnicodeMeasurementOffsets,
   Metrics,
@@ -49,6 +48,19 @@ function stubBoundingClientRectWidth(width: number | (() => number)): {
       });
     },
   };
+}
+
+function stubCanvasTextWidth(measureTextWidth: (text: string) => number): void {
+  Object.defineProperty(window.HTMLCanvasElement.prototype, 'getContext', {
+    configurable: true,
+    value: (contextId: string) =>
+      contextId === '2d'
+        ? {
+            font: '',
+            measureText: (text: string) => ({ width: measureTextWidth(text) }),
+          }
+        : null,
+  });
 }
 
 describe('needsDomTextMeasurement', () => {
@@ -188,29 +200,58 @@ describe('getExpandedAsciiTextColumns', () => {
   });
 });
 
-describe('expandTabsToSpaces', () => {
-  test('returns the input unchanged when there are no tabs', () => {
-    const text = 'no tabs here';
-    expect(expandTabsToSpaces(text, 4)).toBe(text);
-  });
+describe('Metrics.measureTextWidth (tab stops)', () => {
+  function installTabMetrics(): {
+    cleanup(): void;
+    metrics: Metrics;
+  } {
+    const { cleanup } = installDom();
+    const realGetComputedStyle = globalThis.getComputedStyle;
+    globalThis.getComputedStyle = (() =>
+      ({
+        fontSize: '12px',
+        fontFamily: 'monospace',
+        tabSize: '4',
+        lineHeight: '20px',
+        paddingTop: '0px',
+      }) as CSSStyleDeclaration) as typeof getComputedStyle;
 
-  test('expands leading tabs to a full tab stop', () => {
-    expect(expandTabsToSpaces('\t', 4)).toBe('    ');
-    expect(expandTabsToSpaces('\t\t', 4)).toBe('        ');
-  });
+    // ASCII and spaces are 1ch. CJK characters are 2ch, matching common
+    // monospace rendering where East Asian glyphs are double-width.
+    stubCanvasTextWidth((text) => {
+      let width = 0;
+      for (const char of text) {
+        const codePoint = char.codePointAt(0)!;
+        width += codePoint >= 0x4e00 && codePoint <= 0x9fff ? 20 : 10;
+      }
+      return width;
+    });
 
-  // Regression: the space count for a mid-line tab depends on its column.
-  test('expands mid-line tabs to the next tab stop', () => {
-    // 'foo' (col 3) -> 1 space to reach col 4.
-    expect(expandTabsToSpaces('foo\t', 4)).toBe('foo ');
-    expect(expandTabsToSpaces('foo\tbar', 4)).toBe('foo bar');
-    // tabSize 2: 'a' (col 1) -> 1 space to reach col 2.
-    expect(expandTabsToSpaces('a\tb', 2)).toBe('a b');
-  });
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    const metrics = new Metrics();
+    metrics.init(root);
 
-  test('preserves non-ASCII characters while expanding tabs by column', () => {
-    // 'é' occupies one column; the tab then fills cols 1-4.
-    expect(expandTabsToSpaces('é\t', 4)).toBe('é   ');
+    return {
+      cleanup(): void {
+        globalThis.getComputedStyle = realGetComputedStyle;
+        cleanup();
+      },
+      metrics,
+    };
+  }
+
+  test('advances tabs from measured pixel width after wide glyphs', () => {
+    const { cleanup, metrics } = installTabMetrics();
+    try {
+      expect(metrics.ch).toBe(10);
+      expect(metrics.measureTextWidth('\t')).toBe(40);
+      expect(metrics.measureTextWidth('a\tvalue')).toBe(90);
+      expect(metrics.measureTextWidth('変\tvalue')).toBe(90);
+      expect(metrics.measureTextWidth('変数\tvalue')).toBe(130);
+    } finally {
+      cleanup();
+    }
   });
 });
 


### PR DESCRIPTION
1. Open the diffs editor with a line containing `変数\tvalue`.
2. Place the caret after `value`, select across the tab, or enable wrapping near the tab stop.
3. Observe the caret, selection block, or wrap decision drift left because the tab after `変数` is measured from two logical columns instead of the glyphs' rendered width.

Measure tabs by accumulating rendered pixel width between tab characters and advancing to the next pixel tab stop. Keep the ASCII column fast path for plain ASCII text, and remove the stale tab-to-spaces expansion helper.

Add coverage with a fake canvas where CJK glyphs are 2ch wide, including the case where `変数` lands exactly on a tab stop and the tab advances a full stop.
