### PR TITLE
[diffs/edit] Add undo-traversal seals and delete-direction stops to coalescing

### DIFF
--- a/apps/docs/app/(diffs)/docs/Editor/constants.ts
+++ b/apps/docs/app/(diffs)/docs/Editor/constants.ts
@@ -775,22 +775,13 @@ editor.cleanUp();
 editor.cleanUp(true);
 
 // Apply text edits to the attached document. Positions are zero-based.
-// Pass true as the second argument to push the edits onto the undo stack.
+// Edits always join the undo stack, exactly like typed input.
 editor.applyEdits([
   {
     range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
     newText: 'Hello, world!',
   },
 ]);
-editor.applyEdits(
-  [
-    {
-      range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
-      newText: 'Hello, world!',
-    },
-  ],
-  true
-);
 
 // Live FileContents for the attached document. Undefined when nothing is
 // attached.

--- a/apps/docs/app/(diffs)/docs/Editor/content.mdx
+++ b/apps/docs/app/(diffs)/docs/Editor/content.mdx
@@ -210,11 +210,13 @@ while you edit. Pass an empty array to clear them.
 
 #### History
 
-The editor keeps an undo stack for user edits and for programmatic edits applied
-with `applyEdits(..., true)`. Use `editor.canUndo` and `editor.canRedo` to
-enable or disable toolbar buttons, and call `editor.undo()` or `editor.redo()`
-to step through history from code. These methods share the same stack as the
-keyboard shortcuts (<kbd>Cmd/Ctrl-Z</kbd> and <kbd>Cmd/Ctrl-Shift-Z</kbd>).
+The editor keeps a single undo stack covering user edits and programmatic edits
+alike — `applyEdits` joins the same timeline as typed input, so a mixed sequence
+undoes exactly like an all-local one. Use `editor.canUndo` and `editor.canRedo`
+to enable or disable toolbar buttons, and call `editor.undo()` or
+`editor.redo()` to step through history from code. These methods share the same
+stack as the keyboard shortcuts (<kbd>Cmd/Ctrl-Z</kbd> and
+<kbd>Cmd/Ctrl-Shift-Z</kbd>).
 
 `undo()` and `redo()` are no-ops when there is nothing to undo or redo. Both run
 through the same change path as a normal edit, so your `onChange` handler fires

--- a/apps/docs/app/(diffs)/docs/Editor/content.mdx
+++ b/apps/docs/app/(diffs)/docs/Editor/content.mdx
@@ -216,6 +216,7 @@ undoes exactly like an all-local one. Use `editor.canUndo` and `editor.canRedo`
 to enable or disable toolbar buttons, and call `editor.undo()` or
 `editor.redo()` to step through history from code. These methods share the same
 stack as the keyboard shortcuts (<kbd>Cmd/Ctrl-Z</kbd> and
+
 <kbd>Cmd/Ctrl-Shift-Z</kbd>).
 
 `undo()` and `redo()` are no-ops when there is nothing to undo or redo. Both run

--- a/packages/diffs/src/editor/editStack.ts
+++ b/packages/diffs/src/editor/editStack.ts
@@ -28,6 +28,24 @@ export interface EditStackEntry<LAnnotation> {
    * typing and would merge into the previous keystroke.
    */
   undoBoundary?: boolean;
+  /**
+   * When `true`, an undo or redo has exposed this entry as the top of the
+   * undo stack. Traversed history is committed: a later edit must start a new
+   * undo step instead of coalescing into this entry (which would fuse fresh
+   * typing into pre-undo history and, via the redo clear, destroy the parked
+   * entries above it). Stamped by `popUndoToRedo`/`popRedoToUndo`.
+   */
+  sealed?: boolean;
+  /**
+   * Which delete key produced this pure-delete entry, when the recorded
+   * pre-edit selections were collapsed carets: 'backspace' deleted the range
+   * before each caret, 'delete' the range after it. Backspace and forward
+   * delete at the same pivot produce identical edit geometry, so the caret
+   * side is the only signal that separates a continuing delete run from a
+   * direction switch. Unset for non-delete entries and for deletes recorded
+   * without caret selections, which keep the geometry-only coalescing rules.
+   */
+  deleteDirection?: 'backspace' | 'delete';
 }
 
 /** Options for the edit stack. */
@@ -119,6 +137,7 @@ export class EditStack<LAnnotation> {
     const entry = this.#undoStack.pop();
     if (entry !== undefined) {
       this.#redoStack.push(entry);
+      this.#sealTopUndo();
       return entry;
     }
   }
@@ -128,7 +147,19 @@ export class EditStack<LAnnotation> {
     const entry = this.#redoStack.pop();
     if (entry !== undefined) {
       this.#undoStack.push(entry);
+      this.#sealTopUndo();
       return entry;
+    }
+  }
+
+  // Marks the entry an undo or redo just exposed as the top of the undo stack
+  // (after undo, the entry beneath the popped one; after redo, the re-pushed
+  // entry itself) so later edits start a new undo step instead of coalescing
+  // into traversed history.
+  #sealTopUndo(): void {
+    const topEntry = this.#undoStack[this.#undoStack.length - 1];
+    if (topEntry !== undefined) {
+      topEntry.sealed = true;
     }
   }
 }
@@ -156,7 +187,7 @@ export function createEditStackEntry<LAnnotation>(
     });
     offsetDelta += edit.text.length - (edit.end - edit.start);
   }
-  return {
+  const entry: EditStackEntry<LAnnotation> = {
     forwardEdits: forwardEdits.map((edit) => ({ ...edit })),
     inverseEdits: inverseEdits,
     versionBefore,
@@ -168,12 +199,84 @@ export function createEditStackEntry<LAnnotation>(
     lineAnnotationsBefore: lineAnnotationsBefore?.slice(),
     lineAnnotationsAfter: lineAnnotationsAfter?.slice(),
   };
+  const deleteDirection = classifyDeleteDirection(
+    textDocument,
+    forwardEdits,
+    selectionsBefore
+  );
+  if (deleteDirection !== undefined) {
+    entry.deleteDirection = deleteDirection;
+  }
+  return entry;
+}
+
+// Classifies which delete key produced a pure-delete batch from where the
+// recorded pre-edit carets sit relative to the deleted ranges: Backspace
+// deletes the range before the caret (caret at `edit.end`), forward Delete
+// the range after it (caret at `edit.start`). Both keys produce identical
+// edit geometry at the same pivot, so the caret side is the only available
+// signal. Returns `undefined` — keeping the geometry-only coalescing rules —
+// when the batch is not purely deletes, the selections are missing,
+// non-collapsed (a selection deletion has no key direction), or miscounted
+// (e.g. carets with nothing to delete recorded alongside eligible ones), or
+// the carets do not sit consistently on one edge.
+function classifyDeleteDirection<LAnnotation>(
+  textDocument: TextDocument<LAnnotation>,
+  forwardEdits: readonly ResolvedTextEdit[],
+  selectionsBefore?: EditorSelection[]
+): 'backspace' | 'delete' | undefined {
+  if (
+    selectionsBefore === undefined ||
+    selectionsBefore.length !== forwardEdits.length
+  ) {
+    return undefined;
+  }
+  for (const edit of forwardEdits) {
+    if (edit.text.length > 0 || edit.end <= edit.start) {
+      return undefined;
+    }
+  }
+  const caretOffsets: number[] = [];
+  for (const selection of selectionsBefore) {
+    if (
+      selection.start.line !== selection.end.line ||
+      selection.start.character !== selection.end.character
+    ) {
+      return undefined;
+    }
+    caretOffsets.push(textDocument.offsetAt(selection.start));
+  }
+  // `forwardEdits` is already sorted ascending; sort the carets the same way
+  // so each pairs with the range it deleted.
+  caretOffsets.sort((a, b) => a - b);
+  let atEveryEnd = true;
+  let atEveryStart = true;
+  for (let i = 0; i < forwardEdits.length; i++) {
+    atEveryEnd &&= caretOffsets[i] === forwardEdits[i].end;
+    atEveryStart &&= caretOffsets[i] === forwardEdits[i].start;
+  }
+  if (atEveryEnd) {
+    return 'backspace';
+  }
+  if (atEveryStart) {
+    return 'delete';
+  }
+  return undefined;
 }
 
 /** Determines if the change matches following modes:
  * - 'insert': simple typing
  * - 'backspace': backward delete
  * - 'delete': forward delete
+ *
+ * A previous entry that has been traversed by undo/redo (`sealed`) never
+ * accepts coalescing, and two delete entries whose key directions
+ * (`deleteDirection`) are both known and opposite never merge — a direction
+ * switch starts a new undo step. When either side's direction is unknown
+ * (untracked or programmatic edits, deletes recorded without caret
+ * selections), the geometry-only rules apply unchanged, so a caret that
+ * merely coincides with a delete edge (e.g. an outdent's leading-whitespace
+ * delete) cannot break grouping against unlabeled neighbors.
  */
 export function shouldCoalesceEditStackEntry<LAnnotation>(
   previousEntry: EditStackEntry<LAnnotation> | undefined,
@@ -181,12 +284,28 @@ export function shouldCoalesceEditStackEntry<LAnnotation>(
 ): boolean {
   if (
     previousEntry === undefined ||
+    previousEntry.sealed === true ||
     previousEntry.undoBoundary === true ||
     nextEntry.undoBoundary === true ||
     previousEntry.forwardEdits.length === 0 ||
     previousEntry.forwardEdits.length !== previousEntry.inverseEdits.length ||
     previousEntry.forwardEdits.length !== nextEntry.forwardEdits.length ||
     nextEntry.forwardEdits.length !== nextEntry.inverseEdits.length
+  ) {
+    return false;
+  }
+  // Backspace and forward Delete at the same pivot leave identical edit
+  // geometry (the pivot offset maps onto both the end of a just-deleted range
+  // and the resting spot after a Backspace), so geometry alone cannot see a
+  // direction switch. When both entries carry a known key direction and they
+  // disagree, this is a switch, not a continuing run. Requiring BOTH sides
+  // keeps a false or coincidental label (a programmatic delete whose recorded
+  // caret happens to sit on an edit edge) from blocking merges with unlabeled
+  // neighbors, which keep the geometry-only rules.
+  if (
+    previousEntry.deleteDirection !== undefined &&
+    nextEntry.deleteDirection !== undefined &&
+    previousEntry.deleteDirection !== nextEntry.deleteDirection
   ) {
     return false;
   }
@@ -237,6 +356,8 @@ export function shouldCoalesceEditStackEntry<LAnnotation>(
       nextInverse.text.length > 0;
     if (previousWasDelete && nextIsDelete) {
       if (mappedNextStart === previousForward.end) {
+        // Forward-delete-run shape (the direction-switch check above already
+        // rejected a known backspace-vs-delete conflict).
         mode ??= 'delete';
         if (mode !== 'delete') {
           return false;
@@ -249,6 +370,8 @@ export function shouldCoalesceEditStackEntry<LAnnotation>(
       ) {
         return false;
       }
+      // Backspace-run shape; the mirror of the pivot ambiguity above, covered
+      // by the same direction-switch check.
       mode ??= 'backspace';
       if (mode !== 'backspace') {
         return false;
@@ -305,7 +428,7 @@ export function coalesceEditStackEntries<LAnnotation>(
     replacedTexts.push(nextInverse.text + previousInverse.text);
   }
 
-  return {
+  const mergedEntry: EditStackEntry<LAnnotation> = {
     forwardEdits,
     inverseEdits: buildInverseEditsFromReplacedTexts(
       forwardEdits,
@@ -318,6 +441,15 @@ export function coalesceEditStackEntries<LAnnotation>(
     lineAnnotationsBefore: previousEntry.lineAnnotationsBefore?.slice(),
     lineAnnotationsAfter: nextEntry.lineAnnotationsAfter?.slice(),
   };
+  // Keep the run's key direction on the merged entry (either side may be an
+  // unclassified untracked edit) so a later opposite-direction delete still
+  // reads as a switch and starts a new undo step.
+  const deleteDirection =
+    previousEntry.deleteDirection ?? nextEntry.deleteDirection;
+  if (deleteDirection !== undefined) {
+    mergedEntry.deleteDirection = deleteDirection;
+  }
+  return mergedEntry;
 }
 
 function buildInverseEditsFromReplacedTexts(

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -444,9 +444,16 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   }
 
   /**
-   * Apply edits to current attached file.
+   * Apply edits to current attached file. Every edit joins the undo timeline:
+   * a programmatic edit must leave the document and its history exactly as
+   * the same edit typed by the user would (history equivalence — see
+   * TextDocument.applyResolvedEdits), so it is undoable like any other edit.
+   *
+   * @param _updateHistory Deprecated: has no effect. Programmatic edits are
+   * always undoable; history is reset by rebuilding the document (and its
+   * EditStack), never by bypassing it.
    */
-  applyEdits(edits: TextEdit[], updateHistory = false): void {
+  applyEdits(edits: TextEdit[], _updateHistory?: boolean): void {
     const textDocument = this.#textDocument;
     if (textDocument == null) {
       throw new Error('Editor is not attached');
@@ -484,11 +491,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
             })
             .sort((a, b) => a.start - b.start);
 
-    const change = textDocument.applyEdits(
-      edits,
-      updateHistory,
-      selectionsBefore
-    );
+    const change = textDocument.applyEdits(edits, true, selectionsBefore);
     if (change === undefined) {
       return;
     }
@@ -509,9 +512,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         selectionOffsetsBefore,
         resolvedEditOffsets
       );
-      if (updateHistory) {
-        textDocument.setLastUndoSelectionsAfter(nextSelections);
-      }
+      textDocument.setLastUndoSelectionsAfter(nextSelections);
     }
 
     this.#applyChange(
@@ -4041,7 +4042,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         get selection(): EditorSelection {
           return getActiveSelection();
         },
-        applyEdits: (edits: TextEdit[]) => this.applyEdits(edits, true),
+        applyEdits: (edits: TextEdit[]) => this.applyEdits(edits),
         getSelectionText: () =>
           this.#textDocument?.getText(getActiveSelection()) ?? '',
         replaceSelectionText: (text: string) => {

--- a/packages/diffs/src/editor/textDocument.ts
+++ b/packages/diffs/src/editor/textDocument.ts
@@ -212,6 +212,16 @@ export class TextDocument<LAnnotation> {
     );
   }
 
+  // Every edit joins the undo timeline: an edit applied with
+  // `updateHistory=false` affects the edit stack exactly as the identical
+  // call with `updateHistory=true` and no selections or undo boundary would.
+  // The flag only controls whether the caller's interaction metadata is
+  // recorded on the entry; the entry itself is always pushed (clearing any
+  // pending redo) and coalesces by the normal geometry rules. This keeps a
+  // mixed tracked/untracked sequence equivalent to the all-tracked sequence —
+  // undo-to-exhaustion restores the original text, redo-to-exhaustion the
+  // final text — instead of leaving frozen entries whose offsets go stale.
+  // Only history replay (undo/redo) writes to the buffer without recording.
   applyResolvedEdits(
     edits: ResolvedTextEdit[],
     updateHistory = false,
@@ -223,35 +233,30 @@ export class TextDocument<LAnnotation> {
       return undefined;
     }
     const resolvedEdits = this.#sortAndValidateResolvedEdits(edits);
-    if (updateHistory) {
-      const entry = createEditStackEntry(
-        this,
-        resolvedEdits,
-        this.#version,
-        this.#version + 1,
-        selectionsBefore,
-        selectionsAfter
-      );
-      if (undoBoundary) {
-        entry.undoBoundary = true;
-      }
-      const previousEntry = this.#editStack.peekUndo();
-      const change = this.#applyResolvedEditsToBuffer(resolvedEdits);
-      this.#version++;
-      if (
-        change.lineDelta === 0 &&
-        shouldCoalesceEditStackEntry(previousEntry, entry)
-      ) {
-        this.#editStack.replaceLastUndo(
-          coalesceEditStackEntries(previousEntry!, entry)
-        );
-      } else {
-        this.#editStack.push(entry);
-      }
-      return change;
+    const entry = createEditStackEntry(
+      this,
+      resolvedEdits,
+      this.#version,
+      this.#version + 1,
+      updateHistory ? selectionsBefore : undefined,
+      updateHistory ? selectionsAfter : undefined
+    );
+    if (updateHistory && undoBoundary) {
+      entry.undoBoundary = true;
     }
+    const previousEntry = this.#editStack.peekUndo();
     const change = this.#applyResolvedEditsToBuffer(resolvedEdits);
     this.#version++;
+    if (
+      change.lineDelta === 0 &&
+      shouldCoalesceEditStackEntry(previousEntry, entry)
+    ) {
+      this.#editStack.replaceLastUndo(
+        coalesceEditStackEntries(previousEntry!, entry)
+      );
+    } else {
+      this.#editStack.push(entry);
+    }
     return change;
   }
 

--- a/packages/diffs/test/README.md
+++ b/packages/diffs/test/README.md
@@ -103,7 +103,7 @@ order. If you touch one of these areas, consider adding the missing coverage:
 - **IME composition deferrals** — IME/composition interaction with editing and
   undo-coalescing is deferred and not covered.
 
-## Known bugs pinned as `test.failing` (30)
+## Known bugs pinned as `test.failing`
 
 - **EditStack coalescing** (3) — coalescing decisions compare a new edit against
   whatever sits on top of the undo stack purely by geometry, with no state reset
@@ -133,21 +133,6 @@ order. If you touch one of these areas, consider adding the missing coverage:
   the indent unit on empty and whitespace-only lines inside the selection,
   injecting trailing whitespace on lines the user never touched (outdent
   round-trips it away, bounding the damage).
-- **History equivalence across non-history edits** (7) — edits applied with
-  `updateHistory=false` are an implementation detail of how an edit reaches
-  `applyEdits`, not a separate semantic class: a mixed programmatic/local
-  sequence must leave history equivalent to the same sequence applied all-local,
-  so undo-to-exhaustion restores the original byte-exact text and
-  redo-to-exhaustion the final text. Today untracked edits bypass the edit stack
-  and existing entries apply at stale offsets, so exhaustion corrupts instead: a
-  stale-offset undo deletes the wrong characters, a replacement batch breaks
-  across an interleaved untracked insert, an untracked interior insert is erased
-  while tracked text is stranded, an untracked whole-document replace produces
-  spliced states that never existed on any timeline, typing coalesced around an
-  untracked insert unwinds to the untracked remainder instead of the original
-  text, the unwind that should restore recorded selections verbatim never
-  reaches the original text, and a pending redo survives an untracked edit
-  (instead of being cleared like any new edit) and replays at stale offsets.
 - **Position round-trip losing a column** (1) — a position-from-offset
   computation can return a position strictly inside a CRLF pair (a character
   beyond the line's own length) that the inverse offset-from-position

--- a/packages/diffs/test/README.md
+++ b/packages/diffs/test/README.md
@@ -105,13 +105,6 @@ order. If you touch one of these areas, consider adding the missing coverage:
 
 ## Known bugs pinned as `test.failing`
 
-- **EditStack coalescing** (3) — coalescing decisions compare a new edit against
-  whatever sits on top of the undo stack purely by geometry, with no state reset
-  after undo/redo: an undo can expose a stale top entry that new typing then
-  fuses into; an undo-boundary marker stops blocking merges once it is undone;
-  and backspace followed by forward-delete at the same pivot coalesces into a
-  single undo step instead of getting an undo stop when the delete direction
-  flips.
 - **Surrogate-pair edit boundaries** (3) — edit range endpoints landing strictly
   inside a surrogate pair split the pair and corrupt the buffer instead of
   snapping to pair boundaries; affects insert-inside-a-pair and replaces

--- a/packages/diffs/test/editorEditStack.test.ts
+++ b/packages/diffs/test/editorEditStack.test.ts
@@ -250,6 +250,35 @@ describe('shouldCoalesceEditStackEntry', () => {
     const next = stackEntry('w', [{ start: 1, end: 1, text: 'o' }], 1, 2);
     expect(shouldCoalesceEditStackEntry(previous, next)).toBe(true);
   });
+
+  // Backspace and forward Delete at the same pivot leave identical edit
+  // geometry; only the caret side of the recorded selections separates them.
+  // A direction stop requires BOTH entries' key directions known and
+  // opposite — a lone labeled side keeps the geometry-only rules, so a
+  // caret that merely coincides with a delete edge (an outdent's
+  // leading-whitespace delete, a host-applied programmatic delete) cannot
+  // break grouping against unlabeled neighbors.
+  test('does not coalesce known-opposite delete directions at the same pivot', () => {
+    const previous = stackEntry('abc', [{ start: 1, end: 2, text: '' }], 0, 1, [
+      caret(2), // caret at the deleted range's end: backspace posture
+    ]);
+    const next = stackEntry('ac', [{ start: 1, end: 2, text: '' }], 1, 2, [
+      caret(1), // caret at the deleted range's start: forward-delete posture
+    ]);
+    expect(shouldCoalesceEditStackEntry(previous, next)).toBe(false);
+  });
+
+  test('coalesces at the pivot when only one delete direction is known', () => {
+    const unlabeled = stackEntry('abc', [{ start: 1, end: 2, text: '' }], 0, 1);
+    const backspaceNext = stackEntry(
+      'ac',
+      [{ start: 1, end: 2, text: '' }],
+      1,
+      2,
+      [caret(2)]
+    );
+    expect(shouldCoalesceEditStackEntry(unlabeled, backspaceNext)).toBe(true);
+  });
 });
 
 // --- Shared helpers for the undo/redo coalescing and history scenarios below ---
@@ -359,100 +388,127 @@ function redoAll(d: ReturnType<typeof doc>) {
   return steps;
 }
 
-// Undo/redo coalescing scenarios. The three test.failing entries here are
-// known bugs: coalescing is decided purely by comparing edit geometry against
-// whatever entry sits on top of the undo stack, with no state reset after
-// undo()/redo() and no sticky typing-mode tracking.
+// Undo/redo coalescing scenarios. Undo/redo traversal is itself a coalescing
+// boundary: every pop seals the entry it exposes as the new top of the undo
+// stack, so fresh typing after an undo or redo always starts a new undo step
+// instead of fusing into traversed history. Delete entries additionally
+// record which key produced them (backspace vs forward delete, read from the
+// caret side of the recorded selections), so a switch between two known
+// directions at the same pivot gets its own undo stop even though both keys
+// leave identical edit geometry. A lone labeled side keeps the geometry-only
+// rules, so deletes whose recorded caret merely coincides with an edit edge
+// (outdent, programmatic edits) cannot break grouping against unlabeled
+// neighbors.
 describe('EditStack coalescing across undo and redo', () => {
-  // KNOWN BUG: after undo() pops the top entry, new typing that happens to sit
-  // adjacent to the newly exposed entry coalesces into it, so one undo wipes out
-  // committed pre-undo history along with the fresh keystroke.
-  test.failing(
-    'typing after an undo never merges into pre-undo history',
-    () => {
-      const d = doc('hello\nworld');
-      typeAt(d, 0, 0, 'a'); // entry 1: "ahello\nworld"
-      typeAt(d, 1, 0, 'Z'); // entry 2 (different line, no coalesce): "ahello\nZworld"
-      d.undo(); // pops entry 2, entry 1 is now on top
-      expect(d.getText()).toBe('ahello\nworld');
+  // After undo() pops the top entry, the newly exposed entry is sealed: new
+  // typing that happens to sit adjacent to it starts a fresh undo step, so one
+  // undo removes only the new keystroke, never committed pre-undo history.
+  test('typing after an undo never merges into pre-undo history', () => {
+    const d = doc('hello\nworld');
+    typeAt(d, 0, 0, 'a'); // entry 1: "ahello\nworld"
+    typeAt(d, 1, 0, 'Z'); // entry 2 (different line, no coalesce): "ahello\nZworld"
+    d.undo(); // pops entry 2, entry 1 is now on top
+    expect(d.getText()).toBe('ahello\nworld');
 
-      typeAt(d, 0, 1, 'b'); // brand-new keystroke, adjacent to entry 1's insert
-      expect(d.getText()).toBe('abhello\nworld');
+    typeAt(d, 0, 1, 'b'); // brand-new keystroke, adjacent to entry 1's insert
+    expect(d.getText()).toBe('abhello\nworld');
 
-      // One undo must remove only the new 'b', not entry 1's 'a' with it.
-      d.undo();
-      expect(d.getText()).toBe('ahello\nworld');
+    // One undo removes only the new 'b', not entry 1's 'a' with it.
+    d.undo();
+    expect(d.getText()).toBe('ahello\nworld');
 
-      // Redo direction: the 'b' keystroke comes back on its own.
-      d.redo();
-      expect(d.getText()).toBe('abhello\nworld');
+    // Redo direction: the 'b' keystroke comes back on its own.
+    d.redo();
+    expect(d.getText()).toBe('abhello\nworld');
 
-      // The full history unwinds one keystroke at a time.
-      d.undo();
-      d.undo();
-      expect(d.getText()).toBe('hello\nworld');
-      expect(d.canUndo).toBe(false);
-    }
-  );
+    // The full history unwinds one keystroke at a time.
+    d.undo();
+    d.undo();
+    expect(d.getText()).toBe('hello\nworld');
+    expect(d.canUndo).toBe(false);
+  });
 
-  // KNOWN BUG: an undoBoundary entry blocks merging only while it sits on the
-  // undo stack; once it is undone, the entry beneath it is exposed and new
-  // typing merges straight through into it as if the boundary never existed.
-  test.failing(
-    'an undone boundary entry still shields the entry beneath it from coalescing',
-    () => {
-      const d = doc('hello');
-      typeAt(d, 0, 0, 'a'); // entry 1: "ahello"
-      typeAt(d, 0, 1, 'XYZ', true); // paste with boundary: "aXYZhello"
-      d.undo(); // pops the paste, entry 1 is on top again
-      expect(d.getText()).toBe('ahello');
+  // Undoing a boundary entry seals the entry it exposes, so the shield
+  // effectively survives the boundary's removal: new typing starts its own
+  // step instead of merging into the entry beneath the undone paste.
+  test('an undone boundary entry still shields the entry beneath it from coalescing', () => {
+    const d = doc('hello');
+    typeAt(d, 0, 0, 'a'); // entry 1: "ahello"
+    typeAt(d, 0, 1, 'XYZ', true); // paste with boundary: "aXYZhello"
+    d.undo(); // pops the paste, entry 1 is on top again
+    expect(d.getText()).toBe('ahello');
 
-      typeAt(d, 0, 1, 'b'); // ordinary keystroke adjacent to entry 1's insert
-      expect(d.getText()).toBe('abhello');
+    typeAt(d, 0, 1, 'b'); // ordinary keystroke adjacent to entry 1's insert
+    expect(d.getText()).toBe('abhello');
 
-      // One undo must remove only 'b'; 'a' predates the paste boundary.
-      d.undo();
-      expect(d.getText()).toBe('ahello');
+    // One undo removes only 'b'; 'a' predates the paste boundary.
+    d.undo();
+    expect(d.getText()).toBe('ahello');
 
-      // Redo direction: only the 'b' keystroke replays.
-      d.redo();
-      expect(d.getText()).toBe('abhello');
+    // Redo direction: only the 'b' keystroke replays.
+    d.redo();
+    expect(d.getText()).toBe('abhello');
 
-      d.undo();
-      d.undo();
-      expect(d.getText()).toBe('hello');
-      expect(d.canUndo).toBe(false);
-    }
-  );
+    d.undo();
+    d.undo();
+    expect(d.getText()).toBe('hello');
+    expect(d.canUndo).toBe(false);
+  });
 
-  // KNOWN BUG: a Backspace followed by a forward Delete at the same pivot
-  // coalesces into one undo step; the pivot offset maps ambiguously onto the end
-  // of the just-deleted range, so the pair passes the 'delete'-mode check.
-  test.failing(
-    'switching from backspace to forward delete creates a new undo stop',
-    () => {
-      const d = doc('abc');
-      backspaceAt(d, 0, 2); // removes 'b' -> "ac", caret lands at (0,1)
-      forwardDeleteAt(d, 0, 1); // removes 'c' -> "a"
-      expect(d.getText()).toBe('a');
+  // Backspace and forward Delete at the same pivot leave identical edit
+  // geometry (the pivot offset maps onto the end of the just-deleted range),
+  // so entries record which delete key produced them from the caret side of
+  // the recorded selections; a direction switch starts a new undo stop
+  // instead of continuing the run.
+  test('switching from backspace to forward delete creates a new undo stop', () => {
+    const d = doc('abc');
+    backspaceAt(d, 0, 2); // removes 'b' -> "ac", caret lands at (0,1)
+    forwardDeleteAt(d, 0, 1); // removes 'c' -> "a"
+    expect(d.getText()).toBe('a');
 
-      // First undo restores only the forward-deleted character.
-      d.undo();
-      expect(d.getText()).toBe('ac');
+    // First undo restores only the forward-deleted character.
+    d.undo();
+    expect(d.getText()).toBe('ac');
 
-      // Second undo restores the backspaced character.
-      d.undo();
-      expect(d.getText()).toBe('abc');
-      expect(d.canUndo).toBe(false);
+    // Second undo restores the backspaced character.
+    d.undo();
+    expect(d.getText()).toBe('abc');
+    expect(d.canUndo).toBe(false);
 
-      // Redo direction: the two deletes replay as separate steps.
-      d.redo();
-      expect(d.getText()).toBe('ac');
-      d.redo();
-      expect(d.getText()).toBe('a');
-      expect(d.canRedo).toBe(false);
-    }
-  );
+    // Redo direction: the two deletes replay as separate steps.
+    d.redo();
+    expect(d.getText()).toBe('ac');
+    d.redo();
+    expect(d.getText()).toBe('a');
+    expect(d.canRedo).toBe(false);
+  });
+
+  // The editor's indent dispatch records the live caret alongside outdent's
+  // leading-whitespace deletes, so an entry can carry a coincidental
+  // delete-key posture (caret exactly at the deleted range's edge) without
+  // any delete key being pressed. A lone labeled side must not break the
+  // geometry grouping: two consecutive outdents stay one undo step.
+  test('outdent-shaped deletes with a coincidental caret edge keep geometry grouping', () => {
+    const outdentEdit = {
+      range: {
+        start: { line: 0, character: 0 },
+        end: { line: 0, character: 2 },
+      },
+      newText: '',
+    };
+    const d = doc('    foo');
+    // Caret at the text start (col 4): on neither edge of [0,2) -> unlabeled.
+    d.applyEdits([outdentEdit], true, [caretAt(0, 4)], [caretAt(0, 2)]);
+    expect(d.getText()).toBe('  foo');
+    // Caret now at col 2: coincides with this delete's end (a backspace
+    // posture), but the previous entry has no known direction.
+    d.applyEdits([outdentEdit], true, [caretAt(0, 2)], [caretAt(0, 0)]);
+    expect(d.getText()).toBe('foo');
+
+    d.undo();
+    expect(d.getText()).toBe('    foo');
+    expect(d.canUndo).toBe(false);
+  });
 
   // DIVERGENCE: the conventional behavior breaks typed runs at whitespace (a
   // lone space merges with the word before it, but typing after the space
@@ -1444,10 +1500,10 @@ describe('randomized keystroke-run history oracle', () => {
   // document and checks the recorded patch in both directions, this drives
   // seeded keystroke runs through history-tracked applyEdits and checks the
   // coalesced history in both directions via exhaustion. CONSTRAINTS: this
-  // must stay a passing invariant test, so the run never undoes mid-stream
-  // (coalescing across undo/redo is the known-bug family in the "EditStack
-  // coalescing across undo and redo" describe above) and never applies
-  // history-skipping edits (the frozen-entry known bugs live in the
+  // stays a pure coalescing oracle, so the run never undoes mid-stream
+  // (traversal seals entries against further coalescing — pinned
+  // deterministically in the "EditStack coalescing across undo and redo"
+  // describe above) and never applies history-skipping edits (pinned in the
   // "undo/redo across non-history edits" describe above); undo/redo run only
   // in the final exhaustion phase.
   test('seeded keystroke runs keep per-step text fidelity and byte-exact undo/redo exhaustion', () => {

--- a/packages/diffs/test/editorEditStack.test.ts
+++ b/packages/diffs/test/editorEditStack.test.ts
@@ -818,8 +818,9 @@ function localEdit(
   );
 }
 
-// A non-history edit: updateHistory=false, exactly what Editor.applyEdits
-// defaults to for programmatic/remote changes.
+// A non-history edit: updateHistory=false, the TextDocument-level shape of a
+// programmatic/remote change. It still joins the undo timeline (history
+// equivalence), just without selection/undo-boundary metadata.
 function remoteEdit(
   d: ReturnType<typeof doc>,
   startCharacter: number,
@@ -831,305 +832,274 @@ function remoteEdit(
 
 // Undo/redo interacting with non-history edits (updateHistory=false).
 //
-// DESIGN MODEL (equivalence): applying an edit with updateHistory=false is an
-// implementation detail of how the edit reaches applyEdits (the default for
-// Editor.applyEdits — collaborative patches, programmatic fixes, etc.), not a
-// separate semantic class of edit. A mixed tracked/untracked sequence must
-// leave the document and its history in a state equivalent to the same
-// sequence applied all-tracked. The observable contract — chosen because it
-// sidesteps per-step grouping ambiguity — is exhaustion: after any edit
-// sequence, undo-to-exhaustion restores the ORIGINAL byte-exact text and
-// redo-to-exhaustion restores the FINAL text, no matter which edits skipped
-// history tracking. Where a per-step value is asserted, it is the value the
-// all-tracked reference run of the same script produces (probed with
-// undoBoundary=true per edit to defeat coalescing noise); the literals below
-// are embedded from those reference runs. The previously pinned rebasing
-// model — untracked edits survive undo while frozen history entries remap
-// around them — is rejected.
-//
-// KNOWN BUG shared by every test.failing below: untracked edits bypass the
-// edit stack entirely and existing entries are never reconciled with them, so
-// traversal strands or erases untracked text and applies inverse/forward
-// edits at stale offsets, corrupting the buffer instead of reproducing the
-// all-tracked timeline. Two passing tests in this describe pin today's
-// stopgap behavior in the geometries where it happens not to corrupt (the
-// after-the-tracked-range baseline and the stack-liveness test); they predate
-// the equivalence model and will need flipping when it lands.
+// DESIGN MODEL (equivalence, implemented in TextDocument.applyResolvedEdits):
+// applying an edit with updateHistory=false is an implementation detail of
+// how the edit reaches applyEdits (the shape of programmatic/remote changes —
+// collaborative patches, codemod fixes, etc.), not a separate semantic class
+// of edit. Every edit joins the undo timeline: an untracked edit
+// affects the edit stack exactly as the identical tracked call with no
+// selections and no undo boundary would — it gets an entry (clearing any
+// pending redo), coalesces by the normal geometry rules, and is unwound by
+// undo and replayed by redo like any other entry, never rebased around. A
+// mixed tracked/untracked sequence therefore leaves the document and its
+// history in a state equivalent to the same sequence applied all-tracked.
+// The headline contract — chosen because it sidesteps per-step grouping
+// ambiguity — is exhaustion: after any edit sequence, undo-to-exhaustion
+// restores the ORIGINAL byte-exact text and redo-to-exhaustion restores the
+// FINAL text, no matter which edits skipped history tracking. Where a
+// per-step value is asserted, it is the value the all-tracked reference run
+// of the same script produces; the literals below are embedded from those
+// reference runs. The rejected alternative — untracked edits survive undo
+// while frozen history entries remap around them (rebasing) — is pinned
+// against explicitly (the interior-insert and whole-document-replace tests).
 describe('undo/redo across non-history edits', () => {
-  // TODAY'S BEHAVIOR, not an equivalence pin: an untracked edit strictly
-  // AFTER the tracked range leaves the entry's stored offsets valid, so the
-  // single undo happens to restore exactly the tracked change without
-  // corrupting anything. Under the equivalence model even this geometry
-  // changes — the all-tracked reference unwinds the suffix first
-  // ("sour lemon", then "lemon") — so this pin documents the one arrangement
-  // where today's frozen entries stay coherent, and will need flipping when
-  // equivalence lands.
-  test('undo works when the non-history edit sits after the tracked range', () => {
+  // An untracked edit after the tracked range is its own timeline entry
+  // sitting above the tracked one (insert at 10 is not adjacent to the
+  // tracked insert's end at 5, so no coalescing), and LIFO order unwinds it
+  // first — matching the all-tracked reference "sour lemon tart" ->
+  // "sour lemon" -> "lemon". Previously this geometry pinned the old bypass
+  // model (a single undo that skipped the untracked suffix).
+  test('an untracked edit after the tracked range is its own undo step above it', () => {
     const d = doc('lemon');
     localEdit(d, 0, 0, 'sour '); // tracked: "sour lemon"
     remoteEdit(d, 10, 10, ' tart'); // remote suffix: "sour lemon tart"
+    expect(d.getText()).toBe('sour lemon tart');
     d.undo();
-    expect(d.getText()).toBe('lemon tart');
+    expect(d.getText()).toBe('sour lemon');
+    expect(d.canUndo).toBe(true);
+    expect(d.canRedo).toBe(true);
+    d.undo();
+    expect(d.getText()).toBe('lemon');
     expect(d.canUndo).toBe(false);
     expect(d.canRedo).toBe(true);
     d.redo();
+    expect(d.getText()).toBe('sour lemon');
+    d.redo();
     expect(d.getText()).toBe('sour lemon tart');
+    expect(d.canRedo).toBe(false);
   });
 
-  // KNOWN BUG: the equivalence expectation is that the two untracked inserts
-  // are part of the timeline, so exhaustion reproduces the all-tracked
-  // reference ("syncpilot?" -> "syncpilot" -> "pilot" -> "" and back).
-  // Actual today: the untracked inserts never enter history and the lone
-  // tracked entry's inverse applies at its stale offsets, deleting the
-  // untracked prefix plus part of the shifted typed text — undo-to-exhaustion
-  // yields "ilot?" and redo-to-exhaustion compounds it to "pilotilot?".
-  test.failing(
-    'a mixed tracked/untracked insert sequence unwinds and replays like the all-tracked timeline',
-    () => {
-      const d = doc('');
-      localEdit(d, 0, 0, 'pilot'); // tracked typing
-      remoteEdit(d, 0, 0, 'sync'); // untracked prefix: "syncpilot"
-      remoteEdit(d, 9, 9, '?'); // untracked suffix: "syncpilot?"
-      expect(d.getText()).toBe('syncpilot?');
+  // The two untracked inserts are part of the timeline, so exhaustion
+  // reproduces the all-tracked reference ("syncpilot?" -> "syncpilot" ->
+  // "pilot" -> "" and back); geometry blocks coalescing at both steps.
+  test('a mixed tracked/untracked insert sequence unwinds and replays like the all-tracked timeline', () => {
+    const d = doc('');
+    localEdit(d, 0, 0, 'pilot'); // tracked typing
+    remoteEdit(d, 0, 0, 'sync'); // untracked prefix: "syncpilot"
+    remoteEdit(d, 9, 9, '?'); // untracked suffix: "syncpilot?"
+    expect(d.getText()).toBe('syncpilot?');
 
-      // Undo-to-exhaustion restores the original byte-exact text...
-      undoAll(d);
-      expect(d.getText()).toBe('');
+    // Undo-to-exhaustion restores the original byte-exact text...
+    undoAll(d);
+    expect(d.getText()).toBe('');
 
-      // ...and redo-to-exhaustion restores the final text.
-      redoAll(d);
-      expect(d.getText()).toBe('syncpilot?');
+    // ...and redo-to-exhaustion restores the final text.
+    redoAll(d);
+    expect(d.getText()).toBe('syncpilot?');
+  });
+
+  // The untracked insert is one more logical step (it cannot coalesce with a
+  // three-edit batch), so exhaustion reproduces the all-tracked reference
+  // ("UV####WXYZ" -> "UVWXYZ" -> "pqr" and back) — the untracked text is
+  // unwound before the batch inverse applies, keeping its offsets valid.
+  test('a replacement batch with an interleaved untracked insert unwinds and replays like the all-tracked timeline', () => {
+    const d = doc('pqr');
+    // One tracked batch of three adjacent replacements.
+    d.applyEdits(
+      [lineEdit(0, 1, 'UV'), lineEdit(1, 2, 'WX'), lineEdit(2, 3, 'YZ')],
+      true,
+      [caretAt(0, 3)]
+    );
+    expect(d.getText()).toBe('UVWXYZ');
+
+    // Untracked insert exactly between the first and second replacements.
+    remoteEdit(d, 2, 2, '####');
+    expect(d.getText()).toBe('UV####WXYZ');
+
+    // Undo-to-exhaustion restores the original byte-exact text — the
+    // untracked insert is unwound too, exactly as if it had been tracked.
+    undoAll(d);
+    expect(d.getText()).toBe('pqr');
+
+    // Redo-to-exhaustion restores the final text.
+    redoAll(d);
+    expect(d.getText()).toBe('UV####WXYZ');
+  });
+
+  // The untracked interior insert does NOT survive undo — it is one of the
+  // undo steps like any other edit (rebasing it around the tracked entry is
+  // the rejected model), and exhaustion reproduces the all-tracked reference
+  // ("WXjYZ" -> "WXYZ" -> "" and back).
+  test('an untracked insert inside a tracked insertion unwinds and replays like the all-tracked timeline', () => {
+    const d = doc('');
+    localEdit(d, 0, 0, 'WXYZ'); // tracked insertion
+    remoteEdit(d, 2, 2, 'j'); // untracked insert in the middle of it
+    expect(d.getText()).toBe('WXjYZ');
+
+    undoAll(d);
+    expect(d.getText()).toBe('');
+
+    redoAll(d);
+    expect(d.getText()).toBe('WXjYZ');
+  });
+
+  // An untracked replace that wipes the region a tracked insertion lives in
+  // reads as one more logical step: the all-tracked reference unwinds
+  // "core" -> "oGHk" -> "ok" and replays "oGHk" -> "core", and no state along
+  // the way mixes the two texts — the strongest anti-corruption pin, since a
+  // mixture like "cGHe" never existed on any timeline.
+  test('an untracked whole-document replace over a tracked insertion unwinds and replays like the all-tracked timeline', () => {
+    const d = doc('ok');
+    localEdit(d, 1, 1, 'GH'); // tracked insert: "oGHk"
+    remoteEdit(d, 0, 4, 'core'); // untracked replace of the whole doc
+    expect(d.getText()).toBe('core');
+
+    const visited: string[] = [];
+    while (d.canUndo) {
+      d.undo();
+      visited.push(d.getText());
     }
-  );
+    expect(d.getText()).toBe('ok');
 
-  // KNOWN BUG: the equivalence expectation is that the untracked insert is
-  // one more logical step, so exhaustion reproduces the all-tracked reference
-  // ("UV####WXYZ" -> "UVWXYZ" -> "pqr" and back). Actual today: the batch
-  // entry's chained inverse offsets ignore the untracked insert that landed
-  // between its sub-edits, so undo treats the untracked text as if it were
-  // the tracked replacements — undo-to-exhaustion yields "pqrWXYZ" and
-  // redo-to-exhaustion "UVWXYZWXYZ".
-  test.failing(
-    'a replacement batch with an interleaved untracked insert unwinds and replays like the all-tracked timeline',
-    () => {
-      const d = doc('pqr');
-      // One tracked batch of three adjacent replacements.
-      d.applyEdits(
-        [lineEdit(0, 1, 'UV'), lineEdit(1, 2, 'WX'), lineEdit(2, 3, 'YZ')],
-        true,
-        [caretAt(0, 3)]
-      );
-      expect(d.getText()).toBe('UVWXYZ');
-
-      // Untracked insert exactly between the first and second replacements.
-      remoteEdit(d, 2, 2, '####');
-      expect(d.getText()).toBe('UV####WXYZ');
-
-      // Undo-to-exhaustion restores the original byte-exact text — the
-      // untracked insert is unwound too, exactly as if it had been tracked.
-      undoAll(d);
-      expect(d.getText()).toBe('pqr');
-
-      // Redo-to-exhaustion restores the final text.
-      redoAll(d);
-      expect(d.getText()).toBe('UV####WXYZ');
+    while (d.canRedo) {
+      d.redo();
+      visited.push(d.getText());
     }
-  );
+    expect(d.getText()).toBe('core');
 
-  // KNOWN BUG: under the equivalence model the untracked interior insert
-  // does NOT survive undo — it is one of the undo steps like any other edit,
-  // and exhaustion reproduces the all-tracked reference ("WXjYZ" -> "WXYZ" ->
-  // "" and back). Actual today: the tracked insertion's stale inverse [0,4)
-  // is deleted from "WXjYZ" wholesale, erasing the untracked "j" and
-  // stranding a tracked "Z" — undo-to-exhaustion yields "Z" and
-  // redo-to-exhaustion "WXYZZ".
-  test.failing(
-    'an untracked insert inside a tracked insertion unwinds and replays like the all-tracked timeline',
-    () => {
-      const d = doc('');
-      localEdit(d, 0, 0, 'WXYZ'); // tracked insertion
-      remoteEdit(d, 2, 2, 'j'); // untracked insert in the middle of it
-      expect(d.getText()).toBe('WXjYZ');
-
-      undoAll(d);
-      expect(d.getText()).toBe('');
-
-      redoAll(d);
-      expect(d.getText()).toBe('WXjYZ');
+    // Every state the traversal visits must be one the all-tracked
+    // timeline visits — no mixtures like "cGHe".
+    for (const state of visited) {
+      expect(['ok', 'oGHk', 'core']).toContain(state);
     }
-  );
+  });
 
-  // KNOWN BUG: an untracked replace that wipes the region a tracked insertion
-  // lives in must read as one more logical step: the all-tracked reference
-  // unwinds "core" -> "oGHk" -> "ok" and replays "oGHk" -> "core", and no
-  // state along the way mixes the two texts. Actual today: the frozen entry
-  // points at text that no longer exists, so undo deletes unrelated
-  // characters ("core" -> "ce") and redo splices the tracked insert into the
-  // replacement text ("cGHe") — a corruption artifact that never existed on
-  // any timeline.
-  test.failing(
-    'an untracked whole-document replace over a tracked insertion unwinds and replays like the all-tracked timeline',
-    () => {
-      const d = doc('ok');
-      localEdit(d, 1, 1, 'GH'); // tracked insert: "oGHk"
-      remoteEdit(d, 0, 4, 'core'); // untracked replace of the whole doc
-      expect(d.getText()).toBe('core');
+  // Stored selections need no remapping at all — by the time the tracked
+  // delete's entry is undone, the untracked insert has itself been unwound,
+  // so the document is back in the exact coordinate space the selections
+  // were recorded in and they restore verbatim. The all-tracked reference
+  // unwinds " worXYld" -> " world" -> "hello world" with the final undo
+  // returning carets [6, 11] unchanged.
+  test('undo exhaustion across an untracked insert restores the original text and the verbatim recorded selections', () => {
+    const d = doc('hello world');
+    // Tracked delete of the leading word, with two carets recorded.
+    d.applyEdits([lineEdit(0, 5, '')], true, [caretAt(0, 6), caretAt(0, 11)]);
+    expect(d.getText()).toBe(' world');
 
-      const visited: string[] = [];
-      while (d.canUndo) {
-        d.undo();
-        visited.push(d.getText());
-      }
-      expect(d.getText()).toBe('ok');
+    // Untracked insert; in the original coordinates this lands at offset 9,
+    // between the two stored carets.
+    remoteEdit(d, 4, 4, 'XY');
+    expect(d.getText()).toBe(' worXYld');
 
-      while (d.canRedo) {
-        d.redo();
-        visited.push(d.getText());
-      }
-      expect(d.getText()).toBe('core');
-
-      // Every state the traversal visits must be one the all-tracked
-      // timeline visits — no mixtures like "cGHe".
-      for (const state of visited) {
-        expect(['ok', 'oGHk', 'core']).toContain(state);
-      }
+    let lastUndo: ReturnType<typeof d.undo>;
+    while (d.canUndo) {
+      lastUndo = d.undo();
     }
-  );
+    expect(d.getText()).toBe('hello world');
+    // Mirrors the all-tracked reference: the final undo hands back the
+    // entry's stored selectionsBefore untouched.
+    expect(lastUndo?.[1]?.map((s) => s.start.character)).toEqual([6, 11]);
 
-  // KNOWN BUG: under the equivalence model stored selections need no
-  // remapping at all — by the time the tracked delete's entry is undone, the
-  // untracked insert has itself been unwound, so the document is back in the
-  // exact coordinate space the selections were recorded in and they restore
-  // verbatim. The all-tracked reference unwinds " worXYld" -> " world" ->
-  // "hello world" with the final undo returning carets [6, 11] unchanged.
-  // Actual today: the selections half already matches (they come back
-  // verbatim), but the text half fails — the untracked insert is never
-  // unwound, so the single undo reinserts "hello" at a stale offset and
-  // exhaustion ends at "hello worXYld" instead of "hello world".
-  test.failing(
-    'undo exhaustion across an untracked insert restores the original text and the verbatim recorded selections',
-    () => {
-      const d = doc('hello world');
-      // Tracked delete of the leading word, with two carets recorded.
-      d.applyEdits([lineEdit(0, 5, '')], true, [caretAt(0, 6), caretAt(0, 11)]);
-      expect(d.getText()).toBe(' world');
+    redoAll(d);
+    expect(d.getText()).toBe(' worXYld');
+  });
 
-      // Untracked insert; in the original coordinates this lands at offset 9,
-      // between the two stored carets.
-      remoteEdit(d, 4, 4, 'XY');
-      expect(d.getText()).toBe(' worXYld');
+  // The untracked "b" is part of the timeline like any other edit — and
+  // subject to NORMAL typing coalescing, not a forced boundary — so
+  // undo-to-exhaustion restores the original (empty) text, not an untracked
+  // remainder. The all-tracked run of this script unwinds "acb" -> "ab" -> ""
+  // and replays "" -> "ab" -> "acb" (the "b" coalesces into the "a"
+  // keystroke; "c" lands inside the merged insert and starts a new step);
+  // however the mixed run groups its steps, exhaustion must hit the same
+  // endpoints.
+  test('typing around an untracked insert unwinds to the original text, not to an untracked remainder', () => {
+    const d = doc('');
+    localEdit(d, 0, 0, 'a'); // tracked keystroke: "a"
+    remoteEdit(d, 1, 1, 'b'); // untracked: "ab"
+    localEdit(d, 1, 1, 'c'); // tracked keystroke right after the "a": "acb"
+    expect(d.getText()).toBe('acb');
 
-      let lastUndo: ReturnType<typeof d.undo>;
-      while (d.canUndo) {
-        lastUndo = d.undo();
-      }
-      expect(d.getText()).toBe('hello world');
-      // Mirrors the all-tracked reference: the final undo hands back the
-      // entry's stored selectionsBefore untouched.
-      expect(lastUndo?.[1]?.map((s) => s.start.character)).toEqual([6, 11]);
+    // Undo-to-exhaustion restores the original byte-exact text...
+    undoAll(d);
+    expect(d.getText()).toBe('');
 
-      redoAll(d);
-      expect(d.getText()).toBe(' worXYld');
-    }
-  );
+    // ...and redo-to-exhaustion restores the final text.
+    redoAll(d);
+    expect(d.getText()).toBe('acb');
+  });
 
-  // KNOWN BUG (was a passing pin under the old rebasing model, where undo
-  // "keeping the untracked text" looked correct by geometric accident):
-  // under the equivalence model the untracked "b" is part of the timeline
-  // like any other edit, so undo-to-exhaustion restores the original (empty)
-  // text — not an untracked remainder. The all-tracked run of this script
-  // unwinds "acb" -> "ab" -> "" and replays "" -> "ab" -> "acb" (the "b"
-  // coalesces into the "a" keystroke; "c" lands inside the merged insert and
-  // starts a new step); however the mixed run groups its steps, exhaustion
-  // must hit the same endpoints. Actual today: the two tracked keystrokes
-  // coalesce into one entry whose single undo leaves exactly "b", and
-  // canUndo goes false with the untracked text stranded as if it were
-  // original.
-  test.failing(
-    'typing around an untracked insert unwinds to the original text, not to an untracked remainder',
-    () => {
-      const d = doc('');
-      localEdit(d, 0, 0, 'a'); // tracked keystroke: "a"
-      remoteEdit(d, 1, 1, 'b'); // untracked: "ab"
-      localEdit(d, 1, 1, 'c'); // tracked keystroke right after the "a": "acb"
-      expect(d.getText()).toBe('acb');
-
-      // Undo-to-exhaustion restores the original byte-exact text...
-      undoAll(d);
-      expect(d.getText()).toBe('');
-
-      // ...and redo-to-exhaustion restores the final text.
-      redoAll(d);
-      expect(d.getText()).toBe('acb');
-    }
-  );
-
-  // TODAY'S BEHAVIOR, not an equivalence pin: untracked edits currently touch
-  // neither stack, so undo entries survive and a pending redo is not cleared.
-  // Geometry keeps every untracked edit after the tracked offsets so the
-  // surviving entries also APPLY cleanly today. Under the equivalence model
-  // an untracked edit is a new edit like any other — it joins the undo
-  // timeline and clears a pending redo (the failing pin below) — so this pin
-  // documents the stopgap and will need flipping when equivalence lands.
-  test('a non-history edit neither consumes undo entries nor clears the redo stack', () => {
+  // An untracked edit is a new edit like any other: it joins the undo
+  // timeline (here coalescing into the tracked keystroke by the normal
+  // insert-adjacency rule, exactly as the all-tracked reference does) and,
+  // while a redo entry is pending, pushing it clears the redo stack — the
+  // parked entry never replays anywhere. Previously pinned the old bypass
+  // model, where untracked edits touched neither stack.
+  test('a non-history edit joins the undo timeline and clears the redo stack', () => {
     const d = doc('alpha');
     localEdit(d, 5, 5, '!'); // tracked: "alpha!"
     expect(d.canUndo).toBe(true);
     expect(d.canRedo).toBe(false);
 
+    // Starts exactly where the tracked insert ends, so it coalesces into the
+    // "!" entry like continued typing would.
     remoteEdit(d, 6, 6, ' beta'); // "alpha! beta"
+    expect(d.getText()).toBe('alpha! beta');
     expect(d.canUndo).toBe(true);
     expect(d.canRedo).toBe(false);
 
+    // One coalesced step unwinds both inserts.
     d.undo();
-    expect(d.getText()).toBe('alpha beta');
+    expect(d.getText()).toBe('alpha');
     expect(d.canUndo).toBe(false);
     expect(d.canRedo).toBe(true);
 
-    // A non-history edit while a redo entry is pending keeps it alive.
-    remoteEdit(d, 10, 10, '?'); // "alpha beta?"
-    expect(d.canRedo).toBe(true);
-
-    d.redo();
-    expect(d.getText()).toBe('alpha! beta?');
+    // A non-history edit while a redo entry is pending pushes a new entry
+    // and clears the redo — the parked "! beta" entry is gone for good.
+    remoteEdit(d, 5, 5, '?'); // "alpha?"
+    expect(d.getText()).toBe('alpha?');
     expect(d.canUndo).toBe(true);
     expect(d.canRedo).toBe(false);
+
+    d.redo(); // no-op: nothing left to redo
+    expect(d.getText()).toBe('alpha?');
+    expect(d.canUndo).toBe(true);
+    expect(d.canRedo).toBe(false);
+
+    expect(undoAll(d)).toBe(1);
+    expect(d.getText()).toBe('alpha');
+    redoAll(d);
+    expect(d.getText()).toBe('alpha?');
   });
 
-  // KNOWN BUG: under the equivalence model the untracked ">> " insert is an
-  // ordinary new edit, and a new edit while a redo is pending clears the redo
-  // stack (the same rule tracked edits already follow). The all-tracked
+  // The untracked ">> " insert is an ordinary new edit, and a new edit while
+  // a redo is pending clears the redo stack (the same rule tracked edits
+  // already follow) — the parked "!" entry never replays anywhere, so its
+  // forward edit can never land at a stale offset. Matches the all-tracked
   // reference run: canRedo goes false after the ">> " edit, redo() is a
   // no-op at ">> note", undo-to-exhaustion yields "note", redo-to-exhaustion
-  // ">> note". Actual today: the pending redo entry survives the untracked
-  // edit and replays its forward edit at a stale offset, landing the "!"
-  // mid-word (">> n!ote"), and undo-to-exhaustion from there strands the
-  // untracked prefix at ">> note" instead of returning to "note".
-  test.failing(
-    'an untracked edit while a redo is pending behaves like a tracked edit and clears the redo',
-    () => {
-      const d = doc('note');
-      localEdit(d, 4, 4, '!'); // tracked: "note!"
-      d.undo();
-      expect(d.getText()).toBe('note');
-      expect(d.canRedo).toBe(true);
+  // ">> note".
+  test('an untracked edit while a redo is pending behaves like a tracked edit and clears the redo', () => {
+    const d = doc('note');
+    localEdit(d, 4, 4, '!'); // tracked: "note!"
+    d.undo();
+    expect(d.getText()).toBe('note');
+    expect(d.canRedo).toBe(true);
 
-      remoteEdit(d, 0, 0, '>> '); // untracked prefix while redo is pending
-      expect(d.getText()).toBe('>> note');
+    remoteEdit(d, 0, 0, '>> '); // untracked prefix while redo is pending
+    expect(d.getText()).toBe('>> note');
 
-      // Mirrors the all-tracked reference: pushing a new edit clears redo,
-      // so the pending "!" never replays anywhere.
-      expect(d.canRedo).toBe(false);
-      d.redo();
-      expect(d.getText()).toBe('>> note');
+    // Mirrors the all-tracked reference: pushing a new edit clears redo,
+    // so the pending "!" never replays anywhere.
+    expect(d.canRedo).toBe(false);
+    d.redo();
+    expect(d.getText()).toBe('>> note');
 
-      // Exhaustion in both directions matches the reference timeline.
-      undoAll(d);
-      expect(d.getText()).toBe('note');
-      redoAll(d);
-      expect(d.getText()).toBe('>> note');
-    }
-  );
+    // Exhaustion in both directions matches the reference timeline.
+    undoAll(d);
+    expect(d.getText()).toBe('note');
+    redoAll(d);
+    expect(d.getText()).toBe('>> note');
+  });
 });
 
 function insertEdit(

--- a/packages/diffs/test/editorTextDocument.test.ts
+++ b/packages/diffs/test/editorTextDocument.test.ts
@@ -1130,7 +1130,12 @@ describe('TextDocument', () => {
     expect(d.canUndo).toBe(false);
   });
 
-  test('applyEdits default does not record undo', () => {
+  // History equivalence: an edit applied without updateHistory joins the
+  // undo timeline exactly like the identical tracked call with no recorded
+  // selections would (see 'undo/redo across non-history edits' in
+  // editorEditStack.test.ts). This used to pin the old bypass model, where
+  // the default skipped the edit stack entirely.
+  test('applyEdits default records an undoable entry without selection metadata', () => {
     const d = doc('a');
     d.applyEdits([
       {
@@ -1142,8 +1147,13 @@ describe('TextDocument', () => {
       },
     ]);
     expect(d.getText()).toBe('ab');
-    expect(d.canUndo).toBe(false);
-    expect(d.undo()).toBeUndefined();
+    expect(d.canUndo).toBe(true);
+    const undoResult = d.undo();
+    expect(d.getText()).toBe('a');
+    // No interaction metadata is recorded for the untracked call.
+    expect(undoResult?.[1]).toBeUndefined();
+    d.redo();
+    expect(d.getText()).toBe('ab');
   });
 
   test('undo and redo', () => {


### PR DESCRIPTION
## What

Fixes the three pinned EditStack coalescing bugs (stacked on #987, which it builds on):

1. **Typing after undo fused into pre-undo history** — one undo then erased both the old and new text.
2. **An undo-boundary entry stopped shielding once undone** — paste boundaries evaporated from the redo stack.
3. **Backspace then forward-delete at the same pivot merged** into a single undo step instead of getting a stop when the delete direction flips.

## How

- **Traversal seals (bugs 1+2, one mechanism):** every `popUndoToRedo`/`popRedoToUndo` stamps the newly exposed top undo entry with a durable `sealed` flag; `shouldCoalesceEditStackEntry` rejects a sealed previous entry. Traversal is an undo stop in both directions — typing after undo, after redo, or at any depth of ping-pong starts a fresh step. `undoBoundary`'s paste/cut semantics are untouched.
- **Delete-direction stops (bug 3):** pure-delete entries whose caret selections pair 1:1 with edit edges get a `deleteDirection` label (`backspace`/`delete`); coalescing rejects **only when both entries' labels are known and opposite**. Labels propagate through merges, so a whole backspace run still stops a forward delete. Anything ambiguous (range selections, multi-caret partial eligibility, untracked edits) stays on today's geometry-only rules.

## The judgment call reviewers should look at

The both-known rule exists because a single-sided version **regressed consecutive outdent grouping** — outdent deletes coincidentally place carets on edit edges, and two Shift+Tabs started costing two undo steps. Caught by adversarial review probes, fixed, and pinned by three new regression tests. One documented residual: an outdent pair with the caret mid-indent is byte-identical to backspace-then-forward-delete, so it keeps getting two steps — no classifier can split those without breaking the pinned contract. Threading explicit direction from the command layer (delete handlers, indent dispatch) is the noted follow-up if we want editor-level precision.

## Verification

- 3 pins flipped with assertions unchanged (audit: removed-expect set byte-identical to added-expect set); 3 new regression tests for the outdent interaction.
- 55/55 independent review probes: ping-pong typing, same-direction runs (single/multi-char/multi-caret), forward→backspace symmetry, boundary shields, maxEntries, seal-vs-run-continuation.
- Full diffs suite 1281 pass / 0 fail (twice, identical); typecheck + oxlint + oxfmt clean.
- Known-bug pins remaining: 20.

Third PR of the burn-down (#986, #987).

🤖 Generated with [Claude Code](https://claude.com/claude-code)