### PR TITLE
[diffs/edit] Add persisted editor state caching

### DIFF
--- a/apps/docs/app/(diffs)/docs/CoreTypes/constants.ts
+++ b/apps/docs/app/(diffs)/docs/CoreTypes/constants.ts
@@ -27,10 +27,9 @@ interface FileContents {
   // See: https://shiki.style/languages
   lang?: SupportedLanguages;
 
-  // Optional identity for Worker Pool caching and Editor persistence.
-  // For read-only rendering, change it whenever the content, filename,
-  // language, or revision changes. With Editor.persistState, reusing a key
-  // intentionally resumes that cached editing session.
+  // Optional identity for Worker Pool caching. Required when
+  // Editor.persistState is enabled; use a unique, stable key for that editing
+  // session and reuse it only when the cached document should resume.
   cacheKey?: string;
 }
 

--- a/apps/docs/app/(diffs)/docs/CoreTypes/constants.ts
+++ b/apps/docs/app/(diffs)/docs/CoreTypes/constants.ts
@@ -27,10 +27,10 @@ interface FileContents {
   // See: https://shiki.style/languages
   lang?: SupportedLanguages;
 
-  // Optional: Cache key for AST caching in Worker Pool.
-  // When provided, rendered AST results are cached and reused.
-  // IMPORTANT: The key must change whenever the content, filename,
-  // lang, or revision changes!
+  // Optional identity for Worker Pool caching and Editor persistence.
+  // For read-only rendering, change it whenever the content, filename,
+  // language, or revision changes. With Editor.persistState, reusing a key
+  // intentionally resumes that cached editing session.
   cacheKey?: string;
 }
 
@@ -39,7 +39,7 @@ const file: FileContents = {
   // We'll attempt to detect the language based on file extension
   name: 'example.tsx',
   contents: 'export function Hello() { return <div>Hello</div>; }',
-  cacheKey: 'example-file-v1', // Must change if contents change
+  cacheKey: 'example-file-v1',
 };
 
 // With explicit language override

--- a/apps/docs/app/(diffs)/docs/CoreTypes/content.mdx
+++ b/apps/docs/app/(diffs)/docs/CoreTypes/content.mdx
@@ -17,6 +17,13 @@ does not exist. Empty file contents are still a real file; represent them with
 
 <DocsCodeExample {...fileContentsType} />
 
+For read-only rendering and Worker Pool caching, treat `cacheKey` as a revision
+identity and change it with the contents, filename, language, or revision. When
+[`Editor.persistState`](#edit-mode-persisting-file-state) is enabled, reusing a
+key instead resumes the cached editable document and editor state. Use unique,
+stable keys for editing sessions, and change the key when incoming contents
+should replace the cached document.
+
 ### FileDiffMetadata
 
 `FileDiffMetadata` represents the differences between file versions. It contains

--- a/apps/docs/app/(diffs)/docs/CoreTypes/content.mdx
+++ b/apps/docs/app/(diffs)/docs/CoreTypes/content.mdx
@@ -17,12 +17,13 @@ does not exist. Empty file contents are still a real file; represent them with
 
 <DocsCodeExample {...fileContentsType} />
 
-For read-only rendering and Worker Pool caching, treat `cacheKey` as a revision
-identity and change it with the contents, filename, language, or revision. When
-[`Editor.persistState`](#edit-mode-persisting-file-state) is enabled, reusing a
-key instead resumes the cached editable document and editor state. Use unique,
-stable keys for editing sessions, and change the key when incoming contents
-should replace the cached document.
+For read-only rendering and Worker Pool caching, `cacheKey` is optional; when
+provided, treat it as a revision identity and change it with the contents,
+filename, language, or revision. When
+[`Editor.persistState`](#edit-mode-persisting-file-state) is enabled, every
+editable file requires an explicit, non-empty `cacheKey`. Use unique, stable
+keys for editing sessions, and change the key when incoming contents should
+replace the cached document.
 
 ### FileDiffMetadata
 

--- a/apps/docs/app/(diffs)/docs/Editor/constants.ts
+++ b/apps/docs/app/(diffs)/docs/Editor/constants.ts
@@ -486,8 +486,9 @@ interface EditorOptions<LAnnotation> {
   // Max undo stack entries
   historyMaxEntries?: number;
 
-  // Preserve each File's document and editor state between renders
-  // (default: false)
+  // Preserve each File's document and editor state between renders.
+  // Requires every editable file to provide a unique, stable cacheKey.
+  // Default: false.
   persistState?: boolean;
 
   // Where serializable editor state is stored. Text documents and undo

--- a/apps/docs/app/(diffs)/docs/Editor/constants.ts
+++ b/apps/docs/app/(diffs)/docs/Editor/constants.ts
@@ -480,11 +480,20 @@ export const EDITOR_OPTIONS_TYPE: PreloadFileOptions<undefined> = {
   DiffsEditableComponent,
   FileContents,
 } from '@pierre/diffs';
-import { Editor } from '@pierre/diffs/editor';
+import { Editor, type IStateStorage } from '@pierre/diffs/editor';
 
 interface EditorOptions<LAnnotation> {
   // Max undo stack entries
   historyMaxEntries?: number;
+
+  // Preserve each File's document and editor state between renders
+  // (default: false)
+  persistState?: boolean;
+
+  // Where serializable editor state is stored. Text documents and undo
+  // history remain in this Editor instance's in-memory cache.
+  // Defaults to 'inMemory' when persistState is enabled.
+  persistStateStorage?: 'inMemory' | 'indexedDB' | IStateStorage;
 
   // Render rounded corners on selection ranges (default: true)
   roundedSelection?: boolean;

--- a/apps/docs/app/(diffs)/docs/Editor/content.mdx
+++ b/apps/docs/app/(diffs)/docs/Editor/content.mdx
@@ -99,6 +99,56 @@ Pass these when constructing `new Editor({ ... })`, or update them later with
 
 <DocsCodeExample {...editorOptionsType} />
 
+#### Persisting file state
+
+State persistence is disabled by default. Set `persistState: true` to preserve
+an editable `File`'s text document, undo history, selections, and scroll
+position when the attached file renders a different file and later returns. This
+currently applies to `File` and `VirtualizedFile` surfaces; diff surfaces do not
+use the persistence cache.
+
+Files are identified by `file.cacheKey ?? file.name`. Use a unique `cacheKey`
+when filenames may collide. Reuse the same key when a rename or move should
+resume the same editing session; change it when new incoming contents should
+start a fresh document.
+
+```ts
+import type { EditorState, FileContents } from '@pierre/diffs';
+import { Editor, type IStateStorage } from '@pierre/diffs/editor';
+
+const editor = new Editor({
+  persistState: true,
+  persistStateStorage: 'inMemory',
+});
+
+const file: FileContents = {
+  name: 'src/example.ts',
+  contents: 'export const value = 1;',
+  cacheKey: 'workspace-file-1',
+};
+
+// Custom storage may be synchronous or asynchronous.
+const states = new Map<string, EditorState>();
+const customStorage: IStateStorage = {
+  get(cacheKey) {
+    return states.get(cacheKey);
+  },
+  set(cacheKey, state) {
+    states.set(cacheKey, state);
+  },
+};
+
+const editorWithCustomStorage = new Editor({
+  persistState: true,
+  persistStateStorage: customStorage,
+});
+```
+
+`persistStateStorage` accepts `'inMemory'`, `'indexedDB'`, or an `IStateStorage`
+implementation. It defaults to `'inMemory'`. Text documents and undo history
+remain scoped to the `Editor` instance; IndexedDB and custom storage persist
+only the serializable editor state (`selections` and `view`).
+
 ### API Reference
 
 These methods are available on an `Editor` instance. Attach it to a rendered

--- a/apps/docs/app/(diffs)/docs/Editor/content.mdx
+++ b/apps/docs/app/(diffs)/docs/Editor/content.mdx
@@ -107,10 +107,12 @@ position when the attached file renders a different file and later returns. This
 currently applies to `File` and `VirtualizedFile` surfaces; diff surfaces do not
 use the persistence cache.
 
-Files are identified by `file.cacheKey ?? file.name`. Use a unique `cacheKey`
-when filenames may collide. Reuse the same key when a rename or move should
-resume the same editing session; change it when new incoming contents should
-start a fresh document.
+Every editable file must provide an explicit, non-empty `file.cacheKey` while
+`persistState` is enabled. The editor throws if it encounters an unkeyed file;
+it does not fall back to `file.name`. Cache keys must be unique and stable
+within the persistence storage namespace. Reuse the same key when a rename or
+move should resume the same editing session; change it when new incoming
+contents should start a fresh document.
 
 ```ts
 import type { EditorState, FileContents } from '@pierre/diffs';

--- a/apps/docs/app/(trees)/_components/DemoTreeApp.tsx
+++ b/apps/docs/app/(trees)/_components/DemoTreeApp.tsx
@@ -1,3 +1,4 @@
+import type { FileContents } from '@pierre/diffs';
 import { preloadFile } from '@pierre/diffs/ssr';
 import { FILE_TREE_DENSITY_PRESETS } from '@pierre/trees';
 import { preloadFileTree } from '@pierre/trees/ssr';
@@ -30,6 +31,16 @@ const TREE_APP_LIGHT_FILE_OPTIONS = {
   themeType: 'light',
 } as const;
 
+// Initial paths are unique and survive moves because every file remap spreads
+// the existing value. Use them as stable editor identities for this demo.
+const TREE_APP_EDITOR_FILES: Readonly<Record<string, FileContents>> =
+  Object.fromEntries(
+    Object.entries(TREE_APP_DEMO_FILES).map(
+      ([path, file]) =>
+        [path, { ...file, cacheKey: file.cacheKey ?? path }] as const
+    )
+  );
+
 export async function DemoTreeApp() {
   const treePreloadedData = preloadFileTree({
     dragAndDrop: true,
@@ -54,7 +65,7 @@ export async function DemoTreeApp() {
   // fall back to an on-the-fly highlighter pass. Each file produces two
   // results, so we run them all in a single Promise.all to minimize latency.
   const preloadedEntries = await Promise.all(
-    Object.entries(TREE_APP_DEMO_FILES).map(async ([path, file]) => {
+    Object.entries(TREE_APP_EDITOR_FILES).map(async ([path, file]) => {
       const [darkResult, lightResult] = await Promise.all([
         preloadFile({ file, options: TREE_APP_DARK_FILE_OPTIONS }),
         preloadFile({ file, options: TREE_APP_LIGHT_FILE_OPTIONS }),
@@ -81,7 +92,7 @@ export async function DemoTreeApp() {
 
   return (
     <DemoTreeAppClient
-      files={TREE_APP_DEMO_FILES}
+      files={TREE_APP_EDITOR_FILES}
       initialActivePath={TREE_APP_DEMO_INITIAL_ACTIVE_PATH}
       initialExpandedPaths={TREE_APP_DEMO_INITIAL_EXPANDED_PATHS}
       paths={TREE_APP_DEMO_PATHS}

--- a/apps/docs/app/(trees)/_components/TreeApp.tsx
+++ b/apps/docs/app/(trees)/_components/TreeApp.tsx
@@ -203,7 +203,7 @@ export interface TreeAppProps<LAnnotation = unknown> {
   // HTML map and the file options may be scoped per theme so the active File
   // picks up the right syntax-highlight colors when the theme toggles. Give
   // files unique, rename-stable cacheKeys so persisted editor state follows
-  // moves; without one, Editor falls back to the file name.
+  // moves; without one, TreeApp uses the current path.
   files?: Readonly<Record<string, FileContents>>;
   prerenderedHTMLByPath?: TreeAppThemeValue<Readonly<Record<string, string>>>;
   fileOptions?: TreeAppThemeValue<FileOptions<LAnnotation>>;
@@ -1656,6 +1656,15 @@ export function TreeApp<LAnnotation = unknown>({
     activePath != null && usesLocalFile
       ? (editedFilesByPath[activePath] ?? activeHostFile)
       : activeHostFile;
+  // File names are commonly only basenames, so use the unique tree path as
+  // the persistence identity unless the caller supplied a stable cache key.
+  const activeEditorFile = useMemo(
+    () =>
+      activeFile == null || activePath == null || activeFile.cacheKey != null
+        ? activeFile
+        : { ...activeFile, cacheKey: activePath },
+    [activeFile, activePath]
+  );
   // Skip stale prerendered HTML while the editor is showing local contents.
   const activePrerenderedHTML =
     activePath == null || usesLocalFile
@@ -1879,7 +1888,7 @@ export function TreeApp<LAnnotation = unknown>({
                     width: '100%',
                   }}
                 >
-                  {activeFile == null ? (
+                  {activeEditorFile == null ? (
                     (renderEmpty?.() ?? <DefaultEmpty theme={theme} />)
                   ) : (
                     <File
@@ -1888,7 +1897,7 @@ export function TreeApp<LAnnotation = unknown>({
                         flex: '1 1 auto',
                         minWidth: '100%',
                       }}
-                      file={activeFile}
+                      file={activeEditorFile}
                       options={fileOptions}
                       prerenderedHTML={activePrerenderedHTML}
                       contentEditable

--- a/apps/docs/app/(trees)/_components/TreeApp.tsx
+++ b/apps/docs/app/(trees)/_components/TreeApp.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { EditorState, FileContents, FileOptions } from '@pierre/diffs';
+import type { FileContents, FileOptions } from '@pierre/diffs';
 import { Editor } from '@pierre/diffs/editor';
 import { EditProvider, File, Virtualizer } from '@pierre/diffs/react';
 import {
@@ -201,7 +201,9 @@ export interface TreeAppProps<LAnnotation = unknown> {
   // Editor side: files keyed by their tree path. Mirrors the
   // preloadedDataById pattern already used by tree demos. Both the prerendered
   // HTML map and the file options may be scoped per theme so the active File
-  // picks up the right syntax-highlight colors when the theme toggles.
+  // picks up the right syntax-highlight colors when the theme toggles. Give
+  // files unique, rename-stable cacheKeys so persisted editor state follows
+  // moves; without one, Editor falls back to the file name.
   files?: Readonly<Record<string, FileContents>>;
   prerenderedHTMLByPath?: TreeAppThemeValue<Readonly<Record<string, string>>>;
   fileOptions?: TreeAppThemeValue<FileOptions<LAnnotation>>;
@@ -292,7 +294,7 @@ function getParentPath(path: string): string {
     : `${normalizedPath.slice(0, lastSlashIndex + 1)}`;
 }
 
-// Remaps one path after a tree move so open tabs and editor state keep
+// Remaps one path after a tree move so open tabs and path-keyed state keep
 // following the same file or directory even when its parent folder changes.
 function remapMovedPath(
   path: string,
@@ -303,12 +305,13 @@ function remapMovedPath(
     return toPath;
   }
 
-  const descendantPrefix = `${fromPath}/`;
+  const descendantPrefix = fromPath.endsWith('/') ? fromPath : `${fromPath}/`;
   if (!path.startsWith(descendantPrefix)) {
     return path;
   }
 
-  return `${toPath}${path.slice(fromPath.length)}`;
+  const destinationPrefix = toPath.endsWith('/') ? toPath : `${toPath}/`;
+  return `${destinationPrefix}${path.slice(descendantPrefix.length)}`;
 }
 
 function remapMovedPaths(
@@ -614,9 +617,6 @@ interface UseOpenTabsOptions {
   // are discarded the moment the viewport flips to mobile.
   isMobile?: boolean;
   model: FileTreeModel;
-  // Fired immediately before `activePath` changes so the host can snapshot
-  // editor scroll/selection via getState before the editable File remounts.
-  onBeforeActivePathChange?: () => void;
 }
 
 interface UseOpenTabsResult {
@@ -634,7 +634,6 @@ function useOpenTabs({
   initialOpenPaths,
   isMobile = false,
   model,
-  onBeforeActivePathChange,
 }: UseOpenTabsOptions): UseOpenTabsResult {
   const [openPaths, setOpenPaths] = useState<readonly string[]>(() => {
     const seed = initialOpenPaths ?? [];
@@ -651,29 +650,6 @@ function useOpenTabs({
     initialActivePath ?? null
   );
   const selectedPaths = useFileTreeSelection(model);
-  const onBeforeActivePathChangeRef = useRef(onBeforeActivePathChange);
-  onBeforeActivePathChangeRef.current = onBeforeActivePathChange;
-  // Mirrors `activePath` for changeActivePath so path transitions can snapshot
-  // editor state without putting side effects inside a setState updater.
-  const activePathRefForTabs = useRef<string | null>(activePath);
-  activePathRefForTabs.current = activePath;
-
-  // Snapshot editor state, then update activePath. Reads the live path from
-  // activePathRefForTabs so we never put side effects inside a setState
-  // updater. Skips the callback when the path is unchanged.
-  const changeActivePath = useCallback(
-    (nextPath: string | null | ((current: string | null) => string | null)) => {
-      const current = activePathRefForTabs.current;
-      const resolved =
-        typeof nextPath === 'function' ? nextPath(current) : nextPath;
-      if (resolved !== current) {
-        onBeforeActivePathChangeRef.current?.();
-      }
-      activePathRefForTabs.current = resolved;
-      setActivePath(resolved);
-    },
-    []
-  );
 
   // Track which selected paths we have already turned into tabs so a re-render
   // does not re-open a tab the user just closed.
@@ -706,10 +682,10 @@ function useOpenTabs({
         }
         return current.includes(candidate) ? current : [...current, candidate];
       });
-      changeActivePath(candidate);
+      setActivePath(candidate);
       break;
     }
-  }, [changeActivePath, isMobile, model, selectedPaths]);
+  }, [isMobile, model, selectedPaths]);
 
   // When the viewport flips into mobile, drop any extra tabs from a previous
   // desktop session so only the active file remains. We never re-expand the
@@ -742,11 +718,9 @@ function useOpenTabs({
         return nextOpen;
       });
 
-      // Resolve the next active tab outside setState so changeActivePath can
-      // snapshot editor state before the remount without nesting updaters.
       const currentOpen = openPaths;
       const nextOpen = currentOpen.filter((entry) => entry !== path);
-      changeActivePath((currentActive) => {
+      setActivePath((currentActive) => {
         if (currentActive !== path) {
           return currentActive;
         }
@@ -758,15 +732,12 @@ function useOpenTabs({
         return nextOpen[fallbackIndex] ?? null;
       });
     },
-    [activePath, changeActivePath, model, openPaths]
+    [activePath, model, openPaths]
   );
 
-  const activateTab = useCallback(
-    (path: string) => {
-      changeActivePath(path);
-    },
-    [changeActivePath]
-  );
+  const activateTab = useCallback((path: string) => {
+    setActivePath(path);
+  }, []);
 
   useEffect(() => {
     if (activePath == null) {
@@ -814,7 +785,7 @@ function useOpenTabs({
           }
           return nextPaths;
         });
-        changeActivePath((current) => {
+        setActivePath((current) => {
           if (current == null) {
             return current;
           }
@@ -826,7 +797,7 @@ function useOpenTabs({
           return nextPath;
         });
       }),
-    [changeActivePath, model]
+    [model]
   );
 
   return { activePath, activateTab, closeTab, openPaths };
@@ -1202,10 +1173,6 @@ export function TreeApp<LAnnotation = unknown>({
   const theme = themeProp ?? internalTheme;
   const chrome = CHROME_STYLES[theme];
 
-  // Per-path scroll + selection snapshots. The editable File remounts on
-  // path/theme changes (keyed below), so we getState before the remount and
-  // setState from onAttach once the new editor is attached.
-  const editorStateByPathRef = useRef(new Map<string, EditorState>());
   const activePathRef = useRef<string | null>(initialActivePath ?? null);
   // Edited buffers keyed by path. Prefer these over the caller-supplied `files`
   // map so tab switches keep unsaved text without requiring the host to own
@@ -1233,37 +1200,21 @@ export function TreeApp<LAnnotation = unknown>({
   unsavedPathsRef.current = unsavedPaths;
   const containerRef = useRef<HTMLDivElement | null>(null);
 
-  // Keep attach/change handlers fresh without recreating the Editor. The
+  // Keep the change handler fresh without recreating the Editor. The
   // shared instance must stay stable across tab/theme switches so EditProvider
   // does not clean it up between remounts of the keyed File.
-  const handleEditorAttachRef = useRef<(editor: Editor<LAnnotation>) => void>(
-    () => {}
-  );
   const handleEditorChangeRef = useRef<(file: FileContents) => void>(() => {});
   const editor = useMemo(
     () =>
       new Editor<LAnnotation>({
-        onAttach(nextEditor) {
-          handleEditorAttachRef.current(nextEditor);
-        },
+        persistState: true,
+        persistStateStorage: 'inMemory',
         onChange(file) {
           handleEditorChangeRef.current(file);
         },
       }),
     []
   );
-
-  const saveActiveEditorState = useCallback(() => {
-    const path = activePathRef.current;
-    if (path == null) {
-      return;
-    }
-    try {
-      editorStateByPathRef.current.set(path, editor.getState());
-    } catch {
-      // Editor may already be detached mid-unmount; skip the snapshot.
-    }
-  }, [editor]);
 
   // Marks a path unsaved (or clean). Snapshots edited contents so tab switches
   // keep the dirty buffer.
@@ -1308,15 +1259,12 @@ export function TreeApp<LAnnotation = unknown>({
   );
 
   const toggleTheme = useCallback(() => {
-    // Theme remounts the editable File (keyed by path:theme); snapshot first
-    // so the restored editor keeps scroll/selection after the palette flip.
-    saveActiveEditorState();
     const nextTheme: TreeAppTheme = theme === 'dark' ? 'light' : 'dark';
     if (themeProp == null) {
       setInternalTheme(nextTheme);
     }
     onThemeChange?.(nextTheme);
-  }, [onThemeChange, saveActiveEditorState, theme, themeProp]);
+  }, [onThemeChange, theme, themeProp]);
 
   // Resolve the theme-scoped inputs once. The caller can pass either a plain
   // value or a `{ light, dark }` pair; `pickByTheme` returns the right one.
@@ -1468,7 +1416,6 @@ export function TreeApp<LAnnotation = unknown>({
     initialOpenPaths,
     isMobile,
     model,
-    onBeforeActivePathChange: saveActiveEditorState,
   });
   activePathRef.current = activePath;
 
@@ -1484,16 +1431,6 @@ export function TreeApp<LAnnotation = unknown>({
         if (moveEvents.length === 0) {
           return;
         }
-
-        let nextStateByPath = editorStateByPathRef.current;
-        for (const moveEvent of moveEvents) {
-          nextStateByPath = remapPathMap(
-            nextStateByPath,
-            moveEvent.from,
-            moveEvent.to
-          );
-        }
-        editorStateByPathRef.current = nextStateByPath;
 
         let nextHostFilesAtSave = hostFilesAtSaveByPathRef.current;
         for (const moveEvent of moveEvents) {
@@ -1531,18 +1468,6 @@ export function TreeApp<LAnnotation = unknown>({
     [model]
   );
 
-  const handleEditorAttach = useCallback((nextEditor: Editor<LAnnotation>) => {
-    const path = activePathRef.current;
-    if (path == null) {
-      return;
-    }
-    const saved = editorStateByPathRef.current.get(path);
-    if (saved == null) {
-      return;
-    }
-    nextEditor.setState(saved);
-  }, []);
-  handleEditorAttachRef.current = handleEditorAttach;
   handleEditorChangeRef.current = handleEditorChange;
 
   const mutations = useTreeMutations({
@@ -1942,8 +1867,8 @@ export function TreeApp<LAnnotation = unknown>({
               {/* Key File by path+theme so prerendered HTML (theme-specific
                   syntax colors) remounts cleanly when the toggle flips.
                   Keep EditProvider stable so the shared Editor is not cleaned
-                  up between tab/theme switches. Scroll/selection restore via
-                  getState/setState in onAttach. */}
+                  up between tab/theme switches. Editor persistence restores
+                  the cached document and view state. */}
               <EditProvider editor={editor}>
                 <Virtualizer
                   className="relative min-h-0 min-w-0 flex-1 overflow-auto"

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -608,7 +608,9 @@ export class File<
       (lineAnnotations.length > 0 || this.lineAnnotations.length > 0)
         ? lineAnnotations !== this.lineAnnotations
         : false;
-    const didFileChange = !areFilesEqual(this.file, file);
+    const didFileChange =
+      !areFilesEqual(this.file, file) ||
+      this.fileRenderer.hasUnkeyedFileContentsChanged(file);
     if (
       !collapsed &&
       !forceRender &&

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -524,7 +524,18 @@ export class File<
     this.editor?.cleanUp();
     this.editor = editor;
     this.interactionManager.setEditorAttached(true);
-    this.syncRenderViewToEditor();
+    const preparedFile =
+      this.file == null ? undefined : editor.__prepareFile?.(this.file);
+    if (preparedFile !== undefined && preparedFile !== this.file) {
+      this.render({
+        file: preparedFile,
+        forceRender: true,
+        preventEmit: true,
+        renderRange: this.renderRange,
+      });
+    } else {
+      this.syncRenderViewToEditor();
+    }
     return () => {
       this.editor = undefined;
       this.interactionManager.setEditorAttached(false);
@@ -571,10 +582,10 @@ export class File<
       );
     }
 
+    file = this.editor?.__prepareFile?.(file) ?? file;
+
     // use the file name as the cache key if it is not set
-    if (file.cacheKey === undefined) {
-      file.cacheKey = file.name;
-    }
+    file.cacheKey ??= file.name;
 
     // postpone background tokenizing to next frame for avoiding UI freeze
     // during render

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -527,7 +527,7 @@ export class File<
     const preparedFile =
       this.file == null ? undefined : editor.__prepareFile?.(this.file);
     if (preparedFile !== undefined && preparedFile !== this.file) {
-      this.render({
+      this.renderPreparedFile({
         file: preparedFile,
         forceRender: true,
         preventEmit: true,
@@ -566,7 +566,22 @@ export class File<
     this.fileRenderer.updateRenderCache(dirtyLines, themeType);
   }
 
-  public render({
+  public render(props: FileRenderProps<LAnnotation>): boolean {
+    if (!this.enabled) {
+      throw new Error(
+        'File.render: attempting to call render after cleaned up'
+      );
+    }
+
+    const file = this.editor?.__prepareFile?.(props.file) ?? props.file;
+    return this.renderPreparedFile(
+      file === props.file ? props : { ...props, file }
+    );
+  }
+
+  // Renders a file whose persisted document has already been restored. The
+  // virtualized subclass overrides this phase so layout uses the same file.
+  protected renderPreparedFile({
     file,
     fileContainer,
     forceRender = false,
@@ -576,14 +591,6 @@ export class File<
     lineAnnotations,
     renderRange,
   }: FileRenderProps<LAnnotation>): boolean {
-    if (!this.enabled) {
-      throw new Error(
-        'File.render: attempting to call render after cleaned up'
-      );
-    }
-
-    file = this.editor?.__prepareFile?.(file) ?? file;
-
     // use the file name as the cache key if it is not set
     file.cacheKey ??= file.name;
 

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -209,6 +209,10 @@ export class File<
     });
   }
 
+  public __getCurrentFile(): FileContents | undefined {
+    return this.file;
+  }
+
   public onThemeChange(): void {
     this.fileRenderer.clearRenderCache();
     this.rerender();
@@ -591,9 +595,6 @@ export class File<
     lineAnnotations,
     renderRange,
   }: FileRenderProps<LAnnotation>): boolean {
-    // use the file name as the cache key if it is not set
-    file.cacheKey ??= file.name;
-
     // postpone background tokenizing to next frame for avoiding UI freeze
     // during render
     this.editor?.__postponeBgTokenizeToNextFrame();

--- a/packages/diffs/src/components/VirtualizedFile.ts
+++ b/packages/diffs/src/components/VirtualizedFile.ts
@@ -317,8 +317,12 @@ export class VirtualizedFile<
     lineAnnotations?: LineAnnotation<LAnnotation>[]
   ): number {
     const annotationsChanged = this.syncLineAnnotations(lineAnnotations);
+    const unkeyedContentsChanged =
+      this.fileRenderer.hasUnkeyedFileContentsChanged(file);
     let shouldResetLayoutCache =
-      reset?.resetFileLayoutCache === true || annotationsChanged;
+      reset?.resetFileLayoutCache === true ||
+      annotationsChanged ||
+      unkeyedContentsChanged;
     if (reset?.metrics != null) {
       this.metrics = reset.metrics;
       shouldResetLayoutCache = true;
@@ -668,7 +672,10 @@ export class VirtualizedFile<
     lineAnnotations,
     ...props
   }: FileRenderProps<LAnnotation>): boolean {
-    const didFileChange = this.file == null || !areFilesEqual(this.file, file);
+    const didFileChange =
+      this.file == null ||
+      !areFilesEqual(this.file, file) ||
+      this.fileRenderer.hasUnkeyedFileContentsChanged(file);
     const { forceRenderOverride, isSetup } = this;
     this.forceRenderOverride = undefined;
     const annotationsChanged = this.syncLineAnnotations(lineAnnotations);

--- a/packages/diffs/src/components/VirtualizedFile.ts
+++ b/packages/diffs/src/components/VirtualizedFile.ts
@@ -661,7 +661,7 @@ export class VirtualizedFile<
     }
   }
 
-  override render({
+  protected override renderPreparedFile({
     fileContainer,
     file,
     forceRender = false,
@@ -725,7 +725,7 @@ export class VirtualizedFile<
       fileTop,
       windowSpecs
     );
-    const rendered = super.render({
+    const rendered = super.renderPreparedFile({
       file: this.file,
       fileContainer,
       renderRange,

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -146,10 +146,15 @@ function getShadowRootRange(shadowRoot: ShadowRoot): StaticRange | undefined {
   };
 }
 
-function getPersistedCacheKey(
+function requirePersistedCacheKey(
   file: Pick<FileContents, 'cacheKey' | 'name'>
 ): string {
-  return file.cacheKey ?? file.name;
+  if (typeof file.cacheKey !== 'string' || file.cacheKey.length === 0) {
+    throw new Error(
+      `Editor persistState requires a non-empty file.cacheKey for "${file.name}". Provide a unique, stable cacheKey for every editable file.`
+    );
+  }
+  return file.cacheKey;
 }
 
 function isPromise<T>(value: T | Promise<T>): value is Promise<T> {
@@ -164,7 +169,10 @@ function isPromise<T>(value: T | Promise<T>): value is Promise<T> {
 export interface EditorOptions<LAnnotation> {
   /** The maximum number of entries to keep in the undo stack. */
   historyMaxEntries?: number;
-  /** Preserve each file's document and editor state when switching files. */
+  /**
+   * Preserve each file's document and editor state when switching files.
+   * Every editable file must provide a unique, stable `cacheKey`.
+   */
   persistState?: boolean;
   /**
    * Storage for serializable editor state. Text documents stay in this Editor's
@@ -362,10 +370,20 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   setOptions(options: EditorOptions<LAnnotation>): void {
     const previousStorageOption =
       this.#options.persistStateStorage ?? 'inMemory';
-    this.#options = {
+    const nextOptions = {
       ...this.#options,
       ...options,
     };
+    if (
+      nextOptions.persistState === true &&
+      this.#fileInstance?.type === 'file'
+    ) {
+      const file = this.#fileInstance.__getCurrentFile?.() ?? this.#fileInfo;
+      if (file !== undefined) {
+        requirePersistedCacheKey(file);
+      }
+    }
+    this.#options = nextOptions;
     if (this.#options.persistState !== true) {
       this.#textDocumentCache.clear();
       this.#stateRestoreGeneration++;
@@ -383,6 +401,12 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   }
 
   edit(fileInstance: DiffsEditableComponent<LAnnotation>): () => void {
+    if (this.#options.persistState === true && fileInstance.type === 'file') {
+      const file = fileInstance.__getCurrentFile?.();
+      if (file !== undefined) {
+        requirePersistedCacheKey(file);
+      }
+    }
     const {
       useTokenTransformer,
       enableGutterUtility,
@@ -716,18 +740,19 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       return file;
     }
 
+    const cacheKey = requirePersistedCacheKey(file);
     const fileInfo = this.#fileInfo;
     const languageId = file.lang ?? getFiletypeFromFileName(file.name);
     if (
       fileInfo !== undefined &&
-      (getPersistedCacheKey(fileInfo) !== getPersistedCacheKey(file) ||
+      (requirePersistedCacheKey(fileInfo) !== cacheKey ||
         fileInfo.name !== file.name ||
         this.#textDocument?.languageId !== languageId)
     ) {
       this.#stateRestoreGeneration++;
       this.#persistCurrentState();
     }
-    const textDocument = this.#getCachedTextDocument(file);
+    const textDocument = this.#getCachedTextDocument(file, cacheKey);
     if (
       textDocument === undefined ||
       textDocument.getText() === file.contents
@@ -816,6 +841,9 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       this.#fileInfo.name !== fileOrDiff.name ||
       this.#fileInfo.lang !== fileOrDiff.lang ||
       this.#fileInfo.cacheKey !== fileOrDiff.cacheKey;
+    const persistedCacheKey = this.#isStatePersistenceEnabled
+      ? requirePersistedCacheKey(fileOrDiff)
+      : undefined;
 
     let persistedStateTarget:
       | { cacheKey: string; textDocument: TextDocument<LAnnotation> }
@@ -833,16 +861,16 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       });
       const { name, lang, cacheKey } = fileOrDiff;
       const languageId = lang ?? getFiletypeFromFileName(fileOrDiff.name);
-      const persistedCacheKey = getPersistedCacheKey(fileOrDiff);
-      const cachedTextDocument = this.#isStatePersistenceEnabled
-        ? this.#getCachedTextDocument(fileOrDiff)
-        : undefined;
+      const cachedTextDocument =
+        persistedCacheKey !== undefined
+          ? this.#getCachedTextDocument(fileOrDiff, persistedCacheKey)
+          : undefined;
       const textDocument =
         cachedTextDocument ??
         new TextDocument(fileOrDiff.name, contents, languageId, 0, editStack);
       this.#fileInfo = { name, lang, cacheKey };
       this.#textDocument = textDocument;
-      if (this.#isStatePersistenceEnabled) {
+      if (persistedCacheKey !== undefined) {
         this.#textDocumentCache.set(persistedCacheKey, textDocument);
         persistedStateTarget = {
           cacheKey: persistedCacheKey,
@@ -867,11 +895,11 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     if (
       persistedStateTarget === undefined &&
       this.#restoreStateOnNextSync &&
-      this.#isStatePersistenceEnabled &&
+      persistedCacheKey !== undefined &&
       this.#textDocument !== undefined
     ) {
       persistedStateTarget = {
-        cacheKey: getPersistedCacheKey(fileOrDiff),
+        cacheKey: persistedCacheKey,
         textDocument: this.#textDocument,
       };
     }
@@ -1033,11 +1061,10 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   }
 
   #getCachedTextDocument(
-    file: FileContents | FileDiffMetadata
+    file: FileContents | FileDiffMetadata,
+    cacheKey: string
   ): TextDocument<LAnnotation> | undefined {
-    const textDocument = this.#textDocumentCache.get(
-      getPersistedCacheKey(file)
-    );
+    const textDocument = this.#textDocumentCache.get(cacheKey);
     const languageId = file.lang ?? getFiletypeFromFileName(file.name);
     return textDocument?.languageId === languageId ? textDocument : undefined;
   }
@@ -1065,7 +1092,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       return;
     }
 
-    const cacheKey = getPersistedCacheKey(fileInfo);
+    const cacheKey = requirePersistedCacheKey(fileInfo);
     this.#textDocumentCache.set(cacheKey, textDocument);
 
     let storage: IStateStorage;
@@ -1158,7 +1185,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         currentView?.scrollLeft !== view?.scrollLeft ||
         currentView?.scrollTop !== view?.scrollTop ||
         this.#fileInfo === undefined ||
-        getPersistedCacheKey(this.#fileInfo) !== cacheKey
+        requirePersistedCacheKey(this.#fileInfo) !== cacheKey
       ) {
         return;
       }

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -94,6 +94,12 @@ import {
 } from './selectionAction';
 import { createSpriteElement } from './sprite';
 import {
+  cloneEditorState,
+  createStateStorage,
+  type IStateStorage,
+  type PersistStateStorage,
+} from './stateStorage';
+import {
   type ResolvedTextEdit,
   TextDocument,
   type TextDocumentChange,
@@ -140,9 +146,31 @@ function getShadowRootRange(shadowRoot: ShadowRoot): StaticRange | undefined {
   };
 }
 
+function getPersistedCacheKey(
+  file: Pick<FileContents, 'cacheKey' | 'name'>
+): string {
+  return file.cacheKey ?? file.name;
+}
+
+function isPromise<T>(value: T | Promise<T>): value is Promise<T> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'then' in value &&
+    typeof value.then === 'function'
+  );
+}
+
 export interface EditorOptions<LAnnotation> {
   /** The maximum number of entries to keep in the undo stack. */
   historyMaxEntries?: number;
+  /** Preserve each file's document and editor state when switching files. */
+  persistState?: boolean;
+  /**
+   * Storage for serializable editor state. Text documents stay in this Editor's
+   * in-memory cache. Defaults to `"inMemory"`.
+   */
+  persistStateStorage?: PersistStateStorage;
   /** Render rounded corners for selection ranges, default is true. */
   roundedSelection?: boolean;
   /** Highlight matching brackets near the caret, default is true. */
@@ -200,6 +228,20 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   #metrics = new Metrics();
   #tokenizer?: EditorTokenizer;
   #popoverManager?: PopoverManager;
+  #textDocumentCache = new Map<string, TextDocument<LAnnotation>>();
+  #stateStorage?: IStateStorage;
+  #stateStorageOption?: PersistStateStorage;
+  #pendingStateWrites = new Map<string, Promise<void>>();
+  #pendingStateRestore?: {
+    cacheKey: string;
+    textDocument: TextDocument<LAnnotation>;
+    documentVersion: number;
+    selections: EditorSelection[] | undefined;
+    view: EditorState['view'];
+    completion: Promise<void>;
+  };
+  #stateRestoreGeneration = 0;
+  #restoreStateOnNextSync = false;
 
   // event disposes
   #editorEventDisposes?: (() => void)[];
@@ -318,10 +360,26 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   }
 
   setOptions(options: EditorOptions<LAnnotation>): void {
+    const previousStorageOption =
+      this.#options.persistStateStorage ?? 'inMemory';
     this.#options = {
       ...this.#options,
       ...options,
     };
+    if (this.#options.persistState !== true) {
+      this.#textDocumentCache.clear();
+      this.#stateRestoreGeneration++;
+      this.#restoreStateOnNextSync = false;
+    }
+    if (
+      (this.#options.persistStateStorage ?? 'inMemory') !==
+      previousStorageOption
+    ) {
+      this.#stateRestoreGeneration++;
+      this.#stateStorage = undefined;
+      this.#stateStorageOption = undefined;
+      this.#pendingStateWrites.clear();
+    }
   }
 
   edit(fileInstance: DiffsEditableComponent<LAnnotation>): () => void {
@@ -580,6 +638,10 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   }
 
   cleanUp(recycle = false): void {
+    const shouldRestoreState = this.#isStatePersistenceEnabled;
+    this.#stateRestoreGeneration++;
+    this.#persistCurrentState();
+    this.#restoreStateOnNextSync = shouldRestoreState;
     dequeueRender(this.#handleCustomPasteEvent);
     // The tokenizer is destroyed in both modes: it holds highlighter/worker
     // resources and writes into the (removed below) theme style element.
@@ -646,6 +708,33 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     }
 
     this.#resetState();
+  }
+
+  /** @internal Capture outgoing state and substitute cached text before render. */
+  __prepareFile(file: FileContents): FileContents {
+    if (this.#options.persistState !== true) {
+      return file;
+    }
+
+    const fileInfo = this.#fileInfo;
+    const languageId = file.lang ?? getFiletypeFromFileName(file.name);
+    if (
+      fileInfo !== undefined &&
+      (getPersistedCacheKey(fileInfo) !== getPersistedCacheKey(file) ||
+        fileInfo.name !== file.name ||
+        this.#textDocument?.languageId !== languageId)
+    ) {
+      this.#stateRestoreGeneration++;
+      this.#persistCurrentState();
+    }
+    const textDocument = this.#getCachedTextDocument(file);
+    if (
+      textDocument === undefined ||
+      textDocument.getText() === file.contents
+    ) {
+      return file;
+    }
+    return { ...file, contents: textDocument.getText() };
   }
 
   /** @internal */
@@ -728,6 +817,10 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       this.#fileInfo.lang !== fileOrDiff.lang ||
       this.#fileInfo.cacheKey !== fileOrDiff.cacheKey;
 
+    let persistedStateTarget:
+      | { cacheKey: string; textDocument: TextDocument<LAnnotation> }
+      | undefined;
+
     if (shouldRebuildDocument) {
       let contents = '';
       if ('contents' in fileOrDiff) {
@@ -740,15 +833,22 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       });
       const { name, lang, cacheKey } = fileOrDiff;
       const languageId = lang ?? getFiletypeFromFileName(fileOrDiff.name);
-      const textDocument = new TextDocument(
-        fileOrDiff.name,
-        contents,
-        languageId,
-        0,
-        editStack
-      );
+      const persistedCacheKey = getPersistedCacheKey(fileOrDiff);
+      const cachedTextDocument = this.#isStatePersistenceEnabled
+        ? this.#getCachedTextDocument(fileOrDiff)
+        : undefined;
+      const textDocument =
+        cachedTextDocument ??
+        new TextDocument(fileOrDiff.name, contents, languageId, 0, editStack);
       this.#fileInfo = { name, lang, cacheKey };
       this.#textDocument = textDocument;
+      if (this.#isStatePersistenceEnabled) {
+        this.#textDocumentCache.set(persistedCacheKey, textDocument);
+        persistedStateTarget = {
+          cacheKey: persistedCacheKey,
+          textDocument,
+        };
+      }
       this.#tokenizer?.cleanUp();
       this.#tokenizer = undefined;
       this.#resetState();
@@ -762,6 +862,18 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
           fileOrDiff.name
         );
       }
+    }
+
+    if (
+      persistedStateTarget === undefined &&
+      this.#restoreStateOnNextSync &&
+      this.#isStatePersistenceEnabled &&
+      this.#textDocument !== undefined
+    ) {
+      persistedStateTarget = {
+        cacheKey: getPersistedCacheKey(fileOrDiff),
+        textDocument: this.#textDocument,
+      };
     }
 
     // The tokenizer is (re)created whenever the current document lacks one:
@@ -904,7 +1016,190 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         'lines'
       );
     }
+
+    if (persistedStateTarget !== undefined) {
+      this.#restoreStateOnNextSync = false;
+      this.#restorePersistedState(
+        persistedStateTarget.cacheKey,
+        persistedStateTarget.textDocument
+      );
+    }
   };
+
+  get #isStatePersistenceEnabled(): boolean {
+    return (
+      this.#options.persistState === true && this.#fileInstance?.type === 'file'
+    );
+  }
+
+  #getCachedTextDocument(
+    file: FileContents | FileDiffMetadata
+  ): TextDocument<LAnnotation> | undefined {
+    const textDocument = this.#textDocumentCache.get(
+      getPersistedCacheKey(file)
+    );
+    const languageId = file.lang ?? getFiletypeFromFileName(file.name);
+    return textDocument?.languageId === languageId ? textDocument : undefined;
+  }
+
+  #getStateStorage(): IStateStorage {
+    const option = this.#options.persistStateStorage ?? 'inMemory';
+    if (
+      this.#stateStorage === undefined ||
+      this.#stateStorageOption !== option
+    ) {
+      this.#stateStorage = createStateStorage(option);
+      this.#stateStorageOption = option;
+    }
+    return this.#stateStorage;
+  }
+
+  #persistCurrentState(): void {
+    const fileInfo = this.#fileInfo;
+    const textDocument = this.#textDocument;
+    if (
+      !this.#isStatePersistenceEnabled ||
+      fileInfo === undefined ||
+      textDocument === undefined
+    ) {
+      return;
+    }
+
+    const cacheKey = getPersistedCacheKey(fileInfo);
+    this.#textDocumentCache.set(cacheKey, textDocument);
+
+    let storage: IStateStorage;
+    try {
+      storage = this.#getStateStorage();
+    } catch {
+      return;
+    }
+    const state = cloneEditorState(this.getState());
+    const pendingRestore = this.#pendingStateRestore;
+    if (
+      pendingRestore?.cacheKey === cacheKey &&
+      pendingRestore.textDocument === textDocument
+    ) {
+      this.#pendingStateRestore = undefined;
+      if (
+        textDocument.version === pendingRestore.documentVersion &&
+        this.#selections === pendingRestore.selections &&
+        state.view?.scrollLeft === pendingRestore.view?.scrollLeft &&
+        state.view?.scrollTop === pendingRestore.view?.scrollTop
+      ) {
+        return;
+      }
+      this.#writeState(storage, cacheKey, state, pendingRestore.completion);
+      return;
+    }
+
+    this.#writeState(storage, cacheKey, state);
+  }
+
+  // Writes for the same key stay ordered even when custom storage is async.
+  #writeState(
+    storage: IStateStorage,
+    cacheKey: string,
+    state: EditorState,
+    waitFor?: Promise<void>
+  ): void {
+    const previousWrite = this.#pendingStateWrites.get(cacheKey);
+    if (waitFor !== undefined || previousWrite !== undefined) {
+      let pending = waitFor ?? Promise.resolve();
+      if (previousWrite !== undefined) {
+        pending = pending.then(() => previousWrite);
+      }
+      this.#trackStateWrite(
+        cacheKey,
+        pending.then(() => storage.set(cacheKey, state))
+      );
+      return;
+    }
+
+    let result: void | Promise<void>;
+    try {
+      result = storage.set(cacheKey, state);
+    } catch {
+      return;
+    }
+    if (!isPromise(result)) {
+      return;
+    }
+
+    this.#trackStateWrite(cacheKey, result);
+  }
+
+  #trackStateWrite(cacheKey: string, result: Promise<void>): void {
+    const pending = result.catch(() => {});
+    this.#pendingStateWrites.set(cacheKey, pending);
+    void pending.finally(() => {
+      if (this.#pendingStateWrites.get(cacheKey) === pending) {
+        this.#pendingStateWrites.delete(cacheKey);
+      }
+    });
+  }
+
+  #restorePersistedState(
+    cacheKey: string,
+    textDocument: TextDocument<LAnnotation>
+  ): void {
+    const generation = ++this.#stateRestoreGeneration;
+    const documentVersion = textDocument.version;
+    const selections = this.#selections;
+    const view = this.getState().view;
+    const applyState = (state: EditorState | undefined): void => {
+      const currentView = this.getState().view;
+      if (
+        state === undefined ||
+        generation !== this.#stateRestoreGeneration ||
+        this.#textDocument !== textDocument ||
+        textDocument.version !== documentVersion ||
+        this.#selections !== selections ||
+        currentView?.scrollLeft !== view?.scrollLeft ||
+        currentView?.scrollTop !== view?.scrollTop ||
+        this.#fileInfo === undefined ||
+        getPersistedCacheKey(this.#fileInfo) !== cacheKey
+      ) {
+        return;
+      }
+      this.setState(cloneEditorState(state));
+    };
+    const readState = (): void | Promise<void> => {
+      let result: EditorState | undefined | Promise<EditorState | undefined>;
+      try {
+        result = this.#getStateStorage().get(cacheKey);
+      } catch {
+        return;
+      }
+      if (isPromise(result)) {
+        return result.then(applyState).catch(() => {});
+      } else {
+        try {
+          applyState(result);
+        } catch {}
+      }
+    };
+
+    const pendingWrite = this.#pendingStateWrites.get(cacheKey);
+    const result =
+      pendingWrite === undefined ? readState() : pendingWrite.then(readState);
+    if (isPromise(result)) {
+      const pendingRestore = {
+        cacheKey,
+        textDocument,
+        documentVersion,
+        selections,
+        view,
+        completion: result.catch(() => {}),
+      };
+      this.#pendingStateRestore = pendingRestore;
+      void pendingRestore.completion.finally(() => {
+        if (this.#pendingStateRestore === pendingRestore) {
+          this.#pendingStateRestore = undefined;
+        }
+      });
+    }
+  }
 
   // Whether a zero-based document line has (or will have on scroll) a
   // rendered row. False only for lines hidden inside a collapsed unchanged

--- a/packages/diffs/src/editor/index.ts
+++ b/packages/diffs/src/editor/index.ts
@@ -1,2 +1,3 @@
 export * from './editor';
+export type { IStateStorage, PersistStateStorage } from './stateStorage';
 export * from './textDocument';

--- a/packages/diffs/src/editor/stateStorage.ts
+++ b/packages/diffs/src/editor/stateStorage.ts
@@ -1,0 +1,108 @@
+import type { EditorState } from '../types';
+
+export interface IStateStorage {
+  /** Read the editor state stored for a file cache key. */
+  get(
+    cacheKey: string
+  ): EditorState | undefined | Promise<EditorState | undefined>;
+  /** Store the editor state for a file cache key. */
+  set(cacheKey: string, state: EditorState): void | Promise<void>;
+}
+
+export type PersistStateStorage = 'inMemory' | 'indexedDB' | IStateStorage;
+
+export function cloneEditorState(state: EditorState): EditorState {
+  return {
+    selections: state.selections?.map((selection) => ({
+      start: { ...selection.start },
+      end: { ...selection.end },
+      direction: selection.direction,
+    })),
+    view: state.view === undefined ? undefined : { ...state.view },
+  };
+}
+
+export function createStateStorage(
+  storage: PersistStateStorage
+): IStateStorage {
+  return typeof storage === 'object'
+    ? storage
+    : storage === 'indexedDB'
+      ? new IndexedDBStateStorage()
+      : new InMemoryStateStorage();
+}
+
+class InMemoryStateStorage implements IStateStorage {
+  #states = new Map<string, EditorState>();
+
+  get(cacheKey: string): EditorState | undefined {
+    const state = this.#states.get(cacheKey);
+    return state === undefined ? undefined : cloneEditorState(state);
+  }
+
+  set(cacheKey: string, state: EditorState): void {
+    this.#states.set(cacheKey, cloneEditorState(state));
+  }
+}
+
+const DATABASE_NAME = 'pierre-diffs-editor-state';
+const DATABASE_VERSION = 1;
+const STORE_NAME = 'states';
+
+class IndexedDBStateStorage implements IStateStorage {
+  #database = openDatabase();
+
+  async get(cacheKey: string): Promise<EditorState | undefined> {
+    const database = await this.#database;
+    if (database === undefined) {
+      return undefined;
+    }
+    const state = await requestToPromise<EditorState | undefined>(
+      database
+        .transaction(STORE_NAME, 'readonly')
+        .objectStore(STORE_NAME)
+        .get(cacheKey)
+    );
+    return state === undefined ? undefined : cloneEditorState(state);
+  }
+
+  async set(cacheKey: string, state: EditorState): Promise<void> {
+    const database = await this.#database;
+    if (database === undefined) {
+      return;
+    }
+    await requestToPromise(
+      database
+        .transaction(STORE_NAME, 'readwrite')
+        .objectStore(STORE_NAME)
+        .put(cloneEditorState(state), cacheKey)
+    );
+  }
+}
+
+function openDatabase(): Promise<IDBDatabase | undefined> {
+  try {
+    const factory = globalThis.indexedDB;
+    if (factory === undefined) {
+      return Promise.resolve(undefined);
+    }
+
+    const request = factory.open(DATABASE_NAME, DATABASE_VERSION);
+    request.onupgradeneeded = () => {
+      const database = request.result;
+      if (!database.objectStoreNames.contains(STORE_NAME)) {
+        database.createObjectStore(STORE_NAME);
+      }
+    };
+    return requestToPromise(request);
+  } catch {
+    return Promise.resolve(undefined);
+  }
+}
+
+function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}

--- a/packages/diffs/src/renderers/FileRenderer.ts
+++ b/packages/diffs/src/renderers/FileRenderer.ts
@@ -84,7 +84,16 @@ export interface FileRenderResult {
 
 interface LineCache {
   cacheKey: string | undefined;
+  file: FileContents;
   lines: string[];
+}
+
+// Explicit keys may share cached lines across equivalent file objects. Unkeyed
+// files stay isolated by object identity while still supporting edit recycle.
+function isLineCacheForFile(lineCache: LineCache, file: FileContents): boolean {
+  return file.cacheKey == null
+    ? lineCache.file === file
+    : lineCache.cacheKey === file.cacheKey;
 }
 
 export interface FileRendererOptions extends BaseCodeOptions {
@@ -165,8 +174,7 @@ export class FileRenderer<LAnnotation = undefined> {
     if (
       renderCache?.isDirty !== true ||
       lineCache == null ||
-      renderCache.file.cacheKey == null ||
-      renderCache.file.cacheKey !== lineCache.cacheKey
+      !isLineCacheForFile(lineCache, renderCache.file)
     ) {
       return;
     }
@@ -247,17 +255,11 @@ export class FileRenderer<LAnnotation = undefined> {
   }
 
   public getOrCreateLineCache(file: FileContents): string[] {
-    // Uncached files will get split every time, not the greatest experience
-    // tbh... but something people should try to optimize away
-    if (file.cacheKey == null) {
-      this.lineCache = undefined;
-      return linesFromFileContents(file.contents);
-    }
-
     let { lineCache } = this;
-    if (lineCache == null || lineCache.cacheKey !== file.cacheKey) {
+    if (lineCache == null || !isLineCacheForFile(lineCache, file)) {
       lineCache = {
         cacheKey: file.cacheKey,
+        file,
         lines: linesFromFileContents(file.contents),
       };
     }
@@ -292,9 +294,7 @@ export class FileRenderer<LAnnotation = undefined> {
     // indexes map 1:1; lines past the cache (document grew) are handled by
     // applyDocumentChange instead.
     const lineCache =
-      this.lineCache != null &&
-      file.cacheKey != null &&
-      this.lineCache.cacheKey === file.cacheKey
+      this.lineCache != null && isLineCacheForFile(this.lineCache, file)
         ? this.lineCache
         : undefined;
     for (const [line, tokens] of dirtyLines) {
@@ -389,12 +389,11 @@ export class FileRenderer<LAnnotation = undefined> {
     // A line-count change invalidates the per-line sync updateRenderCache
     // performs, so rebuild the split-line cache from the document wholesale
     // (the file analog of DiffHunksRenderer re-splitting `additionLines`).
-    if (file.cacheKey != null) {
-      this.lineCache = {
-        cacheKey: file.cacheKey,
-        lines: linesFromFileContents(textDocument.getText()),
-      };
-    }
+    this.lineCache = {
+      cacheKey: file.cacheKey,
+      file,
+      lines: linesFromFileContents(textDocument.getText()),
+    };
     this.textDocumentCache.set(file, textDocument);
   }
 

--- a/packages/diffs/src/renderers/FileRenderer.ts
+++ b/packages/diffs/src/renderers/FileRenderer.ts
@@ -85,6 +85,7 @@ export interface FileRenderResult {
 interface LineCache {
   cacheKey: string | undefined;
   file: FileContents;
+  sourceContents: string;
   lines: string[];
 }
 
@@ -92,7 +93,7 @@ interface LineCache {
 // files stay isolated by object identity while still supporting edit recycle.
 function isLineCacheForFile(lineCache: LineCache, file: FileContents): boolean {
   return file.cacheKey == null
-    ? lineCache.file === file
+    ? lineCache.file === file && lineCache.sourceContents === file.contents
     : lineCache.cacheKey === file.cacheKey;
 }
 
@@ -181,6 +182,26 @@ export class FileRenderer<LAnnotation = undefined> {
     renderCache.file.contents = lineCache.lines.join('');
   }
 
+  // Unkeyed files use object identity, so compare the retained source text to
+  // detect in-place mutations that an aliased file object cannot reveal.
+  public hasUnkeyedFileContentsChanged(file: FileContents): boolean {
+    const { lineCache } = this;
+    return (
+      file.cacheKey == null &&
+      lineCache != null &&
+      lineCache.file === file &&
+      lineCache.sourceContents !== file.contents
+    );
+  }
+
+  private invalidateChangedUnkeyedFile(file: FileContents): void {
+    if (!this.hasUnkeyedFileContentsChanged(file)) return;
+    this.workerManager?.cleanUpTasks(this);
+    this.clearRenderCache();
+    this.lineCache = undefined;
+    this.textDocumentCache = new WeakMap();
+  }
+
   public clearRenderCache(): void {
     this.syncEditedContentsToFile();
     const renderCache = this.renderCache;
@@ -255,11 +276,13 @@ export class FileRenderer<LAnnotation = undefined> {
   }
 
   public getOrCreateLineCache(file: FileContents): string[] {
+    this.invalidateChangedUnkeyedFile(file);
     let { lineCache } = this;
     if (lineCache == null || !isLineCacheForFile(lineCache, file)) {
       lineCache = {
         cacheKey: file.cacheKey,
         file,
+        sourceContents: file.contents,
         lines: linesFromFileContents(file.contents),
       };
     }
@@ -270,10 +293,8 @@ export class FileRenderer<LAnnotation = undefined> {
   // when a emitLineCountChange is called,
   // calculate the line count using the cached text document
   public getLineCount(file: FileContents): number {
-    return (
-      this.textDocumentCache.get(file)?.lineCount ??
-      this.getOrCreateLineCache(file).length
-    );
+    const lines = this.getOrCreateLineCache(file);
+    return this.textDocumentCache.get(file)?.lineCount ?? lines.length;
   }
 
   public updateRenderCache(
@@ -392,6 +413,7 @@ export class FileRenderer<LAnnotation = undefined> {
     this.lineCache = {
       cacheKey: file.cacheKey,
       file,
+      sourceContents: file.contents,
       lines: linesFromFileContents(textDocument.getText()),
     };
     this.textDocumentCache.set(file, textDocument);
@@ -404,6 +426,7 @@ export class FileRenderer<LAnnotation = undefined> {
     if (file == null) {
       return undefined;
     }
+    this.invalidateChangedUnkeyedFile(file);
     if (
       this.renderCache?.isDirty === true &&
       !areFilesEqual(file, this.renderCache.file)

--- a/packages/diffs/src/types.ts
+++ b/packages/diffs/src/types.ts
@@ -32,9 +32,10 @@ export interface FileContents {
   lang?: SupportedLanguages;
   /** Optional header passed to the jsdiff library's `createTwoFilesPatch`. */
   header?: string;
-  /** This unique key is only used for Worker Pools to avoid subsequent requests
-   * if we've already highlighted the file.  Please note that if you modify the
-   * `contents` or `name`, you must update the `cacheKey`. */
+  /**
+   * Identifies a file revision for worker highlighting and persisted editor
+   * state. Editor persistence falls back to `name` when this is omitted.
+   */
   cacheKey?: string;
 }
 
@@ -1080,6 +1081,8 @@ export interface DiffsEditableComponent<
 }
 
 export interface DiffsEditor<LAnnotation> {
+  /** @internal */
+  __prepareFile?(file: FileContents): FileContents;
   __postponeBgTokenizeToNextFrame(): void;
   __syncRenderView(
     highlighter: DiffsHighlighter,

--- a/packages/diffs/src/types.ts
+++ b/packages/diffs/src/types.ts
@@ -33,8 +33,9 @@ export interface FileContents {
   /** Optional header passed to the jsdiff library's `createTwoFilesPatch`. */
   header?: string;
   /**
-   * Identifies a file revision for worker highlighting and persisted editor
-   * state. Editor persistence falls back to `name` when this is omitted.
+   * Identifies a file for caching. Optional for read-only rendering, but
+   * required and expected to be unique and stable when Editor `persistState`
+   * is enabled.
    */
   cacheKey?: string;
 }
@@ -1017,6 +1018,8 @@ export interface DiffsBaseComponent {
 export interface DiffsEditableComponent<
   LAnnotation,
 > extends DiffsBaseComponent {
+  /** @internal Return the current file when this component renders one. */
+  __getCurrentFile?: () => FileContents | undefined;
   /**
    * Return the position and height of a one-based line relative to this component.
    * The host uses it to scroll to virtualized lines before their DOM nodes exist.

--- a/packages/diffs/test/FileRenderer.test.ts
+++ b/packages/diffs/test/FileRenderer.test.ts
@@ -49,4 +49,18 @@ describe('FileRenderer', () => {
     const cache = (instance as unknown as FileRendererCacheProbe).renderCache;
     expect(cache?.result?.code).toHaveLength(2);
   });
+
+  test('rebuilds an unkeyed file mutated in place', async () => {
+    const instance = new FileRenderer();
+    const file: FileContents = {
+      contents: 'alpha',
+      name: 'mutable.ts',
+    };
+
+    await instance.asyncRender(file);
+    expect(instance.renderFile(file)?.rowCount).toBe(1);
+
+    file.contents = 'alpha\nbeta\ngamma';
+    expect(instance.renderFile(file)?.rowCount).toBe(3);
+  });
 });

--- a/packages/diffs/test/e2e/fixtures/persist-state-indexeddb.html
+++ b/packages/diffs/test/e2e/fixtures/persist-state-indexeddb.html
@@ -1,0 +1,136 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>diffs persisted editor state fixture</title>
+  </head>
+  <body>
+    <div data-editor-mount></div>
+    <div data-persist-state-result data-status="pending"></div>
+
+    <script type="module">
+      import { File } from '/dist/index.js';
+      import { Editor } from '/dist/editor/index.js';
+
+      const DATABASE_NAME = 'pierre-diffs-editor-state';
+      const STORE_NAME = 'states';
+      const CACHE_KEY = 'persist-state-indexeddb-test';
+      const mount = document.querySelector('[data-editor-mount]');
+      const result = document.querySelector('[data-persist-state-result]');
+
+      if (!(mount instanceof HTMLElement) || !(result instanceof HTMLElement)) {
+        throw new Error('Missing persisted-state fixture nodes.');
+      }
+
+      const requestResult = (request) =>
+        new Promise((resolve, reject) => {
+          request.onsuccess = () => resolve(request.result);
+          request.onerror = () => reject(request.error);
+        });
+
+      const waitFor = async (getValue) => {
+        const started = performance.now();
+        while (true) {
+          const value = await getValue();
+          if (value !== undefined) {
+            return value;
+          }
+          if (performance.now() - started > 5000) {
+            throw new Error('Timed out waiting for persisted editor state.');
+          }
+          await new Promise((resolve) => requestAnimationFrame(resolve));
+        }
+      };
+
+      const deleteDatabase = () =>
+        requestResult(indexedDB.deleteDatabase(DATABASE_NAME));
+
+      const readState = async () => {
+        const database = await requestResult(indexedDB.open(DATABASE_NAME, 1));
+        try {
+          return await requestResult(
+            database
+              .transaction(STORE_NAME, 'readonly')
+              .objectStore(STORE_NAME)
+              .get(CACHE_KEY)
+          );
+        } finally {
+          database.close();
+        }
+      };
+
+      const createSession = async () => {
+        const file = new File({
+          disableFileHeader: true,
+          theme: { dark: 'pierre-dark', light: 'pierre-light' },
+          themeType: 'dark',
+          useTokenTransformer: true,
+        });
+        file.render({
+          file: {
+            cacheKey: CACHE_KEY,
+            name: 'persisted.ts',
+            contents: 'alpha\nbravo\n',
+          },
+          containerWrapper: mount,
+        });
+
+        const editor = new Editor({
+          persistState: true,
+          persistStateStorage: 'indexedDB',
+        });
+        editor.edit(file);
+        await waitFor(() =>
+          editor.getFile() === undefined ? undefined : true
+        );
+        return { editor, file };
+      };
+
+      try {
+        await deleteDatabase();
+
+        const first = await createSession();
+        first.editor.setSelections([
+          {
+            start: { line: 0, character: 3 },
+            end: { line: 0, character: 3 },
+            direction: 'none',
+          },
+        ]);
+        first.file.render({
+          file: {
+            cacheKey: 'other-file',
+            name: 'other.ts',
+            contents: 'other\n',
+          },
+          containerWrapper: mount,
+          forceRender: true,
+        });
+
+        const storedState = await waitFor(readState);
+        result.dataset.storedCharacter = String(
+          storedState.selections?.[0]?.start.character
+        );
+        first.editor.cleanUp();
+        first.file.cleanUp();
+
+        const second = await createSession();
+        const restoredState = await waitFor(() => {
+          const state = second.editor.getState();
+          return state.selections?.[0]?.start.character === 3
+            ? state
+            : undefined;
+        });
+        result.dataset.restoredCharacter = String(
+          restoredState.selections[0].start.character
+        );
+        result.dataset.status = 'ready';
+      } catch (error) {
+        result.dataset.status = 'error';
+        result.textContent =
+          error instanceof Error ? error.message : String(error);
+      }
+    </script>
+  </body>
+</html>

--- a/packages/diffs/test/e2e/persist-state-indexeddb.pw.ts
+++ b/packages/diffs/test/e2e/persist-state-indexeddb.pw.ts
@@ -1,0 +1,10 @@
+import { expect, test } from '@playwright/test';
+
+test('indexedDB storage restores state in a fresh editor', async ({ page }) => {
+  await page.goto('/test/e2e/fixtures/persist-state-indexeddb.html');
+
+  const result = page.locator('[data-persist-state-result]');
+  await expect(result).toHaveAttribute('data-status', 'ready');
+  await expect(result).toHaveAttribute('data-stored-character', '3');
+  await expect(result).toHaveAttribute('data-restored-character', '3');
+});

--- a/packages/diffs/test/editorApplyEdits.test.ts
+++ b/packages/diffs/test/editorApplyEdits.test.ts
@@ -63,7 +63,11 @@ async function createEditorFixture(
     ...fileOptions,
   });
   const editor = new Editor<undefined>(editorOptions);
-  const initialFile: FileContents = { name: 'edits.ts', contents };
+  const initialFile: FileContents = {
+    name: 'edits.ts',
+    contents,
+    ...(editorOptions?.persistState === true ? { cacheKey: 'edits-file' } : {}),
+  };
 
   file.render({ file: initialFile, fileContainer, forceRender: true });
   editor.edit(file);
@@ -139,7 +143,6 @@ async function renderFileAndWait(
   fixture: EditorFixture,
   fileContents: FileContents
 ): Promise<void> {
-  const cacheKey = fileContents.cacheKey ?? fileContents.name;
   fixture.file.render({
     file: fileContents,
     fileContainer: fixture.fileContainer,
@@ -147,11 +150,68 @@ async function renderFileAndWait(
   });
   await waitFor(() => {
     const file = fixture.editor.getFile();
-    return file !== undefined && (file.cacheKey ?? file.name) === cacheKey;
+    return (
+      file?.name === fileContents.name &&
+      file.cacheKey === fileContents.cacheKey
+    );
   });
 }
 
 describe('Editor persisted file state', () => {
+  test('requires an explicit cache key when enabled', () => {
+    const dom = installDom();
+    const fileContainer = document.createElement('div');
+    const fileContents: FileContents = {
+      name: 'unkeyed.ts',
+      contents: 'alpha\n',
+    };
+    const file = new File<undefined>({
+      disableFileHeader: true,
+      theme: DEFAULT_THEMES,
+    });
+    const editor = new Editor<undefined>({ persistState: true });
+
+    try {
+      file.render({ file: fileContents, fileContainer, forceRender: true });
+
+      expect(() => editor.edit(file)).toThrow(
+        'Editor persistState requires a non-empty file.cacheKey for "unkeyed.ts".'
+      );
+      expect(fileContents.cacheKey).toBeUndefined();
+    } finally {
+      editor.cleanUp();
+      file.cleanUp();
+      dom.cleanup();
+    }
+  });
+
+  test('rejects enabling persistence before an attached file finishes syncing', () => {
+    const dom = installDom();
+    const fileContainer = document.createElement('div');
+    const file = new File<undefined>({
+      disableFileHeader: true,
+      theme: DEFAULT_THEMES,
+    });
+    const editor = new Editor<undefined>();
+
+    try {
+      file.render({
+        file: { name: 'edits.ts', contents: 'alpha\n' },
+        fileContainer,
+        forceRender: true,
+      });
+      editor.edit(file);
+
+      expect(() => editor.setOptions({ persistState: true })).toThrow(
+        'Editor persistState requires a non-empty file.cacheKey for "edits.ts".'
+      );
+    } finally {
+      editor.cleanUp();
+      file.cleanUp();
+      dom.cleanup();
+    }
+  });
+
   test('is disabled by default', async () => {
     const storageCalls: string[] = [];
     const storage: IStateStorage = {
@@ -177,6 +237,7 @@ describe('Editor persisted file state', () => {
       await renderFileAndWait(fixture, {
         name: 'edits.ts',
         contents: 'alpha\nbravo\n',
+        cacheKey: 'edits-file',
       });
 
       expect(fixture.editor.getText()).toBe('alpha\nbravo\n');
@@ -207,11 +268,11 @@ describe('Editor persisted file state', () => {
         contents: 'one\n',
         cacheKey: 'other',
       });
-      // This fresh object carries the original contents and no explicit key;
-      // the persisted document is found through the filename fallback.
+      // A fresh object with the same explicit key resumes the editing session.
       await renderFileAndWait(fixture, {
         name: 'edits.ts',
         contents: 'alpha\nbravo\n',
+        cacheKey: 'edits-file',
       });
 
       expect(fixture.editor.getText()).toBe('Xalpha\nbravo\n');
@@ -236,7 +297,7 @@ describe('Editor persisted file state', () => {
     }
   });
 
-  test('uses a custom state storage with the normalized file key', async () => {
+  test('uses a custom state storage with the explicit file key', async () => {
     const states = new Map<string, ReturnType<Editor<undefined>['getState']>>();
     const calls: string[] = [];
     const storage: IStateStorage = {
@@ -270,12 +331,13 @@ describe('Editor persisted file state', () => {
       await renderFileAndWait(fixture, {
         name: 'edits.ts',
         contents: 'alpha\nbravo\n',
+        cacheKey: 'edits-file',
       });
 
-      expect(calls).toContain('set:edits.ts');
+      expect(calls).toContain('set:edits-file');
       expect(calls).toContain('get:other-revision');
       expect(calls).toContain('set:other-revision');
-      expect(calls.at(-1)).toBe('get:edits.ts');
+      expect(calls.at(-1)).toBe('get:edits-file');
       expect(fixture.editor.getState().selections?.[0]).toMatchObject({
         start: { line: 0, character: 2 },
         end: { line: 0, character: 2 },

--- a/packages/diffs/test/editorApplyEdits.test.ts
+++ b/packages/diffs/test/editorApplyEdits.test.ts
@@ -2,10 +2,10 @@ import { afterAll, describe, expect, mock, spyOn, test } from 'bun:test';
 
 import { File, type FileOptions } from '../src/components/File';
 import { DEFAULT_THEMES } from '../src/constants';
-import { Editor, type EditorOptions } from '../src/editor/editor';
+import { Editor, type EditorOptions, type IStateStorage } from '../src/editor';
 import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
 import type { FileContents } from '../src/types';
-import { installDom, wait } from './domHarness';
+import { installDom, wait, waitFor } from './domHarness';
 
 afterAll(async () => {
   await disposeHighlighter();
@@ -119,6 +119,173 @@ function pressMoveLine(
     })
   );
 }
+
+function insertAtStart(editor: Editor<undefined>, text: string): void {
+  editor.applyEdits(
+    [
+      {
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 0 },
+        },
+        newText: text,
+      },
+    ],
+    true
+  );
+}
+
+async function renderFileAndWait(
+  fixture: EditorFixture,
+  fileContents: FileContents
+): Promise<void> {
+  const cacheKey = fileContents.cacheKey ?? fileContents.name;
+  fixture.file.render({
+    file: fileContents,
+    fileContainer: fixture.fileContainer,
+    forceRender: true,
+  });
+  await waitFor(() => {
+    const file = fixture.editor.getFile();
+    return file !== undefined && (file.cacheKey ?? file.name) === cacheKey;
+  });
+}
+
+describe('Editor persisted file state', () => {
+  test('is disabled by default', async () => {
+    const storageCalls: string[] = [];
+    const storage: IStateStorage = {
+      get(cacheKey) {
+        storageCalls.push(`get:${cacheKey}`);
+        return undefined;
+      },
+      set(cacheKey) {
+        storageCalls.push(`set:${cacheKey}`);
+      },
+    };
+    const fixture = await createEditorFixture('alpha\nbravo\n', {
+      persistStateStorage: storage,
+    });
+
+    try {
+      insertAtStart(fixture.editor, 'X');
+      await renderFileAndWait(fixture, {
+        name: 'other.ts',
+        contents: 'one\n',
+        cacheKey: 'other',
+      });
+      await renderFileAndWait(fixture, {
+        name: 'edits.ts',
+        contents: 'alpha\nbravo\n',
+      });
+
+      expect(fixture.editor.getText()).toBe('alpha\nbravo\n');
+      expect(fixture.editor.canUndo).toBe(false);
+      expect(storageCalls).toEqual([]);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('restores the cached document, undo history, and editor state', async () => {
+    const fixture = await createEditorFixture('alpha\nbravo\n', {
+      persistState: true,
+    });
+
+    try {
+      insertAtStart(fixture.editor, 'X');
+      fixture.editor.setSelections([
+        {
+          start: { line: 1, character: 1 },
+          end: { line: 1, character: 4 },
+          direction: 'forward',
+        },
+      ]);
+
+      await renderFileAndWait(fixture, {
+        name: 'other.ts',
+        contents: 'one\n',
+        cacheKey: 'other',
+      });
+      // This fresh object carries the original contents and no explicit key;
+      // the persisted document is found through the filename fallback.
+      await renderFileAndWait(fixture, {
+        name: 'edits.ts',
+        contents: 'alpha\nbravo\n',
+      });
+
+      expect(fixture.editor.getText()).toBe('Xalpha\nbravo\n');
+      expect(fixture.editor.getState().selections).toEqual([
+        {
+          start: { line: 1, character: 1 },
+          end: { line: 1, character: 4 },
+          direction: 1,
+        },
+      ]);
+      expect(
+        fixture.fileContainer.shadowRoot?.querySelector(
+          '[data-content] [data-line="1"]'
+        )?.textContent
+      ).toBe('Xalpha');
+      expect(fixture.editor.canUndo).toBe(true);
+
+      fixture.editor.undo();
+      expect(fixture.editor.getText()).toBe('alpha\nbravo\n');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('uses a custom state storage with the normalized file key', async () => {
+    const states = new Map<string, ReturnType<Editor<undefined>['getState']>>();
+    const calls: string[] = [];
+    const storage: IStateStorage = {
+      get(cacheKey) {
+        calls.push(`get:${cacheKey}`);
+        return states.get(cacheKey);
+      },
+      set(cacheKey, state) {
+        calls.push(`set:${cacheKey}`);
+        states.set(cacheKey, state);
+      },
+    };
+    const fixture = await createEditorFixture('alpha\nbravo\n', {
+      persistState: true,
+      persistStateStorage: storage,
+    });
+
+    try {
+      fixture.editor.setSelections([
+        {
+          start: { line: 0, character: 2 },
+          end: { line: 0, character: 2 },
+          direction: 'none',
+        },
+      ]);
+      await renderFileAndWait(fixture, {
+        name: 'other.ts',
+        contents: 'one\n',
+        cacheKey: 'other-revision',
+      });
+      await renderFileAndWait(fixture, {
+        name: 'edits.ts',
+        contents: 'alpha\nbravo\n',
+      });
+
+      expect(calls).toContain('set:edits.ts');
+      expect(calls).toContain('get:other-revision');
+      expect(calls).toContain('set:other-revision');
+      expect(calls.at(-1)).toBe('get:edits.ts');
+      expect(fixture.editor.getState().selections?.[0]).toMatchObject({
+        start: { line: 0, character: 2 },
+        end: { line: 0, character: 2 },
+        direction: 0,
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});
 
 describe('Editor.applyEdits selection sync', () => {
   test('keeps inserted file lines coherent when switching files', async () => {

--- a/packages/diffs/test/editorPersistStateLifecycle.test.ts
+++ b/packages/diffs/test/editorPersistStateLifecycle.test.ts
@@ -14,6 +14,7 @@ afterAll(async () => {
 const ORIGINAL_FILE: FileContents = {
   name: 'persisted.ts',
   contents: 'alpha\nbravo\n',
+  cacheKey: 'persisted.ts',
 };
 
 interface AttachedFile {
@@ -74,10 +75,12 @@ async function renderFile(
     fileContainer: attached.container,
     forceRender: true,
   });
-  const expectedKey = fileContents.cacheKey ?? fileContents.name;
   await waitFor(() => {
     const file = editor.getFile();
-    return file !== undefined && (file.cacheKey ?? file.name) === expectedKey;
+    return (
+      file?.name === fileContents.name &&
+      file.cacheKey === fileContents.cacheKey
+    );
   });
 }
 
@@ -154,6 +157,7 @@ describe('Editor persisted state lifecycle', () => {
       await renderFile(editor, attached, {
         name: 'next.ts',
         contents: 'zulu\n',
+        cacheKey: 'next.ts',
       });
       editor.setSelections([
         {
@@ -204,12 +208,14 @@ describe('Editor persisted state lifecycle', () => {
       await renderFile(editor, attached, {
         name: 'saved.ts',
         contents: 'saved\n',
+        cacheKey: 'saved.ts',
       });
       await waitFor(() => delayedReadStarted);
 
       await renderFile(editor, attached, {
         name: 'next.ts',
         contents: 'next\n',
+        cacheKey: 'next.ts',
       });
       pendingRead.resolve(storedState);
       await wait(0);
@@ -219,6 +225,7 @@ describe('Editor persisted state lifecycle', () => {
       await renderFile(editor, attached, {
         name: 'saved.ts',
         contents: 'saved\n',
+        cacheKey: 'saved.ts',
       });
       expect(editor.getState().selections).toEqual(storedState.selections);
     } finally {
@@ -272,6 +279,7 @@ describe('Editor persisted state lifecycle', () => {
       await renderFile(editor, attached, {
         name: 'next.ts',
         contents: 'next\n',
+        cacheKey: 'next.ts',
       });
 
       await renderFile(editor, attached, { ...ORIGINAL_FILE });
@@ -285,6 +293,7 @@ describe('Editor persisted state lifecycle', () => {
       await renderFile(editor, attached, {
         name: 'next.ts',
         contents: 'next\n',
+        cacheKey: 'next.ts',
       });
 
       expect(writes).toHaveLength(1);

--- a/packages/diffs/test/editorPersistStateLifecycle.test.ts
+++ b/packages/diffs/test/editorPersistStateLifecycle.test.ts
@@ -1,0 +1,439 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+
+import { File } from '../src/components/File';
+import { DEFAULT_THEMES } from '../src/constants';
+import { Editor, type IStateStorage } from '../src/editor';
+import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
+import type { EditorState, FileContents } from '../src/types';
+import { installDom, wait, waitFor } from './domHarness';
+
+afterAll(async () => {
+  await disposeHighlighter();
+});
+
+const ORIGINAL_FILE: FileContents = {
+  name: 'persisted.ts',
+  contents: 'alpha\nbravo\n',
+};
+
+interface AttachedFile {
+  container: HTMLElement;
+  file: File<undefined>;
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+async function attachFile(
+  editor: Editor<undefined>,
+  fileContents: FileContents
+): Promise<AttachedFile> {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const file = new File<undefined>({
+    disableErrorHandling: true,
+    disableFileHeader: true,
+    theme: DEFAULT_THEMES,
+  });
+
+  file.render({
+    file: fileContents,
+    fileContainer: container,
+    forceRender: true,
+  });
+  editor.edit(file);
+  await waitFor(() => {
+    const content = container.shadowRoot?.querySelector('[data-content]');
+    return (
+      content instanceof HTMLElement &&
+      (content.contentEditable === 'true' ||
+        content.getAttribute('contenteditable') === 'true')
+    );
+  });
+
+  return { container, file };
+}
+
+async function renderFile(
+  editor: Editor<undefined>,
+  attached: AttachedFile,
+  fileContents: FileContents
+): Promise<void> {
+  attached.file.render({
+    file: fileContents,
+    fileContainer: attached.container,
+    forceRender: true,
+  });
+  const expectedKey = fileContents.cacheKey ?? fileContents.name;
+  await waitFor(() => {
+    const file = editor.getFile();
+    return file !== undefined && (file.cacheKey ?? file.name) === expectedKey;
+  });
+}
+
+function savedCaret(character: number): EditorState {
+  return {
+    selections: [
+      {
+        start: { line: 0, character },
+        end: { line: 0, character },
+        direction: 0,
+      },
+    ],
+  };
+}
+
+describe('Editor persisted state lifecycle', () => {
+  test('an async restore survives an unchanged file rerender', async () => {
+    const dom = installDom();
+    const pendingState = createDeferred<EditorState | undefined>();
+    const gets: string[] = [];
+    const sets: string[] = [];
+    const storage: IStateStorage = {
+      get(cacheKey) {
+        gets.push(cacheKey);
+        return pendingState.promise;
+      },
+      set(cacheKey) {
+        sets.push(cacheKey);
+      },
+    };
+    const editor = new Editor<undefined>({
+      persistState: true,
+      persistStateStorage: storage,
+    });
+    let attached: AttachedFile | undefined;
+
+    try {
+      attached = await attachFile(editor, { ...ORIGINAL_FILE });
+      await waitFor(() => gets.length === 1);
+
+      await renderFile(editor, attached, { ...ORIGINAL_FILE });
+      pendingState.resolve(savedCaret(3));
+      await waitFor(
+        () => editor.getState().selections?.[0]?.start.character === 3
+      );
+
+      expect(gets).toEqual(['persisted.ts']);
+      expect(sets).toEqual([]);
+      expect(editor.getState().selections).toEqual(savedCaret(3).selections);
+    } finally {
+      editor.cleanUp();
+      attached?.file.cleanUp();
+      dom.cleanup();
+    }
+  });
+
+  test('a stale async restore cannot overwrite the next file state', async () => {
+    const dom = installDom();
+    const pendingState = createDeferred<EditorState | undefined>();
+    const storage: IStateStorage = {
+      get(cacheKey) {
+        return cacheKey === 'persisted.ts' ? pendingState.promise : undefined;
+      },
+      set() {},
+    };
+    const editor = new Editor<undefined>({
+      persistState: true,
+      persistStateStorage: storage,
+    });
+    let attached: AttachedFile | undefined;
+
+    try {
+      attached = await attachFile(editor, { ...ORIGINAL_FILE });
+      await renderFile(editor, attached, {
+        name: 'next.ts',
+        contents: 'zulu\n',
+      });
+      editor.setSelections([
+        {
+          start: { line: 0, character: 1 },
+          end: { line: 0, character: 1 },
+          direction: 'none',
+        },
+      ]);
+
+      pendingState.resolve(savedCaret(4));
+      await wait(0);
+
+      expect(editor.getFile()?.name).toBe('next.ts');
+      expect(editor.getState().selections).toEqual(savedCaret(1).selections);
+    } finally {
+      editor.cleanUp();
+      attached?.file.cleanUp();
+      dom.cleanup();
+    }
+  });
+
+  test('leaving during the first read does not clobber stored state', async () => {
+    const dom = installDom();
+    const pendingRead = createDeferred<EditorState | undefined>();
+    const storedState = savedCaret(4);
+    const states = new Map<string, EditorState>([['saved.ts', storedState]]);
+    let delayedReadStarted = false;
+    const storage: IStateStorage = {
+      get(cacheKey) {
+        if (cacheKey === 'saved.ts' && !delayedReadStarted) {
+          delayedReadStarted = true;
+          return pendingRead.promise;
+        }
+        return states.get(cacheKey);
+      },
+      set(cacheKey, state) {
+        states.set(cacheKey, state);
+      },
+    };
+    const editor = new Editor<undefined>({
+      persistState: true,
+      persistStateStorage: storage,
+    });
+    let attached: AttachedFile | undefined;
+
+    try {
+      attached = await attachFile(editor, { ...ORIGINAL_FILE });
+      await renderFile(editor, attached, {
+        name: 'saved.ts',
+        contents: 'saved\n',
+      });
+      await waitFor(() => delayedReadStarted);
+
+      await renderFile(editor, attached, {
+        name: 'next.ts',
+        contents: 'next\n',
+      });
+      pendingRead.resolve(storedState);
+      await wait(0);
+
+      expect(states.get('saved.ts')).toEqual(storedState);
+
+      await renderFile(editor, attached, {
+        name: 'saved.ts',
+        contents: 'saved\n',
+      });
+      expect(editor.getState().selections).toEqual(storedState.selections);
+    } finally {
+      editor.cleanUp();
+      attached?.file.cleanUp();
+      dom.cleanup();
+    }
+  });
+
+  test('serializes delayed writes so the newest state wins', async () => {
+    const dom = installDom();
+    const firstWrite = createDeferred<void>();
+    const secondWrite = createDeferred<void>();
+    const writeGates = [firstWrite, secondWrite];
+    const writes: EditorState[] = [];
+    const states = new Map<string, EditorState>();
+    const storage: IStateStorage = {
+      get(cacheKey) {
+        return states.get(cacheKey);
+      },
+      set(cacheKey, state) {
+        if (cacheKey !== 'persisted.ts') {
+          states.set(cacheKey, state);
+          return;
+        }
+        const gate = writeGates[writes.length];
+        if (gate === undefined) {
+          throw new Error('unexpected persisted.ts write');
+        }
+        writes.push(state);
+        return gate.promise.then(() => {
+          states.set(cacheKey, state);
+        });
+      },
+    };
+    const editor = new Editor<undefined>({
+      persistState: true,
+      persistStateStorage: storage,
+    });
+    let attached: AttachedFile | undefined;
+
+    try {
+      attached = await attachFile(editor, { ...ORIGINAL_FILE });
+      editor.setSelections([
+        {
+          start: { line: 0, character: 1 },
+          end: { line: 0, character: 1 },
+          direction: 'none',
+        },
+      ]);
+      await renderFile(editor, attached, {
+        name: 'next.ts',
+        contents: 'next\n',
+      });
+
+      await renderFile(editor, attached, { ...ORIGINAL_FILE });
+      editor.setSelections([
+        {
+          start: { line: 0, character: 2 },
+          end: { line: 0, character: 2 },
+          direction: 'none',
+        },
+      ]);
+      await renderFile(editor, attached, {
+        name: 'next.ts',
+        contents: 'next\n',
+      });
+
+      expect(writes).toHaveLength(1);
+      secondWrite.resolve();
+      firstWrite.resolve();
+      await waitFor(
+        () => states.get('persisted.ts')?.selections?.[0]?.start.character === 2
+      );
+
+      expect(writes).toHaveLength(2);
+      expect(states.get('persisted.ts')?.selections).toEqual(
+        savedCaret(2).selections
+      );
+
+      await renderFile(editor, attached, { ...ORIGINAL_FILE });
+      expect(editor.getState().selections).toEqual(savedCaret(2).selections);
+    } finally {
+      editor.cleanUp();
+      attached?.file.cleanUp();
+      dom.cleanup();
+    }
+  });
+
+  test('full cleanup restores cached text into a fresh File mount', async () => {
+    const dom = installDom();
+    const editor = new Editor<undefined>({ persistState: true });
+    let first: AttachedFile | undefined;
+    let second: AttachedFile | undefined;
+
+    try {
+      first = await attachFile(editor, { ...ORIGINAL_FILE });
+      editor.applyEdits(
+        [
+          {
+            range: {
+              start: { line: 0, character: 0 },
+              end: { line: 0, character: 0 },
+            },
+            newText: 'X',
+          },
+        ],
+        true
+      );
+
+      editor.cleanUp();
+      first.file.cleanUp();
+      first = undefined;
+
+      second = await attachFile(editor, { ...ORIGINAL_FILE });
+      await waitFor(
+        () =>
+          second?.container.shadowRoot?.querySelector(
+            '[data-content] [data-line="1"]'
+          )?.textContent === 'Xalpha'
+      );
+
+      expect(editor.getText()).toBe('Xalpha\nbravo\n');
+      expect(
+        second.container.shadowRoot?.querySelector(
+          '[data-content] [data-line="1"]'
+        )?.textContent
+      ).toBe('Xalpha');
+      expect(editor.canUndo).toBe(true);
+    } finally {
+      editor.cleanUp();
+      first?.file.cleanUp();
+      second?.file.cleanUp();
+      dom.cleanup();
+    }
+  });
+
+  test('a rename with the same cache key keeps text, state, and history', async () => {
+    const dom = installDom();
+    const editor = new Editor<undefined>({ persistState: true });
+    let attached: AttachedFile | undefined;
+
+    try {
+      attached = await attachFile(editor, {
+        ...ORIGINAL_FILE,
+        cacheKey: 'logical-file',
+      });
+      editor.applyEdits(
+        [
+          {
+            range: {
+              start: { line: 0, character: 0 },
+              end: { line: 0, character: 0 },
+            },
+            newText: 'X',
+          },
+        ],
+        true
+      );
+      editor.setSelections([
+        {
+          start: { line: 0, character: 3 },
+          end: { line: 0, character: 3 },
+          direction: 'none',
+        },
+      ]);
+
+      await renderFile(editor, attached, {
+        ...ORIGINAL_FILE,
+        name: 'renamed.ts',
+        cacheKey: 'logical-file',
+      });
+      await waitFor(
+        () =>
+          editor.getFile()?.name === 'renamed.ts' &&
+          editor.getText() === 'Xalpha\nbravo\n'
+      );
+
+      expect(editor.getState().selections).toEqual(savedCaret(3).selections);
+      expect(editor.canUndo).toBe(true);
+    } finally {
+      editor.cleanUp();
+      attached?.file.cleanUp();
+      dom.cleanup();
+    }
+  });
+
+  test('recycle cleanup restores state without rebuilding the document', async () => {
+    const dom = installDom();
+    const editor = new Editor<undefined>({ persistState: true });
+    let first: AttachedFile | undefined;
+    let second: AttachedFile | undefined;
+
+    try {
+      first = await attachFile(editor, { ...ORIGINAL_FILE });
+      editor.setSelections([
+        {
+          start: { line: 0, character: 2 },
+          end: { line: 0, character: 2 },
+          direction: 'none',
+        },
+      ]);
+
+      editor.cleanUp(true);
+      first.file.cleanUp(true);
+      first = undefined;
+
+      second = await attachFile(editor, { ...ORIGINAL_FILE });
+
+      expect(editor.getState().selections).toEqual(savedCaret(2).selections);
+    } finally {
+      editor.cleanUp();
+      first?.file.cleanUp();
+      second?.file.cleanUp();
+      dom.cleanup();
+    }
+  });
+});

--- a/packages/diffs/test/virtualizedFilePersistedLayout.test.ts
+++ b/packages/diffs/test/virtualizedFilePersistedLayout.test.ts
@@ -34,7 +34,10 @@ const virtualizer = {
   isInstanceVisible() {
     return false;
   },
+  markDOMDirty() {},
 } as never;
+
+const codeView = { type: 'advanced' } as never;
 
 describe('VirtualizedFile persisted layout', () => {
   test('prepares cached contents before computing approximate height', () => {
@@ -82,5 +85,54 @@ describe('VirtualizedFile persisted layout', () => {
       instance.cleanUp();
       dom.cleanup();
     }
+  });
+
+  test('recomputes height when an unkeyed file is mutated in place', () => {
+    const dom = installDom();
+    const file: FileContents = {
+      name: 'mutable.ts',
+      contents: 'one',
+    };
+    const instance = new VirtualizedFile({}, virtualizer, metrics);
+    const fileContainer = document.createElement('div');
+
+    try {
+      instance.render({ file, fileContainer, forceRender: true });
+      expect(instance.getVirtualizedHeight()).toBe(
+        getVirtualFileHeaderRegion(metrics, false) +
+          metrics.lineHeight +
+          getVirtualFilePaddingBottom(metrics)
+      );
+
+      file.contents = 'one\ntwo\nthree';
+      instance.render({ file, fileContainer, forceRender: true });
+      expect(instance.getVirtualizedHeight()).toBe(
+        getVirtualFileHeaderRegion(metrics, false) +
+          3 * metrics.lineHeight +
+          getVirtualFilePaddingBottom(metrics)
+      );
+    } finally {
+      instance.cleanUp();
+      dom.cleanup();
+    }
+  });
+
+  test('recomputes CodeView height for an unkeyed in-place mutation', () => {
+    const file: FileContents = {
+      name: 'mutable.ts',
+      contents: 'one',
+    };
+    const instance = new VirtualizedFile({}, codeView, metrics);
+    const headerHeight = getVirtualFileHeaderRegion(metrics, false);
+    const paddingBottom = getVirtualFilePaddingBottom(metrics);
+
+    expect(instance.prepareCodeViewItem(file, 0)).toBe(
+      headerHeight + metrics.lineHeight + paddingBottom
+    );
+
+    file.contents = 'one\ntwo\nthree';
+    expect(instance.prepareCodeViewItem(file, 0)).toBe(
+      headerHeight + 3 * metrics.lineHeight + paddingBottom
+    );
   });
 });

--- a/packages/diffs/test/virtualizedFilePersistedLayout.test.ts
+++ b/packages/diffs/test/virtualizedFilePersistedLayout.test.ts
@@ -42,6 +42,7 @@ describe('VirtualizedFile persisted layout', () => {
     const originalFile: FileContents = {
       name: 'file.ts',
       contents: 'one',
+      cacheKey: 'file',
     };
     const cachedFile: FileContents = {
       ...originalFile,

--- a/packages/diffs/test/virtualizedFilePersistedLayout.test.ts
+++ b/packages/diffs/test/virtualizedFilePersistedLayout.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test';
+
+import { VirtualizedFile } from '../src/components/VirtualizedFile';
+import type {
+  DiffsEditor,
+  FileContents,
+  VirtualFileMetrics,
+} from '../src/types';
+import {
+  getVirtualFileHeaderRegion,
+  getVirtualFilePaddingBottom,
+} from '../src/utils/computeVirtualFileMetrics';
+import { installDom } from './domHarness';
+
+const metrics: VirtualFileMetrics = {
+  hunkLineCount: 50,
+  lineHeight: 10,
+  diffHeaderHeight: 30,
+  spacing: 4,
+};
+
+const virtualizer = {
+  type: 'simple',
+  config: {},
+  connect() {},
+  disconnect() {},
+  getWindowSpecs() {
+    return { top: 0, bottom: 0 };
+  },
+  getOffsetInScrollContainer() {
+    return 0;
+  },
+  instanceChanged() {},
+  isInstanceVisible() {
+    return false;
+  },
+} as never;
+
+describe('VirtualizedFile persisted layout', () => {
+  test('prepares cached contents before computing approximate height', () => {
+    const dom = installDom();
+    const originalFile: FileContents = {
+      name: 'file.ts',
+      contents: 'one',
+    };
+    const cachedFile: FileContents = {
+      ...originalFile,
+      contents: 'one\ntwo\nthree\nfour',
+    };
+    let prepareCalls = 0;
+    const editor: DiffsEditor<undefined> = {
+      __prepareFile() {
+        prepareCalls++;
+        return cachedFile;
+      },
+      __postponeBgTokenizeToNextFrame() {},
+      __syncRenderView() {},
+      edit() {
+        return () => {};
+      },
+      cleanUp() {},
+    };
+    const instance = new VirtualizedFile({}, virtualizer, metrics);
+    const detach = instance.attachEditor(editor);
+
+    try {
+      instance.render({
+        file: originalFile,
+        fileContainer: document.createElement('div'),
+      });
+
+      expect(prepareCalls).toBe(1);
+      expect(instance.file?.contents).toBe(cachedFile.contents);
+      expect(instance.getVirtualizedHeight()).toBe(
+        getVirtualFileHeaderRegion(metrics, false) +
+          4 * metrics.lineHeight +
+          getVirtualFilePaddingBottom(metrics)
+      );
+    } finally {
+      detach();
+      instance.cleanUp();
+      dom.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
**Adds opt-in editor state and `TextDocument` persistence across file renders.**

When persistence is enabled, the editor uses `file.cacheKey ?? file.name` to identify files. Calling `file.render({ file: newFile })` stores the current editor state and restores the cached document, selection, scroll position, and undo history when that file is rendered again.

Persistence remains disabled by default.

```ts
import { Editor, type IStateStorage } from '@pierre/diffs/editor';

const editor = new Editor({
  persistState: true,
  persistStateStorage: 'inMemory',
});

file.render({
  file: {
    name: 'src/index.ts',
    contents: 'export const value = 1;',
    cacheKey: 'src/index.ts',
  },
});
```

IndexedDB can be used for state that survives page reloads:

```ts
const editor = new Editor({
  persistState: true,
  persistStateStorage: 'indexedDB',
});
```

Custom storage implementations are also supported:

```ts
const states = new Map();

const storage: IStateStorage = {
  get(cacheKey) {
    return states.get(cacheKey);
  },
  set(cacheKey, state) {
    states.set(cacheKey, state);
  },
};

const editor = new Editor({
  persistState: true,
  persistStateStorage: storage,
});
```