### PR TITLE
docs(diffs): Document editable line annotations

### DIFF
--- a/apps/docs/app/(diffs)/_docs/DocsPage.tsx
+++ b/apps/docs/app/(diffs)/_docs/DocsPage.tsx
@@ -21,6 +21,7 @@ import {
 import {
   FILE_CONTENTS_TYPE,
   FILE_DIFF_METADATA_TYPE,
+  LINE_ANNOTATION_TYPES,
   PARSE_DIFF_FROM_FILE_EXAMPLE,
   PARSE_PATCH_FILES_EXAMPLE,
 } from '../docs/CoreTypes/constants';
@@ -237,11 +238,13 @@ async function CoreTypesSection() {
   const [
     fileContentsType,
     fileDiffMetadataType,
+    lineAnnotationTypes,
     parseDiffFromFileExample,
     parsePatchFilesExample,
   ] = await Promise.all([
     preloadFile(FILE_CONTENTS_TYPE),
     preloadFile(FILE_DIFF_METADATA_TYPE),
+    preloadFile(LINE_ANNOTATION_TYPES),
     preloadFile(PARSE_DIFF_FROM_FILE_EXAMPLE),
     preloadFile(PARSE_PATCH_FILES_EXAMPLE),
   ]);
@@ -250,6 +253,7 @@ async function CoreTypesSection() {
     scope: {
       fileContentsType,
       fileDiffMetadataType,
+      lineAnnotationTypes,
       parseDiffFromFileExample,
       parsePatchFilesExample,
     },

--- a/apps/docs/app/(diffs)/_edit/EditReference.tsx
+++ b/apps/docs/app/(diffs)/_edit/EditReference.tsx
@@ -139,7 +139,7 @@ const CAPABILITY_GROUPS: ReferenceGroup[] = [
       {
         term: 'Diff annotations',
         description:
-          'Line annotations shift and survive edits and undo—the basis for agent/AUI surfaces.',
+          'Editable-side annotations follow structural edits and history, including line merges; read-only old-file-side annotations stay fixed.',
       },
       {
         term: 'SSR & hydration',

--- a/apps/docs/app/(diffs)/docs/CodeView/content.mdx
+++ b/apps/docs/app/(diffs)/docs/CodeView/content.mdx
@@ -158,6 +158,28 @@ through React would be expensive. In imperative mode, omit `items`, optionally
 seed the viewer with `initialItems`, and use the `CodeViewHandle` to add new
 items or update existing ones.
 
+### Editing Item Annotations
+
+When an editable item has annotations, `onItemEditChange` receives the owning
+item, its edited `FileContents`, and the complete current annotation collection.
+For a diff item, those contents represent the editable new-file side. When the
+emitted annotation array is a different object, replace `item.annotations` and
+increment the item's `version`. `CodeView` does not write either value for you.
+
+When React owns the `CodeView` item list through `items`, publish a new `items`
+array containing the updated item inside `flushSync` so annotation placement
+updates with the edited content before paint. When `CodeView` owns the list in
+React's imperative mode, call `updateItem` through the component ref; in vanilla
+JS, call `updateItem` on the `CodeView` instance. Skip the update when the
+emitted array is the same object as the item's current annotations, since
+ordinary same-line typing reuses that array.
+
+Keep `onItemEditComplete` focused on committing the final `file` contents or
+rebuilding `fileDiff` with a fresh `cacheKey`. Live annotations should already
+be synchronized through `onItemEditChange`. See
+[Editing with line annotations](#edit-mode-editing-with-line-annotations) for
+remapping rules, stable metadata IDs, and annotation-content lifetime guidance.
+
 ### Usage Notes
 
 - In React, pass `items` for controlled item ownership.

--- a/apps/docs/app/(diffs)/docs/CodeView/content.mdx
+++ b/apps/docs/app/(diffs)/docs/CodeView/content.mdx
@@ -166,6 +166,11 @@ For a diff item, those contents represent the editable new-file side. When the
 emitted annotation array is a different object, replace `item.annotations` and
 increment the item's `version`. `CodeView` does not write either value for you.
 
+The callback annotation type is `LineAnnotation[] | DiffLineAnnotation[]`: file
+items emit the side-less shape and diff items emit annotations with a `side`.
+Use `isFileAnnotationCollection` or `isDiffAnnotationCollection` to narrow it
+before reading shape-specific fields.
+
 When React owns the `CodeView` item list through `items`, publish a new `items`
 array containing the updated item inside `flushSync` so annotation placement
 updates with the edited content before paint. When `CodeView` owns the list in

--- a/apps/docs/app/(diffs)/docs/CoreTypes/constants.ts
+++ b/apps/docs/app/(diffs)/docs/CoreTypes/constants.ts
@@ -139,6 +139,40 @@ interface ChangeContent {
   options,
 };
 
+export const LINE_ANNOTATION_TYPES: PreloadFileOptions<undefined> = {
+  file: {
+    name: 'line_annotations.ts',
+    contents: `import type {
+  DiffLineAnnotation,
+  LineAnnotation,
+} from '@pierre/diffs';
+
+interface ThreadMetadata {
+  // Position-independent identity for application-owned state.
+  id: string;
+}
+
+const fileAnnotations: LineAnnotation<ThreadMetadata>[] = [
+  { lineNumber: 0, metadata: { id: 'file-summary' } },
+  { lineNumber: 5, metadata: { id: 'line-five-review' } },
+];
+
+const diffAnnotations: DiffLineAnnotation<ThreadMetadata>[] = [
+  {
+    side: 'additions',
+    lineNumber: 12,
+    metadata: { id: 'new-line-review' },
+  },
+  {
+    side: 'deletions',
+    lineNumber: 9,
+    metadata: { id: 'old-line-review' },
+  },
+];`,
+  },
+  options,
+};
+
 export const PARSE_DIFF_FROM_FILE_EXAMPLE: PreloadFileOptions<undefined> = {
   file: {
     name: 'parseDiffFromFile.ts',

--- a/apps/docs/app/(diffs)/docs/CoreTypes/content.mdx
+++ b/apps/docs/app/(diffs)/docs/CoreTypes/content.mdx
@@ -62,6 +62,12 @@ one-based on the selected file side, not row positions in the rendered diff. Use
 `lineNumber: 0` for a file-level annotation above the first file line or, in a
 diff, above the first hunk or row on that side.
 
+Callbacks shared by file and diff surfaces use
+`LineAnnotation[] | DiffLineAnnotation[]`. Use `isFileAnnotationCollection` or
+`isDiffAnnotationCollection` to narrow the collection before reading
+shape-specific fields. For individual annotation unions, use `isFileAnnotation`
+or `isDiffAnnotation`.
+
 Store a stable, position-independent application ID in metadata when an
 annotation owns drafts or other interactive state. For annotations that survive
 an edit, edit mode preserves metadata while remapping line coordinates. For the

--- a/apps/docs/app/(diffs)/docs/CoreTypes/content.mdx
+++ b/apps/docs/app/(diffs)/docs/CoreTypes/content.mdx
@@ -1,7 +1,7 @@
 ## Core Types
 
-Before diving into the components, it's helpful to understand the two core data
-structures used throughout the library.
+Before diving into the components, it's helpful to understand the core file,
+diff, and annotation data structures used throughout the library.
 
 ### FileContents
 
@@ -51,6 +51,24 @@ hydrated segment as a fallback.
 [`parsePatchFiles`](#utilities-parsepatchfiles) (from a patch string).
 
 <DocsCodeExample {...fileDiffMetadataType} />
+
+### LineAnnotation and DiffLineAnnotation
+
+`LineAnnotation<T>` places content on a file line and contains `lineNumber` plus
+typed `metadata`. Metadata is required when `T` is a concrete type and omitted
+when `T` is `undefined`. `DiffLineAnnotation<T>` adds
+`side: 'additions' | 'deletions'` to select a file side. Line coordinates are
+one-based on the selected file side, not row positions in the rendered diff. Use
+`lineNumber: 0` for a file-level annotation above the first file line or, in a
+diff, above the first hunk or row on that side.
+
+Store a stable, position-independent application ID in metadata when an
+annotation owns drafts or other interactive state. For annotations that survive
+an edit, edit mode preserves metadata while remapping line coordinates. For the
+controlled update pattern and exact remapping rules, see
+[Editing with line annotations](#edit-mode-editing-with-line-annotations).
+
+<DocsCodeExample {...lineAnnotationTypes} />
 
 ### Creating Diffs
 

--- a/apps/docs/app/(diffs)/docs/Editor/constants.ts
+++ b/apps/docs/app/(diffs)/docs/Editor/constants.ts
@@ -105,49 +105,83 @@ export const EDITOR_VANILLA_FILE_DIFF_EXAMPLE: PreloadFileOptions<undefined> = {
   file: {
     name: 'editor_vanilla_file_diff.ts',
     contents: `import {
+  type DiffLineAnnotation,
   Virtualizer,
   VirtualizedFileDiff,
   type FileContents,
 } from '@pierre/diffs';
 import { Editor } from '@pierre/diffs/editor';
 
+interface ThreadMetadata {
+  id: string;
+}
+
 const root = document.getElementById('diff-scroll-root');
 const content = document.getElementById('diff-scroll-content');
 if (root == null || content == null) {
   throw new Error('Expected virtualized diff containers to exist');
 }
+const contentWrapper = content;
 
 const oldFile: FileContents = {
   name: 'example.ts',
   contents: 'export function greet(name: string) {\\n  return name;\\n}',
 };
 
-const newFile: FileContents = {
+let newFile: FileContents = {
   ...oldFile,
   contents:
     'export function greet(name: string) {\\n  return "Hello, " + name;\\n}',
 };
 
-const virtualizer = new Virtualizer();
-virtualizer.setup(root, content);
+let lineAnnotations: DiffLineAnnotation<ThreadMetadata>[] = [
+  {
+    side: 'additions',
+    lineNumber: 2,
+    metadata: { id: 'greeting-review' },
+  },
+];
 
-const fileDiffInstance = new VirtualizedFileDiff(
-  { theme: { dark: 'pierre-dark', light: 'pierre-light' } },
+const virtualizer = new Virtualizer();
+virtualizer.setup(root, contentWrapper);
+
+const fileDiffInstance = new VirtualizedFileDiff<ThreadMetadata>(
+  {
+    theme: { dark: 'pierre-dark', light: 'pierre-light' },
+    renderAnnotation(annotation) {
+      const element = document.createElement('div');
+      element.textContent = 'Thread ' + annotation.metadata.id;
+      return element;
+    },
+  },
   virtualizer
 );
-fileDiffInstance.render({ oldFile, newFile, containerWrapper: content });
 
-const editor = new Editor({
-  onChange(file, lineAnnotations) {
-    console.log('change', file.name, lineAnnotations);
+function renderFromApplicationState() {
+  fileDiffInstance.render({
+    oldFile,
+    newFile,
+    lineAnnotations,
+    containerWrapper: contentWrapper,
+  });
+}
+
+renderFromApplicationState();
+
+const editor = new Editor<ThreadMetadata>({
+  onChange(file, nextAnnotations) {
+    // Preserve application-owned fields and replace only the edited contents.
+    newFile = { ...newFile, contents: file.contents };
+
+    // Replace application state first, then redraw after onChange returns.
+    if (nextAnnotations != null && nextAnnotations !== lineAnnotations) {
+      lineAnnotations = nextAnnotations;
+      queueMicrotask(renderFromApplicationState);
+    }
   },
 });
 
 editor.edit(fileDiffInstance);
-
-// Update the file, editor retains to work with the new file
-const newFile: FileContents = { ... }
-fileInstance.render({ file: newFile });
 
 // Later, when the editor is no longer needed:
 editor.cleanUp();`,
@@ -158,8 +192,25 @@ editor.cleanUp();`,
 export const EDITOR_VANILLA_CODE_VIEW_EXAMPLE: PreloadFileOptions<undefined> = {
   file: {
     name: 'editor_vanilla_code_view.ts',
-    contents: `import { CodeView, type CodeViewItem } from '@pierre/diffs';
+    contents: `import {
+  CodeView,
+  parseDiffFromFile,
+  type CodeViewItem,
+} from '@pierre/diffs';
 import { Editor } from '@pierre/diffs/editor';
+
+interface ThreadMetadata {
+  id: string;
+}
+
+const oldFile = {
+  name: 'example.ts',
+  contents: 'export const answer = 41;',
+};
+const newFile = {
+  name: 'example.ts',
+  contents: 'export const answer = 42;',
+};
 
 const root = document.getElementById('code-view');
 const toggleButton = document.getElementById('toggle-editing');
@@ -170,38 +221,67 @@ if (root == null || toggleButton == null) {
 root.style.height = '24rem';
 root.style.overflow = 'auto';
 
-const viewer = new CodeView({
+const viewer = new CodeView<ThreadMetadata>({
   theme: { dark: 'pierre-dark', light: 'pierre-light' },
   createEditor(options) {
     return new Editor(options);
   },
-  onItemEditComplete(item, file) {
-    if (item.type !== 'file') {
+  onItemEditChange(item, _file, nextAnnotations) {
+    if (
+      item.type !== 'diff' ||
+      nextAnnotations == null ||
+      item.annotations === nextAnnotations
+    ) {
       return;
     }
-    const version = (item.version ?? 0) + 1;
+
+    const current = viewer.getItem(item.id);
+    if (current?.type !== 'diff') {
+      return;
+    }
     viewer.updateItem({
-      ...item,
+      ...current,
+      annotations: nextAnnotations,
+      version: (current.version ?? 0) + 1,
+    });
+  },
+  onItemEditComplete(item, file) {
+    const current = viewer.getItem(item.id);
+    if (current?.type !== 'diff') {
+      return;
+    }
+    const version = (current.version ?? 0) + 1;
+    const cacheKey = current.id + ':v' + version;
+    viewer.updateItem({
+      ...current,
       edit: false,
       version,
-      file: {
-        ...item.file,
-        contents: file.contents,
-        cacheKey: \`\${item.id}:v\${version}\`,
+      fileDiff: {
+        ...parseDiffFromFile(oldFile, { ...file, cacheKey }),
+        cacheKey,
       },
     });
+  },
+  renderAnnotation(annotation) {
+    const element = document.createElement('div');
+    element.textContent = 'Thread ' + annotation.metadata.id;
+    return element;
   },
 });
 
 viewer.setup(root);
 
-const item: CodeViewItem = {
+const item: CodeViewItem<ThreadMetadata> = {
   id: 'example.ts',
-  type: 'file',
-  file: {
-    name: 'example.ts',
-    contents: 'export const answer = 42;',
-  },
+  type: 'diff',
+  fileDiff: parseDiffFromFile(oldFile, newFile),
+  annotations: [
+    {
+      side: 'additions',
+      lineNumber: 1,
+      metadata: { id: 'answer-review' },
+    },
+  ],
   edit: true,
   version: 0,
 };
@@ -491,6 +571,7 @@ export const EDITOR_REACT_FILE_DIFF_EXAMPLE: PreloadFileOptions<undefined> = {
     name: 'editor_react_file_diff.tsx',
     contents: `import {
   parseDiffFromFile,
+  type DiffLineAnnotation,
   type FileDiffMetadata,
   type FileDiffOptions,
 } from '@pierre/diffs';
@@ -500,7 +581,20 @@ import {
   FileDiff,
   Virtualizer,
 } from '@pierre/diffs/react';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
+import { flushSync } from 'react-dom';
+
+interface ThreadMetadata {
+  id: string;
+}
+
+const initialAnnotations: DiffLineAnnotation<ThreadMetadata>[] = [
+  {
+    side: 'additions',
+    lineNumber: 1,
+    metadata: { id: 'updated-message-review' },
+  },
+];
 
 // FileDiff takes a pre-parsed FileDiffMetadata object.
 const fileDiff: FileDiffMetadata = parseDiffFromFile(
@@ -508,7 +602,7 @@ const fileDiff: FileDiffMetadata = parseDiffFromFile(
   { name: 'example.ts', contents: 'console.warn("Updated message")' }
 );
 
-const fileDiffOptions: FileDiffOptions<undefined> = {
+const fileDiffOptions: FileDiffOptions<ThreadMetadata> = {
   theme: { dark: 'pierre-dark', light: 'pierre-light' },
 };
 
@@ -518,16 +612,29 @@ const virtualizerStyle = {
   borderRadius: '0.5rem',
 } as const;
 
-function createEditor(options: EditorOptions<undefined>) {
+function createEditor(options: EditorOptions<ThreadMetadata>) {
   return new Editor(options);
 }
 
 export function EditorComponent() {
   const [editable, setEditable] = useState(true);
-  const editOptions = useMemo<EditorOptions<undefined>>(
+  const [annotations, setAnnotations] = useState(initialAnnotations);
+  const annotationsRef = useRef(initialAnnotations);
+  // Key interaction state by stable metadata rather than line coordinates.
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const editOptions = useMemo<EditorOptions<ThreadMetadata>>(
     () => ({
-      onChange(file, lineAnnotations) {
-        console.log('change', file.name, lineAnnotations);
+      onChange(_file, nextAnnotations) {
+        if (
+          nextAnnotations == null ||
+          nextAnnotations === annotationsRef.current
+        ) {
+          return;
+        }
+
+        annotationsRef.current = nextAnnotations;
+        // Publish remapped annotations before the browser paints the edit.
+        flushSync(() => setAnnotations(nextAnnotations));
       },
     }),
     []
@@ -541,12 +648,29 @@ export function EditorComponent() {
       <button type="button" onClick={() => setEditable((value) => !value)}>
         {editable ? 'Disable editing' : 'Enable editing'}
       </button>
+
       <Virtualizer style={virtualizerStyle}>
-        <FileDiff
+        <FileDiff<ThreadMetadata>
           fileDiff={fileDiff}
+          lineAnnotations={annotations}
           options={fileDiffOptions}
           edit={editable}
           editOptions={editOptions}
+          renderAnnotation={(annotation) => {
+            const id = annotation.metadata.id;
+            return (
+              <textarea
+                aria-label="Review draft"
+                value={drafts[id] ?? ''}
+                onChange={(event) =>
+                  setDrafts((current) => ({
+                    ...current,
+                    [id]: event.target.value,
+                  }))
+                }
+              />
+            );
+          }}
         />
       </Virtualizer>
     </EditProvider>
@@ -559,22 +683,42 @@ export function EditorComponent() {
 export const EDITOR_REACT_CODE_VIEW_EXAMPLE: PreloadFileOptions<undefined> = {
   file: {
     name: 'editor_react_code_view.tsx',
-    contents: `import type {
-  CodeViewItem,
-  FileContents,
+    contents: `import {
+  parseDiffFromFile,
+  type CodeViewItem,
+  type DiffLineAnnotation,
+  type FileContents,
 } from '@pierre/diffs';
 import { Editor, type EditorOptions } from '@pierre/diffs/editor';
 import { CodeView, EditProvider } from '@pierre/diffs/react';
 import { useCallback, useState } from 'react';
+import { flushSync } from 'react-dom';
 
-const initialItems: CodeViewItem[] = [
+interface ThreadMetadata {
+  id: string;
+}
+
+const oldFile = {
+  name: 'example.ts',
+  contents: 'export const answer = 41;',
+};
+const newFile = {
+  name: 'example.ts',
+  contents: 'export const answer = 42;',
+};
+
+const initialItems: CodeViewItem<ThreadMetadata>[] = [
   {
     id: 'example.ts',
-    type: 'file',
-    file: {
-      name: 'example.ts',
-      contents: 'export const answer = 42;',
-    },
+    type: 'diff',
+    fileDiff: parseDiffFromFile(oldFile, newFile),
+    annotations: [
+      {
+        side: 'additions',
+        lineNumber: 1,
+        metadata: { id: 'answer-review' },
+      },
+    ],
     edit: true,
     version: 0,
   },
@@ -582,7 +726,7 @@ const initialItems: CodeViewItem[] = [
 
 const codeViewStyle = { height: '24rem', overflow: 'auto' } as const;
 
-function createEditor(options: EditorOptions<undefined>) {
+function createEditor(options: EditorOptions<ThreadMetadata>) {
   return new Editor(options);
 }
 
@@ -599,26 +743,60 @@ export function EditableCodeView() {
     );
   }, []);
 
-  const commitEdit = useCallback((item: CodeViewItem, file: FileContents) => {
-    setItems((current) =>
-      current.map((existing) => {
-        if (existing.id !== item.id || existing.type !== 'file') {
-          return existing;
-        }
-        const version = (existing.version ?? 0) + 1;
-        return {
-          ...existing,
-          edit: false,
-          version,
-          file: {
-            ...existing.file,
-            contents: file.contents,
-            cacheKey: \`\${existing.id}:v\${version}\`,
-          },
-        };
-      })
-    );
-  }, []);
+  const syncAnnotations = useCallback(
+    (
+      item: CodeViewItem<ThreadMetadata>,
+      _file: FileContents,
+      nextAnnotations?: DiffLineAnnotation<ThreadMetadata>[]
+    ) => {
+      if (
+        item.type !== 'diff' ||
+        nextAnnotations == null ||
+        item.annotations === nextAnnotations
+      ) {
+        return;
+      }
+
+      flushSync(() => {
+        setItems((current) =>
+          current.map((existing) =>
+            existing.id === item.id && existing.type === 'diff'
+              ? {
+                  ...existing,
+                  annotations: nextAnnotations,
+                  version: (existing.version ?? 0) + 1,
+                }
+              : existing
+          )
+        );
+      });
+    },
+    []
+  );
+
+  const commitEdit = useCallback(
+    (item: CodeViewItem<ThreadMetadata>, file: FileContents) => {
+      setItems((current) =>
+        current.map((existing) => {
+          if (existing.id !== item.id || existing.type !== 'diff') {
+            return existing;
+          }
+          const version = (existing.version ?? 0) + 1;
+          const cacheKey = existing.id + ':v' + version;
+          return {
+            ...existing,
+            edit: false,
+            version,
+            fileDiff: {
+              ...parseDiffFromFile(oldFile, { ...file, cacheKey }),
+              cacheKey,
+            },
+          };
+        })
+      );
+    },
+    []
+  );
 
   // This example is self-contained. Apps should usually mount EditProvider near
   // the root so its factory is available to every editable File, diff, and
@@ -631,7 +809,11 @@ export function EditableCodeView() {
       <CodeView
         items={items}
         style={codeViewStyle}
+        onItemEditChange={syncAnnotations}
         onItemEditComplete={commitEdit}
+        renderAnnotation={(annotation) => (
+          <div>Thread {annotation.metadata.id}</div>
+        )}
       />
     </EditProvider>
   );
@@ -774,7 +956,10 @@ interface EditorOptions<LAnnotation> {
     fileInstance: DiffsEditableComponent<LAnnotation>
   ) => void;
 
-  // Fires after each edit. file.contents reflects the live document.
+  // Fires after each edit. file.contents reflects the live document. When
+  // present, lineAnnotations is the complete current collection, not a delta;
+  // replace the application-owned source with it. Unaffected edits reuse the
+  // existing array reference.
   onChange?: (
     file: FileContents,
     lineAnnotations?: DiffLineAnnotation<LAnnotation>[]
@@ -793,26 +978,33 @@ interface EditorOptions<LAnnotation> {
 export const EDITOR_PUBLIC_API: PreloadFileOptions<undefined> = {
   file: {
     name: 'editor_public_api.ts',
-    contents: `import type {
-  EditorState,
-  FileContents,
+    contents: `import {
+  File,
+  type EditorState,
+  type FileContents,
 } from '@pierre/diffs';
 import { Editor } from '@pierre/diffs/editor';
 
 // Editor
 // Most methods require an attached surface via edit().
 
-const editor = new Editor();
+const fileInstance = new File();
+fileInstance.render({
+  file: { name: 'example.ts', contents: '...' },
+  containerWrapper: document.body,
+});
 
-// attach to a rendered File, FileDiff, or virtualized variant.
-const dispose = editor.edit(fileInstance);
+const editor = new Editor();
 
 // Merge partial options at runtime. Existing fields are preserved.
 // onChange and similar handlers read from the latest options on each call;
 // pass onFocus/onBlur before edit() attaches, or set them in the constructor.
 editor.setOptions({
   onChange(file, lineAnnotations) {
-    console.log('change', file.name, lineAnnotations);
+    // Save file in application state.
+    if (lineAnnotations != null) {
+      // Replace the application-owned annotation collection.
+    }
   },
 });
 

--- a/apps/docs/app/(diffs)/docs/Editor/constants.ts
+++ b/apps/docs/app/(diffs)/docs/Editor/constants.ts
@@ -105,6 +105,7 @@ export const EDITOR_VANILLA_FILE_DIFF_EXAMPLE: PreloadFileOptions<undefined> = {
   file: {
     name: 'editor_vanilla_file_diff.ts',
     contents: `import {
+  isDiffAnnotationCollection,
   type DiffLineAnnotation,
   Virtualizer,
   VirtualizedFileDiff,
@@ -174,7 +175,11 @@ const editor = new Editor<ThreadMetadata>({
     newFile = { ...newFile, contents: file.contents };
 
     // Replace application state first, then redraw after onChange returns.
-    if (nextAnnotations != null && nextAnnotations !== lineAnnotations) {
+    if (
+      nextAnnotations != null &&
+      isDiffAnnotationCollection(nextAnnotations) &&
+      nextAnnotations !== lineAnnotations
+    ) {
       lineAnnotations = nextAnnotations;
       queueMicrotask(renderFromApplicationState);
     }
@@ -572,6 +577,7 @@ export const EDITOR_REACT_FILE_DIFF_EXAMPLE: PreloadFileOptions<undefined> = {
   file: {
     name: 'editor_react_file_diff.tsx',
     contents: `import {
+  isDiffAnnotationCollection,
   parseDiffFromFile,
   type DiffLineAnnotation,
   type FileDiffMetadata,
@@ -629,6 +635,7 @@ export function EditorComponent() {
       onChange(_file, nextAnnotations) {
         if (
           nextAnnotations == null ||
+          !isDiffAnnotationCollection(nextAnnotations) ||
           nextAnnotations === annotationsRef.current
         ) {
           return;

--- a/apps/docs/app/(diffs)/docs/Editor/constants.ts
+++ b/apps/docs/app/(diffs)/docs/Editor/constants.ts
@@ -194,6 +194,7 @@ export const EDITOR_VANILLA_CODE_VIEW_EXAMPLE: PreloadFileOptions<undefined> = {
     name: 'editor_vanilla_code_view.ts',
     contents: `import {
   CodeView,
+  isDiffAnnotationCollection,
   parseDiffFromFile,
   type CodeViewItem,
 } from '@pierre/diffs';
@@ -230,6 +231,7 @@ const viewer = new CodeView<ThreadMetadata>({
     if (
       item.type !== 'diff' ||
       nextAnnotations == null ||
+      !isDiffAnnotationCollection(nextAnnotations) ||
       item.annotations === nextAnnotations
     ) {
       return;
@@ -684,10 +686,12 @@ export const EDITOR_REACT_CODE_VIEW_EXAMPLE: PreloadFileOptions<undefined> = {
   file: {
     name: 'editor_react_code_view.tsx',
     contents: `import {
+  isDiffAnnotationCollection,
   parseDiffFromFile,
   type CodeViewItem,
   type DiffLineAnnotation,
   type FileContents,
+  type LineAnnotation,
 } from '@pierre/diffs';
 import { Editor, type EditorOptions } from '@pierre/diffs/editor';
 import { CodeView, EditProvider } from '@pierre/diffs/react';
@@ -747,11 +751,14 @@ export function EditableCodeView() {
     (
       item: CodeViewItem<ThreadMetadata>,
       _file: FileContents,
-      nextAnnotations?: DiffLineAnnotation<ThreadMetadata>[]
+      nextAnnotations?:
+        | LineAnnotation<ThreadMetadata>[]
+        | DiffLineAnnotation<ThreadMetadata>[]
     ) => {
       if (
         item.type !== 'diff' ||
         nextAnnotations == null ||
+        !isDiffAnnotationCollection(nextAnnotations) ||
         item.annotations === nextAnnotations
       ) {
         return;
@@ -909,6 +916,7 @@ export const EDITOR_OPTIONS_TYPE: PreloadFileOptions<undefined> = {
   DiffLineAnnotation,
   DiffsEditableComponent,
   FileContents,
+  LineAnnotation,
 } from '@pierre/diffs';
 import { Editor, type IStateStorage } from '@pierre/diffs/editor';
 
@@ -962,7 +970,9 @@ interface EditorOptions<LAnnotation> {
   // existing array reference.
   onChange?: (
     file: FileContents,
-    lineAnnotations?: DiffLineAnnotation<LAnnotation>[]
+    lineAnnotations?:
+      | LineAnnotation<LAnnotation>[]
+      | DiffLineAnnotation<LAnnotation>[]
   ) => void;
 
   // Fires when the editable content area gains focus (tab, click, or editor.focus()).

--- a/apps/docs/app/(diffs)/docs/Editor/content.mdx
+++ b/apps/docs/app/(diffs)/docs/Editor/content.mdx
@@ -114,6 +114,12 @@ For annotations that survive, remapping changes only their coordinates. Metadata
 is preserved, so give each interactive annotation a stable, position-independent
 ID in `metadata` and key application-owned drafts or UI state by that ID.
 
+The shared `onChange` callback accepts either annotation shape: standalone
+`File` surfaces emit `LineAnnotation[]`, while diff surfaces emit
+`DiffLineAnnotation[]`. Narrow the collection before reading the diff-only
+`side` property. Use `isFileAnnotationCollection` or
+`isDiffAnnotationCollection` when the surface type is not already known.
+
 In React, synchronously publish a changed annotation array with `flushSync` so
 the annotation placement updates with the edited content before paint. Do not
 wrap every `onChange` update in `flushSync`: bail out when the emitted array is

--- a/apps/docs/app/(diffs)/docs/Editor/content.mdx
+++ b/apps/docs/app/(diffs)/docs/Editor/content.mdx
@@ -75,6 +75,74 @@ expand buttons keep working. The diff layout is preserved, so a `FileDiff` or
 `MultiFileDiff` stays in whatever view it was rendered in; in unified diffs,
 deleted lines and annotation lines remain read-only.
 
+### Editing with line annotations
+
+Applications own the annotation collection passed to a `File`, `FileDiff`, or
+other editable surface. When an edit affects annotation coordinates, the editor
+remaps them and passes the complete current collection to `onChange` alongside
+the edited file. This collection is authoritative when present; it is not a
+delta. Replace your application-owned collection with it before a later render
+can reapply stale coordinates.
+
+The editor preserves the existing array reference for ordinary same-line edits
+and other edits that do not affect any annotation. When a structural edit
+touches, moves, or removes an annotation, it returns a new array. Check that
+identity before publishing state so ordinary typing does not cause unnecessary
+annotation renders.
+
+Remapping follows these rules:
+
+- A `LineAnnotation`, or a `DiffLineAnnotation` on the `additions` side, follows
+  structural edits in the editable file. Inserting lines above it moves it down;
+  deleting earlier lines moves it up.
+- A `DiffLineAnnotation` on the `deletions` side stays attached to the read-only
+  old-file side and is not remapped.
+- `lineNumber: 0` remains a file-level annotation and is not remapped.
+- Deleting only an annotated line's text leaves an annotated blank line. To
+  remove a non-final line and its annotation, delete from its start through the
+  start of the next line, consuming its trailing line break. To remove a final
+  line that has a preceding line, delete from the end of the preceding line
+  through EOF, consuming the preceding line break. A one-line document always
+  retains one blank line.
+- Deleting only the line break before an annotated line while retaining its text
+  merges that text into the previous line and moves the annotation to the merged
+  line.
+- Undo and redo use the same `onChange` path, restoring or removing annotations
+  with the corresponding document state.
+
+For annotations that survive, remapping changes only their coordinates. Metadata
+is preserved, so give each interactive annotation a stable, position-independent
+ID in `metadata` and key application-owned drafts or UI state by that ID.
+
+In React, synchronously publish a changed annotation array with `flushSync` so
+the annotation placement updates with the edited content before paint. Do not
+wrap every `onChange` update in `flushSync`: bail out when the emitted array is
+the same object.
+
+<Notice variant="warning" icon={<IconCiWarningFill />}>
+  React may recreate annotation content when annotations are removed, restored,
+  or reordered, or when a `CodeView` item leaves the virtualized window.
+  `flushSync` keeps the placement update visually atomic, but it does not
+  preserve component-local state. Keep drafts and other interactive state in
+  application-owned state keyed by a stable annotation metadata ID. We intend to
+  preserve annotation node identity in a future release, so current remounting
+  behavior is not a long-term API contract.
+</Notice>
+
+In vanilla JS, replace the annotation collection in your external variable or
+store before updating the surface. When the emitted array changes, schedule the
+same render function used for the initial surface after `onChange` returns,
+passing the edited file and replacement annotations. For `CodeView`, pass the
+collection to `updateItem` with a `version` increment. In every case, updating
+the source of truth prevents a later render from restoring stale line numbers.
+
+Use one `Editor` per concurrently editable standalone surface. `CodeView`
+instead creates and manages one editor per editable item. See the
+[playground](/playground) for the complete interaction: submit a line
+annotation, enable editing, insert a line above it, remove its logical line,
+then use undo and redo. The playground controls demonstrate the integration;
+they are not additional public editor options.
+
 ### React
 
 Give a permanently mounted `EditProvider` a stable `createEditor` factory, then
@@ -126,7 +194,7 @@ to true. Re-entering edit mode creates a fresh editor with fresh history and
 state. Sibling editable surfaces receive independent editors and callbacks; use
 `onAttach` with your own ref when controls need imperative APIs such as history,
 selections, markers, save, or search. Use `Virtualizer` for large editable
-files.
+files. The `FileDiff` tab below shows the controlled annotation feedback loop.
 
 <EditorComponentTabs
   fileExample={editorReactExample}
@@ -138,7 +206,9 @@ files.
 
 Render with `File` or `FileDiff` first, then attach the editor with
 `editor.edit(component)`. Use `VirtualizedFile` and `VirtualizedFileDiff` for
-large editable files. Call `cleanUp()` when the editor is removed.
+large editable files. Keep any emitted annotation collection in your external
+source of truth before a later render. Call `cleanUp()` when the editor is
+removed. The `FileDiff` tab below includes this synchronization.
 
 <EditorComponentTabs
   fileExample={editorVanillaFileExample}
@@ -154,11 +224,13 @@ item, and pass creation-time item-editor behavior through the `CodeView`
 instead. Increment the item's `version` whenever `edit` changes.
 
 `CodeView` uses item-aware callbacks instead of `editOptions.onChange`.
-`onItemEditChange` receives the owning item with each live change.
-`onItemEditComplete` receives the item and latest contents when a changed
-session ends because editing is disabled or the item is collapsed or removed.
-Sessions with no changes do not emit it. Resetting, cleaning up, or unmounting
-the viewer is silent teardown.
+`onItemEditChange` receives the owning item with each live change: replace that
+item's annotations whenever the emitted array changes, and increment its
+`version`. This live update keeps annotation coordinates synchronized throughout
+the edit session. `onItemEditComplete` receives the item and latest contents
+when a changed session ends because editing is disabled or the item is collapsed
+or removed. Sessions with no changes do not emit it. Resetting, cleaning up, or
+unmounting the viewer is silent teardown.
 
 Persist edited contents to the item's `file`, or rebuild its `fileDiff`. Assign
 a fresh `cacheKey` and increment `version`; `CodeView` does not update item data

--- a/apps/docs/app/(diffs)/docs/ReactAPI/constants.ts
+++ b/apps/docs/app/(diffs)/docs/ReactAPI/constants.ts
@@ -401,11 +401,30 @@ export const REACT_API_SHARED_DIFF_RENDER_PROPS: PreloadFileOptions<undefined> =
 // ============================================================
 // These props are shared by MultiFileDiff, PatchDiff, and FileDiff.
 
-import { MultiFileDiff } from '@pierre/diffs/react';
+import {
+  type DiffLineAnnotation,
+  MultiFileDiff,
+} from '@pierre/diffs/react';
 
 interface ThreadMetadata {
   threadId: string;
 }
+
+// This is static read-only data. In edit mode, initialize state with this array
+// and replace that state when Editor.onChange emits a different collection.
+const lineAnnotations: DiffLineAnnotation<ThreadMetadata>[] = [
+  {
+    side: 'additions',
+    lineNumber: 0,
+    metadata: { threadId: 'file-summary' },
+  },
+  {
+    side: 'additions',
+    // One-based line number on the selected file side.
+    lineNumber: 16,
+    metadata: { threadId: 'abc123' },
+  },
+];
 
 <MultiFileDiff<ThreadMetadata>
   {...}
@@ -415,23 +434,12 @@ interface ThreadMetadata {
   // ─────────────────────────────────────────────────────────────
 
   // Array of annotations to display on specific lines.
-  // Keep annotation arrays stable (useState/useMemo) to avoid re-renders.
+  // Keep the same array reference until the annotations change.
   // Annotation metadata can be typed any way you'd like.
   // Multiple annotations can target the same side/line.
   // Use lineNumber: 0 for a file-level annotation rendered above the first
   // hunk separator or diff row.
-  lineAnnotations={[
-    {
-      side: 'additions',
-      lineNumber: 0,
-      metadata: { threadId: 'file-summary' },
-    },
-    {
-      side: 'additions', // or 'deletions'
-      lineNumber: 16,    // visual line number in the diff
-      metadata: { threadId: 'abc123' },
-    },
-  ]}
+  lineAnnotations={lineAnnotations}
 
   // Render function for each annotation. Despite the diff being
   // rendered in shadow DOM, annotations use slots so you can use
@@ -1081,11 +1089,25 @@ export const REACT_API_SHARED_FILE_RENDER_PROPS: PreloadFileOptions<undefined> =
 // ============================================================
 // These props are available on the File component.
 
-import { File } from '@pierre/diffs/react';
+import { File, type LineAnnotation } from '@pierre/diffs/react';
 
 interface CommentMetadata {
   commentId: string;
 }
+
+// This is static read-only data. In edit mode, initialize state with this array
+// and replace that state when Editor.onChange emits a different collection.
+const lineAnnotations: LineAnnotation<CommentMetadata>[] = [
+  {
+    lineNumber: 0,
+    metadata: { commentId: 'file-summary' },
+  },
+  {
+    // One-based line number in the file.
+    lineNumber: 5,
+    metadata: { commentId: 'comment-123' },
+  },
+];
 
 <File<CommentMetadata>
   {...}
@@ -1095,7 +1117,7 @@ interface CommentMetadata {
   // ─────────────────────────────────────────────────────────────
 
   // Array of annotations to display on specific lines.
-  // Keep annotation arrays stable (useState/useMemo) to avoid re-renders.
+  // Keep the same array reference until the annotations change.
   // Annotation metadata can be typed any way you'd like.
   // Multiple annotations can target the same line.
   //
@@ -1103,16 +1125,7 @@ interface CommentMetadata {
   // has no 'side' property since there's only one column.
   // Use lineNumber: 0 for a file-level annotation rendered above the
   // first file line.
-  lineAnnotations={[
-    {
-      lineNumber: 0,
-      metadata: { commentId: 'file-summary' },
-    },
-    {
-      lineNumber: 5,    // visual line number in the file
-      metadata: { commentId: 'comment-123' },
-    },
-  ]}
+  lineAnnotations={lineAnnotations}
 
   // Render function for each annotation. Despite the file being
   // rendered in shadow DOM, annotations use slots so you can use

--- a/apps/docs/app/(diffs)/docs/ReactAPI/content.mdx
+++ b/apps/docs/app/(diffs)/docs/ReactAPI/content.mdx
@@ -75,6 +75,12 @@ common set of props for configuration, annotations, and styling. The `File`
 component has similar props, but uses `LineAnnotation` instead of
 `DiffLineAnnotation` (no `side` property).
 
+When one of these components is attached to an `Editor`, keep its annotations in
+application-owned state and replace them with the current collection emitted by
+`Editor.onChange`. See
+[Editing with line annotations](#edit-mode-editing-with-line-annotations) for
+the React `flushSync` pattern and annotation-content lifetime guidance.
+
 `CodeView` reuses many of the same option names internally, but it has its own
 controlled `items` mode, imperative mode with optional `initialItems`, viewer
 ref, and mixed-item render props. See [CodeView](#codeview) for the dedicated

--- a/apps/docs/app/(diffs)/docs/Utilities/content.mdx
+++ b/apps/docs/app/(diffs)/docs/Utilities/content.mdx
@@ -5,6 +5,15 @@
   framework or rendering approach.
 </Notice>
 
+### Annotation type guards [toc-ignore]
+
+Use `isDiffAnnotation` and `isFileAnnotation` to tell diff annotations from file
+annotations. Use `isDiffAnnotationCollection` and `isFileAnnotationCollection`
+for arrays.
+
+Both collection helpers return `true` for an empty array. Use the current file
+or diff context if that distinction matters.
+
 ### diffAcceptRejectHunk [toc-ignore]
 
 Programmatically accept or reject individual hunks (or specific change blocks

--- a/apps/docs/app/(diffs)/docs/VanillaAPI/constants.ts
+++ b/apps/docs/app/(diffs)/docs/VanillaAPI/constants.ts
@@ -314,12 +314,32 @@ export const VANILLA_API_FILE_DIFF_PROPS: PreloadFileOptions<undefined> = {
     name: 'file_diff_props.ts',
     contents: `import {
   FileDiff,
+  type DiffLineAnnotation,
   type DiffTokenEventBaseProps,
   type FileDiffContentsLoader,
 } from '@pierre/diffs';
 
+interface ThreadMetadata {
+  threadId: string;
+}
+
+// Keep this array in application-owned storage when annotations can change.
+let lineAnnotations: DiffLineAnnotation<ThreadMetadata>[] = [
+  {
+    side: 'additions',
+    lineNumber: 0,
+    metadata: { threadId: 'file-summary' },
+  },
+  {
+    side: 'additions',
+    // One-based line number on the selected file side.
+    lineNumber: 5,
+    metadata: { threadId: 'abc' },
+  },
+];
+
 // All available options for the FileDiff class
-const instance = new FileDiff({
+const instance = new FileDiff<ThreadMetadata>({
 
   // ─────────────────────────────────────────────────────────────
   // THEMING
@@ -607,21 +627,21 @@ instance.render({
   // not omit only one side.
   oldFile: { name: 'file.ts', contents: '...' },
   newFile: { name: 'file.ts', contents: '...' },
-  lineAnnotations: [
-    { side: 'additions', lineNumber: 0, metadata: {} },
-    { side: 'additions', lineNumber: 5, metadata: {} },
-  ],
+  lineAnnotations,
   containerWrapper: document.body,
 });
 
 // Update options (full replacement, not merge)
 instance.setOptions({ ...instance.options, diffStyle: 'unified' });
+instance.rerender();
 
 // Update line annotations after initial render
-instance.setLineAnnotations([
+lineAnnotations = [
   { side: 'additions', lineNumber: 0, metadata: { threadId: 'file-summary' } },
   { side: 'additions', lineNumber: 5, metadata: { threadId: 'abc' } }
-]);
+];
+instance.setLineAnnotations(lineAnnotations);
+instance.rerender();
 
 // Programmatically control selected lines
 instance.setSelectedLines({
@@ -630,9 +650,6 @@ instance.setSelectedLines({
   side: 'additions',
   endSide: 'deletions',
 });
-
-// Force re-render (useful after changing options)
-instance.rerender();
 
 // Programmatically expand a collapsed hunk
 instance.expandHunk(0, 'down'); // hunkIndex, direction: 'up' | 'down' | 'both'
@@ -656,10 +673,28 @@ instance.cleanUp();`,
 export const VANILLA_API_FILE_PROPS: PreloadFileOptions<undefined> = {
   file: {
     name: 'file_props.ts',
-    contents: `import { File, type TokenEventBase } from '@pierre/diffs';
+    contents: `import {
+  File,
+  type LineAnnotation,
+  type TokenEventBase,
+} from '@pierre/diffs';
+
+interface CommentMetadata {
+  commentId: string;
+}
+
+// Keep this array in application-owned storage when annotations can change.
+let lineAnnotations: LineAnnotation<CommentMetadata>[] = [
+  { lineNumber: 0, metadata: { commentId: 'file-summary' } },
+  {
+    // One-based line number in the file.
+    lineNumber: 5,
+    metadata: { commentId: 'abc' },
+  },
+];
 
 // All available options for the File class
-const instance = new File({
+const instance = new File<CommentMetadata>({
 
   // ─────────────────────────────────────────────────────────────
   // THEMING
@@ -872,27 +907,24 @@ const instance = new File({
 // Render the file
 instance.render({
   file: { name: 'example.ts', contents: '...' },
-  lineAnnotations: [
-    { lineNumber: 0, metadata: {} },
-    { lineNumber: 5, metadata: {} },
-  ],
+  lineAnnotations,
   containerWrapper: document.body,
 });
 
 // Update options (full replacement, not merge)
 instance.setOptions({ ...instance.options, overflow: 'wrap' });
+instance.rerender();
 
 // Update line annotations after initial render
-instance.setLineAnnotations([
+lineAnnotations = [
   { lineNumber: 0, metadata: { commentId: 'file-summary' } },
   { lineNumber: 5, metadata: { commentId: 'abc' } }
-]);
+];
+instance.setLineAnnotations(lineAnnotations);
+instance.rerender();
 
 // Programmatically control selected lines
 instance.setSelectedLines({ start: 3, end: 8 });
-
-// Force re-render (useful after changing options)
-instance.rerender();
 
 // Change the active theme type
 instance.setThemeType('dark'); // 'dark' | 'light' | 'system'

--- a/apps/docs/app/(diffs)/docs/VanillaAPI/content.mdx
+++ b/apps/docs/app/(diffs)/docs/VanillaAPI/content.mdx
@@ -40,6 +40,12 @@ Both `FileDiff` and `File` accept an options object in their constructor. The
 `File` component has similar options, but excludes diff-specific settings and
 uses `LineAnnotation` instead of `DiffLineAnnotation` (no `side` property).
 
+When one of these components is attached to an `Editor`, keep its annotations in
+an external variable or store and replace them with the current collection
+emitted by `Editor.onChange`. See
+[Editing with line annotations](#edit-mode-editing-with-line-annotations) for
+the synchronization pattern and remapping rules.
+
 When rendering direct file contents with `FileDiff.render`, pass `FileContents`
 for each existing side. Use `oldFile: null` for a new file, or `newFile: null`
 for a deleted file.

--- a/apps/docs/app/(diffs)/docs/Virtualization/content.mdx
+++ b/apps/docs/app/(diffs)/docs/Virtualization/content.mdx
@@ -76,3 +76,9 @@ In vanilla JS, create a `Virtualizer` instance and pass it into
 - Use `resizeDebugging` with the `Virtualizer` temporarily when tuning metrics,
   and to confirm everything is working properly. Don't forget to disable it in
   production.
+- Edit mode's annotation feedback contract is unchanged on virtualized surfaces:
+  replace the current collection from `onChange` or `onItemEditChange` before a
+  later render. A virtualized surface may recreate rendered annotation content
+  as it leaves and re-enters the rendered window, so keep interactive annotation
+  state outside that content. See
+  [Editing with line annotations](#edit-mode-editing-with-line-annotations).

--- a/apps/docs/app/(diffs)/playground/PlaygroundClient.tsx
+++ b/apps/docs/app/(diffs)/playground/PlaygroundClient.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import type {
-  AnnotationSide,
-  DiffIndicators,
-  DiffLineAnnotation,
-  FileDiffOptions,
-  SelectedLineRange,
+import {
+  type AnnotationSide,
+  type DiffIndicators,
+  type DiffLineAnnotation,
+  type FileDiffOptions,
+  isDiffAnnotationCollection,
+  type SelectedLineRange,
 } from '@pierre/diffs';
 import type { Editor, EditorOptions } from '@pierre/diffs/editor';
 import {
@@ -728,7 +729,10 @@ export function PlaygroundClient({ prerenderedDiff }: PlaygroundClientProps) {
         editorRef.current = editor;
       },
       onChange: (_file, lineAnnotations) => {
-        if (lineAnnotations != null) {
+        if (
+          lineAnnotations != null &&
+          isDiffAnnotationCollection(lineAnnotations)
+        ) {
           flushSync(() => {
             setAnnotations(lineAnnotations);
           });

--- a/apps/docs/app/(diffs)/playground/PlaygroundCodeView.tsx
+++ b/apps/docs/app/(diffs)/playground/PlaygroundCodeView.tsx
@@ -6,6 +6,8 @@ import {
   type CodeViewLineSelection,
   type DiffLineAnnotation,
   type FileContents,
+  isDiffAnnotationCollection,
+  isFileAnnotationCollection,
   type LineAnnotation,
   parseDiffFromFile,
   type SelectedLineRange,
@@ -88,7 +90,9 @@ export function PlaygroundCodeView({
     (
       item: PlaygroundItem,
       _file: FileContents,
-      lineAnnotations?: DiffLineAnnotation<PlaygroundAnnotationMetadata>[]
+      lineAnnotations?:
+        | LineAnnotation<PlaygroundAnnotationMetadata>[]
+        | DiffLineAnnotation<PlaygroundAnnotationMetadata>[]
     ) => {
       if (lineAnnotations == null) {
         return;
@@ -99,15 +103,30 @@ export function PlaygroundCodeView({
           if (target == null || target.annotations === lineAnnotations) {
             return current;
           }
-          return current.map((existing) =>
-            existing.id === item.id
-              ? {
-                  ...existing,
-                  annotations: lineAnnotations,
-                  version: (existing.version ?? 0) + 1,
-                }
-              : existing
-          );
+          return current.map((existing) => {
+            if (existing.id !== item.id || existing.type !== item.type) {
+              return existing;
+            }
+            const version = (existing.version ?? 0) + 1;
+            if (existing.type === 'file') {
+              if (!isFileAnnotationCollection(lineAnnotations)) {
+                return existing;
+              }
+              return {
+                ...existing,
+                annotations: lineAnnotations,
+                version,
+              };
+            }
+            if (!isDiffAnnotationCollection(lineAnnotations)) {
+              return existing;
+            }
+            return {
+              ...existing,
+              annotations: lineAnnotations,
+              version,
+            };
+          });
         });
       });
     },

--- a/apps/docs/app/(diffs)/playground/PlaygroundVirtualizerElementView.tsx
+++ b/apps/docs/app/(diffs)/playground/PlaygroundVirtualizerElementView.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import type {
-  AnnotationSide,
-  DiffLineAnnotation,
-  FileDiffMetadata,
-  FileDiffOptions,
-  SelectedLineRange,
+import {
+  type AnnotationSide,
+  type DiffLineAnnotation,
+  type FileDiffMetadata,
+  type FileDiffOptions,
+  isDiffAnnotationCollection,
+  type SelectedLineRange,
 } from '@pierre/diffs';
 import type { EditorOptions } from '@pierre/diffs/editor';
 import { FileDiff, useStableCallback, Virtualizer } from '@pierre/diffs/react';
@@ -97,7 +98,10 @@ function ElementVirtualizerDiff({
   const editOptions = useMemo<EditorOptions<PlaygroundAnnotationMetadata>>(
     () => ({
       onChange(_file, lineAnnotations) {
-        if (lineAnnotations != null) {
+        if (
+          lineAnnotations != null &&
+          isDiffAnnotationCollection(lineAnnotations)
+        ) {
           flushSync(() => {
             setAnnotations(lineAnnotations);
           });

--- a/apps/docs/app/(diffs)/playground/PlaygroundVirtualizerView.tsx
+++ b/apps/docs/app/(diffs)/playground/PlaygroundVirtualizerView.tsx
@@ -4,6 +4,7 @@ import {
   type DiffLineAnnotation,
   type FileDiffMetadata,
   type FileDiffOptions,
+  isDiffAnnotationCollection,
   VirtualizedFileDiff,
   Virtualizer,
 } from '@pierre/diffs';
@@ -150,7 +151,10 @@ export function PlaygroundVirtualizerView({
       // the set; retire its orphaned React root.
       const editor = new Editor<VirtualizerAnnotationMetadata>({
         onChange: (_file, lineAnnotations) => {
-          if (lineAnnotations == null) {
+          if (
+            lineAnnotations == null ||
+            !isDiffAnnotationCollection(lineAnnotations)
+          ) {
             return;
           }
           const previous = annotationsRef.current[index];

--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -31,6 +31,7 @@ import type {
   DiffsEditor,
   FileContents,
   HunkSeparators,
+  LineAnnotation,
   PendingCodeViewLayoutReset,
   SelectedLineRange,
   SelectionSide,
@@ -438,7 +439,10 @@ interface CodeViewItemEditChange<LAnnotation> {
   // session ends because the item was removed from the CodeView.
   item: CodeViewItem<LAnnotation>;
   file: FileContents;
-  lineAnnotations: DiffLineAnnotation<LAnnotation>[] | undefined;
+  lineAnnotations:
+    | LineAnnotation<LAnnotation>[]
+    | DiffLineAnnotation<LAnnotation>[]
+    | undefined;
 }
 
 // Mutable per-editor state shared with the CodeView-built onChange closure.
@@ -547,7 +551,9 @@ export interface CodeViewOptions<LAnnotation>
   onItemEditChange?(
     item: CodeViewItem<LAnnotation>,
     file: FileContents,
-    lineAnnotations?: DiffLineAnnotation<LAnnotation>[]
+    lineAnnotations?:
+      | LineAnnotation<LAnnotation>[]
+      | DiffLineAnnotation<LAnnotation>[]
   ): void;
   /**
    * Called once when an item's edit session ends — edit turned off, item
@@ -565,7 +571,9 @@ export interface CodeViewOptions<LAnnotation>
   onItemEditComplete?(
     item: CodeViewItem<LAnnotation>,
     file: FileContents,
-    lineAnnotations?: DiffLineAnnotation<LAnnotation>[]
+    lineAnnotations?:
+      | LineAnnotation<LAnnotation>[]
+      | DiffLineAnnotation<LAnnotation>[]
   ): void;
 
   /** Render a non-virtualized element at the very start of the scroll content,

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -13,6 +13,7 @@ import type {
   FileContents,
   FileDiffMetadata,
   HighlightedToken,
+  LineAnnotation,
   Position,
   Range,
   RenderRange,
@@ -231,7 +232,9 @@ export interface EditorOptions<LAnnotation> {
   /** Callback when the editor document changes. */
   onChange?: (
     file: FileContents,
-    lineAnnotations?: DiffLineAnnotation<LAnnotation>[]
+    lineAnnotations?:
+      | LineAnnotation<LAnnotation>[]
+      | DiffLineAnnotation<LAnnotation>[]
   ) => void;
   /** Callback when the editor gains focus. */
   onFocus?: () => void;

--- a/packages/diffs/src/index.ts
+++ b/packages/diffs/src/index.ts
@@ -42,6 +42,7 @@ export * from './renderers/DiffHunksRenderer';
 export * from './renderers/FileRenderer';
 export * from './shiki-stream';
 export * from './sprite';
+export * from './utils/annotationHelpers';
 export * from './utils/areDiffLineAnnotationsEqual';
 export * from './utils/areDiffRenderOptionsEqual';
 export * from './utils/areDiffTargetsEqual';

--- a/packages/diffs/src/react/CodeView.tsx
+++ b/packages/diffs/src/react/CodeView.tsx
@@ -78,7 +78,9 @@ interface CodeViewBaseProps<LAnnotation> {
   onItemEditChange?(
     item: CodeViewItem<LAnnotation>,
     file: FileContents,
-    lineAnnotations?: DiffLineAnnotation<LAnnotation>[]
+    lineAnnotations?:
+      | LineAnnotation<LAnnotation>[]
+      | DiffLineAnnotation<LAnnotation>[]
   ): void;
   /**
    * Called once with the final contents when an item's edit session ends
@@ -90,7 +92,9 @@ interface CodeViewBaseProps<LAnnotation> {
   onItemEditComplete?(
     item: CodeViewItem<LAnnotation>,
     file: FileContents,
-    lineAnnotations?: DiffLineAnnotation<LAnnotation>[]
+    lineAnnotations?:
+      | LineAnnotation<LAnnotation>[]
+      | DiffLineAnnotation<LAnnotation>[]
   ): void;
   renderCustomHeader?(item: CodeViewItem<LAnnotation>): ReactNode;
   renderHeaderPrefix?(item: CodeViewItem<LAnnotation>): ReactNode;
@@ -255,7 +259,9 @@ function CodeViewInner<LAnnotation = undefined>(
     (
       item: CodeViewItem<LAnnotation>,
       file: FileContents,
-      lineAnnotations?: DiffLineAnnotation<LAnnotation>[]
+      lineAnnotations?:
+        | LineAnnotation<LAnnotation>[]
+        | DiffLineAnnotation<LAnnotation>[]
     ) => {
       onItemEditChange?.(item, file, lineAnnotations);
     }
@@ -264,7 +270,9 @@ function CodeViewInner<LAnnotation = undefined>(
     (
       item: CodeViewItem<LAnnotation>,
       file: FileContents,
-      lineAnnotations?: DiffLineAnnotation<LAnnotation>[]
+      lineAnnotations?:
+        | LineAnnotation<LAnnotation>[]
+        | DiffLineAnnotation<LAnnotation>[]
     ) => {
       onItemEditComplete?.(item, file, lineAnnotations);
     }

--- a/packages/diffs/src/types.ts
+++ b/packages/diffs/src/types.ts
@@ -1235,6 +1235,8 @@ export interface DiffsTextDocument {
 export interface CodeViewCreateEditorOptions<LAnnotation> {
   onChange: (
     file: FileContents,
-    lineAnnotations?: DiffLineAnnotation<LAnnotation>[]
+    lineAnnotations?:
+      | LineAnnotation<LAnnotation>[]
+      | DiffLineAnnotation<LAnnotation>[]
   ) => void;
 }

--- a/packages/diffs/src/utils/annotationHelpers.ts
+++ b/packages/diffs/src/utils/annotationHelpers.ts
@@ -1,0 +1,37 @@
+import type { DiffLineAnnotation, LineAnnotation } from '../types';
+
+/** Narrow an annotation to the side-tagged diff shape. */
+export function isDiffAnnotation<LAnnotation = undefined>(
+  annotation: LineAnnotation<LAnnotation> | DiffLineAnnotation<LAnnotation>
+): annotation is DiffLineAnnotation<LAnnotation> {
+  return 'side' in annotation;
+}
+
+/** Narrow an annotation to the side-less file shape. */
+export function isFileAnnotation<LAnnotation = undefined>(
+  annotation: LineAnnotation<LAnnotation> | DiffLineAnnotation<LAnnotation>
+): annotation is LineAnnotation<LAnnotation> {
+  return !isDiffAnnotation(annotation);
+}
+
+/**
+ * Narrow a homogeneous editor annotation collection to diff annotations.
+ * Empty collections return true because they are valid for either shape.
+ */
+export function isDiffAnnotationCollection<LAnnotation = undefined>(
+  annotations: LineAnnotation<LAnnotation>[] | DiffLineAnnotation<LAnnotation>[]
+): annotations is DiffLineAnnotation<LAnnotation>[] {
+  const first = annotations[0];
+  return first == null || isDiffAnnotation(first);
+}
+
+/**
+ * Narrow a homogeneous editor annotation collection to file annotations.
+ * Empty collections return true because they are valid for either shape.
+ */
+export function isFileAnnotationCollection<LAnnotation = undefined>(
+  annotations: LineAnnotation<LAnnotation>[] | DiffLineAnnotation<LAnnotation>[]
+): annotations is LineAnnotation<LAnnotation>[] {
+  const first = annotations[0];
+  return first == null || isFileAnnotation(first);
+}

--- a/packages/diffs/test/CodeView.edit.test.ts
+++ b/packages/diffs/test/CodeView.edit.test.ts
@@ -10,6 +10,7 @@ import type {
   DiffsEditor,
   FileContents,
   HighlightedToken,
+  LineAnnotation,
 } from '../src/types';
 import { parseDiffFromFile } from '../src/utils/parseDiffFromFile';
 import {
@@ -29,7 +30,9 @@ interface StubEditor extends DiffsEditor<undefined> {
   /** The CodeView-built onChange handed to the factory. */
   emitChange(
     file: FileContents,
-    lineAnnotations?: DiffLineAnnotation<undefined>[]
+    lineAnnotations?:
+      | LineAnnotation<undefined>[]
+      | DiffLineAnnotation<undefined>[]
   ): void;
 }
 
@@ -799,6 +802,55 @@ describe('CodeView item edit mode', () => {
 
       editors[0].emitChange({ name: 'a.ts', contents: 'edited' });
       expect(changes).toEqual([['a', 'edited']]);
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+
+  test('forwards file and diff annotation collections by reference', async () => {
+    const { cleanup } = installDom();
+    const { editors, createEditor } = createEditorHarness();
+    const changes: Array<{
+      item: CodeViewItem<undefined>;
+      lineAnnotations:
+        | LineAnnotation<undefined>[]
+        | DiffLineAnnotation<undefined>[]
+        | undefined;
+    }> = [];
+    const viewer = new CodeView({
+      createEditor,
+      onItemEditChange(item, _file, lineAnnotations) {
+        changes.push({ item, lineAnnotations });
+      },
+    });
+    try {
+      viewer.setup(createRoot());
+      await renderItems(viewer, [
+        makeEditFileItem('file'),
+        makeEditDiffItem('diff'),
+      ]);
+
+      const fileAnnotations: LineAnnotation<undefined>[] = [{ lineNumber: 2 }];
+      const diffAnnotations: DiffLineAnnotation<undefined>[] = [
+        { side: 'additions', lineNumber: 2 },
+      ];
+      editors[0].emitChange(makeFile('file.ts'), fileAnnotations);
+      editors[1].emitChange(
+        { name: 'diff.txt', contents: 'one\n' },
+        diffAnnotations
+      );
+
+      expect(changes.length).toBe(2);
+      expect(changes[0].item.type).toBe('file');
+      expect(changes[0].item.id).toBe('file');
+      // The delivered collection is the exact array the editor reported, so
+      // consumers can bail on reference equality for unaffected edits.
+      expect(changes[0].lineAnnotations).toBe(fileAnnotations);
+      expect(changes[1].item.type).toBe('diff');
+      expect(changes[1].item.id).toBe('diff');
+      expect(changes[1].lineAnnotations).toBe(diffAnnotations);
     } finally {
       viewer.cleanUp();
       await wait(0);

--- a/packages/diffs/test/annotationHelpers.test.ts
+++ b/packages/diffs/test/annotationHelpers.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { DiffLineAnnotation, LineAnnotation } from '../src/types';
+import {
+  isDiffAnnotation,
+  isDiffAnnotationCollection,
+  isFileAnnotation,
+  isFileAnnotationCollection,
+} from '../src/utils/annotationHelpers';
+
+describe('annotation type guards', () => {
+  test('identifies file annotations', () => {
+    const annotation: LineAnnotation = { lineNumber: 1 };
+
+    expect(isFileAnnotation(annotation)).toBe(true);
+    expect(isDiffAnnotation(annotation)).toBe(false);
+  });
+
+  test('identifies diff annotations', () => {
+    const annotation: DiffLineAnnotation = {
+      side: 'additions',
+      lineNumber: 1,
+    };
+
+    expect(isDiffAnnotation(annotation)).toBe(true);
+    expect(isFileAnnotation(annotation)).toBe(false);
+  });
+
+  test('identifies file annotation collections', () => {
+    const annotations: LineAnnotation[] = [{ lineNumber: 1 }];
+
+    expect(isFileAnnotationCollection(annotations)).toBe(true);
+    expect(isDiffAnnotationCollection(annotations)).toBe(false);
+  });
+
+  test('identifies diff annotation collections', () => {
+    const annotations: DiffLineAnnotation[] = [
+      { side: 'additions', lineNumber: 1 },
+    ];
+
+    expect(isDiffAnnotationCollection(annotations)).toBe(true);
+    expect(isFileAnnotationCollection(annotations)).toBe(false);
+  });
+
+  test('accepts empty collections as either annotation shape', () => {
+    const annotations: LineAnnotation[] | DiffLineAnnotation[] = [];
+
+    expect(isDiffAnnotationCollection(annotations)).toBe(true);
+    expect(isFileAnnotationCollection(annotations)).toBe(true);
+  });
+});

--- a/packages/diffs/test/editorLineAnnotations.test.ts
+++ b/packages/diffs/test/editorLineAnnotations.test.ts
@@ -129,6 +129,73 @@ describe('applyDocumentChangeToLineAnnotations', () => {
     ]);
   });
 
+  test('keeps a final-line annotation when only its text is deleted', () => {
+    const textDocument = new TextDocument('inmemory://1', 'one\ntwo\nthree');
+    const annotations: DiffLineAnnotation<string>[] = [
+      { side: 'additions', lineNumber: 3, metadata: 'three' },
+    ];
+
+    const change = textDocument.applyEdits([
+      {
+        range: {
+          start: { line: 2, character: 0 },
+          end: { line: 2, character: 5 },
+        },
+        newText: '',
+      },
+    ]);
+
+    expect(textDocument.getText()).toBe('one\ntwo\n');
+    expect(
+      applyDocumentChangeToLineAnnotations(change!, annotations)
+    ).toBeUndefined();
+  });
+
+  test('keeps an only-line annotation when all document text is deleted', () => {
+    const textDocument = new TextDocument('inmemory://1', 'only');
+    const annotations: DiffLineAnnotation<string>[] = [
+      { side: 'additions', lineNumber: 1, metadata: 'only' },
+    ];
+
+    const change = textDocument.applyEdits([
+      {
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 4 },
+        },
+        newText: '',
+      },
+    ]);
+
+    expect(textDocument.getText()).toBe('');
+    expect(
+      applyDocumentChangeToLineAnnotations(change!, annotations)
+    ).toBeUndefined();
+  });
+
+  test('drops a final-line annotation when its preceding line break is removed through EOF', () => {
+    const textDocument = new TextDocument('inmemory://1', 'one\ntwo\nthree');
+    const annotations: DiffLineAnnotation<string>[] = [
+      { side: 'additions', lineNumber: 2, metadata: 'two' },
+      { side: 'additions', lineNumber: 3, metadata: 'three' },
+    ];
+
+    const change = textDocument.applyEdits([
+      {
+        range: {
+          start: { line: 1, character: 3 },
+          end: { line: 2, character: 5 },
+        },
+        newText: '',
+      },
+    ]);
+
+    expect(textDocument.getText()).toBe('one\ntwo');
+    expect(applyDocumentChangeToLineAnnotations(change!, annotations)).toEqual([
+      { side: 'additions', lineNumber: 2, metadata: 'two' },
+    ]);
+  });
+
   test('does not borrow EOF from a later insertion when remapping deleted lines', () => {
     const textDocument = new TextDocument('inmemory://1', 'l0\nl1\nl2\nl3');
     const annotations: DiffLineAnnotation<string>[] = [


### PR DESCRIPTION
Most a bunch of additional docs for how to handle line annotations when editing.

- Document how to manage edit-mode line annotation updates across Editor, CodeView, React, vanilla, and virtualized surfaces.
  - Add examples for synchronizing remapped annotations, committing edited content, updating CodeView versions, and preserving application state with stable metadata IDs.
- Clarify annotation remapping, deletion, undo/redo, file-level annotations, and annotation content lifecycle behavior.
- Correct Editor and CodeView callback types to support both `LineAnnotation[]` and `DiffLineAnnotation[]`.
  - Before it was annotated always as `DiffLineAnnotation[]` which was technically not accurate
  - Add annotation and collection type guards to make the APIs with ambiguity easier.
- Add regression coverage for annotation guards, CodeView forwarding, and final-line deletion semantics.
