### PR TITLE
[diffs/edit] Fix search-replace capture expansion with lookaround

### DIFF
--- a/packages/diffs/src/editor/pieceTable.ts
+++ b/packages/diffs/src/editor/pieceTable.ts
@@ -1026,7 +1026,6 @@ export function buildSearchReplacementText(
   const lineText = getLineText(position.line);
   const lineStart = offsetAt({ line: position.line, character: 0 });
   const relStart = matchStart - lineStart;
-  const matched = lineText.slice(relStart, relStart + (matchEnd - matchStart));
 
   let pattern: RegExp;
   try {
@@ -1039,9 +1038,15 @@ export function buildSearchReplacementText(
     return searchParams.replaceText;
   }
 
-  const re = new RegExp(pattern.source, pattern.flags.replace('g', ''));
-  const match = re.exec(matched);
-  if (match === null || match[0].length !== matched.length) {
+  // Re-run at the original line offset so lookaround can inspect context
+  // outside the matched range while captures still come from this exact hit.
+  pattern.lastIndex = relStart;
+  const match = pattern.exec(lineText);
+  if (
+    match === null ||
+    match.index !== relStart ||
+    match[0].length !== matchEnd - matchStart
+  ) {
     return searchParams.replaceText;
   }
   return expandReplaceString(searchParams.replaceText, match);

--- a/packages/diffs/test/README.md
+++ b/packages/diffs/test/README.md
@@ -156,12 +156,6 @@ order. If you touch one of these areas, consider adding the missing coverage:
   positions but never reorders a start-after-end pair, storing an inverted
   selection that violates the start-before-or-equal-end invariant downstream
   code assumes.
-- **Search-replace capture expansion with lookaround** (3) — replacement-text
-  expansion re-executes the pattern against only the matched slice, so
-  lookaround context outside the slice is lost: a lookbehind whose context sits
-  before the slice, a lookahead whose context sits after the slice, and a
-  lookahead that re-matches shorter on the slice all fall back to inserting the
-  literal (unexpanded) replacement text.
 - **Soft-wrap vertical motion splits surrogate pairs** (2) — vertical motion
   into a wrapped continuation row computes the landing spot as raw UTF-16 units
   with no grapheme/surrogate snapping, so moving down into a continuation row

--- a/packages/diffs/test/editorSearchPanel.test.ts
+++ b/packages/diffs/test/editorSearchPanel.test.ts
@@ -531,47 +531,29 @@ describe('regex replace capture references', () => {
     ).toEqual(['$&-$1']);
   });
 
-  // KNOWN BUG: buildSearchReplacementText re-executes the pattern against only
-  // the matched slice; a lookbehind's context sits before the slice, so the
-  // re-execution finds nothing, falls back to the raw replaceText, and the
-  // literal "$1" is inserted into the document.
-  test.failing(
-    'lookbehind context before the match still expands its captures',
-    () => {
-      expect(
-        replacementsFor(
-          'k77',
-          searchParams('(?<=k)(\\d+)', { replaceText: 'n$1' })
-        )
-      ).toEqual(['n77']);
-    }
-  );
+  test('lookbehind context before the match still expands its captures', () => {
+    expect(
+      replacementsFor(
+        'k77',
+        searchParams('(?<=k)(\\d+)', { replaceText: 'n$1' })
+      )
+    ).toEqual(['n77']);
+  });
 
-  // KNOWN BUG: a lookahead's context sits after the matched slice, so the
-  // slice-only re-execution fails and the unexpanded replaceText is inserted.
-  test.failing(
-    'lookahead context after the match still expands its captures',
-    () => {
-      expect(
-        replacementsFor(
-          'run!',
-          searchParams('(\\w+)(?=!)', { replaceText: '<$1>' })
-        )
-      ).toEqual(['<run>']);
-    }
-  );
+  test('lookahead context after the match still expands its captures', () => {
+    expect(
+      replacementsFor(
+        'run!',
+        searchParams('(\\w+)(?=!)', { replaceText: '<$1>' })
+      )
+    ).toEqual(['<run>']);
+  });
 
-  // KNOWN BUG: on the matched slice the lookahead re-matches SHORTER than the
-  // original match (the trailing context character is part of the slice), the
-  // full-length guard rejects it, and the literal "[$&]" is inserted.
-  test.failing(
-    'a lookahead that re-matches shorter on the slice still expands',
-    () => {
-      expect(
-        replacementsFor('ooo', searchParams('o+(?=o)', { replaceText: '[$&]' }))
-      ).toEqual(['[oo]']);
-    }
-  );
+  test('a lookahead that re-matches shorter on the slice still expands', () => {
+    expect(
+      replacementsFor('ooo', searchParams('o+(?=o)', { replaceText: '[$&]' }))
+    ).toEqual(['[oo]']);
+  });
 
   test('a pattern that matches nowhere leaves the document untouched', async () => {
     const host = mountReplaceHost('gray goose');


### PR DESCRIPTION
> **Search-replace capture expansion with lookaround** (3) — replacement-text
  expansion re-executes the pattern against only the matched slice, so
  lookaround context outside the slice is lost: a lookbehind whose context sits
  before the slice, a lookahead whose context sits after the slice, and a
  lookahead that re-matches shorter on the slice all fall back to inserting the
  literal (unexpanded) replacement text.

Fixed search-replace capture expansion with lookaround.
- Re-executes regex against the full line at the original match offset.
- Validates the exact match range before expanding captures.
