### PR TITLE
[diffs/edit] Use editor gutter interaction handler for line selection

### DIFF
--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -538,6 +538,7 @@ export class File<
   public attachEditor(editor: DiffsEditor<LAnnotation>): () => void {
     this.editor?.cleanUp();
     this.editor = editor;
+    this.interactionManager.setEditorAttached(true);
     const preparedFile =
       this.file == null ? undefined : editor.__prepareFile?.(this.file);
     if (preparedFile !== undefined && preparedFile !== this.file) {
@@ -552,6 +553,7 @@ export class File<
     }
     return () => {
       this.editor = undefined;
+      this.interactionManager.setEditorAttached(false);
     };
   }
 

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -1334,6 +1334,7 @@ export class FileDiff<
     }
     this.editor?.cleanUp();
     this.editor = editor;
+    this.interactionManager.setEditorAttached(true);
     this.hunksRenderer.beginEditSession();
     // The editor sync below refuses partial diffs (it needs the full file
     // contents); kick off hydration so the loaded re-render re-runs it.
@@ -1343,6 +1344,7 @@ export class FileDiff<
     this.syncRenderViewToEditor();
     return (recycle?: boolean) => {
       this.editor = undefined;
+      this.interactionManager.setEditorAttached(false);
       // A recycle detach is a virtualized unmount mid-session: the session
       // continues on remount, so hunks stay session-shaped. Only a genuine
       // end runs the exit recompute.

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -426,6 +426,8 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         requirePersistedCacheKey(file);
       }
     }
+    // force `useTokenTransformer` to true to ensure the `data-char` attr is
+    // added to the token elements, that is used for rendering the selection ranges
     if (fileInstance.options.useTokenTransformer !== true) {
       fileInstance.setOptions({
         ...fileInstance.options,
@@ -1542,14 +1544,8 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     this.#selectEventDisposes = disposes;
   }
 
-  // Normal line selection owns gutter gestures when enabled, so the editor
-  // must not also turn the same drag into a text selection.
-  #isLineSelectionEnabled(): boolean {
-    return this.#fileInstance?.options.enableLineSelection === true;
-  }
-
-  // Gutter gestures owned by diff interactions must not replace the editor's
-  // text selections through a browser-generated selectionchange.
+  // Gutter utility gestures owned by diff interactions must not replace the
+  // editor's text selections through a browser-generated selectionchange.
   #preserveEditorSelectionsForGutterGesture(): void {
     this.#suppressNativeSelectionSync = this.#selections !== undefined;
   }
@@ -1939,10 +1935,6 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
                 ? target.closest('[data-column-number]')
                 : null;
             if (gutterRow instanceof HTMLElement) {
-              if (this.#isLineSelectionEnabled()) {
-                this.#preserveEditorSelectionsForGutterGesture();
-                return;
-              }
               if (
                 this.#beginDeletionGutterSelection(
                   gutterRow,
@@ -2008,10 +2000,6 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
             const gutterRow = resolveGutterTarget(
               path[0] as HTMLElement | undefined
             );
-            if (gutterRow !== undefined && this.#isLineSelectionEnabled()) {
-              this.#preserveEditorSelectionsForGutterGesture();
-              return;
-            }
             // Clicking a read-only deleted line's number (unified view) selects
             // that line's text natively, since the line is not in the editor's
             // document. This runs before the mouse-only gate below: a deletion
@@ -3941,11 +3929,14 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       const top = this.#getLineY(line) + wrapLine * lineHeight;
       // Match the corner mask to the line color behind the selection; when
       // absent (context lines) the CSS falls back to the editor base bg.
-      const lineElement = this.#getLineElement(line);
+      const lineEl = this.#getLineElement(line);
       let cornerBg = 'initial';
-      if (this.#isDiff && lineElement?.dataset.lineType === 'change-addition') {
-        cornerBg =
-          getComputedStyle(lineElement).getPropertyValue('--diffs-line-bg');
+      if (
+        lineEl !== undefined &&
+        (lineEl.dataset.lineType === 'change-addition' ||
+          lineEl.dataset.selectedLine !== undefined)
+      ) {
+        cornerBg = getComputedStyle(lineEl).getPropertyValue('--diffs-line-bg');
       }
       const css = `width:${ch}px;transform:translateX(${left}px) translateY(${top}px);--diffs-selection-corner-bg:${cornerBg}`;
       const dataset = {

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -330,7 +330,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   // editors, without regressing a same-tick setSelections-then-applyEdits flow.
   #contentHasFocus = false;
   #isComposing = false;
-  #isGutterMouseDown = false;
+  #gutterPointerId?: number;
   #isContentMouseDown = false;
   #shiftKeyPressed = false;
   #selectionStart: EditorSelection | undefined;
@@ -647,7 +647,8 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       getGutterWidth: () => this.#getGutterWidth(),
       getCharX: (line, character) => this.#getCharX(line, character),
       getLineY: (line) => this.#getLineY(line),
-      isMouseDown: () => this.#isContentMouseDown || this.#isGutterMouseDown,
+      isMouseDown: () =>
+        this.#isContentMouseDown || this.#gutterPointerId !== undefined,
     });
     this.#markerRenderer.setMarkers(markers, textDocument);
     if (this.#contentElement !== undefined) {
@@ -705,6 +706,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     this.#editorEventDisposes = undefined;
     this.#selectEventDisposes?.forEach((dispose) => dispose());
     this.#selectEventDisposes = undefined;
+    this.#gutterPointerId = undefined;
     this.#detach?.(recycle);
     this.#detach = undefined;
 
@@ -1477,32 +1479,26 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         document,
         'pointerup',
         (e) => {
-          if (e.pointerType !== 'mouse') {
+          const gutterPointerId = this.#gutterPointerId;
+          if (
+            (gutterPointerId !== undefined &&
+              e.pointerId !== gutterPointerId) ||
+            (gutterPointerId === undefined && e.pointerType !== 'mouse')
+          ) {
             return;
           }
 
-          this.#selectEventDisposes?.forEach((dispose) => dispose());
-          this.#selectEventDisposes = undefined;
+          this.#finishPointerSelection(gutterPointerId !== undefined);
+        },
+        { passive: true }
+      ),
 
-          if (this.#isGutterMouseDown) {
-            this.#isGutterMouseDown = false;
-            this.#focus();
-          }
-          this.#shouldIgnoreSelectionChange = false;
-          this.#isContentMouseDown = false;
-          this.#shiftKeyPressed = false;
-          this.#selectionStart = undefined;
-          this.#reservedSelections = undefined;
-          // The popover is suppressed while the mouse is down so it doesn't
-          // flicker under the cursor mid-drag. Now that the drag has ended,
-          // re-run the overlay pass so a settled ranged selection reveals it.
-          if (
-            this.#options.enabledSelectionAction === true &&
-            this.#selections !== undefined &&
-            this.#selections.length > 0 &&
-            !isCollapsedSelection(this.#selections.at(-1)!)
-          ) {
-            this.#updateSelections(this.#selections);
+      addEventListener(
+        document,
+        'pointercancel',
+        (e) => {
+          if (e.pointerId === this.#gutterPointerId) {
+            this.#finishPointerSelection(false);
           }
         },
         { passive: true }
@@ -1542,6 +1538,32 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   #replaceSelectEventListeners(disposes: (() => void)[]): void {
     this.#selectEventDisposes?.forEach((dispose) => dispose());
     this.#selectEventDisposes = disposes;
+  }
+
+  // Clears transient listeners and selection state after a completed or
+  // canceled pointer gesture.
+  #finishPointerSelection(focusGutter: boolean): void {
+    this.#selectEventDisposes?.forEach((dispose) => dispose());
+    this.#selectEventDisposes = undefined;
+    this.#gutterPointerId = undefined;
+    if (focusGutter) {
+      this.#focus();
+    }
+    this.#shouldIgnoreSelectionChange = false;
+    this.#isContentMouseDown = false;
+    this.#shiftKeyPressed = false;
+    this.#selectionStart = undefined;
+    this.#reservedSelections = undefined;
+    // The popover is suppressed while the pointer is down so it doesn't
+    // flicker mid-drag. Re-run the overlay pass for the settled selection.
+    if (
+      this.#options.enabledSelectionAction === true &&
+      this.#selections !== undefined &&
+      this.#selections.length > 0 &&
+      !isCollapsedSelection(this.#selections.at(-1)!)
+    ) {
+      this.#updateSelections(this.#selections);
+    }
   }
 
   // Gutter utility gestures owned by diff interactions must not replace the
@@ -2002,9 +2024,8 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
             );
             // Clicking a read-only deleted line's number (unified view) selects
             // that line's text natively, since the line is not in the editor's
-            // document. This runs before the mouse-only gate below: a deletion
-            // tap registers no drag state to strand, so it works on touch too,
-            // matching the split deletions column.
+            // document. Touch and pen taps select one line without registering
+            // drag state; mouse pointers can extend the native selection.
             if (gutterRow?.dataset.lineType === 'change-deletion') {
               const code = gutterRow.closest('[data-code]');
               if (code != null) {
@@ -2017,12 +2038,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
               return;
             }
 
-            // Editable gutter drag-selection is mouse-only: the global pointerup
-            // that clears #isGutterMouseDown and disposes the mousemove listener
-            // bails for non-mouse pointers, so reacting to a touch/pen tap here
-            // would strand that state and leak the listener. Mirror the content
-            // pointerdown guard.
-            if (e.pointerType !== 'mouse') {
+            if (this.#gutterPointerId !== undefined) {
               return;
             }
 
@@ -2038,7 +2054,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
               lineIndex,
               textDocument
             );
-            this.#isGutterMouseDown = true;
+            this.#gutterPointerId = e.pointerId;
             this.#selectionStart = selection;
             this.#updateSelections([selection]);
             // Span the native selection across the clicked line and focus
@@ -2051,15 +2067,32 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
             this.#replaceSelectEventListeners([
               addEventListener(
                 document,
-                'mousemove',
+                'pointermove',
                 (e) => {
-                  if (!this.#isGutterMouseDown) {
+                  if (e.pointerId !== this.#gutterPointerId) {
                     return;
+                  }
+                  let eventTarget: EventTarget | null | undefined =
+                    e.composedPath()[0];
+                  if (e.pointerType !== 'mouse') {
+                    const root = gutterEl.getRootNode() as Node & {
+                      elementFromPoint?: (
+                        x: number,
+                        y: number
+                      ) => Element | null;
+                    };
+                    eventTarget = (
+                      typeof root.elementFromPoint === 'function'
+                        ? root.elementFromPoint.bind(root)
+                        : document.elementFromPoint.bind(document)
+                    )(e.clientX, e.clientY);
                   }
                   const textDocument = this.#textDocument;
                   const lineIndex = resolveEditableLine(
                     resolveGutterTarget(
-                      e.composedPath()[0] as HTMLElement | undefined,
+                      eventTarget instanceof HTMLElement
+                        ? eventTarget
+                        : undefined,
                       true
                     )
                   );
@@ -3480,7 +3513,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     }
     this.#selectDeletedLines(anchorContent, anchorContent, code);
     // The document pointerup disposes this listener; it must not set
-    // #isGutterMouseDown, whose pointerup focuses the editor and would collapse
+    // #gutterPointerId, whose pointerup focuses the editor and would collapse
     // the native deletion selection.
     if (isMouse) {
       this.#replaceSelectEventListeners([

--- a/packages/diffs/src/managers/InteractionManager.ts
+++ b/packages/diffs/src/managers/InteractionManager.ts
@@ -270,6 +270,7 @@ export class InteractionManager<TMode extends InteractionManagerMode> {
 
   private hasPointerListeners = false;
   private hasDocumentPointerListeners = false;
+  private hasEditorAttached = false;
 
   private selectedRange: SelectedLineRange | null = null;
   private selectedRangeHighlightSide: SelectionSide | undefined;
@@ -292,6 +293,21 @@ export class InteractionManager<TMode extends InteractionManagerMode> {
 
   setOptions(options: InteractionManagerOptions<TMode>): void {
     this.options = options;
+  }
+
+  // An attached editor owns ordinary line-number selection gestures. Other
+  // host interactions, including gutter utilities, remain active.
+  setEditorAttached(attached: boolean): void {
+    this.hasEditorAttached = attached;
+    const { mode } = this.pointerSession;
+    if (
+      attached &&
+      (mode === 'selecting' || mode === 'pendingSingleLineUnselect')
+    ) {
+      this.clearPointerSession();
+      this.detachDocumentPointerListeners();
+      this.selectionAnchor = undefined;
+    }
   }
 
   cleanUp(): void {
@@ -806,7 +822,7 @@ export class InteractionManager<TMode extends InteractionManagerMode> {
 
   private startLineSelectionFromPointerDown(event: PointerEvent): void {
     const { enableLineSelection = false } = this.options;
-    if (!enableLineSelection) {
+    if (!enableLineSelection || this.hasEditorAttached) {
       return;
     }
 

--- a/packages/diffs/test/e2e/edit.pw.ts
+++ b/packages/diffs/test/e2e/edit.pw.ts
@@ -2,13 +2,21 @@ import { expect, type Page, test } from '@playwright/test';
 
 const ADDITIONS = '[data-code][data-additions] [data-content]';
 const DELETIONS = '[data-code][data-deletions] [data-content]';
+const ADDITIONS_GUTTER = '[data-code][data-additions] [data-gutter]';
 
 async function openFixture(
   page: Page,
-  options: { gutterUtility?: boolean } = {}
+  options: { gutterUtility?: boolean; lineSelection?: boolean } = {}
 ): Promise<void> {
-  const query = options.gutterUtility === true ? '?gutterUtility' : '';
-  await page.goto(`/test/e2e/fixtures/edit.html${query}`);
+  const query = [
+    options.gutterUtility === true ? 'gutterUtility' : '',
+    options.lineSelection === true ? 'lineSelection' : '',
+  ]
+    .filter(Boolean)
+    .join('&');
+  await page.goto(
+    `/test/e2e/fixtures/edit.html${query === '' ? '' : `?${query}`}`
+  );
   await page.waitForFunction(() => window.__editReady === true);
 }
 
@@ -100,10 +108,51 @@ test.describe('edit mode', () => {
     await expect(page.locator(ADDITIONS)).toContainText('Z');
   });
 
+  test('editor owns gutter selection when line selection is enabled', async ({
+    page,
+  }) => {
+    await openFixture(page, { lineSelection: true });
+
+    const from = await page
+      .locator(`${ADDITIONS_GUTTER} [data-column-number="1"]`)
+      .boundingBox();
+    const to = await page
+      .locator(`${ADDITIONS_GUTTER} [data-column-number="3"]`)
+      .boundingBox();
+    if (from == null || to == null) {
+      throw new Error('missing additions gutter rows');
+    }
+
+    await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(to.x + to.width / 2, to.y + to.height / 2, {
+      steps: 5,
+    });
+    await page.mouse.up();
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const selection = window.__editor?.getState().selections?.at(-1);
+          return selection == null
+            ? null
+            : { start: selection.start, end: selection.end };
+        })
+      )
+      .toEqual({
+        start: { line: 0, character: 0 },
+        end: { line: 2, character: 21 },
+      });
+    await expect(page.locator('[data-selected-line]')).toHaveCount(0);
+    expect(await page.evaluate(() => window.__selectionChanges ?? [])).toEqual(
+      []
+    );
+  });
+
   test('programmatic refocus accepts the first input after a gutter gesture', async ({
     page,
   }) => {
-    await openFixture(page, { gutterUtility: true });
+    await openFixture(page, { gutterUtility: true, lineSelection: true });
 
     // A real deletion-gutter click creates a native read-only selection while
     // leaving the editor without its own text selection.
@@ -129,6 +178,10 @@ test.describe('edit mode', () => {
       .toBe(0);
     await expect(page.locator('pre[data-deleted-text-selection]')).toHaveCount(
       1
+    );
+    await expect(page.locator('[data-selected-line]')).toHaveCount(0);
+    expect(await page.evaluate(() => window.__selectionChanges ?? [])).toEqual(
+      []
     );
 
     // The utility gesture uses the same selection-preservation path as diff

--- a/packages/diffs/test/e2e/fixtures/edit.html
+++ b/packages/diffs/test/e2e/fixtures/edit.html
@@ -76,7 +76,11 @@ export default value;
       // Every onChange payload is recorded so tests can assert the editor emits
       // the updated file contents rather than inspecting the DOM alone.
       const events = [];
+      const selectionChanges = [];
       window.__editorEvents = events;
+      window.__selectionChanges = selectionChanges;
+
+      const searchParams = new URLSearchParams(location.search);
 
       const editor = new Editor({
         onChange(file) {
@@ -91,10 +95,15 @@ export default value;
         theme: { dark: 'pierre-dark', light: 'pierre-light' },
         themeType: 'dark',
         diffStyle: 'split',
-        enableGutterUtility: new URLSearchParams(location.search).has(
-          'gutterUtility'
-        ),
+        enableGutterUtility: searchParams.has('gutterUtility'),
+        enableLineSelection: searchParams.has('lineSelection'),
         onGutterUtilityClick() {},
+        onLineSelectionChange(range) {
+          selectionChanges.push(range);
+        },
+        onLineSelected(range) {
+          selectionChanges.push(range);
+        },
       });
 
       instance.render({ oldFile, newFile, containerWrapper: mount });

--- a/packages/diffs/test/editorActiveLineHighlight.test.ts
+++ b/packages/diffs/test/editorActiveLineHighlight.test.ts
@@ -3,6 +3,7 @@ import { afterAll, describe, expect, test } from 'bun:test';
 import { File, type FileOptions } from '../src/components/File';
 import { DEFAULT_THEMES } from '../src/constants';
 import { Editor } from '../src/editor/editor';
+import { DirectionForward } from '../src/editor/selection';
 import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
 import type { FileContents, SelectedLineRange } from '../src/types';
 import { installDom, wait } from './domHarness';
@@ -153,6 +154,62 @@ describe('editor active line highlight', () => {
       // ...and text selection is not a gutter line selection, so the
       // onLineSelected handler must not fire.
       expect(notifiedRanges).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('editor owns gutter drags when line selection is enabled', async () => {
+    const changedRanges: (SelectedLineRange | null)[] = [];
+    const selectedRanges: (SelectedLineRange | null)[] = [];
+    const { cleanup, content, editor } = await createEditorFixture(
+      'alpha\nbravo\ncharlie\ndelta',
+      {
+        enableLineSelection: true,
+        onLineSelected: (range) => selectedRanges.push(range),
+        onLineSelectionChange: (range) => changedRanges.push(range),
+      }
+    );
+    try {
+      const code = content.closest('[data-code]');
+      const second = code?.querySelector<HTMLElement>(
+        '[data-gutter] > [data-column-number="2"]'
+      );
+      const fourth = code?.querySelector<HTMLElement>(
+        '[data-gutter] > [data-column-number="4"]'
+      );
+      if (second == null || fourth == null) {
+        throw new Error('missing gutter rows');
+      }
+
+      second.dispatchEvent(
+        new PointerEvent('pointerdown', {
+          bubbles: true,
+          composed: true,
+          pointerType: 'mouse',
+        })
+      );
+      fourth.dispatchEvent(
+        new MouseEvent('mousemove', { bubbles: true, composed: true })
+      );
+      document.dispatchEvent(
+        new PointerEvent('pointerup', {
+          bubbles: true,
+          composed: true,
+          pointerType: 'mouse',
+        })
+      );
+
+      expect(editor.getState().selections).toEqual([
+        {
+          start: { line: 1, character: 0 },
+          end: { line: 3, character: 5 },
+          direction: DirectionForward,
+        },
+      ]);
+      expect(changedRanges).toEqual([]);
+      expect(selectedRanges).toEqual([]);
+      expect(code?.querySelector('[data-selected-line]')).toBeNull();
     } finally {
       cleanup();
     }

--- a/packages/diffs/test/editorActiveLineHighlight.test.ts
+++ b/packages/diffs/test/editorActiveLineHighlight.test.ts
@@ -5,7 +5,11 @@ import { DEFAULT_THEMES } from '../src/constants';
 import { Editor } from '../src/editor/editor';
 import { DirectionForward } from '../src/editor/selection';
 import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
-import type { FileContents, SelectedLineRange } from '../src/types';
+import type {
+  EditorSelection,
+  FileContents,
+  SelectedLineRange,
+} from '../src/types';
 import { installDom, wait } from './domHarness';
 
 afterAll(async () => {
@@ -34,6 +38,7 @@ interface EditorFixture {
   cleanup(): void;
   content: HTMLElement;
   editor: Editor<undefined>;
+  setElementFromPoint(x: number, y: number, element: Element): void;
 }
 
 async function createEditorFixture(
@@ -65,6 +70,7 @@ async function createEditorFixture(
     },
     content,
     editor,
+    setElementFromPoint: dom.setElementFromPoint,
   };
 }
 
@@ -75,6 +81,27 @@ function highlightedLineNumbers(content: HTMLElement): number[] {
   return [...content.querySelectorAll('[data-line][data-editor-active-line]')]
     .map((el) => Number(el.getAttribute('data-line')))
     .sort((a, b) => a - b);
+}
+
+function dispatchPointer(
+  target: EventTarget,
+  type: string,
+  pointerType: string,
+  pointerId = 0,
+  clientX = 0,
+  clientY = 0
+): void {
+  target.dispatchEvent(
+    new PointerEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      clientX,
+      clientY,
+      pointerId,
+      pointerType,
+    })
+  );
 }
 
 describe('editor active line highlight', () => {
@@ -182,23 +209,9 @@ describe('editor active line highlight', () => {
         throw new Error('missing gutter rows');
       }
 
-      second.dispatchEvent(
-        new PointerEvent('pointerdown', {
-          bubbles: true,
-          composed: true,
-          pointerType: 'mouse',
-        })
-      );
-      fourth.dispatchEvent(
-        new MouseEvent('mousemove', { bubbles: true, composed: true })
-      );
-      document.dispatchEvent(
-        new PointerEvent('pointerup', {
-          bubbles: true,
-          composed: true,
-          pointerType: 'mouse',
-        })
-      );
+      dispatchPointer(second, 'pointerdown', 'mouse');
+      dispatchPointer(fourth, 'pointermove', 'mouse');
+      dispatchPointer(document, 'pointerup', 'mouse');
 
       expect(editor.getState().selections).toEqual([
         {
@@ -214,4 +227,66 @@ describe('editor active line highlight', () => {
       cleanup();
     }
   });
+
+  test.each([
+    { pointerId: 7, pointerType: 'touch' },
+    { pointerId: 8, pointerType: 'pen' },
+  ])(
+    'editor owns $pointerType gutter drags when line selection is enabled',
+    async ({ pointerId, pointerType }) => {
+      const changedRanges: (SelectedLineRange | null)[] = [];
+      const selectedRanges: (SelectedLineRange | null)[] = [];
+      const { cleanup, content, editor, setElementFromPoint } =
+        await createEditorFixture('alpha\nbravo\ncharlie\ndelta', {
+          enableLineSelection: true,
+          onLineSelected: (range) => selectedRanges.push(range),
+          onLineSelectionChange: (range) => changedRanges.push(range),
+        });
+      try {
+        const code = content.closest('[data-code]');
+        const second = code?.querySelector<HTMLElement>(
+          '[data-gutter] > [data-column-number="2"]'
+        );
+        const fourth = code?.querySelector<HTMLElement>(
+          '[data-gutter] > [data-column-number="4"]'
+        );
+        if (second == null || fourth == null) {
+          throw new Error('missing gutter rows');
+        }
+
+        dispatchPointer(second, 'pointerdown', pointerType, pointerId);
+        setElementFromPoint(8, 80, fourth);
+        dispatchPointer(second, 'pointermove', pointerType, pointerId, 8, 80);
+        dispatchPointer(document, 'pointerup', pointerType, pointerId);
+
+        const selection: EditorSelection = {
+          start: { line: 1, character: 0 },
+          end: { line: 3, character: 5 },
+          direction: DirectionForward,
+        };
+        expect(editor.getState().selections).toEqual([selection]);
+        expect(changedRanges).toEqual([]);
+        expect(selectedRanges).toEqual([]);
+        expect(code?.querySelector('[data-selected-line]')).toBeNull();
+
+        dispatchPointer(second, 'pointermove', pointerType, pointerId, 8, 80);
+        expect(editor.getState().selections).toEqual([selection]);
+
+        dispatchPointer(second, 'pointerdown', pointerType, pointerId);
+        dispatchPointer(document, 'pointercancel', pointerType, pointerId);
+        dispatchPointer(second, 'pointermove', pointerType, pointerId, 8, 80);
+        expect(editor.getState().selections).toEqual([
+          {
+            start: { line: 1, character: 0 },
+            end: { line: 1, character: 5 },
+            direction: DirectionForward,
+          },
+        ]);
+        expect(changedRanges).toEqual([]);
+        expect(selectedRanges).toEqual([]);
+      } finally {
+        cleanup();
+      }
+    }
+  );
 });

--- a/packages/diffs/test/editorDiffActiveLineHighlight.test.ts
+++ b/packages/diffs/test/editorDiffActiveLineHighlight.test.ts
@@ -798,9 +798,8 @@ describe('editor active-line highlight on a diff', () => {
       );
       expect(deletedGutterNumber).not.toBeNull();
 
-      // A touch tap selects the deleted line the same as a mouse click. The
-      // mouse-only gate guards the editable gutter drag (which would strand
-      // listener state on touch), not a deletion tap, which registers nothing.
+      // A touch tap selects the deleted line through the native read-only path,
+      // which does not need transient drag state.
       deletedGutterNumber?.dispatchEvent(
         new PointerEvent('pointerdown', {
           bubbles: true,
@@ -862,9 +861,10 @@ describe('editor active-line highlight on a diff', () => {
         })
       );
       fourth.dispatchEvent(
-        new MouseEvent('mousemove', {
+        new PointerEvent('pointermove', {
           bubbles: true,
           composed: true,
+          pointerType: 'mouse',
         })
       );
       document.dispatchEvent(
@@ -922,7 +922,11 @@ describe('editor active-line highlight on a diff', () => {
       );
       await waitFor(() => editorActiveGutterNumbers(additions).length > 0);
       line4?.dispatchEvent(
-        new MouseEvent('mousemove', { bubbles: true, composed: true })
+        new PointerEvent('pointermove', {
+          bubbles: true,
+          composed: true,
+          pointerType: 'mouse',
+        })
       );
       await waitFor(() => editorActiveGutterNumbers(additions).includes(4));
       expect(fixture.editor.getState().selections).toEqual([
@@ -947,7 +951,11 @@ describe('editor active-line highlight on a diff', () => {
       );
       await waitFor(() => editorActiveGutterNumbers(additions).includes(4));
       line2?.dispatchEvent(
-        new MouseEvent('mousemove', { bubbles: true, composed: true })
+        new PointerEvent('pointermove', {
+          bubbles: true,
+          composed: true,
+          pointerType: 'mouse',
+        })
       );
       await waitFor(() => editorActiveGutterNumbers(additions).includes(2));
       document.dispatchEvent(

--- a/packages/diffs/test/editorDiffActiveLineHighlight.test.ts
+++ b/packages/diffs/test/editorDiffActiveLineHighlight.test.ts
@@ -660,7 +660,8 @@ describe('editor active-line highlight on a diff', () => {
     }
   });
 
-  test('split: line selection owns deletion gutter drags without replacing the editor selection', async () => {
+  test('split: editor owns deletion gutter drags when line selection is enabled', async () => {
+    const changedRanges: (SelectedLineRange | null)[] = [];
     const selectedRanges: (SelectedLineRange | null)[] = [];
     const fixture = await createDiffEditorFixture(
       'split',
@@ -669,21 +670,11 @@ describe('editor active-line highlight on a diff', () => {
       {
         enableLineSelection: true,
         onLineSelected: (range) => selectedRanges.push(range),
+        onLineSelectionChange: (range) => changedRanges.push(range),
       }
     );
-    let getSelectionStub: { mockRestore(): void } | undefined;
     try {
-      // Let editor setup and focus frames settle before establishing the
-      // selection this gesture must preserve.
-      for (let i = 0; i < 5; i++) {
-        await wait(0);
-      }
       const { additions, deletions } = findCodeColumns(fixture.container);
-      const content = additions?.querySelector<HTMLElement>('[data-content]');
-      const firstLine = content?.querySelector('[data-line="1"]');
-      if (content == null || firstLine == null) {
-        throw new Error('missing editor content');
-      }
       fixture.editor.setSelections([
         {
           start: { line: 0, character: 0 },
@@ -691,18 +682,6 @@ describe('editor active-line highlight on a diff', () => {
           direction: 'forward',
         },
       ]);
-      content.dispatchEvent(new Event('focus'));
-      const editorSelection = fixture.editor.getState().selections;
-      getSelectionStub = spyOn(document, 'getSelection').mockReturnValue({
-        getComposedRanges: () => [
-          {
-            startContainer: firstLine,
-            startOffset: 0,
-            endContainer: firstLine,
-            endOffset: 0,
-          },
-        ],
-      } as unknown as Selection);
       const gutterRows = [
         ...(deletions?.querySelectorAll(
           '[data-gutter] > [data-column-number]'
@@ -717,55 +696,43 @@ describe('editor active-line highlight on a diff', () => {
       if (!(first instanceof HTMLElement) || !(fourth instanceof HTMLElement)) {
         throw new Error('missing deletion gutter rows');
       }
-      fixture.setElementFromPoint(8, 80, fourth);
 
       first.dispatchEvent(
         new PointerEvent('pointerdown', {
           bubbles: true,
-          clientX: 8,
-          clientY: 20,
           composed: true,
-          pointerId: 31,
           pointerType: 'mouse',
         })
       );
-      document.dispatchEvent(new Event('selectionchange'));
-      expect(fixture.editor.getState().selections).toEqual(editorSelection);
-
       fourth.dispatchEvent(
-        new PointerEvent('pointermove', {
+        new MouseEvent('mousemove', {
           bubbles: true,
-          clientX: 8,
-          clientY: 80,
           composed: true,
-          pointerId: 31,
-          pointerType: 'mouse',
         })
       );
-      document.dispatchEvent(new Event('selectionchange'));
-      expect(fixture.editor.getState().selections).toEqual(editorSelection);
-
-      fourth.dispatchEvent(
+      document.dispatchEvent(
         new PointerEvent('pointerup', {
           bubbles: true,
-          clientX: 8,
-          clientY: 80,
           composed: true,
-          pointerId: 31,
           pointerType: 'mouse',
         })
       );
-      document.dispatchEvent(new Event('selectionchange'));
 
-      expect(selectedRanges).toEqual([{ start: 1, end: 4, side: 'deletions' }]);
-      expect(fixture.editor.getState().selections).toEqual(editorSelection);
+      await waitFor(() =>
+        arraysEqual(editorActiveGutterNumbers(deletions), [4])
+      );
+      expect(changedRanges).toEqual([]);
+      expect(selectedRanges).toEqual([]);
+      expect(fixture.editor.getState().selections).toBeUndefined();
+      expect(highlightedLineNumbers(deletions)).toEqual([]);
+      expect(highlightedGutterNumbers(deletions)).toEqual([]);
+      expect(editorActiveGutterNumbers(additions)).toEqual([]);
       expect(
         fixture.container.shadowRoot
           ?.querySelector('pre')
           ?.hasAttribute('data-deleted-text-selection')
-      ).toBe(false);
+      ).toBe(true);
     } finally {
-      getSelectionStub?.mockRestore();
       await fixture.cleanup();
     }
   });
@@ -854,7 +821,7 @@ describe('editor active-line highlight on a diff', () => {
     }
   });
 
-  test('line selection owns addition gutter drags while editing', async () => {
+  test('editor owns addition gutter drags when line selection is enabled', async () => {
     const changedRanges: (SelectedLineRange | null)[] = [];
     const selectedRanges: (SelectedLineRange | null)[] = [];
     const fixture = await createDiffEditorFixture(
@@ -867,38 +834,8 @@ describe('editor active-line highlight on a diff', () => {
         onLineSelectionChange: (range) => changedRanges.push(range),
       }
     );
-    let getSelectionStub: { mockRestore(): void } | undefined;
     try {
-      // Let the editor's setup and focus frames settle before establishing the
-      // selection this gesture must preserve.
-      for (let i = 0; i < 5; i++) {
-        await wait(0);
-      }
       const { additions } = findCodeColumns(fixture.container);
-      const content = additions?.querySelector<HTMLElement>('[data-content]');
-      const firstLine = content?.querySelector('[data-line="1"]');
-      if (content == null || firstLine == null) {
-        throw new Error('missing editor content');
-      }
-      fixture.editor.setSelections([
-        {
-          start: { line: 0, character: 1 },
-          end: { line: 0, character: 1 },
-          direction: 'none',
-        },
-      ]);
-      content.dispatchEvent(new Event('focus'));
-      const editorSelection = fixture.editor.getState().selections;
-      getSelectionStub = spyOn(document, 'getSelection').mockReturnValue({
-        getComposedRanges: () => [
-          {
-            startContainer: firstLine,
-            startOffset: 0,
-            endContainer: firstLine,
-            endOffset: 0,
-          },
-        ],
-      } as unknown as Selection);
       const gutterRows = [
         ...(additions?.querySelectorAll(
           '[data-gutter] > [data-column-number]'
@@ -916,148 +853,41 @@ describe('editor active-line highlight on a diff', () => {
       ) {
         throw new Error('missing addition gutter rows');
       }
-      fixture.setElementFromPoint(8, 80, fourth);
 
       second.dispatchEvent(
         new PointerEvent('pointerdown', {
           bubbles: true,
-          clientX: 8,
-          clientY: 40,
           composed: true,
-          pointerId: 32,
           pointerType: 'mouse',
         })
       );
-      document.dispatchEvent(new Event('selectionchange'));
-      expect(fixture.editor.getState().selections).toEqual(editorSelection);
-
       fourth.dispatchEvent(
-        new PointerEvent('pointermove', {
-          bubbles: true,
-          clientX: 8,
-          clientY: 80,
-          composed: true,
-          pointerId: 32,
-          pointerType: 'mouse',
-        })
-      );
-      document.dispatchEvent(new Event('selectionchange'));
-      const selectedRange: SelectedLineRange = {
-        start: 2,
-        end: 4,
-        side: 'additions',
-      };
-      expect(changedRanges.at(-1)).toEqual(selectedRange);
-      expect(fixture.editor.getState().selections).toEqual(editorSelection);
-      await waitFor(() =>
-        arraysEqual(highlightedLineNumbers(additions), [2, 3, 4])
-      );
-      expect(editorActiveLineNumbers(additions)).toEqual([1]);
-
-      fourth.dispatchEvent(
-        new PointerEvent('pointerup', {
-          bubbles: true,
-          clientX: 8,
-          clientY: 80,
-          composed: true,
-          pointerId: 32,
-          pointerType: 'mouse',
-        })
-      );
-      document.dispatchEvent(new Event('selectionchange'));
-
-      expect(selectedRanges).toEqual([selectedRange]);
-      expect(fixture.editor.getState().selections).toEqual(editorSelection);
-      expect(highlightedLineNumbers(additions)).toEqual([2, 3, 4]);
-      expect(editorActiveLineNumbers(additions)).toEqual([1]);
-
-      // A direct editor interaction ends the protection and allows native
-      // selection changes to update the editor again.
-      content.dispatchEvent(
-        new PointerEvent('pointerdown', {
-          bubbles: true,
-          button: 0,
-          composed: true,
-          pointerType: 'mouse',
-        })
-      );
-      document.dispatchEvent(new Event('selectionchange'));
-      expect(fixture.editor.getState().selections).toEqual([
-        {
-          start: { line: 0, character: 0 },
-          end: { line: 0, character: 0 },
-          direction: 0,
-        },
-      ]);
-    } finally {
-      getSelectionStub?.mockRestore();
-      await fixture.cleanup();
-    }
-  });
-
-  test('line selection does not suppress native sync without an editor selection', async () => {
-    const fixture = await createDiffEditorFixture(
-      'split',
-      'l1\nl2\nl3\n',
-      'l1\nl2\nl3\nl4\n',
-      { enableLineSelection: true }
-    );
-    let getSelectionStub: { mockRestore(): void } | undefined;
-    try {
-      for (let i = 0; i < 5; i++) {
-        await wait(0);
-      }
-      const { additions } = findCodeColumns(fixture.container);
-      const content = additions?.querySelector<HTMLElement>('[data-content]');
-      const firstLine = content?.querySelector('[data-line="1"]');
-      const secondGutter = additions?.querySelector<HTMLElement>(
-        '[data-gutter] > [data-column-number="2"]'
-      );
-      if (content == null || firstLine == null || secondGutter == null) {
-        throw new Error('missing editor rows');
-      }
-      expect(fixture.editor.getState().selections).toBeUndefined();
-
-      getSelectionStub = spyOn(document, 'getSelection').mockReturnValue({
-        getComposedRanges: () => [
-          {
-            startContainer: firstLine,
-            startOffset: 0,
-            endContainer: firstLine,
-            endOffset: 0,
-          },
-        ],
-      } as unknown as Selection);
-
-      content.dispatchEvent(new Event('blur'));
-      secondGutter.dispatchEvent(
-        new PointerEvent('pointerdown', {
+        new MouseEvent('mousemove', {
           bubbles: true,
           composed: true,
-          pointerId: 33,
-          pointerType: 'mouse',
         })
       );
-      secondGutter.dispatchEvent(
+      document.dispatchEvent(
         new PointerEvent('pointerup', {
           bubbles: true,
           composed: true,
-          pointerId: 33,
           pointerType: 'mouse',
         })
       );
 
-      content.dispatchEvent(new Event('focus'));
-      document.dispatchEvent(new Event('selectionchange'));
       expect(fixture.editor.getState().selections).toEqual([
         {
-          start: { line: 0, character: 0 },
-          end: { line: 0, character: 0 },
-          direction: 0,
+          start: { line: 1, character: 0 },
+          end: { line: 3, character: 2 },
+          direction: DirectionForward,
         },
       ]);
+      expect(changedRanges).toEqual([]);
+      expect(selectedRanges).toEqual([]);
+      expect(highlightedLineNumbers(additions)).toEqual([]);
+      expect(highlightedGutterNumbers(additions)).toEqual([]);
+      expect(editorActiveGutterNumbers(additions)).toEqual([4]);
     } finally {
-      getSelectionStub?.mockRestore();
       await fixture.cleanup();
     }
   });


### PR DESCRIPTION
https://github.com/pierrecomputer/pierre/pull/979 fixed `enableLineSelection` and other file/diffs options that did have good compatibility with the editor. however the editor has the own gutter interaction handler.

this pr uses editor gutter interaction when a editor attached without changing the file/difss options, and the previous line selection remain.