### PR TITLE
perf(diffs/edit): skip DOM lookups for offscreen editor lines

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -4865,14 +4865,23 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       return lineElement ?? undefined;
     }
 
+    const renderRange = this.#renderRange;
+    if (
+      renderRange !== undefined &&
+      (line < renderRange.startingLine ||
+        line >= renderRange.startingLine + renderRange.totalLines)
+    ) {
+      return undefined;
+    }
+
     const contentElement = this.#contentElement;
     if (contentElement === undefined) {
       return undefined;
     }
 
     // check if the line is within the render range (fast)
-    if (this.#renderRange !== undefined) {
-      const { startingLine } = this.#renderRange;
+    if (renderRange !== undefined) {
+      const { startingLine } = renderRange;
       const { children } = contentElement;
       for (let i = line - startingLine; i <= children.length; i++) {
         const child = children[i] as HTMLElement | undefined;

--- a/packages/diffs/test/editorVirtualizedEdit.test.ts
+++ b/packages/diffs/test/editorVirtualizedEdit.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, test } from 'bun:test';
+import { afterAll, describe, expect, spyOn, test } from 'bun:test';
 
 import { File } from '../src/components/File';
 import { DEFAULT_THEMES } from '../src/constants';
@@ -300,6 +300,34 @@ describe('Editor edits at the bottom of a virtualized window', () => {
       const rendered = renderedLineNumbers(content);
       expect(Math.max(...rendered)).toBeLessThanOrEqual(150);
     } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('Editor virtualized line lookup', () => {
+  test('does not scan the content subtree for offscreen selected lines', async () => {
+    const { cleanup, content, editor } = await createWindowedEditor(
+      300,
+      makeRange(100, 50)
+    );
+    const querySelector = spyOn(content, 'querySelector');
+    try {
+      editor.setSelections([
+        {
+          start: { line: 0, character: 0 },
+          end: { line: 299, character: 0 },
+          direction: 'forward',
+        },
+      ]);
+
+      const lineQueries = querySelector.mock.calls.filter(
+        ([selector]) =>
+          typeof selector === 'string' && selector.startsWith('[data-line=')
+      );
+      expect(lineQueries).toHaveLength(0);
+    } finally {
+      querySelector.mockRestore();
       cleanup();
     }
   });


### PR DESCRIPTION
Implemented the render-range short-circuit, preventing offscreen lines from reaching querySelector.