### PR TITLE
test(diffs): fill editor public-API and helper coverage gaps

### DIFF
--- a/packages/diffs/test/editorCommand.test.ts
+++ b/packages/diffs/test/editorCommand.test.ts
@@ -150,6 +150,67 @@ describe('resolveEditorShortcutCommand', () => {
       { event: { key: 'Tab', ctrlKey: true }, expected: undefined },
     ]);
   });
+
+  test('opens the search panel with the find shortcut on macOS', () => {
+    expectShortcuts('MacIntel', [
+      { event: { key: 'f', metaKey: true }, expected: 'openSearchPanel' },
+      {
+        event: { key: 'f', metaKey: true, altKey: true },
+        expected: 'openSearchReplacePanel',
+      },
+      // Option+F emits a dead key ('ƒ') on macOS, so the physical F is
+      // recognized through event.code instead of the character.
+      {
+        event: { key: 'ƒ', code: 'KeyF', metaKey: true, altKey: true },
+        expected: 'openSearchReplacePanel',
+      },
+      { event: { key: 'f', ctrlKey: true }, expected: undefined },
+    ]);
+  });
+
+  test('opens the search panel with the find shortcut on windows and linux', () => {
+    expectShortcuts('Linux x86_64', [
+      { event: { key: 'f', ctrlKey: true }, expected: 'openSearchPanel' },
+      {
+        event: { key: 'f', ctrlKey: true, altKey: true },
+        expected: 'openSearchReplacePanel',
+      },
+      { event: { key: 'f', metaKey: true }, expected: undefined },
+    ]);
+  });
+
+  test('maps the find-next shortcut', () => {
+    expectShortcuts('MacIntel', [
+      { event: { key: 'd', metaKey: true }, expected: 'findNextMatch' },
+    ]);
+    expectShortcuts('Linux x86_64', [
+      { event: { key: 'd', ctrlKey: true }, expected: 'findNextMatch' },
+      { event: { key: 'd' }, expected: undefined },
+    ]);
+  });
+
+  test('expands the selection to the document edges with shift', () => {
+    expectShortcuts('MacIntel', [
+      {
+        event: { key: 'ArrowUp', metaKey: true, shiftKey: true },
+        expected: 'expandSelectionDocStart',
+      },
+      {
+        event: { key: 'ArrowDown', metaKey: true, shiftKey: true },
+        expected: 'expandSelectionDocEnd',
+      },
+    ]);
+    expectShortcuts('Linux x86_64', [
+      {
+        event: { key: 'Home', ctrlKey: true, shiftKey: true },
+        expected: 'expandSelectionDocStart',
+      },
+      {
+        event: { key: 'End', ctrlKey: true, shiftKey: true },
+        expected: 'expandSelectionDocEnd',
+      },
+    ]);
+  });
 });
 
 describe('resolveFindAgainShortcut', () => {

--- a/packages/diffs/test/editorLineAnnotations.test.ts
+++ b/packages/diffs/test/editorLineAnnotations.test.ts
@@ -396,6 +396,36 @@ describe('renderLineAnnotations', () => {
       cleanup();
     }
   });
+
+  test('renders addition annotations when there is no paired deletions side', async () => {
+    const { cleanup } = installDom();
+    try {
+      const { content, gutter } = createUnifiedAnnotationHost(3);
+
+      renderLineAnnotations(
+        [{ side: 'additions', lineNumber: 2, metadata: 'new' }],
+        content,
+        gutter
+      );
+      await wait();
+
+      expect(
+        content.querySelector(
+          '[data-line-annotation="0,1"] slot[name="annotation-additions-2"]'
+        )
+      ).not.toBeNull();
+      // Without a deletions sibling only the addition side renders: one content
+      // annotation and one gutter buffer, and no left-side elements at all.
+      expect(content.querySelectorAll('[data-line-annotation]')).toHaveLength(
+        1
+      );
+      expect(
+        gutter.querySelectorAll('[data-gutter-buffer="annotation"]')
+      ).toHaveLength(1);
+    } finally {
+      cleanup();
+    }
+  });
 });
 
 function createSplitAnnotationHost(lineCount: number): {
@@ -442,4 +472,27 @@ function appendRenderedLine(
   const gutterLine = document.createElement('div');
   gutterLine.dataset.columnNumber = String(lineNumber);
   gutter.append(gutterLine);
+}
+
+// A single (unified) code element with no left [data-deletions] sibling, which
+// drives renderLineAnnotations' additions-only path.
+function createUnifiedAnnotationHost(lineCount: number): {
+  content: HTMLElement;
+  gutter: HTMLElement;
+} {
+  const root = document.createElement('div');
+  const code = document.createElement('div');
+  const gutter = document.createElement('div');
+  gutter.dataset.gutter = '';
+  const content = document.createElement('div');
+  content.dataset.content = '';
+  code.append(gutter, content);
+  root.append(code);
+  document.body.append(root);
+
+  for (let lineNumber = 1; lineNumber <= lineCount; lineNumber++) {
+    appendRenderedLine(content, gutter, lineNumber);
+  }
+
+  return { content, gutter };
 }

--- a/packages/diffs/test/editorPopover.test.ts
+++ b/packages/diffs/test/editorPopover.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  POPOVER_FLIP_HYSTERESIS_PX,
+  PopoverManager,
+  type PopoverPlacementBounds,
+} from '../src/editor/popover';
+import { installDom } from './domHarness';
+
+function makeManager(): PopoverManager {
+  return new PopoverManager({
+    hasActivePopover: () => false,
+    updateActivePopover: () => {},
+  });
+}
+
+// jsdom performs no layout, so declare the screen-space rect getPlacementBounds
+// reads off the code and scroll-container elements. Only top/bottom matter.
+function stubRect(element: HTMLElement, top: number, bottom: number): void {
+  Object.defineProperty(element, 'getBoundingClientRect', {
+    configurable: true,
+    value: () =>
+      ({
+        top,
+        bottom,
+        left: 0,
+        right: 0,
+        width: 0,
+        height: bottom - top,
+        x: 0,
+        y: top,
+        toJSON: () => ({}),
+      }) as DOMRect,
+  });
+}
+
+const VIEWPORT: PopoverPlacementBounds = { top: 0, bottom: 100 };
+
+describe('PopoverManager.choosePlacement', () => {
+  test('uses the document-edge signal when no viewport geometry is available', () => {
+    const manager = makeManager();
+    const bounds: PopoverPlacementBounds = { top: 10, bottom: 30 };
+    // With no viewport, an anchor at a document edge flips; otherwise it stays.
+    expect(
+      manager.choosePlacement({
+        preferred: bounds,
+        fallback: bounds,
+        viewport: undefined,
+        popoverHeight: 20,
+        atDocumentEdge: true,
+      })
+    ).toBe('fallback');
+    expect(
+      manager.choosePlacement({
+        preferred: bounds,
+        fallback: bounds,
+        viewport: undefined,
+        popoverHeight: 20,
+        atDocumentEdge: false,
+      })
+    ).toBe('preferred');
+    // A popover that has not laid out yet (height 0) is treated the same way.
+    expect(
+      manager.choosePlacement({
+        preferred: bounds,
+        fallback: bounds,
+        viewport: VIEWPORT,
+        popoverHeight: 0,
+        atDocumentEdge: true,
+      })
+    ).toBe('fallback');
+  });
+
+  test('flips to the fallback side only when the preferred side is clipped and the fallback fits', () => {
+    // Preferred fits inside the viewport: keep it.
+    expect(
+      makeManager().choosePlacement({
+        preferred: { top: 10, bottom: 30 },
+        fallback: { top: 40, bottom: 60 },
+        viewport: VIEWPORT,
+        popoverHeight: 20,
+        atDocumentEdge: false,
+      })
+    ).toBe('preferred');
+    // Preferred overflows the top and the fallback fits: flip.
+    expect(
+      makeManager().choosePlacement({
+        preferred: { top: -10, bottom: 30 },
+        fallback: { top: 40, bottom: 60 },
+        viewport: VIEWPORT,
+        popoverHeight: 20,
+        atDocumentEdge: false,
+      })
+    ).toBe('fallback');
+    // Neither side fits: fall back to the preferred side rather than the clipped
+    // fallback.
+    expect(
+      makeManager().choosePlacement({
+        preferred: { top: -10, bottom: 30 },
+        fallback: { top: -5, bottom: 200 },
+        viewport: VIEWPORT,
+        popoverHeight: 20,
+        atDocumentEdge: false,
+      })
+    ).toBe('preferred');
+  });
+
+  test('keeps a flipped popover on the fallback side until the preferred side clears the hysteresis margin', () => {
+    const manager = makeManager();
+    const fallback: PopoverPlacementBounds = { top: 50, bottom: 70 };
+    manager.setPlacement('fallback');
+
+    // Preferred fits, but only within the hysteresis margin, so the popover
+    // stays flipped to avoid flickering back and forth at the boundary.
+    expect(
+      manager.choosePlacement({
+        preferred: { top: POPOVER_FLIP_HYSTERESIS_PX - 2, bottom: 98 },
+        fallback,
+        viewport: VIEWPORT,
+        popoverHeight: 20,
+        atDocumentEdge: false,
+      })
+    ).toBe('fallback');
+
+    // Once preferred clears the margin on both edges, it flips back.
+    expect(
+      manager.choosePlacement({
+        preferred: { top: 10, bottom: 90 },
+        fallback,
+        viewport: VIEWPORT,
+        popoverHeight: 20,
+        atDocumentEdge: false,
+      })
+    ).toBe('preferred');
+  });
+});
+
+describe('PopoverManager.getPlacementBounds', () => {
+  test('expresses the scroll container viewport in code-relative coordinates', () => {
+    const dom = installDom();
+    const manager = makeManager();
+    try {
+      const scroller = document.createElement('div');
+      scroller.style.overflowY = 'auto';
+      const fileContainer = document.createElement('div');
+      const codeElement = document.createElement('div');
+      scroller.appendChild(fileContainer);
+      document.body.appendChild(scroller);
+      stubRect(scroller, 20, 120);
+      stubRect(codeElement, 50, 90);
+
+      manager.setViewportElements(fileContainer, codeElement);
+      // Subtract the code element's top so the bounds are relative to it.
+      expect(manager.getPlacementBounds()).toEqual({ top: -30, bottom: 70 });
+    } finally {
+      manager.cleanUp();
+      dom.cleanup();
+    }
+  });
+
+  test('falls back to the window when there is no scrollable ancestor', () => {
+    const dom = installDom();
+    const manager = makeManager();
+    try {
+      const fileContainer = document.createElement('div');
+      const codeElement = document.createElement('div');
+      document.body.appendChild(fileContainer);
+      stubRect(codeElement, 50, 90);
+
+      manager.setViewportElements(fileContainer, codeElement);
+      expect(manager.getPlacementBounds()).toEqual({
+        top: -50,
+        bottom: window.innerHeight - 50,
+      });
+    } finally {
+      manager.cleanUp();
+      dom.cleanup();
+    }
+  });
+
+  test('returns undefined without a code element or when the viewport is empty', () => {
+    const dom = installDom();
+    const manager = makeManager();
+    try {
+      // No viewport elements set yet.
+      expect(manager.getPlacementBounds()).toBeUndefined();
+
+      const scroller = document.createElement('div');
+      scroller.style.overflowY = 'scroll';
+      const fileContainer = document.createElement('div');
+      const codeElement = document.createElement('div');
+      scroller.appendChild(fileContainer);
+      document.body.appendChild(scroller);
+      // An inverted scroll rect (bottom above top) has no usable height.
+      stubRect(scroller, 100, 50);
+      stubRect(codeElement, 10, 40);
+
+      manager.setViewportElements(fileContainer, codeElement);
+      expect(manager.getPlacementBounds()).toBeUndefined();
+    } finally {
+      manager.cleanUp();
+      dom.cleanup();
+    }
+  });
+});

--- a/packages/diffs/test/editorPublicApi.test.ts
+++ b/packages/diffs/test/editorPublicApi.test.ts
@@ -1,0 +1,352 @@
+import { afterAll, describe, expect, mock, spyOn, test } from 'bun:test';
+
+import { File } from '../src/components/File';
+import { DEFAULT_THEMES } from '../src/constants';
+import { Editor, type EditorOptions } from '../src/editor/editor';
+import type { Marker } from '../src/editor/marker';
+import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
+import type { FileContents } from '../src/types';
+import { installDom, wait } from './domHarness';
+
+afterAll(async () => {
+  await disposeHighlighter();
+});
+
+async function waitForEditableContent(
+  container: HTMLElement
+): Promise<HTMLElement> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const content = container.shadowRoot?.querySelector('[data-content]');
+    if (
+      content instanceof HTMLElement &&
+      (content.contentEditable === 'true' ||
+        content.getAttribute('contenteditable') === 'true')
+    ) {
+      return content;
+    }
+    await wait(0);
+  }
+
+  throw new Error('editor content did not become editable');
+}
+
+interface EditorFixture {
+  cleanup(): void;
+  content: HTMLElement;
+  editor: Editor<undefined>;
+}
+
+// Mounts a real File-backed editor, mirroring the harness the applyEdits and
+// marker suites use, and returns the editor plus its contenteditable element.
+async function createEditorFixture(
+  contents: string,
+  editorOptions?: EditorOptions<undefined>
+): Promise<EditorFixture> {
+  const dom = installDom();
+  const fileContainer = document.createElement('div');
+  document.body.appendChild(fileContainer);
+
+  const file = new File<undefined>({
+    disableFileHeader: true,
+    theme: DEFAULT_THEMES,
+  });
+  const editor = new Editor<undefined>(editorOptions);
+  const initialFile: FileContents = { name: 'edits.ts', contents };
+
+  file.render({ file: initialFile, fileContainer, forceRender: true });
+  editor.edit(file);
+
+  const content = await waitForEditableContent(fileContainer);
+
+  return {
+    cleanup() {
+      editor.cleanUp();
+      file.cleanUp();
+      dom.cleanup();
+    },
+    content,
+    editor,
+  };
+}
+
+function insertText(
+  editor: Editor<undefined>,
+  line: number,
+  character: number,
+  text: string,
+  updateHistory = false
+): void {
+  editor.applyEdits(
+    [
+      {
+        range: {
+          start: { line, character },
+          end: { line, character },
+        },
+        newText: text,
+      },
+    ],
+    updateHistory
+  );
+}
+
+function markerPopup(content: HTMLElement): HTMLElement | null {
+  return (content.getRootNode() as ShadowRoot).querySelector(
+    '[data-marker-popup]'
+  );
+}
+
+// Hovers the marker over `oneIndexedLine` by dispatching a mouseover whose
+// composedPath points at that row's first tokenized span, matching the marker
+// popup suite (jsdom does not report composedPath across the shadow boundary).
+function hoverMarkerLine(content: HTMLElement, oneIndexedLine: number): void {
+  const lineElement = Array.from(
+    content.querySelectorAll<HTMLElement>('[data-line]')
+  ).find((el) => el.dataset.line === String(oneIndexedLine));
+  const charSpan = lineElement?.querySelector<HTMLElement>('[data-char]');
+  if (charSpan == null) {
+    throw new Error(`no tokenized span found on line ${oneIndexedLine}`);
+  }
+  const event = new Event('mouseover', { bubbles: true, composed: true });
+  Object.defineProperty(event, 'composedPath', { value: () => [charSpan] });
+  content.dispatchEvent(event);
+}
+
+describe('Editor state round trip', () => {
+  test('setState restores selections without rebuilding the document or dropping undo history', async () => {
+    const { cleanup, editor } = await createEditorFixture(
+      'alpha\nbravo\ncharlie'
+    );
+    try {
+      editor.setSelections([
+        {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 0 },
+          direction: 'none',
+        },
+      ]);
+      insertText(editor, 1, 0, 'ZZ', true);
+      expect(editor.canUndo).toBe(true);
+      const editedText = editor.getText();
+
+      editor.setSelections([
+        {
+          start: { line: 2, character: 1 },
+          end: { line: 2, character: 4 },
+          direction: 'forward',
+        },
+      ]);
+      const state = editor.getState();
+
+      // Move the caret elsewhere, then restore the captured state.
+      editor.setSelections([
+        {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 0 },
+          direction: 'none',
+        },
+      ]);
+      editor.setState(state);
+
+      expect(editor.getState().selections).toEqual(state.selections);
+      // getState/setState carry no cacheKey, so restoring state neither rebuilds
+      // the document nor discards its undo history.
+      expect(editor.canUndo).toBe(true);
+      expect(editor.getText()).toBe(editedText);
+      editor.undo();
+      expect(editor.getText()).toBe('alpha\nbravo\ncharlie');
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('Editor.setOptions', () => {
+  test('applies an option change after construction', async () => {
+    const onChange = mock(() => {});
+    const { cleanup, editor } = await createEditorFixture('alpha\nbravo');
+    try {
+      // With no onChange configured, an edit notifies nobody.
+      insertText(editor, 0, 5, 'X', true);
+      expect(onChange).not.toHaveBeenCalled();
+
+      // Installing onChange at runtime makes the next edit report the change.
+      editor.setOptions({ onChange });
+      insertText(editor, 0, 0, 'Y', true);
+      expect(onChange).toHaveBeenCalledTimes(1);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('Editor focus lifecycle', () => {
+  test('fires onAttach when the editor attaches to a file', async () => {
+    const onAttach = mock((_editor: Editor<undefined>) => {});
+    const { cleanup, editor } = await createEditorFixture('alpha\nbravo', {
+      onAttach,
+    });
+    try {
+      await wait(0);
+      expect(onAttach).toHaveBeenCalledTimes(1);
+      expect(onAttach.mock.calls[0]?.[0]).toBe(editor);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('fires onFocus and onBlur as the content gains and loses focus', async () => {
+    const onFocus = mock(() => {});
+    const onBlur = mock(() => {});
+    const { cleanup, content } = await createEditorFixture('alpha\nbravo', {
+      onFocus,
+      onBlur,
+    });
+    try {
+      content.dispatchEvent(new Event('focus'));
+      content.dispatchEvent(new Event('blur'));
+      expect(onFocus).toHaveBeenCalledTimes(1);
+      expect(onBlur).toHaveBeenCalledTimes(1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('blur() blurs the content element', async () => {
+    const { cleanup, content, editor } =
+      await createEditorFixture('alpha\nbravo');
+    try {
+      const blurSpy = spyOn(content, 'blur');
+      editor.blur();
+      expect(blurSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('focus() without a selection focuses the content and honors preventScroll', async () => {
+    const { cleanup, content, editor } =
+      await createEditorFixture('alpha\nbravo');
+    try {
+      editor.setSelections([]);
+      const focusSpy = spyOn(content, 'focus');
+      editor.focus();
+      expect(focusSpy).toHaveBeenLastCalledWith({ preventScroll: false });
+      editor.focus({ preventScroll: true });
+      expect(focusSpy).toHaveBeenLastCalledWith({ preventScroll: true });
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('focus() with a selection defers the content focus to a frame', async () => {
+    const { cleanup, content, editor } =
+      await createEditorFixture('alpha\nbravo');
+    try {
+      editor.setSelections([
+        {
+          start: { line: 0, character: 1 },
+          end: { line: 0, character: 1 },
+          direction: 'none',
+        },
+      ]);
+      const focusSpy = spyOn(content, 'focus');
+      editor.focus();
+      // The real focus() runs in a rAF so it does not clobber the re-anchored
+      // native selection.
+      expect(focusSpy).not.toHaveBeenCalled();
+      await wait(0);
+      expect(focusSpy).toHaveBeenLastCalledWith({ preventScroll: false });
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('Editor.setMarkers', () => {
+  test('clearing markers tears down the renderer and its popup', async () => {
+    const { cleanup, editor, content } = await createEditorFixture(
+      'l0\nl1\nl2\nl3\nl4\nl5'
+    );
+    try {
+      // Clearing before any markers were set is a no-op that must not throw.
+      editor.setMarkers([]);
+
+      const markers: Marker[] = [
+        {
+          start: { line: 3, character: 0 },
+          end: { line: 3, character: 2 },
+          severity: 'error',
+          message: 'boom',
+        },
+      ];
+      editor.setMarkers(markers);
+      hoverMarkerLine(content, 4);
+      await wait(350);
+      expect(markerPopup(content)).not.toBeNull();
+
+      // Clearing markers disposes the renderer and removes its popup.
+      editor.setMarkers([]);
+      expect(markerPopup(content)).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('Editor history option plumbing', () => {
+  test('caps the undo history at historyMaxEntries', async () => {
+    const { cleanup, editor } = await createEditorFixture('abcdef', {
+      historyMaxEntries: 2,
+    });
+    try {
+      // Three replacements, none of which coalesce, push three undo entries.
+      editor.applyEdits(
+        [
+          {
+            range: {
+              start: { line: 0, character: 0 },
+              end: { line: 0, character: 1 },
+            },
+            newText: 'X',
+          },
+        ],
+        true
+      );
+      editor.applyEdits(
+        [
+          {
+            range: {
+              start: { line: 0, character: 1 },
+              end: { line: 0, character: 2 },
+            },
+            newText: 'Y',
+          },
+        ],
+        true
+      );
+      editor.applyEdits(
+        [
+          {
+            range: {
+              start: { line: 0, character: 2 },
+              end: { line: 0, character: 3 },
+            },
+            newText: 'Z',
+          },
+        ],
+        true
+      );
+      expect(editor.getText()).toBe('XYZdef');
+
+      // The cap keeps only the two most recent entries, so the oldest edit can
+      // no longer be undone.
+      editor.undo();
+      editor.undo();
+      expect(editor.canUndo).toBe(false);
+      expect(editor.getText()).toBe('Xbcdef');
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/packages/diffs/test/editorSearchPanel.test.ts
+++ b/packages/diffs/test/editorSearchPanel.test.ts
@@ -1,72 +1,293 @@
 import { describe, expect, test } from 'bun:test';
 
-import { type MatchRange, SearchPanelWidget } from '../src/editor/searchPanel';
+import {
+  type MatchRange,
+  type SearchPanelOptions,
+  SearchPanelWidget,
+} from '../src/editor/searchPanel';
+import type { ResolvedTextEdit } from '../src/editor/textDocument';
 import { TextDocument } from '../src/editor/textDocument';
 import { installDom, wait } from './domHarness';
 
-function setSearchQuery(input: HTMLInputElement, value: string): void {
+function setInputValue(input: HTMLInputElement, value: string): void {
   input.value = value;
   input.dispatchEvent(
-    new window.Event('input', {
-      bubbles: true,
-      cancelable: true,
-    })
+    new window.Event('input', { bubbles: true, cancelable: true })
   );
 }
 
-function pressEnter(input: HTMLInputElement, shiftKey = false): KeyboardEvent {
+function pressKey(
+  input: HTMLInputElement,
+  key: string,
+  init: KeyboardEventInit = {}
+): KeyboardEvent {
   const event = new window.KeyboardEvent('keydown', {
-    key: 'Enter',
-    shiftKey,
+    key,
     bubbles: true,
     cancelable: true,
+    ...init,
   });
   input.dispatchEvent(event);
   return event;
 }
 
+interface WidgetHarness {
+  widget: SearchPanelWidget;
+  input: HTMLInputElement;
+  replaceInput: HTMLInputElement;
+  button(container: string, index: number): HTMLButtonElement;
+  matchesText(): string | null;
+  mode(): string | undefined;
+  scrolled: MatchRange[];
+  applied: ResolvedTextEdit[][];
+  updates: (MatchRange[] | undefined)[];
+  isClosed(): boolean;
+  cleanup(): void;
+}
+
+// Mounts a SearchPanelWidget over an in-memory document and records everything
+// the widget hands back to its host (scroll targets, replace edits, match-set
+// updates, and close). The default onUpdate selects the first match as current,
+// like the editor selecting the first hit on open; pass `selectCurrent: false`
+// to model a host with no match under the caret (the "N results" state).
+function createWidget(
+  contents: string,
+  options: {
+    defaultQuery?: string;
+    mode?: SearchPanelOptions['mode'];
+    selectCurrent?: boolean;
+  } = {}
+): WidgetHarness {
+  const { defaultQuery = '', mode, selectCurrent = true } = options;
+  const dom = installDom();
+  const textDocument = new TextDocument<undefined>(
+    'inmemory://search-panel',
+    contents
+  );
+  const containerElement = document.createElement('div');
+  document.body.appendChild(containerElement);
+
+  const scrolled: MatchRange[] = [];
+  const applied: ResolvedTextEdit[][] = [];
+  const updates: (MatchRange[] | undefined)[] = [];
+
+  let closed = false;
+  const widget = new SearchPanelWidget({
+    textDocument,
+    containerElement,
+    defaultQuery,
+    mode,
+    scrollToMatch: (nextMatch) => scrolled.push([...nextMatch]),
+    applyReplace: (edits) => applied.push(edits),
+    onUpdate: (matches) => {
+      updates.push(matches.map((match) => [...match] as MatchRange));
+      return selectCurrent ? matches[0] : undefined;
+    },
+    onClose: () => {
+      closed = true;
+    },
+  });
+
+  const query = (selector: string) =>
+    document.querySelector<HTMLElement>(`[data-search-panel] ${selector}`);
+
+  return {
+    widget,
+    input: query('input[data-search]') as HTMLInputElement,
+    replaceInput: query('input[data-replace]') as HTMLInputElement,
+    button: (container, index) =>
+      document.querySelectorAll<HTMLButtonElement>(
+        `[data-search-panel] [data-${container}] button`
+      )[index],
+    matchesText: () => query('[data-matches]')?.textContent ?? null,
+    mode: () => query('[data-search-grid]')?.dataset.mode,
+    scrolled,
+    applied,
+    updates,
+    isClosed: () => closed,
+    cleanup: () => {
+      widget.cleanup();
+      containerElement.remove();
+      dom.cleanup();
+    },
+  };
+}
+
 describe('SearchPanelWidget', () => {
-  test('uses Shift+Enter in the find input to navigate to the previous match', async () => {
-    const { cleanup } = installDom();
-    const textDocument = new TextDocument<undefined>(
-      'inmemory://search-panel',
-      'foo foo foo'
-    );
-    const containerElement = document.createElement('div');
-    document.body.appendChild(containerElement);
-    const scrolledMatches: MatchRange[] = [];
-
-    const widget = new SearchPanelWidget({
-      textDocument,
-      containerElement,
-      defaultQuery: '',
-      scrollToMatch: (nextMatch) => {
-        scrolledMatches.push([...nextMatch]);
-      },
-      applyReplace: () => {},
-      onUpdate: (matches) => matches[0],
-      onClose: () => {},
-    });
-
+  test('Shift+Enter in the find input navigates to the previous match', async () => {
+    const harness = createWidget('foo foo foo');
     try {
       await wait(0);
+      setInputValue(harness.input, 'foo');
 
-      const input = document.querySelector<HTMLInputElement>(
-        '[data-search-panel] input[data-search]'
-      );
-      expect(input).not.toBeNull();
-
-      setSearchQuery(input!, 'foo');
-      const forward = pressEnter(input!);
+      const forward = pressKey(harness.input, 'Enter');
       expect(forward.defaultPrevented).toBe(true);
-      expect(scrolledMatches.at(-1)).toEqual([4, 7]);
+      expect(harness.scrolled.at(-1)).toEqual([4, 7]);
 
-      const backward = pressEnter(input!, true);
+      const backward = pressKey(harness.input, 'Enter', { shiftKey: true });
       expect(backward.defaultPrevented).toBe(true);
-      expect(scrolledMatches.at(-1)).toEqual([0, 3]);
+      expect(harness.scrolled.at(-1)).toEqual([0, 3]);
     } finally {
-      widget.cleanup();
-      cleanup();
+      harness.cleanup();
+    }
+  });
+
+  test('shows the running match position and total', async () => {
+    const harness = createWidget('foo foo foo');
+    try {
+      await wait(0);
+      setInputValue(harness.input, 'foo');
+      // onUpdate selects the first match, so the panel reads "1 of 3".
+      expect(harness.matchesText()).toBe('1 of 3');
+      pressKey(harness.input, 'Enter');
+      expect(harness.matchesText()).toBe('2 of 3');
+    } finally {
+      harness.cleanup();
+    }
+  });
+
+  test('shows a bare result count when no match is current', async () => {
+    const harness = createWidget('foo foo', { selectCurrent: false });
+    try {
+      await wait(0);
+      setInputValue(harness.input, 'foo');
+      expect(harness.matchesText()).toBe('2 results');
+    } finally {
+      harness.cleanup();
+    }
+  });
+
+  test('clears the matches and disables navigation for an empty query', async () => {
+    const harness = createWidget('foo foo foo');
+    try {
+      await wait(0);
+      setInputValue(harness.input, 'foo');
+      setInputValue(harness.input, '');
+
+      expect(harness.matchesText()).toBe('No results');
+      // An empty query pushes an empty match set so the editor drops its
+      // highlights, and the prev/next arrows go disabled.
+      expect(harness.updates.at(-1)).toEqual([]);
+      expect(harness.button('search-nav', 0).disabled).toBe(true);
+      expect(harness.button('search-nav', 1).disabled).toBe(true);
+    } finally {
+      harness.cleanup();
+    }
+  });
+
+  test('wraps past the last match to the first and before the first to the last', async () => {
+    const harness = createWidget('foo foo foo');
+    try {
+      await wait(0);
+      setInputValue(harness.input, 'foo'); // current = [0, 3]
+      pressKey(harness.input, 'Enter'); // -> [4, 7]
+      pressKey(harness.input, 'Enter'); // -> [8, 11]
+      pressKey(harness.input, 'Enter'); // wraps -> [0, 3]
+      expect(harness.scrolled.at(-1)).toEqual([0, 3]);
+
+      pressKey(harness.input, 'Enter', { shiftKey: true }); // wraps -> [8, 11]
+      expect(harness.scrolled.at(-1)).toEqual([8, 11]);
+    } finally {
+      harness.cleanup();
+    }
+  });
+
+  test('replace edits the current match and collapses past it', async () => {
+    const harness = createWidget('foo foo foo');
+    try {
+      await wait(0);
+      setInputValue(harness.input, 'foo'); // current = [0, 3]
+      setInputValue(harness.replaceInput, 'bar');
+      pressKey(harness.replaceInput, 'Enter');
+
+      expect(harness.applied).toEqual([[{ start: 0, end: 3, text: 'bar' }]]);
+      // The panel scrolls to a collapsed caret at the end of the replacement.
+      expect(harness.scrolled.at(-1)).toEqual([3, 3]);
+    } finally {
+      harness.cleanup();
+    }
+  });
+
+  test('replace all edits every match at once', async () => {
+    const harness = createWidget('foo foo foo');
+    try {
+      await wait(0);
+      setInputValue(harness.input, 'foo');
+      setInputValue(harness.replaceInput, 'bar');
+      harness.button('replace-actions', 1).click();
+
+      expect(harness.applied.at(-1)).toEqual([
+        { start: 0, end: 3, text: 'bar' },
+        { start: 4, end: 7, text: 'bar' },
+        { start: 8, end: 11, text: 'bar' },
+      ]);
+    } finally {
+      harness.cleanup();
+    }
+  });
+
+  test('replace does nothing when there are no matches', async () => {
+    const harness = createWidget('foo foo foo');
+    try {
+      await wait(0);
+      setInputValue(harness.input, 'zzz'); // no matches
+      setInputValue(harness.replaceInput, 'bar');
+      harness.button('replace-actions', 0).click();
+      expect(harness.applied).toEqual([]);
+    } finally {
+      harness.cleanup();
+    }
+  });
+
+  test('cmd+f and cmd+opt+f toggle the panel between find and replace modes', async () => {
+    const harness = createWidget('foo foo foo');
+    try {
+      await wait(0);
+      expect(harness.mode()).toBe('find');
+
+      pressKey(harness.input, 'f', { metaKey: true, altKey: true });
+      expect(harness.mode()).toBe('replace');
+
+      pressKey(harness.input, 'f', { metaKey: true });
+      expect(harness.mode()).toBe('find');
+
+      // setMode drives the same transition programmatically.
+      harness.widget.setMode('replace');
+      expect(harness.mode()).toBe('replace');
+    } finally {
+      harness.cleanup();
+    }
+  });
+
+  test('toggling case sensitivity re-runs the search', async () => {
+    const harness = createWidget('Foo foo');
+    try {
+      await wait(0);
+      setInputValue(harness.input, 'foo'); // case-insensitive: two matches
+      expect(harness.matchesText()).toBe('1 of 2');
+
+      const caseToggle = harness.button('search-toggles', 0);
+      expect(caseToggle.ariaPressed).toBe('false');
+      caseToggle.click();
+
+      // Case sensitivity now excludes "Foo", leaving a single match.
+      expect(caseToggle.ariaPressed).toBe('true');
+      expect(harness.matchesText()).toBe('1 of 1');
+    } finally {
+      harness.cleanup();
+    }
+  });
+
+  test('Escape closes the panel and notifies the host', async () => {
+    const harness = createWidget('foo foo foo');
+    try {
+      await wait(0);
+      const escape = pressKey(harness.input, 'Escape');
+      expect(escape.defaultPrevented).toBe(true);
+      expect(harness.isClosed()).toBe(true);
+      expect(document.querySelector('[data-search-panel]')).toBeNull();
+    } finally {
+      harness.cleanup();
     }
   });
 });

--- a/packages/diffs/test/editorSelection.test.ts
+++ b/packages/diffs/test/editorSelection.test.ts
@@ -15,18 +15,25 @@ import {
   DirectionNone,
   expandCollapsedSelectionToWord,
   extendSelection,
+  extendSelections,
   findNexMatch,
   getAutoSurroundReplacementTexts,
   getCaretPosition,
   getDocumentBoundarySelection,
+  getDocumentFullSelection,
+  getSelectedLineBlocks,
   getSelectionAnchor,
   getSelectionText,
+  isLineEditable,
   mapCursorMove,
   mapSelectionShift,
   mergeOverlappingSelections,
+  remapSelectionsAfterEdits,
   resolveDeleteCharacterRange,
   resolveIndentEdits,
+  resolveSelectionCut,
   selectionIntersects,
+  shiftSelectionLines,
 } from '../src/editor/selection';
 import { DirectionBackward } from '../src/editor/selection';
 import { TextDocument } from '../src/editor/textDocument';
@@ -2367,6 +2374,90 @@ describe('resolveIndentEdits', () => {
       createSelection(0, 0, 2, 0, DirectionForward)
     );
   });
+
+  test('indent inserts a tab when the line already starts with a tab', () => {
+    const textDocument = new TextDocument('inmemory://1', '\tfoo');
+    const selection = createSelection(0, 1, 0, 2, DirectionForward);
+    const [edits, nextSelection] = resolveIndentEdits(
+      textDocument,
+      selection,
+      4,
+      false
+    );
+
+    expect(edits).toEqual([
+      {
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 0 },
+        },
+        newText: '\t',
+      },
+    ]);
+    // Both edges shift right by the single column the inserted tab occupies.
+    expect(nextSelection).toEqual(
+      createSelection(0, 2, 0, 3, DirectionForward)
+    );
+  });
+
+  test('indent inserts soft-tab spaces and skips a trailing column-zero line', () => {
+    const textDocument = new TextDocument('inmemory://1', 'foo\nbar\nbaz');
+    // The selection ends at the very start of line 2, so line 2 is not indented.
+    const selection = createSelection(0, 0, 2, 0, DirectionForward);
+    const [edits, nextSelection] = resolveIndentEdits(
+      textDocument,
+      selection,
+      2,
+      false
+    );
+
+    expect(edits).toEqual([
+      {
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 0 },
+        },
+        newText: '  ',
+      },
+      {
+        range: {
+          start: { line: 1, character: 0 },
+          end: { line: 1, character: 0 },
+        },
+        newText: '  ',
+      },
+    ]);
+    // Only the start edge sits on an indented line, so only it shifts right.
+    expect(nextSelection).toEqual(
+      createSelection(0, 2, 2, 0, DirectionForward)
+    );
+  });
+
+  test('outdent removes only the leading spaces that exist and skips unindented lines', () => {
+    const textDocument = new TextDocument('inmemory://1', '  foo\nbaz');
+    const selection = createSelection(0, 2, 1, 3, DirectionForward);
+    const [edits, nextSelection] = resolveIndentEdits(
+      textDocument,
+      selection,
+      4,
+      true
+    );
+
+    // Line 0 has only two leading spaces (fewer than tabSize), so only those two
+    // are removed; line 1 has no indentation and produces no edit at all.
+    expect(edits).toEqual([
+      {
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 2 },
+        },
+        newText: '',
+      },
+    ]);
+    expect(nextSelection).toEqual(
+      createSelection(0, 0, 1, 3, DirectionForward)
+    );
+  });
 });
 
 describe('expandCollapsedSelectionToWord', () => {
@@ -2510,6 +2601,222 @@ describe('findNextMatch', () => {
       start: { line: 0, character: 6 },
       end: { line: 0, character: 8 },
       direction: DirectionForward,
+    });
+  });
+});
+
+describe('isLineEditable', () => {
+  test('permits editing context and addition lines only', () => {
+    expect(isLineEditable('context')).toBe(true);
+    expect(isLineEditable('context-expanded')).toBe(true);
+    expect(isLineEditable('change-addition')).toBe(true);
+    expect(isLineEditable('change-deletion')).toBe(false);
+    expect(isLineEditable('spacer')).toBe(false);
+    expect(isLineEditable('')).toBe(false);
+  });
+});
+
+describe('getDocumentFullSelection', () => {
+  test('spans from the document start to the end of the last line', () => {
+    const textDocument = new TextDocument(
+      'inmemory://1',
+      'alpha\nbravo\ncharlie'
+    );
+    expect(getDocumentFullSelection(textDocument)).toEqual(
+      createSelection(0, 0, 2, 7, DirectionForward)
+    );
+  });
+
+  test('collapses to an empty range for an empty document', () => {
+    const textDocument = new TextDocument('inmemory://1', '');
+    expect(getDocumentFullSelection(textDocument)).toEqual(
+      createSelection(0, 0, 0, 0, DirectionForward)
+    );
+  });
+});
+
+describe('getSelectedLineBlocks', () => {
+  test('drops the trailing line when a ranged selection ends at column zero', () => {
+    expect(
+      getSelectedLineBlocks([createSelection(1, 2, 3, 0, DirectionForward)])
+    ).toEqual([{ startLine: 1, endLine: 2 }]);
+  });
+
+  test('keeps the line for a collapsed caret at column zero', () => {
+    expect(getSelectedLineBlocks([createSelection(2, 0, 2, 0)])).toEqual([
+      { startLine: 2, endLine: 2 },
+    ]);
+  });
+
+  test('sorts blocks, merges adjacent ones, and keeps gaps split', () => {
+    const blocks = getSelectedLineBlocks([
+      createSelection(4, 0, 4, 3, DirectionForward),
+      createSelection(0, 0, 1, 2, DirectionForward),
+      createSelection(2, 0, 2, 1, DirectionForward),
+    ]);
+    // Lines 0-1 and line 2 are directly adjacent and merge into one block; line
+    // 4 is separated from line 2 by the gap at line 3 and stays its own block.
+    expect(blocks).toEqual([
+      { startLine: 0, endLine: 2 },
+      { startLine: 4, endLine: 4 },
+    ]);
+  });
+});
+
+describe('shiftSelectionLines', () => {
+  const lineLengths = [5, 6, 7];
+  const getLineLength = (line: number) => lineLengths[line] ?? 0;
+
+  test('moves both edges down one line and keeps their columns', () => {
+    expect(
+      shiftSelectionLines(
+        createSelection(0, 2, 0, 4, DirectionForward),
+        1,
+        3,
+        getLineLength
+      )
+    ).toEqual(createSelection(1, 2, 1, 4, DirectionForward));
+  });
+
+  test('clamps to the end of the last line when moving past the bottom', () => {
+    expect(
+      shiftSelectionLines(
+        createSelection(2, 1, 2, 3, DirectionForward),
+        1,
+        3,
+        getLineLength
+      )
+    ).toEqual(createSelection(2, 7, 2, 7, DirectionForward));
+  });
+
+  test('clamps to the document start when moving past the top', () => {
+    expect(
+      shiftSelectionLines(
+        createSelection(0, 3, 0, 5, DirectionBackward),
+        -1,
+        3,
+        getLineLength
+      )
+    ).toEqual(createSelection(0, 0, 0, 0, DirectionBackward));
+  });
+});
+
+describe('extendSelections', () => {
+  test('extends every selection to the target and merges the overlaps', () => {
+    const result = extendSelections(
+      [createSelection(0, 1, 0, 1), createSelection(0, 4, 0, 4)],
+      createSelection(0, 0, 0, 6, DirectionForward)
+    );
+    // Both carets extend their focus to column 6, so the two resulting ranges
+    // overlap and merge into a single selection.
+    expect(result).toEqual([createSelection(0, 1, 0, 6, DirectionForward)]);
+  });
+});
+
+describe('remapSelectionsAfterEdits', () => {
+  test('shifts a caret right past an earlier insertion', () => {
+    // "hello" with "XYZ" inserted at offset 0 becomes "XYZhello"; the caret that
+    // sat at offset 2 now sits at offset 5.
+    const textDocument = new TextDocument('inmemory://1', 'XYZhello');
+    const remapped = remapSelectionsAfterEdits(
+      textDocument,
+      [createSelection(0, 2, 0, 2)],
+      [[2, 2]],
+      [{ start: 0, end: 0, text: 'XYZ' }]
+    );
+    expect(remapped).toEqual([createSelection(0, 5, 0, 5)]);
+  });
+
+  test('collapses a caret inside a replaced range to the end of the replacement', () => {
+    // "abcde" with offsets [1,4) ("bcd") replaced by "XY" becomes "aXYe"; a caret
+    // that sat inside the replaced text lands just after it, at offset 3.
+    const textDocument = new TextDocument('inmemory://1', 'aXYe');
+    const remapped = remapSelectionsAfterEdits(
+      textDocument,
+      [createSelection(0, 2, 0, 2)],
+      [[2, 2]],
+      [{ start: 1, end: 4, text: 'XY' }]
+    );
+    expect(remapped).toEqual([createSelection(0, 3, 0, 3)]);
+  });
+
+  test('preserves selection direction while remapping both edges', () => {
+    // Deleting offsets [0,2) of "abcdef" leaves "cdef"; a backward selection over
+    // offsets 2..5 shifts to 0..3 and stays backward.
+    const textDocument = new TextDocument('inmemory://1', 'cdef');
+    const remapped = remapSelectionsAfterEdits(
+      textDocument,
+      [createSelection(0, 2, 0, 5, DirectionBackward)],
+      [[2, 5]],
+      [{ start: 0, end: 2, text: '' }]
+    );
+    expect(remapped).toEqual([createSelection(0, 0, 0, 3, DirectionBackward)]);
+  });
+});
+
+describe('resolveSelectionCut', () => {
+  test('cuts only the selected text for a ranged selection', () => {
+    const textDocument = new TextDocument('inmemory://1', 'hello world');
+    expect(
+      resolveSelectionCut(textDocument, [
+        createSelection(0, 0, 0, 5, DirectionForward),
+      ])
+    ).toEqual({
+      text: 'hello',
+      edits: [{ start: 0, end: 5, text: '' }],
+      nextSelectionOffsets: [0],
+    });
+  });
+
+  test('cuts a whole non-final line, including its trailing break, for a caret', () => {
+    const textDocument = new TextDocument(
+      'inmemory://1',
+      'alpha\nbravo\ncharlie'
+    );
+    expect(
+      resolveSelectionCut(textDocument, [createSelection(0, 2, 0, 2)])
+    ).toEqual({
+      text: 'alpha\n',
+      edits: [{ start: 0, end: 6, text: '' }],
+      nextSelectionOffsets: [0],
+    });
+  });
+
+  test('removes the preceding break instead of the trailing one when cutting the final line', () => {
+    const textDocument = new TextDocument('inmemory://1', 'alpha\nbravo');
+    // The clipboard text is just the line content, but the deletion also removes
+    // the newline before it so no blank line is left behind.
+    expect(
+      resolveSelectionCut(textDocument, [createSelection(1, 1, 1, 1)])
+    ).toEqual({
+      text: 'bravo',
+      edits: [{ start: 5, end: 11, text: '' }],
+      nextSelectionOffsets: [5],
+    });
+  });
+
+  test('deletes content only when the caret is on the sole line', () => {
+    const textDocument = new TextDocument('inmemory://1', 'hello');
+    expect(
+      resolveSelectionCut(textDocument, [createSelection(0, 2, 0, 2)])
+    ).toEqual({
+      text: 'hello',
+      edits: [{ start: 0, end: 5, text: '' }],
+      nextSelectionOffsets: [0],
+    });
+  });
+
+  test('merges two carets on the same line into a single deletion', () => {
+    const textDocument = new TextDocument('inmemory://1', 'alpha\nbravo');
+    expect(
+      resolveSelectionCut(textDocument, [
+        createSelection(0, 1, 0, 1),
+        createSelection(0, 3, 0, 3),
+      ])
+    ).toEqual({
+      text: 'alpha\n',
+      edits: [{ start: 0, end: 6, text: '' }],
+      nextSelectionOffsets: [0, 0],
     });
   });
 });

--- a/packages/diffs/test/editorTextDocument.test.ts
+++ b/packages/diffs/test/editorTextDocument.test.ts
@@ -184,6 +184,105 @@ describe('TextDocument', () => {
     expect(d.offsetAt({ line: 2, character: 0 })).toBe(13);
   });
 
+  test('positionsAt maps a batch of offsets to positions', () => {
+    const d = doc('ab\ncd');
+    expect(d.positionsAt([0, 1, 3, 4])).toEqual([
+      { line: 0, character: 0 },
+      { line: 0, character: 1 },
+      { line: 1, character: 0 },
+      { line: 1, character: 1 },
+    ]);
+  });
+
+  test('charAt reads a character by offset or by clamped position', () => {
+    const d = doc('ab\ncd');
+    expect(d.charAt(0)).toBe('a');
+    expect(d.charAt(4)).toBe('d');
+    expect(d.charAt({ line: 1, character: 1 })).toBe('d');
+    // A position past the end of its line is normalized before lookup; here it
+    // clamps to the end of the document, which has no character.
+    expect(d.charAt({ line: 1, character: 99 })).toBe('');
+  });
+
+  test('getTextSlice returns the substring between two offsets', () => {
+    const d = doc('hello world');
+    expect(d.getTextSlice(0, 5)).toBe('hello');
+    expect(d.getTextSlice(6, 11)).toBe('world');
+    expect(d.getTextSlice(3, 3)).toBe('');
+  });
+
+  test('search returns match ranges for the query', () => {
+    const d = doc('foo bar foo');
+    expect(
+      d.search({
+        text: 'foo',
+        replaceText: '',
+        caseSensitive: false,
+        wholeWord: false,
+        regex: false,
+      })
+    ).toEqual([
+      [0, 3],
+      [8, 11],
+    ]);
+  });
+
+  test('findNextNonOverlappingSubstring skips occupied ranges', () => {
+    const d = doc('foo foo foo');
+    // The first "foo" is occupied, so the next match starts at offset 4.
+    expect(d.findNextNonOverlappingSubstring('foo', [[0, 3]])).toBe(4);
+  });
+
+  test('eol reports the document line ending', () => {
+    expect(doc('a\nb').eol).toBe('\n');
+    expect(doc('a\r\nb').eol).toBe('\r\n');
+    expect(doc('a\rb').eol).toBe('\r');
+    // A single-line document has no break to detect and defaults to \n.
+    expect(doc('abc').eol).toBe('\n');
+  });
+
+  test('normalizeEol rewrites mixed line endings to the document EOL', () => {
+    const d = doc('a\r\nb');
+    expect(d.normalizeEol('x\ny\rz\r\nw')).toBe('x\r\ny\r\nz\r\nw');
+  });
+
+  test('normalizePosition clamps line and character into range', () => {
+    const d = doc('ab\ncd');
+    expect(d.normalizePosition({ line: 0, character: 1 })).toEqual({
+      line: 0,
+      character: 1,
+    });
+    // A character past the line content clamps to the line length, which
+    // excludes the trailing line break.
+    expect(d.normalizePosition({ line: 0, character: 99 })).toEqual({
+      line: 0,
+      character: 2,
+    });
+    // A line past the document clamps to the last line.
+    expect(d.normalizePosition({ line: 9, character: 0 })).toEqual({
+      line: 1,
+      character: 0,
+    });
+    // Negative values clamp to zero.
+    expect(d.normalizePosition({ line: -3, character: -5 })).toEqual({
+      line: 0,
+      character: 0,
+    });
+  });
+
+  test('getText clamps an overshooting range column so it excludes the line break', () => {
+    const d = doc('first\nsecond');
+    // A range end whose character overshoots the line (a preserved vertical-move
+    // goal column) clamps to the line content, so the trailing newline is not
+    // pulled into the copied text.
+    expect(
+      d.getText({
+        start: { line: 0, character: 0 },
+        end: { line: 0, character: 99 },
+      })
+    ).toBe('first');
+  });
+
   test('applyEdits single replacement', () => {
     const d = doc('hello world');
     const change = d.applyEdits([


### PR DESCRIPTION
Extends the diffs editor test suite to close public-API and pure-helper coverage gaps. The suite already covered applyEdits re-anchoring, undo/redo, move-line, clipboard, multi-cursor, brackets, and virtualized edits; this adds focused tests for the surfaces that had none.

- command.ts: search-panel (Cmd/Ctrl+F), find/replace (Opt+Cmd+F, including the Option+F dead key resolved via event.code), find-next (Cmd/Ctrl+D), and shift + doc-boundary selection-expansion shortcuts.
- selection.ts: remapSelectionsAfterEdits (the applyEdits re-anchor path, edit-boundary gravity, and a caret inside a replaced range), resolveSelectionCut, shiftSelectionLines, getSelectedLineBlocks, getDocumentFullSelection, extendSelections, isLineEditable, and the indent, partial-space outdent, and skip branches of resolveIndentEdits.
- textDocument.ts: positionsAt, charAt (offset and clamped-position overloads), getTextSlice, search, findNextNonOverlappingSubstring, the eol getter, normalizeEol, normalizePosition, and the getText goal-column clamp that strips a trailing line break.
- searchPanel.ts: the match count states, empty-query clear, forward/backward wrap, single-match and replace-all edits, the case toggle re-running the search, cmd+F / cmd+opt+F mode switching, and Escape close.
- popover.ts: choosePlacement fit/flip/hysteresis and the document-edge fallback, plus getPlacementBounds against a scroll-container ancestor, the window fallback, and the undefined cases.
- lineAnnotations.ts: the additions-only (unified, no deletions side) render path.
- editor.ts: setState(getState()) round-tripping selections, setOptions at runtime, onAttach/onFocus/onBlur, blur/focus (preventScroll and the deferred re-anchor), setMarkers([]) teardown, and historyMaxEntries plumbing.

Test-only; no product code changed.