### PR TITLE
[diffs/edit] Fix surrogate-pair edit boundaries

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -472,17 +472,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     const resolvedEditOffsets =
       selectionsBefore === undefined
         ? undefined
-        : edits
-            .map((edit) => {
-              const a = textDocument.offsetAt(edit.range.start);
-              const b = textDocument.offsetAt(edit.range.end);
-              return {
-                start: Math.min(a, b),
-                end: Math.max(a, b),
-                text: edit.newText,
-              };
-            })
-            .sort((a, b) => a.start - b.start);
+        : textDocument.resolveEdits(edits).sort((a, b) => a.start - b.start);
 
     const change = textDocument.applyEdits(
       edits,

--- a/packages/diffs/src/editor/textDocument.ts
+++ b/packages/diffs/src/editor/textDocument.ts
@@ -204,12 +204,19 @@ export class TextDocument<LAnnotation> {
       return;
     }
     return this.applyResolvedEdits(
-      edits.map((edit) => this.#resolveEdit(edit)),
+      this.resolveEdits(edits),
       updateHistory,
       selectionsBefore,
       selectionsAfter,
       undoBoundary
     );
+  }
+
+  // Converts line/character ranges to the exact UTF-16 offsets applyEdits
+  // uses, including widening invalid boundaries so they cannot split a valid
+  // surrogate pair. Editor caret remapping uses the same resolved geometry.
+  resolveEdits(edits: readonly TextEdit[]): ResolvedTextEdit[] {
+    return edits.map((edit) => this.#resolveEdit(edit));
   }
 
   applyResolvedEdits(
@@ -346,7 +353,29 @@ export class TextDocument<LAnnotation> {
       start = end;
       end = t;
     }
+    const isInsertion = start === end;
+    if (this.#isInsideSurrogatePair(start)) {
+      start--;
+    }
+    if (isInsertion) {
+      end = start;
+    } else if (this.#isInsideSurrogatePair(end)) {
+      end++;
+    }
     return { start, end, text: edit.newText };
+  }
+
+  // A UTF-16 offset is invalid when it sits between the high and low units of
+  // one well-formed surrogate pair. Lone surrogate units remain addressable.
+  #isInsideSurrogatePair(offset: number): boolean {
+    const previous = this.#pieceTable.charAt(offset - 1).charCodeAt(0);
+    const next = this.#pieceTable.charAt(offset).charCodeAt(0);
+    return (
+      previous >= 0xd800 &&
+      previous <= 0xdbff &&
+      next >= 0xdc00 &&
+      next <= 0xdfff
+    );
   }
 
   #sortAndValidateResolvedEdits(edits: ResolvedTextEdit[]): ResolvedTextEdit[] {

--- a/packages/diffs/src/editor/textDocument.ts
+++ b/packages/diffs/src/editor/textDocument.ts
@@ -203,8 +203,8 @@ export class TextDocument<LAnnotation> {
     if (edits.length === 0) {
       return;
     }
-    return this.applyResolvedEdits(
-      this.resolveEdits(edits),
+    return this.#applyResolvedEdits(
+      this.#sortAndValidateResolvedEdits(this.resolveEdits(edits)),
       updateHistory,
       selectionsBefore,
       selectionsAfter,
@@ -229,7 +229,26 @@ export class TextDocument<LAnnotation> {
     if (edits.length === 0) {
       return undefined;
     }
-    const resolvedEdits = this.#sortAndValidateResolvedEdits(edits);
+    return this.#applyResolvedEdits(
+      this.#sortAndValidateResolvedEdits(
+        edits.map((edit) => this.#normalizeResolvedEdit(edit))
+      ),
+      updateHistory,
+      selectionsBefore,
+      selectionsAfter,
+      undoBoundary
+    );
+  }
+
+  // Shared mutation path after public edit coordinates are normalized and
+  // validated. Undo and redo apply their stored inverse offsets separately.
+  #applyResolvedEdits(
+    resolvedEdits: ResolvedTextEdit[],
+    updateHistory: boolean,
+    selectionsBefore: EditorSelection[] | undefined,
+    selectionsAfter: EditorSelection[] | undefined,
+    undoBoundary: boolean
+  ): TextDocumentChange {
     if (updateHistory) {
       const entry = createEditStackEntry(
         this,
@@ -353,6 +372,17 @@ export class TextDocument<LAnnotation> {
       start = end;
       end = t;
     }
+    return this.#normalizeResolvedEdit({
+      start,
+      end,
+      text: edit.newText,
+    });
+  }
+
+  // Snaps an insertion before a pair and widens replacement boundaries
+  // outward, so every edit addresses whole UTF-16 surrogate pairs.
+  #normalizeResolvedEdit(edit: ResolvedTextEdit): ResolvedTextEdit {
+    let { start, end } = edit;
     const isInsertion = start === end;
     if (this.#isInsideSurrogatePair(start)) {
       start--;
@@ -362,7 +392,7 @@ export class TextDocument<LAnnotation> {
     } else if (this.#isInsideSurrogatePair(end)) {
       end++;
     }
-    return { start, end, text: edit.newText };
+    return { start, end, text: edit.text };
   }
 
   // A UTF-16 offset is invalid when it sits between the high and low units of

--- a/packages/diffs/test/README.md
+++ b/packages/diffs/test/README.md
@@ -103,7 +103,7 @@ order. If you touch one of these areas, consider adding the missing coverage:
 - **IME composition deferrals** — IME/composition interaction with editing and
   undo-coalescing is deferred and not covered.
 
-## Known bugs pinned as `test.failing` (30)
+## Known bugs pinned as `test.failing` (27)
 
 - **EditStack coalescing** (3) — coalescing decisions compare a new edit against
   whatever sits on top of the undo stack purely by geometry, with no state reset
@@ -112,10 +112,6 @@ order. If you touch one of these areas, consider adding the missing coverage:
   and backspace followed by forward-delete at the same pivot coalesces into a
   single undo step instead of getting an undo stop when the delete direction
   flips.
-- **Surrogate-pair edit boundaries** (3) — edit range endpoints landing strictly
-  inside a surrogate pair split the pair and corrupt the buffer instead of
-  snapping to pair boundaries; affects insert-inside-a-pair and replaces
-  starting or ending inside one.
 - **PieceTable CRLF line metadata** (5, spanning piece-table and search
   coverage) — line-break bookkeeping goes stale when a CRLF pair is split or
   assembled across edits (deleting exactly the `\n` of a pair, inserting between

--- a/packages/diffs/test/editorApplyEdits.test.ts
+++ b/packages/diffs/test/editorApplyEdits.test.ts
@@ -1810,6 +1810,21 @@ describe('applyEdits: surrogate pair boundaries', () => {
     expect(d.getLineText(0)).toBe('aplans');
   });
 
+  test('applyResolvedEdits normalizes surrogate-pair boundaries', () => {
+    const cases = [
+      [1, 1, 'a📚plans'],
+      [1, 2, 'aplans'],
+      [0, 1, 'aplans'],
+    ] as const;
+
+    for (const [start, end, expected] of cases) {
+      const d = doc('📚plans\nfor the\nweekend');
+      d.applyResolvedEdits([{ start, end, text: 'a' }]);
+      expect(hasLoneSurrogate(d.getText())).toBe(false);
+      expect(d.getLineText(0)).toBe(expected);
+    }
+  });
+
   test('replace spanning exactly the whole surrogate pair replaces it cleanly', () => {
     const d = doc('📚plans\nfor the\nweekend');
     d.applyEdits([edit(0, 0, 0, 2, 'a')]);

--- a/packages/diffs/test/editorApplyEdits.test.ts
+++ b/packages/diffs/test/editorApplyEdits.test.ts
@@ -490,6 +490,41 @@ describe('Editor.applyEdits selection sync', () => {
     }
   });
 
+  test('remaps the caret through an insertion snapped before a surrogate pair', async () => {
+    const { cleanup, editor } = await createEditorFixture('📚 plans');
+
+    try {
+      editor.setSelections([
+        {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 0 },
+          direction: 'none',
+        },
+      ]);
+
+      editor.applyEdits([
+        {
+          range: {
+            start: { line: 0, character: 1 },
+            end: { line: 0, character: 1 },
+          },
+          newText: 'a',
+        },
+      ]);
+
+      expect(editor.getText()).toBe('a📚 plans');
+      expect(editor.getState().selections).toEqual([
+        {
+          start: { line: 0, character: 1 },
+          end: { line: 0, character: 1 },
+          direction: 0,
+        },
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+
   test('shifts both edges of a selected range and preserves direction', async () => {
     const { cleanup, editor } = await createEditorFixture(
       'alpha\nbravo\ncharlie'
@@ -1754,42 +1789,26 @@ describe('applyEdits: surrogate pair boundaries', () => {
   // the high and low surrogate — an invalid caller position that the
   // conventional behavior auto-corrects so the pair is never split.
 
-  // KNOWN BUG: an insert position strictly inside a surrogate pair is not
-  // snapped to the pair boundary; the inserted text lands between the two
-  // units and getText() returns lone surrogates.
-  test.failing(
-    'insert strictly inside a surrogate pair snaps to before the pair',
-    () => {
-      const d = doc('📚plans\nfor the\nweekend');
-      d.applyEdits([edit(0, 1, 0, 1, 'a')]);
-      expect(hasLoneSurrogate(d.getText())).toBe(false);
-      expect(d.getLineText(0)).toBe('a📚plans');
-    }
-  );
+  test('insert strictly inside a surrogate pair snaps to before the pair', () => {
+    const d = doc('📚plans\nfor the\nweekend');
+    d.applyEdits([edit(0, 1, 0, 1, 'a')]);
+    expect(hasLoneSurrogate(d.getText())).toBe(false);
+    expect(d.getLineText(0)).toBe('a📚plans');
+  });
 
-  // KNOWN BUG: a replace range starting strictly inside a surrogate pair is
-  // not widened to the pair start; the high surrogate is left behind alone.
-  test.failing(
-    'replace starting inside a surrogate pair widens to cover the whole pair',
-    () => {
-      const d = doc('📚plans\nfor the\nweekend');
-      d.applyEdits([edit(0, 1, 0, 2, 'a')]);
-      expect(hasLoneSurrogate(d.getText())).toBe(false);
-      expect(d.getLineText(0)).toBe('aplans');
-    }
-  );
+  test('replace starting inside a surrogate pair widens to cover the whole pair', () => {
+    const d = doc('📚plans\nfor the\nweekend');
+    d.applyEdits([edit(0, 1, 0, 2, 'a')]);
+    expect(hasLoneSurrogate(d.getText())).toBe(false);
+    expect(d.getLineText(0)).toBe('aplans');
+  });
 
-  // KNOWN BUG: a replace range ending strictly inside a surrogate pair is not
-  // widened to the pair end; the low surrogate is left behind alone.
-  test.failing(
-    'replace ending inside a surrogate pair widens to cover the whole pair',
-    () => {
-      const d = doc('📚plans\nfor the\nweekend');
-      d.applyEdits([edit(0, 0, 0, 1, 'a')]);
-      expect(hasLoneSurrogate(d.getText())).toBe(false);
-      expect(d.getLineText(0)).toBe('aplans');
-    }
-  );
+  test('replace ending inside a surrogate pair widens to cover the whole pair', () => {
+    const d = doc('📚plans\nfor the\nweekend');
+    d.applyEdits([edit(0, 0, 0, 1, 'a')]);
+    expect(hasLoneSurrogate(d.getText())).toBe(false);
+    expect(d.getLineText(0)).toBe('aplans');
+  });
 
   test('replace spanning exactly the whole surrogate pair replaces it cleanly', () => {
     const d = doc('📚plans\nfor the\nweekend');


### PR DESCRIPTION
> Surrogate-pair edit boundaries (3) — edit range endpoints landing strictly inside a surrogate pair split the pair and corrupt the buffer instead of snapping to pair boundaries; affects insert-inside-a-pair and replaces starting or ending inside one.

Fixed surrogate-pair edit boundaries.
- Inserts inside pairs snap before the pair; replacement endpoints widen outward.- 
- Lone surrogates remain editable.
- Caret remapping uses the same normalized offsets.
- Promoted all three regressions to passing tests and updated the known-bug count.