### PR TITLE
[diffs/edit] Fix edit stack coalescing

### DIFF
--- a/packages/diffs/src/editor/editStack.ts
+++ b/packages/diffs/src/editor/editStack.ts
@@ -4,6 +4,11 @@ import type { ResolvedTextEdit, TextDocument } from './textDocument';
 /** Largest number of undo or redo entries kept; oldest entries drop first once exceeded. */
 const DEFAULT_EDIT_STACK_MAX_ENTRIES = 100;
 
+const COALESCING_MODE_INSERT = 1;
+const COALESCING_MODE_BACKSPACE = 2;
+const COALESCING_MODE_DELETE = 3;
+type EditStackCoalescingMode = 1 | 2 | 3;
+
 /** An entry in the edit stack. */
 export interface EditStackEntry<LAnnotation> {
   /** Forward offset edits from the entry's base text to its final text. */
@@ -22,6 +27,8 @@ export interface EditStackEntry<LAnnotation> {
   lineAnnotationsBefore?: DiffLineAnnotation<LAnnotation>[];
   /** Line annotations after the transaction. */
   lineAnnotationsAfter?: DiffLineAnnotation<LAnnotation>[];
+  /** Input mode inferred from the edit or retained by a coalesced run. */
+  coalescingMode?: EditStackCoalescingMode;
   /**
    * When `true`, this entry is its own undo step and never merges with the
    * entry before or after it. Set for paste and cut, which otherwise look like
@@ -41,6 +48,7 @@ export class EditStack<LAnnotation> {
   #undoStack: EditStackEntry<LAnnotation>[] = [];
   #redoStack: EditStackEntry<LAnnotation>[] = [];
   #maxEntries: number;
+  #canCoalesce = false;
 
   constructor(options?: EditStackOptions) {
     this.#maxEntries = Math.max(
@@ -61,6 +69,7 @@ export class EditStack<LAnnotation> {
   clear(): void {
     this.#undoStack.length = 0;
     this.#redoStack.length = 0;
+    this.#canCoalesce = false;
   }
 
   /** Clears the redo stack. */
@@ -72,6 +81,7 @@ export class EditStack<LAnnotation> {
   push(entry: EditStackEntry<LAnnotation>): void {
     this.#undoStack.push(entry);
     this.clearRedo();
+    this.#canCoalesce = true;
     if (this.#undoStack.length > this.#maxEntries) {
       this.#undoStack.shift();
     }
@@ -104,6 +114,11 @@ export class EditStack<LAnnotation> {
     return this.#undoStack[this.#undoStack.length - 1];
   }
 
+  /** Returns the last undo entry only while its coalescing group is open. */
+  peekUndoForCoalescing(): EditStackEntry<LAnnotation> | undefined {
+    return this.#canCoalesce ? this.peekUndo() : undefined;
+  }
+
   /** Replaces the last undo entry with the given entry. */
   replaceLastUndo(entry: EditStackEntry<LAnnotation>): void {
     if (this.#undoStack.length === 0) {
@@ -112,6 +127,7 @@ export class EditStack<LAnnotation> {
     }
     this.#undoStack[this.#undoStack.length - 1] = entry;
     this.clearRedo();
+    this.#canCoalesce = true;
   }
 
   /** Moves the latest undo entry to the redo stack and returns it, or `undefined` if empty. */
@@ -119,6 +135,7 @@ export class EditStack<LAnnotation> {
     const entry = this.#undoStack.pop();
     if (entry !== undefined) {
       this.#redoStack.push(entry);
+      this.#canCoalesce = false;
       return entry;
     }
   }
@@ -128,6 +145,7 @@ export class EditStack<LAnnotation> {
     const entry = this.#redoStack.pop();
     if (entry !== undefined) {
       this.#undoStack.push(entry);
+      this.#canCoalesce = false;
       return entry;
     }
   }
@@ -145,6 +163,39 @@ export function createEditStackEntry<LAnnotation>(
 ): EditStackEntry<LAnnotation> {
   const forwardEdits = [...resolvedEdits].sort((a, b) => a.start - b.start);
   const inverseEdits: ResolvedTextEdit[] = [];
+  let coalescingMode: EditStackCoalescingMode | undefined;
+  if (selectionsBefore?.length === forwardEdits.length) {
+    const caretOffsets: number[] = [];
+    for (const selection of selectionsBefore) {
+      if (
+        selection.start.line !== selection.end.line ||
+        selection.start.character !== selection.end.character
+      ) {
+        break;
+      }
+      caretOffsets.push(textDocument.offsetAt(selection.start));
+    }
+    if (caretOffsets.length === forwardEdits.length) {
+      caretOffsets.sort((a, b) => a - b);
+      let isBackspace = true;
+      let isDelete = true;
+      for (let i = 0; i < forwardEdits.length; i++) {
+        const edit = forwardEdits[i];
+        if (edit.text.length > 0 || edit.start === edit.end) {
+          isBackspace = false;
+          isDelete = false;
+          break;
+        }
+        isBackspace &&= caretOffsets[i] === edit.end;
+        isDelete &&= caretOffsets[i] === edit.start;
+      }
+      coalescingMode = isBackspace
+        ? COALESCING_MODE_BACKSPACE
+        : isDelete
+          ? COALESCING_MODE_DELETE
+          : undefined;
+    }
+  }
   for (let i = 0, offsetDelta = 0; i < forwardEdits.length; i++) {
     const edit = forwardEdits[i];
     const replacedText = textDocument.getTextSlice(edit.start, edit.end);
@@ -167,6 +218,7 @@ export function createEditStackEntry<LAnnotation>(
     selectionsAfter: selectionsAfter?.map((selection) => ({ ...selection })),
     lineAnnotationsBefore: lineAnnotationsBefore?.slice(),
     lineAnnotationsAfter: lineAnnotationsAfter?.slice(),
+    coalescingMode,
   };
 }
 
@@ -190,7 +242,7 @@ export function shouldCoalesceEditStackEntry<LAnnotation>(
   ) {
     return false;
   }
-  let mode: 'insert' | 'backspace' | 'delete' | undefined;
+  let mode: EditStackCoalescingMode | undefined;
   for (let i = 0; i < previousEntry.forwardEdits.length; i++) {
     const previousForward = previousEntry.forwardEdits[i];
     const previousInverse = previousEntry.inverseEdits[i];
@@ -221,8 +273,14 @@ export function shouldCoalesceEditStackEntry<LAnnotation>(
       if (nextForward.start !== previousInverse.end) {
         return false;
       }
-      mode ??= 'insert';
-      if (mode !== 'insert') {
+      mode ??= COALESCING_MODE_INSERT;
+      if (
+        mode !== COALESCING_MODE_INSERT ||
+        (previousEntry.coalescingMode !== undefined &&
+          previousEntry.coalescingMode !== COALESCING_MODE_INSERT) ||
+        (nextEntry.coalescingMode !== undefined &&
+          nextEntry.coalescingMode !== COALESCING_MODE_INSERT)
+      ) {
         return false;
       }
       continue;
@@ -236,21 +294,25 @@ export function shouldCoalesceEditStackEntry<LAnnotation>(
       nextForward.end > nextForward.start &&
       nextInverse.text.length > 0;
     if (previousWasDelete && nextIsDelete) {
+      let nextMode: EditStackCoalescingMode;
       if (mappedNextStart === previousForward.end) {
-        mode ??= 'delete';
-        if (mode !== 'delete') {
-          return false;
-        }
-        continue;
-      }
-      if (
+        nextMode = COALESCING_MODE_DELETE;
+      } else if (
         mappedNextStart + (nextForward.end - nextForward.start) !==
         previousForward.start
       ) {
         return false;
+      } else {
+        nextMode = COALESCING_MODE_BACKSPACE;
       }
-      mode ??= 'backspace';
-      if (mode !== 'backspace') {
+      mode ??= nextMode;
+      if (
+        mode !== nextMode ||
+        (previousEntry.coalescingMode !== undefined &&
+          previousEntry.coalescingMode !== nextMode) ||
+        (nextEntry.coalescingMode !== undefined &&
+          nextEntry.coalescingMode !== nextMode)
+      ) {
         return false;
       }
       continue;
@@ -267,6 +329,7 @@ export function coalesceEditStackEntries<LAnnotation>(
 ): EditStackEntry<LAnnotation> {
   const forwardEdits: ResolvedTextEdit[] = [];
   const replacedTexts: string[] = [];
+  let coalescingMode: EditStackCoalescingMode | undefined;
   for (let i = 0; i < previousEntry.forwardEdits.length; i++) {
     const previousForward = previousEntry.forwardEdits[i];
     const previousInverse = previousEntry.inverseEdits[i];
@@ -278,6 +341,7 @@ export function coalesceEditStackEntries<LAnnotation>(
     );
 
     if (previousForward.text.length > 0) {
+      coalescingMode ??= COALESCING_MODE_INSERT;
       forwardEdits.push({
         start: previousForward.start,
         end: previousForward.end,
@@ -288,6 +352,7 @@ export function coalesceEditStackEntries<LAnnotation>(
     }
 
     if (mappedNextStart === previousForward.end) {
+      coalescingMode ??= COALESCING_MODE_DELETE;
       forwardEdits.push({
         start: previousForward.start,
         end: mappedNextStart + (nextForward.end - nextForward.start),
@@ -297,6 +362,7 @@ export function coalesceEditStackEntries<LAnnotation>(
       continue;
     }
 
+    coalescingMode ??= COALESCING_MODE_BACKSPACE;
     forwardEdits.push({
       start: Math.min(previousForward.start, mappedNextStart),
       end: previousForward.end,
@@ -317,6 +383,7 @@ export function coalesceEditStackEntries<LAnnotation>(
     selectionsAfter: nextEntry.selectionsAfter?.slice(),
     lineAnnotationsBefore: previousEntry.lineAnnotationsBefore?.slice(),
     lineAnnotationsAfter: nextEntry.lineAnnotationsAfter?.slice(),
+    coalescingMode,
   };
 }
 

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -75,7 +75,7 @@ import {
   expandCollapsedSelectionToWord,
   extendSelection,
   extendSelections,
-  findNexMatch,
+  findNextMatch,
   getAutoSurroundReplacementTexts,
   getCaretPosition,
   getDocumentBoundarySelection,
@@ -2185,7 +2185,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
           this.#updateSelections(expanded);
           this.focus();
         } else {
-          const nextMatch = findNexMatch(textDocument, selections);
+          const nextMatch = findNextMatch(textDocument, selections);
           if (nextMatch !== undefined) {
             this.#updateSelections(nextMatch);
             const primaryMatch = nextMatch.at(-1);

--- a/packages/diffs/src/editor/selection.ts
+++ b/packages/diffs/src/editor/selection.ts
@@ -1668,7 +1668,7 @@ export function shiftSelectionLines(
 /**
  * Finds the next matching word and updates the selections.
  */
-export function findNexMatch(
+export function findNextMatch(
   textDocument: TextDocument<unknown>,
   selections: EditorSelection[]
 ): EditorSelection[] | undefined {

--- a/packages/diffs/src/editor/textDocument.ts
+++ b/packages/diffs/src/editor/textDocument.ts
@@ -281,7 +281,7 @@ export class TextDocument<LAnnotation> {
     if (updateHistory && undoBoundary) {
       entry.undoBoundary = true;
     }
-    const previousEntry = this.#editStack.peekUndo();
+    const previousEntry = this.#editStack.peekUndoForCoalescing();
     const change = this.#applyResolvedEditsToBuffer(resolvedEdits);
     this.#version++;
     if (

--- a/packages/diffs/test/README.md
+++ b/packages/diffs/test/README.md
@@ -102,13 +102,3 @@ order. If you touch one of these areas, consider adding the missing coverage:
   implemented.
 - **IME composition deferrals** — IME/composition interaction with editing and
   undo-coalescing is deferred and not covered.
-
-## Known bugs pinned as `test.failing`
-
-- **EditStack coalescing** (3) — coalescing decisions compare a new edit against
-  whatever sits on top of the undo stack purely by geometry, with no state reset
-  after undo/redo: an undo can expose a stale top entry that new typing then
-  fuses into; an undo-boundary marker stops blocking merges once it is undone;
-  and backspace followed by forward-delete at the same pivot coalesces into a
-  single undo step instead of getting an undo stop when the delete direction
-  flips.

--- a/packages/diffs/test/editorEditStack.test.ts
+++ b/packages/diffs/test/editorEditStack.test.ts
@@ -359,100 +359,106 @@ function redoAll(d: ReturnType<typeof doc>) {
   return steps;
 }
 
-// Undo/redo coalescing scenarios. The three test.failing entries here are
-// known bugs: coalescing is decided purely by comparing edit geometry against
-// whatever entry sits on top of the undo stack, with no state reset after
-// undo()/redo() and no sticky typing-mode tracking.
+// Undo and redo close the current coalescing group. Delete runs additionally
+// retain their input direction because a shared pivot can be geometrically
+// ambiguous after the first character is removed.
 describe('EditStack coalescing across undo and redo', () => {
-  // KNOWN BUG: after undo() pops the top entry, new typing that happens to sit
-  // adjacent to the newly exposed entry coalesces into it, so one undo wipes out
-  // committed pre-undo history along with the fresh keystroke.
-  test.failing(
-    'typing after an undo never merges into pre-undo history',
-    () => {
-      const d = doc('hello\nworld');
-      typeAt(d, 0, 0, 'a'); // entry 1: "ahello\nworld"
-      typeAt(d, 1, 0, 'Z'); // entry 2 (different line, no coalesce): "ahello\nZworld"
-      d.undo(); // pops entry 2, entry 1 is now on top
-      expect(d.getText()).toBe('ahello\nworld');
+  test('typing after an undo never merges into pre-undo history', () => {
+    const d = doc('hello\nworld');
+    typeAt(d, 0, 0, 'a'); // entry 1: "ahello\nworld"
+    typeAt(d, 1, 0, 'Z'); // entry 2 (different line, no coalesce): "ahello\nZworld"
+    d.undo(); // pops entry 2, entry 1 is now on top
+    expect(d.getText()).toBe('ahello\nworld');
 
-      typeAt(d, 0, 1, 'b'); // brand-new keystroke, adjacent to entry 1's insert
-      expect(d.getText()).toBe('abhello\nworld');
+    typeAt(d, 0, 1, 'b'); // brand-new keystroke, adjacent to entry 1's insert
+    expect(d.getText()).toBe('abhello\nworld');
 
-      // One undo must remove only the new 'b', not entry 1's 'a' with it.
-      d.undo();
-      expect(d.getText()).toBe('ahello\nworld');
+    // One undo must remove only the new 'b', not entry 1's 'a' with it.
+    d.undo();
+    expect(d.getText()).toBe('ahello\nworld');
 
-      // Redo direction: the 'b' keystroke comes back on its own.
-      d.redo();
-      expect(d.getText()).toBe('abhello\nworld');
+    // Redo direction: the 'b' keystroke comes back on its own.
+    d.redo();
+    expect(d.getText()).toBe('abhello\nworld');
 
-      // The full history unwinds one keystroke at a time.
-      d.undo();
-      d.undo();
-      expect(d.getText()).toBe('hello\nworld');
-      expect(d.canUndo).toBe(false);
-    }
-  );
+    // The full history unwinds one keystroke at a time.
+    d.undo();
+    d.undo();
+    expect(d.getText()).toBe('hello\nworld');
+    expect(d.canUndo).toBe(false);
+  });
 
-  // KNOWN BUG: an undoBoundary entry blocks merging only while it sits on the
-  // undo stack; once it is undone, the entry beneath it is exposed and new
-  // typing merges straight through into it as if the boundary never existed.
-  test.failing(
-    'an undone boundary entry still shields the entry beneath it from coalescing',
-    () => {
-      const d = doc('hello');
-      typeAt(d, 0, 0, 'a'); // entry 1: "ahello"
-      typeAt(d, 0, 1, 'XYZ', true); // paste with boundary: "aXYZhello"
-      d.undo(); // pops the paste, entry 1 is on top again
-      expect(d.getText()).toBe('ahello');
+  test('typing after a redo never merges into replayed history', () => {
+    const d = doc('hello\nworld');
+    typeAt(d, 0, 0, 'a');
+    typeAt(d, 1, 0, 'Z');
+    d.undo();
+    d.redo();
+    expect(d.getText()).toBe('ahello\nZworld');
 
-      typeAt(d, 0, 1, 'b'); // ordinary keystroke adjacent to entry 1's insert
-      expect(d.getText()).toBe('abhello');
+    typeAt(d, 1, 1, 'b');
+    d.undo();
+    expect(d.getText()).toBe('ahello\nZworld');
+  });
 
-      // One undo must remove only 'b'; 'a' predates the paste boundary.
-      d.undo();
-      expect(d.getText()).toBe('ahello');
+  test('an undone boundary entry still shields the entry beneath it from coalescing', () => {
+    const d = doc('hello');
+    typeAt(d, 0, 0, 'a'); // entry 1: "ahello"
+    typeAt(d, 0, 1, 'XYZ', true); // paste with boundary: "aXYZhello"
+    d.undo(); // pops the paste, entry 1 is on top again
+    expect(d.getText()).toBe('ahello');
 
-      // Redo direction: only the 'b' keystroke replays.
-      d.redo();
-      expect(d.getText()).toBe('abhello');
+    typeAt(d, 0, 1, 'b'); // ordinary keystroke adjacent to entry 1's insert
+    expect(d.getText()).toBe('abhello');
 
-      d.undo();
-      d.undo();
-      expect(d.getText()).toBe('hello');
-      expect(d.canUndo).toBe(false);
-    }
-  );
+    // One undo must remove only 'b'; 'a' predates the paste boundary.
+    d.undo();
+    expect(d.getText()).toBe('ahello');
 
-  // KNOWN BUG: a Backspace followed by a forward Delete at the same pivot
-  // coalesces into one undo step; the pivot offset maps ambiguously onto the end
-  // of the just-deleted range, so the pair passes the 'delete'-mode check.
-  test.failing(
-    'switching from backspace to forward delete creates a new undo stop',
-    () => {
-      const d = doc('abc');
-      backspaceAt(d, 0, 2); // removes 'b' -> "ac", caret lands at (0,1)
-      forwardDeleteAt(d, 0, 1); // removes 'c' -> "a"
-      expect(d.getText()).toBe('a');
+    // Redo direction: only the 'b' keystroke replays.
+    d.redo();
+    expect(d.getText()).toBe('abhello');
 
-      // First undo restores only the forward-deleted character.
-      d.undo();
-      expect(d.getText()).toBe('ac');
+    d.undo();
+    d.undo();
+    expect(d.getText()).toBe('hello');
+    expect(d.canUndo).toBe(false);
+  });
 
-      // Second undo restores the backspaced character.
-      d.undo();
-      expect(d.getText()).toBe('abc');
-      expect(d.canUndo).toBe(false);
+  test('switching from backspace to forward delete creates a new undo stop', () => {
+    const d = doc('abc');
+    backspaceAt(d, 0, 2); // removes 'b' -> "ac", caret lands at (0,1)
+    forwardDeleteAt(d, 0, 1); // removes 'c' -> "a"
+    expect(d.getText()).toBe('a');
 
-      // Redo direction: the two deletes replay as separate steps.
-      d.redo();
-      expect(d.getText()).toBe('ac');
-      d.redo();
-      expect(d.getText()).toBe('a');
-      expect(d.canRedo).toBe(false);
-    }
-  );
+    // First undo restores only the forward-deleted character.
+    d.undo();
+    expect(d.getText()).toBe('ac');
+
+    // Second undo restores the backspaced character.
+    d.undo();
+    expect(d.getText()).toBe('abc');
+    expect(d.canUndo).toBe(false);
+
+    // Redo direction: the two deletes replay as separate steps.
+    d.redo();
+    expect(d.getText()).toBe('ac');
+    d.redo();
+    expect(d.getText()).toBe('a');
+    expect(d.canRedo).toBe(false);
+  });
+
+  test('switching from forward delete to backspace creates a new undo stop', () => {
+    const d = doc('abc');
+    forwardDeleteAt(d, 0, 1); // removes 'b' -> "ac"
+    backspaceAt(d, 0, 1); // removes 'a' -> "c"
+    expect(d.getText()).toBe('c');
+
+    d.undo();
+    expect(d.getText()).toBe('ac');
+    d.undo();
+    expect(d.getText()).toBe('abc');
+  });
 
   // DIVERGENCE: the conventional behavior breaks typed runs at whitespace (a
   // lone space merges with the word before it, but typing after the space

--- a/packages/diffs/test/editorSelection.test.ts
+++ b/packages/diffs/test/editorSelection.test.ts
@@ -20,7 +20,7 @@ import {
   expandCollapsedSelectionToWord,
   extendSelection,
   extendSelections,
-  findNexMatch,
+  findNextMatch,
   getAutoSurroundReplacementTexts,
   getCaretPosition,
   getDocumentBoundarySelection,
@@ -2662,7 +2662,7 @@ describe('expandCollapsedSelectionToWord', () => {
 describe('findNextMatch', () => {
   test('returns undefined for empty selections', () => {
     const doc = new TextDocument('inmemory://x', 'hello');
-    expect(findNexMatch(doc, [])).toBeUndefined();
+    expect(findNextMatch(doc, [])).toBeUndefined();
   });
 
   test('ignores non-collapsed selections with different text', () => {
@@ -2671,13 +2671,13 @@ describe('findNextMatch', () => {
       createSelection(0, 0, 0, 2),
       createSelection(0, 3, 0, 5),
     ];
-    expect(findNexMatch(doc, selections)).toBeUndefined();
+    expect(findNextMatch(doc, selections)).toBeUndefined();
   });
 
   test('expands a collapsed caret to the surrounding word', () => {
     const doc = new TextDocument('inmemory://x', "'foobar'");
     const caret = createSelection(0, 4, 0, 4);
-    const next = findNexMatch(doc, [caret]);
+    const next = findNextMatch(doc, [caret]);
     expect(next).toEqual([
       {
         start: { line: 0, character: 1 },
@@ -2690,7 +2690,7 @@ describe('findNextMatch', () => {
   test('adds the next matching range when one occurrence is selected', () => {
     const doc = new TextDocument('inmemory://x', 'foo x foo');
     const first = createSelection(0, 0, 0, 3);
-    const afterFirst = findNexMatch(doc, [first]);
+    const afterFirst = findNextMatch(doc, [first]);
     expect(afterFirst).toEqual([
       first,
       {
@@ -2699,13 +2699,13 @@ describe('findNextMatch', () => {
         direction: DirectionForward,
       },
     ]);
-    expect(findNexMatch(doc, afterFirst!)).toBeUndefined();
+    expect(findNextMatch(doc, afterFirst!)).toBeUndefined();
   });
 
   test('wraps to an earlier occurrence after the last match in the file', () => {
     const doc = new TextDocument('inmemory://x', 'foo bar foo');
     const secondFoo = createSelection(0, 8, 0, 11);
-    const wrapped = findNexMatch(doc, [secondFoo]);
+    const wrapped = findNextMatch(doc, [secondFoo]);
     expect(wrapped).toEqual([
       secondFoo,
       {
@@ -2721,7 +2721,7 @@ describe('findNextMatch', () => {
     const a = createSelection(0, 0, 0, 2);
     const b = createSelection(0, 3, 0, 5);
     const two = [a, b];
-    const third = findNexMatch(doc, two);
+    const third = findNextMatch(doc, two);
     expect(third?.length).toBe(3);
     expect(third?.[2]).toEqual({
       start: { line: 0, character: 6 },
@@ -3068,14 +3068,14 @@ describe('select next occurrence with touching matches', () => {
 
     // The second "abc" starts exactly where the selected one ends. It must be
     // returned as the next match, not skipped as overlapping.
-    const next = findNexMatch(d, [first]);
+    const next = findNextMatch(d, [first]);
     expect(next).toEqual([
       first,
       createSelection(0, 3, 0, 6, DirectionForward),
     ]);
 
     // Both occurrences are now held; nothing is left to add.
-    expect(findNexMatch(d, next!)).toBeUndefined();
+    expect(findNextMatch(d, next!)).toBeUndefined();
   });
 
   test('repeated next-occurrence walks through touching matches across lines', () => {
@@ -3091,13 +3091,13 @@ describe('select next occurrence with touching matches', () => {
       createSelection(2, 3, 2, 6, DirectionForward), // touching repeat on the last line
     ];
     for (const added of expected) {
-      selections = findNexMatch(d, selections!);
+      selections = findNextMatch(d, selections!);
       expect(selections![selections!.length - 1]).toEqual(added);
     }
     expect(selections!.length).toBe(5);
 
     // All five occurrences selected — the next request finds nothing new.
-    expect(findNexMatch(d, selections!)).toBeUndefined();
+    expect(findNextMatch(d, selections!)).toBeUndefined();
   });
 });
 


### PR DESCRIPTION

> **EditStack coalescing** (3) — coalescing decisions compare a new edit against
  whatever sits on top of the undo stack purely by geometry, with no state reset
  after undo/redo: an undo can expose a stale top entry that new typing then
  fuses into; an undo-boundary marker stops blocking merges once it is undone;
  and backspace followed by forward-delete at the same pivot coalesces into a
  single undo step instead of getting an undo stop when the delete direction
  flips.

- Undo/redo now closes the active coalescing group, preventing stale or boundary-hidden entries from merging.
- Delete entries retain backspace/forward-delete direction, so direction flips create undo stops.