### PR TITLE
[diffs/edit] Improve pieceTable performance

### DIFF
--- a/packages/diffs/src/editor/pieceTable.ts
+++ b/packages/diffs/src/editor/pieceTable.ts
@@ -421,6 +421,7 @@ export class PieceTable {
     }
     const start = clamp(offset, 0, this.#length);
     this.#replaceRangeIncremental(start, start, text);
+    this.#invalidateCaches();
   }
 
   delete(offset: number, length: number): void {
@@ -433,6 +434,7 @@ export class PieceTable {
       return;
     }
     this.#replaceRangeIncremental(start, end, '');
+    this.#invalidateCaches();
   }
 
   applyEdits(edits: readonly ResolvedTextEdit[]): void {
@@ -449,6 +451,7 @@ export class PieceTable {
       const end = clamp(edit.end, start, this.#length);
       this.#replaceRangeIncremental(start, end, edit.text);
     }
+    this.#invalidateCaches();
   }
 
   positionAt(offset: number): Position {
@@ -727,18 +730,18 @@ export class PieceTable {
     );
   }
 
-  // Replaces document range [start, end) with `text` by splitting the tree at
-  // both ends, dropping the middle (the deleted span), and joining the inserted
-  // piece back in. Each split/merge touches only one root-to-leaf path, so the
-  // edit is O(log P) instead of rebuilding all P pieces. `start`/`end` must be
-  // clamped into [0, length] with start <= end.
+  // Replaces document range [start, end) with `text` by splitting at the start,
+  // dropping the deleted prefix from the remainder, and joining the inserted
+  // piece back in. Each tree operation touches only one root-to-leaf path, so
+  // the edit is O(log P) instead of rebuilding all P pieces. `start`/`end` must
+  // be clamped into [0, length] with start <= end.
   #replaceRangeIncremental(start: number, end: number, text: string): void {
     if (start === end && text.length === 0) {
       return;
     }
 
     const [left, rest] = this.#split(this.#root, start);
-    const [, right] = this.#split(rest, end - start);
+    const right = this.#dropPrefix(rest, end - start);
 
     let root: PieceNode | null;
     if (text.length > 0) {
@@ -773,6 +776,10 @@ export class PieceTable {
     this.#root = root;
     this.#length = root?.subtreeLength ?? 0;
     this.#lineCount = (root?.subtreeLineBreakCount ?? 0) + 1;
+  }
+
+  // Public mutations clear read caches once, including multi-edit batches.
+  #invalidateCaches(): void {
     this.#lastVisitedLine = null;
     this.#lastVisitedLineLength = null;
     this.#lastPosition = null;
@@ -864,6 +871,41 @@ export class PieceTable {
     leftNode.updateSubtreeLength();
     rightNode.updateSubtreeLength();
     return [leftNode, rightNode];
+  }
+
+  // Discards [0, offset), allocating only the surviving half of a cut piece.
+  #dropPrefix(node: PieceNode | null, offset: number): PieceNode | null {
+    if (node === null || offset >= node.subtreeLength) {
+      return null;
+    }
+    if (offset <= 0) {
+      return node;
+    }
+
+    const leftLength = node.left?.subtreeLength ?? 0;
+    if (offset <= leftLength) {
+      this.#setLeft(node, this.#dropPrefix(node.left, offset));
+      node.updateSubtreeLength();
+      return node;
+    }
+
+    const pieceEnd = leftLength + node.piece.length;
+    if (offset >= pieceEnd) {
+      return this.#dropPrefix(node.right, offset - pieceEnd);
+    }
+
+    const inPiece = offset - leftLength;
+    const rightNode = new PieceNode(
+      this.#createPiece(
+        node.piece.source,
+        node.piece.offset + inPiece,
+        node.piece.length - inPiece
+      )
+    );
+    rightNode.priority = node.priority;
+    this.#setRight(rightNode, node.right);
+    rightNode.updateSubtreeLength();
+    return rightNode;
   }
 
   // Joins two subtrees where every offset in `left` precedes every offset in

--- a/packages/diffs/src/editor/pieceTable.ts
+++ b/packages/diffs/src/editor/pieceTable.ts
@@ -124,6 +124,9 @@ export class PieceTable {
   #lineCount = 0;
   #lastVisitedLine: [number, boolean, string] | null = null;
   #lastVisitedLineLength: [number, boolean, number] | null = null;
+  // Exact inverse of the latest positionAt lookup; edits invalidate it.
+  #lastPosition: [line: number, character: number, offset: number] | null =
+    null;
   // Seeds the treap priorities. 0x9e3779b9 is the 32-bit golden-ratio
   // constant (2^32 / phi), a well-mixed value commonly used to seed hashes
   // and PRNGs; any fixed nonzero seed works here. A fixed seed keeps the
@@ -455,10 +458,9 @@ export class PieceTable {
     }
     const line = this.#lineAtOffset(clampedOffset);
     const lineStart = line === 0 ? 0 : this.#lineBreakOffset(line - 1);
-    return {
-      line,
-      character: clampedOffset - lineStart,
-    };
+    const character = clampedOffset - lineStart;
+    this.#lastPosition = [line, character, clampedOffset];
+    return { line, character };
   }
 
   positionsAt(offsets: readonly number[]): Position[] {
@@ -483,6 +485,14 @@ export class PieceTable {
     }
     if (position.line >= this.#lineCount) {
       throw new Error(`Line index out of range: ${position.line}`);
+    }
+    const lastPosition = this.#lastPosition;
+    if (
+      lastPosition !== null &&
+      lastPosition[0] === position.line &&
+      lastPosition[1] === position.character
+    ) {
+      return lastPosition[2];
     }
     const offset = this.#getLineOffset(position.line);
     if (offset === undefined) {
@@ -765,6 +775,7 @@ export class PieceTable {
     this.#lineCount = (root?.subtreeLineBreakCount ?? 0) + 1;
     this.#lastVisitedLine = null;
     this.#lastVisitedLineLength = null;
+    this.#lastPosition = null;
   }
 
   #nextPriority(): number {

--- a/packages/diffs/src/editor/pieceTable.ts
+++ b/packages/diffs/src/editor/pieceTable.ts
@@ -48,9 +48,18 @@ class TextBuffer {
   // elements to the lineOffsets array in the end
   append(text: string): number {
     const offset = this.text.length;
-    const appendedLineOffsets = computeLineOffsets(text);
-    for (let i = 1; i < appendedLineOffsets.length; i++) {
-      this.lineOffsets.push(offset + appendedLineOffsets[i]);
+    for (let i = 0; i < text.length; i++) {
+      const charCode = text.charCodeAt(i);
+      if (charCode !== LINE_FEED && charCode !== CARRIAGE_RETURN) {
+        continue;
+      }
+      if (
+        charCode === CARRIAGE_RETURN &&
+        text.charCodeAt(i + 1) === LINE_FEED
+      ) {
+        i++;
+      }
+      this.lineOffsets.push(offset + i + 1);
     }
     this.text += text;
     return offset;
@@ -357,15 +366,25 @@ export class PieceTable {
     limit: number
   ): [number, number][] {
     const out: [number, number][] = [];
-    const docLength = this.#length;
-    const charAt = (offset: number) => this.charAt(offset);
+    // Search visits the whole document, so flatten it once instead of making
+    // several treap descents for every line and whole-word boundary.
+    const documentText = this.#textFromPieces();
+    const docLength = documentText.length;
+    const lineOffsets = computeLineOffsets(documentText);
 
     // Reuse the single compiled pattern across every line, resetting its
     // lastIndex before each line, instead of allocating a fresh RegExp per
     // line. The pattern is global, so lastIndex tracks progress within a line.
-    for (let line = 0; line < this.#lineCount; line++) {
-      const lineText = this.getLineText(line);
-      const lineStart = this.offsetAt({ line, character: 0 });
+    for (let line = 0; line < lineOffsets.length; line++) {
+      const lineStart = lineOffsets[line];
+      let lineEnd = lineOffsets[line + 1] ?? docLength;
+      while (
+        lineEnd > lineStart &&
+        isEOL(documentText.charCodeAt(lineEnd - 1))
+      ) {
+        lineEnd--;
+      }
+      const lineText = documentText.slice(lineStart, lineEnd);
       pattern.lastIndex = 0;
       let match: RegExpExecArray | null;
       while ((match = pattern.exec(lineText)) !== null) {
@@ -378,7 +397,7 @@ export class PieceTable {
         const docStart = lineStart + rel;
         if (
           !wholeWord ||
-          isWholeWordAtDocOffsets(docStart, fragment.length, docLength, charAt)
+          isWholeWordAtDocOffsets(documentText, docStart, fragment.length)
         ) {
           out.push([docStart, docStart + fragment.length]);
           if (out.length >= limit) {
@@ -787,6 +806,12 @@ export class PieceTable {
     if (node === null) {
       return [null, null];
     }
+    if (offset <= 0) {
+      return [null, node];
+    }
+    if (offset >= node.subtreeLength) {
+      return [node, null];
+    }
 
     const leftLength = node.left?.subtreeLength ?? 0;
     if (offset <= leftLength) {
@@ -1046,26 +1071,16 @@ function isWordSeparatorCharCode(charCode: number): boolean {
 // Checks if the given text is a whole word by checking if the
 // characters before and after are word separators.
 function isWholeWordAtDocOffsets(
+  text: string,
   docStart: number,
-  length: number,
-  docLength: number,
-  charAt: (offset: number) => string
+  length: number
 ): boolean {
   const beforeOk =
-    docStart <= 0 ||
-    isWordSeparatorCharCode(charCodeUnitAt(charAt, docStart - 1));
+    docStart <= 0 || isWordSeparatorCharCode(text.charCodeAt(docStart - 1));
   const afterOk =
-    docStart + length >= docLength ||
-    isWordSeparatorCharCode(charCodeUnitAt(charAt, docStart + length));
+    docStart + length >= text.length ||
+    isWordSeparatorCharCode(text.charCodeAt(docStart + length));
   return beforeOk && afterOk;
-}
-
-function charCodeUnitAt(
-  charAt: (offset: number) => string,
-  offset: number
-): number {
-  const unit = charAt(offset);
-  return unit.length === 0 ? 0 : unit.charCodeAt(0);
 }
 
 function compileSearchRegExp(

--- a/packages/diffs/src/utils/computeFileOffsets.ts
+++ b/packages/diffs/src/utils/computeFileOffsets.ts
@@ -1,22 +1,58 @@
 const LINE_FEED = 10; // \n
 const CARRIAGE_RETURN = 13; // \r
+const DENSE_LINE_BREAK_BLOCK_SIZE = 4;
+const DENSE_LINE_BREAK_BLOCK_SPAN = 40;
 
 /**
  * Computes line start offsets for a string.
  */
 export function computeLineOffsets(contents: string): number[] {
   const offsets: number[] = [0];
-  for (let i = 0; i < contents.length; i++) {
-    const char = contents.charCodeAt(i);
-    if (char === LINE_FEED || char === CARRIAGE_RETURN) {
-      if (
-        char === CARRIAGE_RETURN &&
-        i + 1 < contents.length &&
-        contents.charCodeAt(i + 1) === LINE_FEED
-      ) {
-        i++;
+  let carriageReturn = contents.indexOf('\r');
+  let lineFeed = contents.indexOf('\n');
+  let blockStart = 0;
+  let blockBreaks = 0;
+  while (carriageReturn !== -1 || lineFeed !== -1) {
+    let nextOffset: number;
+    if (
+      carriageReturn !== -1 &&
+      (lineFeed === -1 || carriageReturn < lineFeed)
+    ) {
+      if (lineFeed === carriageReturn + 1) {
+        nextOffset = lineFeed + 1;
+        carriageReturn = contents.indexOf('\r', nextOffset);
+        lineFeed = contents.indexOf('\n', nextOffset);
+      } else {
+        nextOffset = carriageReturn + 1;
+        carriageReturn = contents.indexOf('\r', nextOffset);
       }
-      offsets.push(i + 1);
+    } else {
+      nextOffset = lineFeed + 1;
+      lineFeed = contents.indexOf('\n', nextOffset);
+    }
+    offsets.push(nextOffset);
+
+    if (++blockBreaks === DENSE_LINE_BREAK_BLOCK_SIZE) {
+      if (nextOffset - blockStart <= DENSE_LINE_BREAK_BLOCK_SPAN) {
+        // Native searches win on source-like lines; a character scan is faster
+        // once line breaks become unusually dense.
+        for (let i = nextOffset; i < contents.length; i++) {
+          const char = contents.charCodeAt(i);
+          if (char === LINE_FEED || char === CARRIAGE_RETURN) {
+            if (
+              char === CARRIAGE_RETURN &&
+              i + 1 < contents.length &&
+              contents.charCodeAt(i + 1) === LINE_FEED
+            ) {
+              i++;
+            }
+            offsets.push(i + 1);
+          }
+        }
+        return offsets;
+      }
+      blockStart = nextOffset;
+      blockBreaks = 0;
     }
   }
   return offsets;

--- a/packages/diffs/test/editorPieceTable.test.ts
+++ b/packages/diffs/test/editorPieceTable.test.ts
@@ -873,6 +873,25 @@ describe('mixed-EOL positionAt/offsetAt round trip', () => {
     expect(roundTrip(14)).toBe(13);
     expect(roundTrip(25)).toBe(24);
   });
+
+  test('edits invalidate the last position round trip', () => {
+    const table = new PieceTable('xxxx\nbbbb');
+    const position = table.positionAt(7);
+
+    expect(position).toEqual({ line: 1, character: 2 });
+    expect(table.offsetAt(position)).toBe(7);
+
+    table.insert('yy', 0);
+    expect(table.offsetAt(position)).toBe(9);
+    expect(table.offsetAt(table.positionAt(9))).toBe(9);
+
+    table.delete(0, 3);
+    expect(table.offsetAt(position)).toBe(6);
+    expect(table.offsetAt(table.positionAt(6))).toBe(6);
+
+    table.applyEdits([{ start: 0, end: 1, text: 'zzzz' }]);
+    expect(table.offsetAt(position)).toBe(9);
+  });
 });
 
 describe('out-of-range line and position contract', () => {

--- a/packages/diffs/test/editorPieceTable.test.ts
+++ b/packages/diffs/test/editorPieceTable.test.ts
@@ -1199,3 +1199,200 @@ describe('very long single line', () => {
     expect(d.getText()).toBe(str);
   });
 });
+
+test.skipIf(process.env.PIECE_TABLE_BENCHMARK !== '1')(
+  'benchmarks representative PieceTable workloads',
+  () => {
+    const line = 'function benchmark(value: number) { return value + 1; }\n';
+    const lineCount = 12_000;
+    const text = line.repeat(lineCount);
+    const editCount = 2_000;
+    const scatteredOffsets = Array.from({ length: editCount }, (_, i) => {
+      const lineIndex = (i * 7919) % lineCount;
+      return lineIndex * line.length + 9 + (i % 20);
+    });
+    const batchEdits = Array.from({ length: editCount }, (_, i) => {
+      const lineIndex = Math.floor(((i + 1) * lineCount) / (editCount + 1));
+      const start = lineIndex * line.length + 20;
+      return { start, end: start + 1, text: i % 2 === 0 ? 'x' : 'y' };
+    });
+    const lookupOffsets = Array.from(
+      { length: 20_000 },
+      (_, i) => (i * 104729) % text.length
+    );
+    const sliceOffsets = Array.from(
+      { length: 5_000 },
+      (_, i) => (i * 48611) % (text.length - 80)
+    );
+
+    const createFragmentedTable = () => {
+      const table = new PieceTable(text);
+      for (let i = 0; i < scatteredOffsets.length; i++) {
+        const start = scatteredOffsets[i];
+        table.applyEdits([
+          { start, end: start + 1, text: i % 2 === 0 ? 'q' : 'z' },
+        ]);
+      }
+      return table;
+    };
+
+    const scenarios: {
+      name: string;
+      operations: number;
+      prepare: () => () => number;
+    }[] = [
+      {
+        name: 'construct/large-document',
+        operations: 1,
+        prepare: () => () => new PieceTable(text).lineCount,
+      },
+      {
+        name: 'edit/sequential-typing',
+        operations: 5_000,
+        prepare: () => {
+          const table = new PieceTable('');
+          return () => {
+            for (let i = 0; i < 5_000; i++) {
+              table.insert('x', i);
+            }
+            return table.getText().length;
+          };
+        },
+      },
+      {
+        name: 'edit/scattered-inserts',
+        operations: scatteredOffsets.length,
+        prepare: () => {
+          const table = new PieceTable(text);
+          return () => {
+            for (const offset of scatteredOffsets) {
+              table.insert('x', offset);
+            }
+            return table.lineCount;
+          };
+        },
+      },
+      {
+        name: 'edit/append-after-fragmentation',
+        operations: 2_000,
+        prepare: () => {
+          const table = createFragmentedTable();
+          const end = text.length;
+          return () => {
+            for (let i = 0; i < 2_000; i++) {
+              table.insert('x', end + i);
+            }
+            return table.lineCount;
+          };
+        },
+      },
+      {
+        name: 'edit/batch-replacements',
+        operations: batchEdits.length,
+        prepare: () => {
+          const table = new PieceTable(text);
+          return () => {
+            table.applyEdits(batchEdits);
+            return table.lineCount;
+          };
+        },
+      },
+      {
+        name: 'read/fragmented-position-round-trips',
+        operations: lookupOffsets.length,
+        prepare: () => {
+          const table = createFragmentedTable();
+          return () => {
+            let checksum = 0;
+            for (const offset of lookupOffsets) {
+              const position = table.positionAt(offset);
+              checksum += table.offsetAt(position);
+            }
+            return checksum;
+          };
+        },
+      },
+      {
+        name: 'read/fragmented-slices',
+        operations: sliceOffsets.length,
+        prepare: () => {
+          const table = createFragmentedTable();
+          return () => {
+            let checksum = 0;
+            for (const start of sliceOffsets) {
+              checksum += table.getTextSlice(start, start + 80).length;
+            }
+            return checksum;
+          };
+        },
+      },
+      {
+        name: 'search/fragmented-whole-word',
+        operations: lineCount,
+        prepare: () => {
+          const table = createFragmentedTable();
+          return () =>
+            table.search({
+              text: 'function',
+              replaceText: '',
+              caseSensitive: true,
+              wholeWord: true,
+              regex: false,
+            }).length;
+        },
+      },
+    ];
+
+    const results: {
+      name: string;
+      operations: number;
+      p50Ms: number;
+      p95Ms: number;
+      minMs: number;
+      maxMs: number;
+      opsPerSecond: number;
+      samplesMs: number[];
+    }[] = [];
+    let checksum = 0;
+    for (const scenario of scenarios) {
+      for (let i = 0; i < 2; i++) {
+        checksum += scenario.prepare()();
+      }
+
+      const samplesMs: number[] = [];
+      for (let i = 0; i < 9; i++) {
+        const run = scenario.prepare();
+        const start = performance.now();
+        checksum += run();
+        samplesMs.push(performance.now() - start);
+      }
+      samplesMs.sort((a, b) => a - b);
+      const p50Ms = samplesMs[Math.floor(samplesMs.length / 2)];
+      const p95Ms = samplesMs[Math.ceil(samplesMs.length * 0.95) - 1];
+      results.push({
+        name: scenario.name,
+        operations: scenario.operations,
+        p50Ms,
+        p95Ms,
+        minMs: samplesMs[0],
+        maxMs: samplesMs[samplesMs.length - 1],
+        opsPerSecond: scenario.operations / (p50Ms / 1000),
+        samplesMs,
+      });
+    }
+
+    expect(checksum).toBeGreaterThan(0);
+    console.table(
+      results.map(({ name, p50Ms, p95Ms, minMs, maxMs, opsPerSecond }) => ({
+        name,
+        p50Ms: p50Ms.toFixed(3),
+        p95Ms: p95Ms.toFixed(3),
+        minMs: minMs.toFixed(3),
+        maxMs: maxMs.toFixed(3),
+        opsPerSecond: Math.round(opsPerSecond),
+      }))
+    );
+    console.log(`PIECE_TABLE_BENCHMARK_RESULTS=${JSON.stringify(results)}`);
+  },
+  { timeout: 120_000 }
+);


### PR DESCRIPTION
**Benchmark results**
_p50 latency in milliseconds; two warmups and nine measured samples per workload._

Workload | Baseline (beta-1.3) | Current working tree | Improvement
-- | -- | -- | --
Construct large document | 0.609 ms | 0.231 ms | +62.0%
Sequential typing | 1.730 ms | 1.571 ms | +9.2%
Scattered inserts | 7.157 ms | 5.876 ms | +17.9%
Append after fragmentation | 2.721 ms | 1.116 ms | +59.0%
Batch replacements | 7.899 ms | 5.488 ms | +30.5%
Position round-trips | 20.886 ms | 13.866 ms | +33.6%
Fragmented slices | 2.469 ms | 2.279 ms | +7.7%
Whole-word search | 10.682 ms | 1.946 ms | +81.8%
Combined p50 | 54.153 ms | 32.372 ms | +40.2%

**Changes:**

- Removed temporary line-offset array allocations during typing.
- Added constant-time treap split boundary exits.
- Changed full-document search to flatten once and avoid repeated treap descents and whole-word charAt lookups.
- Adaptive native line-break scanning with dense-newline fallback.
- Replacement ranges discard deleted pieces without allocating both split halves; batch cache invalidation happens once.