### PR TITLE
[diffs/edit] Fix the CRLF position round-trip bug

### DIFF
--- a/packages/diffs/src/editor/textDocument.ts
+++ b/packages/diffs/src/editor/textDocument.ts
@@ -127,11 +127,15 @@ export class TextDocument<LAnnotation> {
   }
 
   positionAt(offset: number): Position {
-    return this.#pieceTable.positionAt(offset);
+    return this.normalizePosition(this.#pieceTable.positionAt(offset));
   }
 
   positionsAt(offsets: readonly number[]): Position[] {
-    return this.#pieceTable.positionsAt(offsets);
+    const positions = this.#pieceTable.positionsAt(offsets);
+    for (let i = 0; i < positions.length; i++) {
+      positions[i] = this.normalizePosition(positions[i]);
+    }
+    return positions;
   }
 
   offsetAt(position: Position): number {

--- a/packages/diffs/test/README.md
+++ b/packages/diffs/test/README.md
@@ -148,10 +148,6 @@ order. If you touch one of these areas, consider adding the missing coverage:
   text, the unwind that should restore recorded selections verbatim never
   reaches the original text, and a pending redo survives an untracked edit
   (instead of being cleared like any new edit) and replays at stale offsets.
-- **Position round-trip losing a column** (1) — a position-from-offset
-  computation can return a position strictly inside a CRLF pair (a character
-  beyond the line's own length) that the inverse offset-from-position
-  computation clamps away, so the round trip silently loses a column.
 - **Inverted selection after normalization** (1) — setting selections normalizes
   positions but never reorders a start-after-end pair, storing an inverted
   selection that violates the start-before-or-equal-end invariant downstream

--- a/packages/diffs/test/editorPieceTable.test.ts
+++ b/packages/diffs/test/editorPieceTable.test.ts
@@ -850,34 +850,32 @@ describe('mixed-EOL positionAt/offsetAt round trip', () => {
     expect(table.getLineLength(7)).toBe(0);
   });
 
-  // KNOWN BUG: TextDocument.positionAt delegates to the raw piece-table
-  // mapping and can return a position strictly inside a CRLF pair (character
-  // beyond getLineLength) that its own offsetAt refuses to map back —
-  // normalizePosition clamps it to the line's content end, so
-  // offsetAt(positionAt(o)) silently loses a column. The commented-out clamp
-  // tests at editorTextDocument.test.ts:150 and :169 record the intended
-  // contract (positions clamp to visible content at this layer).
-  test.failing(
-    'TextDocument.positionAt never lands between the \\r and \\n of a CRLF pair',
-    () => {
-      const d = doc(MIXED);
+  test('TextDocument position APIs never land between the \\r and \\n of a CRLF pair', () => {
+    const d = doc(MIXED);
+    const offsets = Array.from({ length: MIXED.length + 1 }, (_, i) => i);
+    const positions = d.positionsAt(offsets);
 
-      for (let offset = 0; offset <= MIXED.length; offset++) {
-        const position = d.positionAt(offset);
-        expect(position.character).toBeLessThanOrEqual(
-          d.getLineLength(position.line)
-        );
-      }
+    for (let offset = 0; offset <= MIXED.length; offset++) {
+      const position = d.positionAt(offset);
+      expect(position).toEqual(positions[offset]);
+      expect(position.character).toBeLessThanOrEqual(
+        d.getLineLength(position.line)
+      );
     }
-  );
+
+    expect(d.positionsAt([4, 14, 25])).toEqual([
+      { line: 0, character: 3 },
+      { line: 3, character: 0 },
+      { line: 7, character: 0 },
+    ]);
+  });
 
   test('TextDocument: offsetAt of positionAt is idempotent and snaps break-interior offsets to content end', () => {
     // Unlike the PieceTable layer, the TextDocument round trip is not the
-    // identity: offsets between the \r and \n of a CRLF pair snap back to the
-    // end of the line's visible content (offsetAt normalizes what positionAt
-    // emitted). The mapping settles after one application — a second round
-    // trip is a fixpoint — which is the conventional stability guarantee for
-    // line/offset conversions.
+    // identity: offsets between the \r and \n of a CRLF pair map to the end of
+    // the line's visible content. The mapping settles after one application —
+    // a second round trip is a fixpoint — which is the conventional stability
+    // guarantee for line/offset conversions.
     const d = doc(MIXED);
     const starts = oracleLineStarts(MIXED);
     const roundTrip = (offset: number) => d.offsetAt(d.positionAt(offset));


### PR DESCRIPTION
> **Position round-trip losing a column** (1) — a position-from-offset
  computation can return a position strictly inside a CRLF pair (a character
  beyond the line's own length) that the inverse offset-from-position
  computation clamps away, so the round trip silently loses a column.

Normalized both positionAt and positionsAt outputs.