### PR TITLE
[diffs/edit] Normalize inverted editor selections

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -607,14 +607,24 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       throw new Error('Text document is not initialized');
     }
     const resolvedSelections = selections.map<EditorSelection>((selection) => {
-      const start = textDocument.normalizePosition(selection.start);
-      const end = textDocument.normalizePosition(selection.end);
-      const direction =
+      let start = textDocument.normalizePosition(selection.start);
+      let end = textDocument.normalizePosition(selection.end);
+      let direction: EditorSelection['direction'] =
         selection.direction === 'none'
           ? DirectionNone
           : selection.direction === 'backward'
             ? DirectionBackward
             : DirectionForward;
+
+      if (comparePosition(start, end) > 0) {
+        [start, end] = [end, start];
+        if (direction !== DirectionNone) {
+          direction =
+            direction === DirectionForward
+              ? DirectionBackward
+              : DirectionForward;
+        }
+      }
       return { direction, start, end };
     });
     this.#updateSelections(resolvedSelections);

--- a/packages/diffs/test/README.md
+++ b/packages/diffs/test/README.md
@@ -152,10 +152,6 @@ order. If you touch one of these areas, consider adding the missing coverage:
   computation can return a position strictly inside a CRLF pair (a character
   beyond the line's own length) that the inverse offset-from-position
   computation clamps away, so the round trip silently loses a column.
-- **Inverted selection after normalization** (1) — setting selections normalizes
-  positions but never reorders a start-after-end pair, storing an inverted
-  selection that violates the start-before-or-equal-end invariant downstream
-  code assumes.
 - **Search-replace capture expansion with lookaround** (3) — replacement-text
   expansion re-executes the pattern against only the matched slice, so
   lookaround context outside the slice is lost: a lookbehind whose context sits

--- a/packages/diffs/test/editorSelection.test.ts
+++ b/packages/diffs/test/editorSelection.test.ts
@@ -3996,40 +3996,29 @@ describe('Editor.setSelections position clamping', () => {
 });
 
 describe('Editor.setSelections with a reversed range', () => {
-  // KNOWN BUG: setSelections normalizes each position independently but never
-  // reorders the pair, so a selection whose start sits after its end is
-  // stored inverted (start 1:3 / end 0:2), violating the start <= end
-  // invariant that downstream code (offset resolution, rendering, merge)
-  // assumes. The conventional normalization of a range(3, 2) input resolves
-  // to from=2/to=3 with the backward flag; the equivalent here is swapping
-  // start/end and flipping the direction to backward, since the focus edge
-  // the caller supplied now sits first.
-  test.failing(
-    'a start-after-end selection is stored with ordered edges and backward direction',
-    async () => {
-      const { cleanup, editor } = await createEditorFixture(
-        'alpha\nbravo\ncharlie'
-      );
-      try {
-        editor.setSelections([
-          {
-            start: { line: 1, character: 3 },
-            end: { line: 0, character: 2 },
-            direction: 'forward',
-          },
-        ]);
-        expect(editor.getState().selections).toEqual([
-          {
-            start: { line: 0, character: 2 },
-            end: { line: 1, character: 3 },
-            direction: DirectionBackward,
-          },
-        ]);
-      } finally {
-        cleanup();
-      }
+  test('a start-after-end selection is stored with ordered edges and backward direction', async () => {
+    const { cleanup, editor } = await createEditorFixture(
+      'alpha\nbravo\ncharlie'
+    );
+    try {
+      editor.setSelections([
+        {
+          start: { line: 1, character: 3 },
+          end: { line: 0, character: 2 },
+          direction: 'forward',
+        },
+      ]);
+      expect(editor.getState().selections).toEqual([
+        {
+          start: { line: 0, character: 2 },
+          end: { line: 1, character: 3 },
+          direction: DirectionBackward,
+        },
+      ]);
+    } finally {
+      cleanup();
     }
-  );
+  });
 });
 
 // Splices `edits` (pre-edit offsets, sorted ascending, non-overlapping) into


### PR DESCRIPTION
> **Inverted selection after normalization** (1) — setting selections normalizes
  positions but never reorders a start-after-end pair, storing an inverted
  selection that violates the start-before-or-equal-end invariant downstream
  code assumes.

Normalized endpoints are reordered and direction is flipped to preserve focus.