### PR TITLE
[diffs/edit] Fix batch edit ordering sensitivity

### DIFF
--- a/packages/diffs/src/editor/textDocument.ts
+++ b/packages/diffs/src/editor/textDocument.ts
@@ -350,7 +350,12 @@ export class TextDocument<LAnnotation> {
   }
 
   #sortAndValidateResolvedEdits(edits: ResolvedTextEdit[]): ResolvedTextEdit[] {
-    const sortedEdits = [...edits].sort((a, b) => a.start - b.start);
+    // Put zero-width edits before ranges at the same start so validation and
+    // application do not depend on the caller's batch order.
+    const sortedEdits = [...edits].sort((a, b) => {
+      const startDelta = a.start - b.start;
+      return startDelta === 0 ? a.end - b.end : startDelta;
+    });
     for (let i = 0; i < sortedEdits.length - 1; i++) {
       if (sortedEdits[i].end > sortedEdits[i + 1].start) {
         throw new Error('Overlapping text edits are not supported');

--- a/packages/diffs/test/README.md
+++ b/packages/diffs/test/README.md
@@ -122,9 +122,6 @@ order. If you touch one of these areas, consider adding the missing coverage:
   the `\r` and `\n`, assembling CRLF from two separate inserts, plus a
   CRLF-biased fuzz oracle), and the same stale metadata drives search astray
   (shifted or missing match ranges) even though `getText()` stays correct.
-- **Batch edit ordering sensitivity** (1) — accepting a batch containing a
-  delete and an insert at the same offset depends on the caller's array order:
-  delete-first throws an overlap error, insert-first succeeds.
 - **Line indent/outdent multi-selection dedupe** (3) — indent dispatch
   concatenates per-selection edits with no shared-line dedupe, so a line under
   two carets/ranges indents twice; the outdent variant emits two identical

--- a/packages/diffs/test/editorApplyEdits.test.ts
+++ b/packages/diffs/test/editorApplyEdits.test.ts
@@ -1961,21 +1961,11 @@ describe('applyEdits batch: insert at a deletion boundary', () => {
     expect(d.getText()).toBe('grapeXYnes');
   });
 
-  // KNOWN BUG: acceptance of the batch {delete [5,7), insert at 5} depends on
-  // the caller's array order. Validation stable-sorts by start offset and
-  // rejects any pair where prev.end > next.start, so with the delete listed
-  // first the (5,7) delete stays ahead of the (5,5) insert and the same
-  // logical batch throws 'Overlapping text edits are not supported', while
-  // the insert-first order succeeds. A deterministic batch model would accept
-  // the batch regardless of input order.
-  test.failing(
-    'the same logical batch with the delete listed first behaves identically',
-    () => {
-      const d = doc('grapevines');
-      d.applyEdits([edit(0, 5, 0, 7, ''), edit(0, 5, 0, 5, 'XY')]);
-      expect(d.getText()).toBe('grapeXYnes');
-    }
-  );
+  test('the same logical batch with the delete listed first behaves identically', () => {
+    const d = doc('grapevines');
+    d.applyEdits([edit(0, 5, 0, 7, ''), edit(0, 5, 0, 5, 'XY')]);
+    expect(d.getText()).toBe('grapeXYnes');
+  });
 });
 
 describe('applyEdits: randomized single-edit invert round-trip', () => {


### PR DESCRIPTION
> **Batch edit ordering sensitivity** (1) — accepting a batch containing a
  delete and an insert at the same offset depends on the caller's array order:
  delete-first throws an overlap error, insert-first succeeds.

Fixed batch edit ordering sensitivity.
Equal-start edits now sort by end offset, placing inserts before deletes regardless of caller order.