### PR TITLE
fix(diffs): Reposition marker popovers on scroll

### DIFF
--- a/packages/diffs/src/editor/editor.css
+++ b/packages/diffs/src/editor/editor.css
@@ -240,9 +240,8 @@
 [data-selection-action-popover] {
   --popover-viewport-left: 0px;
   --popover-viewport-right: 100cqw;
-  --popover-min-left: max(
-    calc(var(--gutter-width, 0px) + 8px),
-    calc(var(--popover-viewport-left) + 8px)
+  --popover-min-left: calc(
+    var(--popover-viewport-left) + var(--gutter-width, 0px) + 8px
   );
   --popover-available-width: max(
     0px,

--- a/packages/diffs/src/editor/editor.css
+++ b/packages/diffs/src/editor/editor.css
@@ -233,18 +233,26 @@
 /* Shared geometry for the overlay popovers (marker hover popup and
    selection-action popover). Both are positioned in overlay coordinate space via
    --popover-x/--popover-y (set in JS). The left edge is clamped so the popover
-   never slides under the line-number gutter (--gutter-width, also set in JS) and
-   the width is capped so it never overflows the visible code column. Builds on
-   [data-editor-widget]. */
+   never slides under the line-number gutter (--gutter-width, also set in JS) or
+   outside the visible scroll viewport, and the width is capped to match. Builds
+   on [data-editor-widget]. */
 [data-marker-popup],
 [data-selection-action-popover] {
-  --popover-min-left: calc(var(--gutter-width, 0px) + 8px);
-  --popover-available-width: calc(100cqw - var(--gutter-width, 0px) - 16px);
+  --popover-viewport-left: 0px;
+  --popover-viewport-right: 100cqw;
+  --popover-min-left: max(
+    calc(var(--gutter-width, 0px) + 8px),
+    calc(var(--popover-viewport-left) + 8px)
+  );
+  --popover-available-width: max(
+    0px,
+    calc(var(--popover-viewport-right) - var(--popover-min-left) - 8px)
+  );
   max-width: min(640px, var(--popover-available-width));
   translate: clamp(
       var(--popover-min-left),
       var(--popover-x, var(--popover-min-left)),
-      calc(100cqw - 8px - 100%)
+      calc(var(--popover-viewport-right) - 8px - 100%)
     )
     calc(var(--popover-y, 0px) + var(--popover-y-shift, 0px));
 }
@@ -255,7 +263,7 @@
     0 4px 8px rgb(0 0 0 / 0.15), 0 6px 18px rgb(0 0 0 / 0.15);
 
   padding: 8px 12px;
-  min-width: min(180px, calc(100cqw - 24px));
+  min-width: min(180px, var(--popover-available-width));
   overflow-wrap: anywhere;
   color: var(--diffs-marker-contrast, contrast-color(#fff, #000));
   white-space: normal;

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -189,6 +189,7 @@ export interface EditorOptions<LAnnotation> {
 // larger inserts fall back to the bounded buffer-only path instead of building a
 // row per inserted line. A safety bound, not a correctness-critical value.
 const MAX_EDIT_WIDEN_WINDOW_MULTIPLE = 2;
+const SELECTION_ACTION_POPOVER_PLACEMENT_KEY = 'selection-action';
 
 export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   #options: EditorOptions<LAnnotation>;
@@ -906,8 +907,13 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
 
   #getPopoverManager(): PopoverManager {
     return (this.#popoverManager ??= new PopoverManager({
-      hasActivePopover: () => this.#selectionAction !== undefined,
-      updateActivePopover: () => this.#updateSelectionActionPopover(),
+      hasActivePopover: () =>
+        this.#selectionAction !== undefined ||
+        this.#markerRenderer?.isPopupVisible() === true,
+      updateActivePopover: () => {
+        this.#updateSelectionActionPopover();
+        this.#markerRenderer?.updatePopupPosition();
+      },
     }));
   }
 
@@ -3380,7 +3386,9 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         () => this.#updateSelectionActionPopover()
       );
       // Avoid biasing the first decision with a stale side from a prior popover.
-      this.#getPopoverManager().resetPlacement();
+      this.#getPopoverManager().resetPlacement(
+        SELECTION_ACTION_POPOVER_PLACEMENT_KEY
+      );
     }
 
     const lineHeight = this.#metrics.lineHeight;
@@ -3422,17 +3430,22 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       : head.line >= lineCount - POPOVER_BOUNDARY_LINES;
     const canUseFallback = this.#isLineVisible(fallback.anchor.line);
     const popoverManager = this.#getPopoverManager();
+    const viewport = popoverManager.getPlacementBounds();
     const useFallback =
       canUseFallback &&
       popoverManager.choosePlacement({
         preferred: preferredGeometry,
         fallback: fallbackGeometry,
-        viewport: popoverManager.getPlacementBounds(),
+        viewport,
         popoverHeight,
         atDocumentEdge,
+        placementKey: SELECTION_ACTION_POPOVER_PLACEMENT_KEY,
       }) === 'fallback';
     if (!canUseFallback) {
-      popoverManager.setPlacement('preferred');
+      popoverManager.setPlacement(
+        'preferred',
+        SELECTION_ACTION_POPOVER_PLACEMENT_KEY
+      );
     }
     const { placeAbove } = useFallback ? fallback : preferred;
     const { left, anchorTop } = useFallback
@@ -3443,7 +3456,8 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       left,
       anchorTop,
       this.#getGutterWidth(),
-      placeAbove
+      placeAbove,
+      viewport
     );
   }
 

--- a/packages/diffs/src/editor/marker.ts
+++ b/packages/diffs/src/editor/marker.ts
@@ -3,6 +3,7 @@ import {
   POPOVER_BOUNDARY_LINES,
   type PopoverManager,
   type PopoverPlacementBounds,
+  setPopoverPositionStyles,
 } from './popover';
 import { selectionIntersects } from './selection';
 import type { TextDocument } from './textDocument';
@@ -10,6 +11,7 @@ import { addEventListener, getLineNumberAttr, h } from './utils';
 
 const MARKER_POPUP_SHOW_DELAY_MS = 300;
 const MARKER_POPUP_HIDE_DELAY_MS = 100;
+const MARKER_POPUP_PLACEMENT_KEY = 'marker-popup';
 
 export type MarkerSeverity = 'error' | 'warning' | 'info' | 'hint';
 
@@ -54,6 +56,20 @@ export class MarkerRenderer {
 
   isPopupVisible(): boolean {
     return this.#hoveredMarkerIndex !== undefined;
+  }
+
+  updatePopupPosition(): void {
+    const hoveredMarkerIndex = this.#hoveredMarkerIndex;
+    const popup = this.#markerPopupElement;
+    if (hoveredMarkerIndex === undefined || popup === undefined) {
+      return;
+    }
+    const marker = this.#markers[hoveredMarkerIndex];
+    if (marker === undefined) {
+      this.removePopup();
+      return;
+    }
+    this.#positionMarkerPopup(popup, marker.start.line, marker.start.character);
   }
 
   setMarkers<LAnnotation>(
@@ -215,15 +231,16 @@ export class MarkerRenderer {
     popup: HTMLElement,
     x: number,
     y: number,
-    placeAbove: boolean
+    placeAbove: boolean,
+    viewport = this.#options.popoverManager.getPlacementBounds()
   ): void {
-    popup.style.setProperty(
-      '--gutter-width',
-      this.#options.getGutterWidth() + 'px'
-    );
-    popup.style.setProperty('--popover-x', x + 'px');
-    popup.style.setProperty('--popover-y', y + 'px');
-    popup.style.setProperty('--popover-y-shift', placeAbove ? '-100%' : '0px');
+    setPopoverPositionStyles(popup, {
+      gutterWidth: this.#options.getGutterWidth(),
+      placeAbove,
+      viewport,
+      x,
+      y,
+    });
   }
 
   // Positions the popup for a marker at `(line, character)`: prefers below
@@ -251,20 +268,22 @@ export class MarkerRenderer {
     };
     const atDocumentEdge = line >= this.#lineCount - POPOVER_BOUNDARY_LINES;
     const viewport = popoverManager.getPlacementBounds();
-    let placeAbove: boolean;
-    if (viewport !== undefined && popoverHeight > 0) {
-      const fits = (bounds: PopoverPlacementBounds): boolean =>
-        bounds.top >= viewport.top && bounds.bottom <= viewport.bottom;
-      placeAbove = !fits(preferred) && fits(fallback);
-    } else {
-      placeAbove = atDocumentEdge;
-    }
+    const placeAbove =
+      popoverManager.choosePlacement({
+        preferred,
+        fallback,
+        viewport,
+        popoverHeight,
+        atDocumentEdge,
+        placementKey: MARKER_POPUP_PLACEMENT_KEY,
+      }) === 'fallback';
 
     this.#setMarkerPopupPosition(
       popup,
       left,
       placeAbove ? rowTop : rowTop + lineHeight,
-      placeAbove
+      placeAbove,
+      viewport
     );
   }
 
@@ -275,6 +294,7 @@ export class MarkerRenderer {
     this.#markerPopupElement = undefined;
     this.#hoveredMarkerIndex = undefined;
     this.#isMarkerPopupHovered = false;
+    this.#options.popoverManager.resetPlacement(MARKER_POPUP_PLACEMENT_KEY);
   }
 
   #renderMarkerPopup(hoveredMarkerIndex: number): void {
@@ -290,6 +310,7 @@ export class MarkerRenderer {
     const { start, message, severity } = this.#markers[hoveredMarkerIndex];
     const { line, character } = start;
     const popup = this.#markerPopupElement;
+    this.#options.popoverManager.resetPlacement(MARKER_POPUP_PLACEMENT_KEY);
 
     if (popup !== undefined) {
       setMarkerPopupSeverity(popup, severity);

--- a/packages/diffs/src/editor/popover.ts
+++ b/packages/diffs/src/editor/popover.ts
@@ -21,6 +21,13 @@ export interface PopoverPlacementBounds {
   bottom: number;
 }
 
+export interface PopoverViewportBounds extends PopoverPlacementBounds {
+  /** The left edge of the visible viewport in overlay coordinate space. */
+  left: number;
+  /** The right edge of the visible viewport in overlay coordinate space. */
+  right: number;
+}
+
 export interface PopoverManagerOptions {
   hasActivePopover: () => boolean;
   updateActivePopover: () => void;
@@ -38,9 +45,12 @@ export class PopoverManager {
   #scrollContainerSource?: HTMLElement;
   #cachedCodeRect?: DOMRect;
   #cachedScrollContainerRect?: DOMRect;
+  #cachedCodeScrollLeft = 0;
+  #cachedCodeScrollTop = 0;
+  #cachedCodeClientWidth = 0;
   #viewportRectsDirty = true;
   #viewportRectListenersDisposes?: (() => void)[];
-  #placement?: 'preferred' | 'fallback';
+  #placements = new Map<string, 'preferred' | 'fallback'>();
 
   readonly #hasActivePopover: () => boolean;
   readonly #updateActivePopover: () => void;
@@ -54,8 +64,11 @@ export class PopoverManager {
     fileContainer: HTMLElement,
     codeElement: HTMLElement
   ): void {
+    const viewportElementChanged =
+      this.#fileContainer !== fileContainer ||
+      this.#codeElement !== codeElement;
     this.#fileContainer = fileContainer;
-    if (this.#codeElement === codeElement) {
+    if (!viewportElementChanged) {
       return;
     }
     this.#codeElement = codeElement;
@@ -63,6 +76,8 @@ export class PopoverManager {
     // full re-render loaded a different file, possibly at a different on-screen
     // position) even without an intervening scroll/resize event.
     this.#viewportRectsDirty = true;
+    this.#viewportRectListenersDisposes?.forEach((dispose) => dispose());
+    this.#viewportRectListenersDisposes = undefined;
   }
 
   cleanUp(): void {
@@ -72,18 +87,24 @@ export class PopoverManager {
     this.#scrollContainerSource = undefined;
     this.#cachedCodeRect = undefined;
     this.#cachedScrollContainerRect = undefined;
+    this.#cachedCodeScrollLeft = 0;
+    this.#cachedCodeScrollTop = 0;
+    this.#cachedCodeClientWidth = 0;
     this.#viewportRectsDirty = true;
     this.#viewportRectListenersDisposes?.forEach((dispose) => dispose());
     this.#viewportRectListenersDisposes = undefined;
-    this.#placement = undefined;
+    this.#placements.clear();
   }
 
-  resetPlacement(): void {
-    this.#placement = undefined;
+  resetPlacement(placementKey = 'default'): void {
+    this.#placements.delete(placementKey);
   }
 
-  setPlacement(placement: 'preferred' | 'fallback'): void {
-    this.#placement = placement;
+  setPlacement(
+    placement: 'preferred' | 'fallback',
+    placementKey = 'default'
+  ): void {
+    this.#placements.set(placementKey, placement);
   }
 
   // Flips to the opposite side only when the preferred side would be clipped by
@@ -100,16 +121,25 @@ export class PopoverManager {
     popoverHeight: number;
     /** Whether the anchor is within the document's first/last rows; only used as a fallback signal when `viewport` is unavailable. */
     atDocumentEdge: boolean;
+    /** Keeps hysteresis independent when more than one popover kind is active. */
+    placementKey?: string;
   }): 'preferred' | 'fallback' {
-    const { preferred, fallback, viewport, popoverHeight, atDocumentEdge } =
-      input;
+    const {
+      preferred,
+      fallback,
+      viewport,
+      popoverHeight,
+      atDocumentEdge,
+      placementKey = 'default',
+    } = input;
+    const previousPlacement = this.#placements.get(placementKey);
     let placement: 'preferred' | 'fallback';
     if (viewport !== undefined && popoverHeight > 0) {
       const fits = (bounds: PopoverPlacementBounds, margin = 0): boolean =>
         bounds.top >= viewport.top + margin &&
         bounds.bottom <= viewport.bottom - margin;
       if (
-        this.#placement === 'fallback' &&
+        previousPlacement === 'fallback' &&
         fits(fallback) &&
         !fits(preferred, POPOVER_FLIP_HYSTERESIS_PX)
       ) {
@@ -122,14 +152,14 @@ export class PopoverManager {
     } else {
       placement = atDocumentEdge ? 'fallback' : 'preferred';
     }
-    this.#placement = placement;
+    this.#placements.set(placementKey, placement);
     return placement;
   }
 
   /**
    * Returns the bounds of the popover in overlay coordinate space.
    */
-  getPlacementBounds(): PopoverPlacementBounds | undefined {
+  getPlacementBounds(): PopoverViewportBounds | undefined {
     const codeRect = this.#getCodeRect();
     if (codeRect === undefined) {
       return undefined;
@@ -149,9 +179,33 @@ export class PopoverManager {
     if (bottomScreen <= topScreen) {
       return undefined;
     }
+    const codeScrollLeft = this.#cachedCodeScrollLeft;
+    const codeScrollTop = this.#cachedCodeScrollTop;
+    const codeViewportWidth =
+      this.#cachedCodeClientWidth > 0
+        ? this.#cachedCodeClientWidth
+        : codeRect.width;
+    const leftScreen =
+      scrollContainerRect !== undefined ? scrollContainerRect.left : 0;
+    const rightScreen =
+      scrollContainerRect !== undefined
+        ? scrollContainerRect.right
+        : window.innerWidth;
+    const codeViewportLeft = codeScrollLeft;
+    const codeViewportRight = codeScrollLeft + codeViewportWidth;
+    const visibleLeft = Math.max(
+      codeViewportLeft,
+      leftScreen - codeRect.left + codeScrollLeft
+    );
+    const visibleRight = Math.min(
+      codeViewportRight,
+      rightScreen - codeRect.left + codeScrollLeft
+    );
     return {
-      top: topScreen - codeRect.top,
-      bottom: bottomScreen - codeRect.top,
+      top: topScreen - codeRect.top + codeScrollTop,
+      bottom: bottomScreen - codeRect.top + codeScrollTop,
+      left: visibleLeft,
+      right: Math.max(visibleLeft, visibleRight),
     };
   }
 
@@ -212,7 +266,11 @@ export class PopoverManager {
       return;
     }
     this.#ensureViewportRectListeners();
-    this.#cachedCodeRect = this.#codeElement?.getBoundingClientRect();
+    const codeElement = this.#codeElement;
+    this.#cachedCodeRect = codeElement?.getBoundingClientRect();
+    this.#cachedCodeScrollLeft = codeElement?.scrollLeft ?? 0;
+    this.#cachedCodeScrollTop = codeElement?.scrollTop ?? 0;
+    this.#cachedCodeClientWidth = codeElement?.clientWidth ?? 0;
     this.#cachedScrollContainerRect =
       this.#getScrollContainer()?.getBoundingClientRect();
     this.#viewportRectsDirty = false;
@@ -248,10 +306,18 @@ export class PopoverManager {
       });
     };
     const scroller = this.#getScrollContainer();
+    const codeElement = this.#codeElement;
     this.#viewportRectListenersDisposes = [
       scroller !== undefined
         ? addEventListener(scroller, 'scroll', markDirty, { passive: true })
         : addEventListener(window, 'scroll', markDirty, { passive: true }),
+      ...(codeElement !== undefined
+        ? [
+            addEventListener(codeElement, 'scroll', markDirty, {
+              passive: true,
+            }),
+          ]
+        : []),
       addEventListener(window, 'resize', markDirty, { passive: true }),
       () => {
         if (repositionRafId !== undefined) {
@@ -261,4 +327,33 @@ export class PopoverManager {
       },
     ];
   }
+}
+
+export function setPopoverPositionStyles(
+  popover: HTMLElement,
+  {
+    gutterWidth,
+    placeAbove,
+    viewport,
+    x,
+    y,
+  }: {
+    gutterWidth: number;
+    placeAbove: boolean;
+    viewport: PopoverViewportBounds | undefined;
+    x: number;
+    y: number;
+  }
+): void {
+  popover.style.setProperty('--gutter-width', gutterWidth + 'px');
+  popover.style.setProperty('--popover-x', x + 'px');
+  popover.style.setProperty('--popover-y', y + 'px');
+  popover.style.setProperty('--popover-y-shift', placeAbove ? '-100%' : '0px');
+  if (viewport === undefined) {
+    popover.style.removeProperty('--popover-viewport-left');
+    popover.style.removeProperty('--popover-viewport-right');
+    return;
+  }
+  popover.style.setProperty('--popover-viewport-left', viewport.left + 'px');
+  popover.style.setProperty('--popover-viewport-right', viewport.right + 'px');
 }

--- a/packages/diffs/src/editor/selectionAction.ts
+++ b/packages/diffs/src/editor/selectionAction.ts
@@ -1,4 +1,8 @@
 import type { EditorSelection, TextEdit } from '../types';
+import {
+  type PopoverViewportBounds,
+  setPopoverPositionStyles,
+} from './popover';
 import type { TextDocument } from './textDocument';
 import { h } from './utils';
 
@@ -63,15 +67,16 @@ export class SelectionActionWidget {
     left: number,
     top: number,
     gutterWidth: number,
-    placeAbove: boolean
+    placeAbove: boolean,
+    viewport?: PopoverViewportBounds
   ): void {
-    this.#root.style.setProperty('--gutter-width', gutterWidth + 'px');
-    this.#root.style.setProperty('--popover-x', left + 'px');
-    this.#root.style.setProperty('--popover-y', top + 'px');
-    this.#root.style.setProperty(
-      '--popover-y-shift',
-      placeAbove ? '-100%' : '0px'
-    );
+    setPopoverPositionStyles(this.#root, {
+      gutterWidth,
+      placeAbove,
+      viewport,
+      x: left,
+      y: top,
+    });
   }
 
   /**

--- a/packages/diffs/test/e2e/fixtures/markers.html
+++ b/packages/diffs/test/e2e/fixtures/markers.html
@@ -48,6 +48,7 @@
   return conut;
 }
 var label = 'x';
+${' '.repeat(80)}scrolledMarkerTarget_${'x'.repeat(180)}();
 `,
       };
 
@@ -83,6 +84,12 @@ var label = 'x';
           message: 'Unexpected var, use let or const',
           start: { line: 4, character: 0 },
           end: { line: 4, character: 3 },
+        },
+        {
+          severity: 'hint',
+          message: 'Long scrolled marker',
+          start: { line: 5, character: 80 },
+          end: { line: 5, character: 100 },
         },
       ];
 

--- a/packages/diffs/test/e2e/markers.pw.ts
+++ b/packages/diffs/test/e2e/markers.pw.ts
@@ -35,14 +35,60 @@ function allWithinHost(page: Page, selector: string): Promise<boolean> {
   }, selector);
 }
 
+function openScrolledMarkerNearGutter(page: Page): Promise<{
+  gutterRight: number;
+  popupLeft: number;
+} | null> {
+  return page.evaluate(async () => {
+    const host = document.querySelector('diffs-container');
+    const root = host?.shadowRoot;
+    if (host == null || root == null) {
+      return null;
+    }
+
+    const code = root.querySelector<HTMLElement>('[data-code]');
+    const gutter = root.querySelector<HTMLElement>('[data-gutter]');
+    const target = root.querySelector<HTMLElement>(
+      '[data-line="6"] [data-char="80"]'
+    );
+    if (code == null || gutter == null || target == null) {
+      return null;
+    }
+
+    const codeRect = code.getBoundingClientRect();
+    const gutterWidth = gutter.getBoundingClientRect().width;
+    const targetRect = target.getBoundingClientRect();
+    const targetX = targetRect.left - codeRect.left + code.scrollLeft;
+    code.scrollLeft = Math.max(0, targetX - gutterWidth - 4);
+    code.dispatchEvent(new Event('scroll', { bubbles: true }));
+
+    target.dispatchEvent(
+      new MouseEvent('mouseover', { bubbles: true, composed: true })
+    );
+    await new Promise((resolve) => setTimeout(resolve, 350));
+
+    const popup = root.querySelector<HTMLElement>('[data-marker-popup]');
+    if (popup == null) {
+      return null;
+    }
+    const popupRect = popup.getBoundingClientRect();
+    const gutterRect = gutter.getBoundingClientRect();
+    return {
+      gutterRight: gutterRect.right,
+      popupLeft: popupRect.left,
+    };
+  });
+}
+
 test.describe('editor markers', () => {
   test('renders one squiggle per severity', async ({ page }) => {
     await openFixture(page);
 
-    await expect(page.locator(RANGE)).toHaveCount(3);
+    await expect(page.locator(RANGE)).toHaveCount(4);
     await expect(page.locator('[data-marker-error]')).toHaveCount(1);
     await expect(page.locator('[data-marker-warning]')).toHaveCount(1);
     await expect(page.locator('[data-marker-info]')).toHaveCount(1);
+    await expect(page.locator('[data-marker-hint]')).toHaveCount(1);
   });
 
   test('hovering a squiggle shows its message popup', async ({ page }) => {
@@ -67,5 +113,20 @@ test.describe('editor markers', () => {
     await page.locator(CONTENT).getByText('conut').hover();
     await expect(page.locator('[data-marker-popup]')).toBeVisible();
     expect(await allWithinHost(page, '[data-marker-popup]')).toBe(true);
+  });
+
+  test('keeps a horizontally scrolled popup clear of the sticky gutter', async ({
+    page,
+  }) => {
+    await openFixture(page);
+
+    const measurement = await openScrolledMarkerNearGutter(page);
+    expect(measurement).not.toBeNull();
+    if (measurement === null) {
+      return;
+    }
+    expect(measurement.popupLeft).toBeGreaterThanOrEqual(
+      measurement.gutterRight + 7
+    );
   });
 });

--- a/packages/diffs/test/editorMarkerPopup.test.ts
+++ b/packages/diffs/test/editorMarkerPopup.test.ts
@@ -3,9 +3,11 @@ import { afterAll, describe, expect, test } from 'bun:test';
 import { File } from '../src/components/File';
 import { DEFAULT_THEMES } from '../src/constants';
 import { Editor } from '../src/editor/editor';
-import type { Marker } from '../src/editor/marker';
+import { type Marker, MarkerRenderer } from '../src/editor/marker';
+import { PopoverManager } from '../src/editor/popover';
+import type { TextDocument } from '../src/editor/textDocument';
 import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
-import type { FileContents } from '../src/types';
+import type { FileContents, Position } from '../src/types';
 import { installDom, wait } from './domHarness';
 
 afterAll(async () => {
@@ -94,6 +96,173 @@ function findMarkerPopup(content: HTMLElement): HTMLElement {
   return popup;
 }
 
+function makeRect({
+  height,
+  left,
+  top,
+  width,
+}: {
+  height: number;
+  left: number;
+  top: number;
+  width: number;
+}): DOMRect {
+  return {
+    bottom: top + height,
+    height,
+    left,
+    right: left + width,
+    top,
+    width,
+    x: left,
+    y: top,
+    toJSON() {
+      return {};
+    },
+  } as DOMRect;
+}
+
+function installMarkerPopupHeight(height: number): () => void {
+  const original = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'offsetHeight'
+  );
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get() {
+      return (this as HTMLElement).dataset.markerPopup !== undefined
+        ? height
+        : 0;
+    },
+  });
+  return () => {
+    if (original === undefined) {
+      delete (HTMLElement.prototype as { offsetHeight?: number }).offsetHeight;
+    } else {
+      Object.defineProperty(HTMLElement.prototype, 'offsetHeight', original);
+    }
+  };
+}
+
+interface DirectMarkerFixture {
+  cleanup(): void;
+  content: HTMLElement;
+  scrollRoot: HTMLElement;
+}
+
+function createDirectMarkerFixture({
+  gutterWidth = 40,
+  initialScrollLeft = 0,
+  initialScrollTop = 0,
+  lineHeight = 20,
+  markerX = 80,
+  rowTop = 70,
+  viewportHeight = 100,
+  viewportWidth = 200,
+}: {
+  gutterWidth?: number;
+  initialScrollLeft?: number;
+  initialScrollTop?: number;
+  lineHeight?: number;
+  markerX?: number;
+  rowTop?: number;
+  viewportHeight?: number;
+  viewportWidth?: number;
+} = {}): DirectMarkerFixture {
+  const dom = installDom();
+  const scrollRoot = document.createElement('div');
+  scrollRoot.style.overflowX = 'auto';
+  scrollRoot.style.overflowY = 'auto';
+  scrollRoot.scrollLeft = initialScrollLeft;
+  scrollRoot.scrollTop = initialScrollTop;
+  Object.defineProperty(scrollRoot, 'getBoundingClientRect', {
+    configurable: true,
+    value: () =>
+      makeRect({
+        height: viewportHeight,
+        left: 0,
+        top: 0,
+        width: viewportWidth,
+      }),
+  });
+
+  const fileContainer = document.createElement('div');
+  const codeElement = document.createElement('div');
+  codeElement.scrollLeft = initialScrollLeft;
+  Object.defineProperty(codeElement, 'clientWidth', {
+    configurable: true,
+    get: () => viewportWidth,
+  });
+  Object.defineProperty(codeElement, 'getBoundingClientRect', {
+    configurable: true,
+    value: () =>
+      makeRect({
+        height: 1000,
+        left: 0,
+        top: -scrollRoot.scrollTop,
+        width: viewportWidth,
+      }),
+  });
+
+  const overlay = document.createElement('div');
+  const content = document.createElement('div');
+  const line = document.createElement('div');
+  line.dataset.line = '5';
+  const span = document.createElement('span');
+  span.dataset.char = '0';
+  span.textContent = 'x';
+  line.appendChild(span);
+  content.appendChild(line);
+
+  fileContainer.append(codeElement, content, overlay);
+  scrollRoot.appendChild(fileContainer);
+  document.body.appendChild(scrollRoot);
+
+  const rendererRef: { current?: MarkerRenderer } = {};
+  const popoverManager = new PopoverManager({
+    hasActivePopover: () => rendererRef.current?.isPopupVisible() === true,
+    updateActivePopover: () => rendererRef.current?.updatePopupPosition(),
+  });
+  popoverManager.setViewportElements(fileContainer, codeElement);
+
+  rendererRef.current = new MarkerRenderer({
+    popoverManager,
+    getLineHeight: () => lineHeight,
+    getOverlayElement: () => overlay,
+    getGutterWidth: () => gutterWidth,
+    getCharX: () => [markerX, 0],
+    getLineY: () => rowTop,
+    isMouseDown: () => false,
+  });
+  rendererRef.current.setMarkers(
+    [
+      {
+        start: { line: 4, character: 0 },
+        end: { line: 4, character: 1 },
+        severity: 'error',
+        message: 'marker message',
+      },
+    ],
+    {
+      lineCount: 20,
+      normalizePosition(position: Position): Position {
+        return position;
+      },
+    } as unknown as TextDocument<undefined>
+  );
+  rendererRef.current.listenHover(content);
+
+  return {
+    cleanup() {
+      rendererRef.current?.cleanup();
+      popoverManager.cleanUp();
+      dom.cleanup();
+    },
+    content,
+    scrollRoot,
+  };
+}
+
 describe('Editor marker popup placement', () => {
   // Default, unchanged by the viewport-aware flip: anchor below the marker.
   test('places the popup below the marker by default', async () => {
@@ -147,6 +316,64 @@ describe('Editor marker popup placement', () => {
       const popup = findMarkerPopup(content);
       expect(popup.style.getPropertyValue('--popover-y-shift').trim()).toBe(
         '-100%'
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('re-flips an open marker popup when the scroll viewport changes', async () => {
+    const { cleanup, content, scrollRoot } = createDirectMarkerFixture({
+      initialScrollTop: 50,
+      rowTop: 70,
+      viewportHeight: 100,
+    });
+    const restoreHeight = installMarkerPopupHeight(60);
+
+    try {
+      hoverMarkerLine(content, 5);
+      await wait(350);
+
+      const popup = findMarkerPopup(content);
+      expect(popup.style.getPropertyValue('--popover-y-shift').trim()).toBe(
+        '0px'
+      );
+
+      scrollRoot.scrollTop = 0;
+      scrollRoot.dispatchEvent(new Event('scroll'));
+      await wait(0);
+
+      expect(popup.style.getPropertyValue('--popover-y-shift').trim()).toBe(
+        '-100%'
+      );
+    } finally {
+      restoreHeight();
+      cleanup();
+    }
+  });
+
+  test('sets horizontal clamp bounds from the visible scroll viewport', async () => {
+    const { cleanup, content } = createDirectMarkerFixture({
+      gutterWidth: 40,
+      initialScrollLeft: 600,
+      markerX: 900,
+      viewportWidth: 160,
+    });
+
+    try {
+      hoverMarkerLine(content, 5);
+      await wait(350);
+
+      const popup = findMarkerPopup(content);
+      expect(
+        popup.style.getPropertyValue('--popover-viewport-left').trim()
+      ).toBe('600px');
+      expect(
+        popup.style.getPropertyValue('--popover-viewport-right').trim()
+      ).toBe('760px');
+      expect(popup.style.getPropertyValue('--popover-x').trim()).toBe('900px');
+      expect(popup.style.getPropertyValue('--gutter-width').trim()).toBe(
+        '40px'
       );
     } finally {
       cleanup();


### PR DESCRIPTION
Reproduce:
1. Open an editable diff with a marker close to the lower-right edge of the visible code viewport.
2. Hover the marker until its message popup opens.
3. Scroll the editor while keeping the popup open.

Before this change, the marker popup keeps the side chosen at hover time and its horizontal clamp is based on the code column rather than the visible scroll viewport, so it can stay clipped or overflow the edge.

Marker popups duplicated the selection-action placement branch, and the shared popover manager only treated selection-action as the active popover. Route marker popups through PopoverManager.choosePlacement, track hysteresis state per popover kind, and expose viewport left/right bounds to the shared popover CSS clamp.
