### PR TITLE
perf(diffs/edit): Cut wrap-mode re-measurement on typing and scroll

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -241,6 +241,12 @@ export interface EditorOptions<LAnnotation> {
 // larger inserts fall back to the bounded buffer-only path instead of building a
 // row per inserted line. A safety bound, not a correctness-critical value.
 const MAX_EDIT_WIDEN_WINDOW_MULTIPLE = 2;
+
+// Wrap offsets persist across render-range syncs (see #resetCache), so
+// scrolling through a very large file could otherwise accumulate an entry per
+// line. Past this many lines the cache resets and refills lazily for whatever
+// is measured next. A memory bound, not a correctness-critical value.
+const MAX_WRAP_OFFSETS_CACHE_LINES = 10_000;
 const SELECTION_ACTION_POPOVER_PLACEMENT_KEY = 'selection-action';
 const MULTI_SELECTION_CLIPBOARD_TYPE =
   'application/vnd.pierre.diffs-selections+json';
@@ -891,6 +897,9 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       this.#tokenizer?.cleanUp();
       this.#tokenizer = undefined;
       this.#resetState();
+      // Wrap offsets survive #resetCache, so a document swap on a reused
+      // content element must drop the previous document's measurements here.
+      this.#wrapLineOffsetsCache.clear();
       this.#selections = this.#initSelections;
       requestAnimationFrame(() => {
         this.#options.onAttach?.(this, this.#fileInstance!);
@@ -1297,9 +1306,15 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     }));
   }
 
+  // Drop the DOM-geometry caches (memoized row elements, measured line Ys,
+  // last caret x). Wrap offsets are intentionally NOT cleared here: they
+  // depend only on line text, font metrics, and content width — not on the
+  // rendered rows — so they stay valid across render-range syncs and row
+  // rebuilds. The sites where those inputs actually change (text edits in
+  // #applyChange, width changes in #handleLayoutResize, font remeasure,
+  // document swaps, cleanUp) invalidate the wrap cache themselves.
   #resetCache(): void {
     this.#lineYCache.clear();
-    this.#wrapLineOffsetsCache.clear();
     this.#lineElementsCache.clear();
     this.#lastAccessedCharX = undefined;
   }
@@ -2829,9 +2844,14 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     // web font finished loading) while this same content element survived, so
     // discard memoized non-ASCII text widths and let them re-measure.
     this.#metrics.clearTextWidthCache();
-    if (contentWidthChanged && (this.#isWrap || lineAnnotations > 0)) {
-      this.#lineYCache.clear();
+    if (contentWidthChanged) {
+      // Wrap points depend on the content width, so cached offsets go stale
+      // even while wrap is off — the mode can be toggled back on before the
+      // next width change.
       this.#wrapLineOffsetsCache.clear();
+      if (this.#isWrap || lineAnnotations > 0) {
+        this.#lineYCache.clear();
+      }
     }
     if (
       this.#selections !== undefined ||
@@ -2873,6 +2893,8 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       this.#gutterWidthCache = undefined;
       this.#contentWidthCache = undefined;
       this.#resetCache();
+      // The loaded font changes glyph widths, which moves every wrap point.
+      this.#wrapLineOffsetsCache.clear();
       if (
         this.#selections !== undefined ||
         this.#matches !== undefined ||
@@ -4684,9 +4706,33 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       }
     }
     if (this.#isWrap) {
-      for (const line of this.#wrapLineOffsetsCache.keys()) {
-        if (line >= change.startLine) {
-          this.#wrapLineOffsetsCache.delete(line);
+      // Lines outside the edited ranges keep both their text and their
+      // numbering when no renumbering happened anywhere, so only the rewritten
+      // lines need new wrap measurements. A net-zero lineDelta alone is not
+      // enough: a multi-edit batch can cancel out (one edit removes a line,
+      // another adds one) while still renumbering the lines between the edits.
+      // It is sufficient when the batch coalesced into a single range (any
+      // renumbered lines sit inside that range), or when every individual edit
+      // kept the line count.
+      const keepsLineNumbers =
+        change.lineDelta === 0 &&
+        (change.changedLineRanges.length === 1 ||
+          change.changedLineChanges?.every(
+            ([, , editLineDelta]) => editLineDelta === 0
+          ) === true);
+      if (keepsLineNumbers) {
+        for (const [rangeStart, rangeEnd] of change.changedLineRanges) {
+          for (let line = rangeStart; line <= rangeEnd; line++) {
+            this.#wrapLineOffsetsCache.delete(line);
+          }
+        }
+      } else {
+        // Renumbering invalidates every cached entry from startLine onward:
+        // its keyed line no longer holds the text that was measured.
+        for (const line of this.#wrapLineOffsetsCache.keys()) {
+          if (line >= change.startLine) {
+            this.#wrapLineOffsetsCache.delete(line);
+          }
         }
       }
     }
@@ -5064,6 +5110,9 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     if (cachedOffsets !== undefined) {
       return cachedOffsets;
     }
+    if (this.#wrapLineOffsetsCache.size >= MAX_WRAP_OFFSETS_CACHE_LINES) {
+      this.#wrapLineOffsetsCache.clear();
+    }
 
     const lineText = this.#textDocument?.getLineText(line);
     if (lineText === undefined || lineText.length === 0) {
@@ -5102,34 +5151,53 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       const wrapLineStartLeft =
         div.getBoundingClientRect().left + this.#metrics.ch;
 
-      let previousOffset = 0;
-      let lastTop = Number.NEGATIVE_INFINITY;
+      // Measurement steps through grapheme clusters when the text needs
+      // Unicode-aware boundaries, single UTF-16 units otherwise. Grapheme
+      // `index` spans [graphemeStart(index), graphemeStart(index + 1)).
+      const graphemeCount =
+        unicodeOffsets === undefined
+          ? lineText.length
+          : unicodeOffsets.length - 1;
+      const graphemeStart = (index: number): number =>
+        unicodeOffsets === undefined ? index : unicodeOffsets[index];
+      const measureGrapheme = (index: number): DOMRect => {
+        range.setStart(textNode, graphemeStart(index));
+        range.setEnd(textNode, graphemeStart(index + 1));
+        return range.getBoundingClientRect();
+      };
 
-      for (let i = 0, offsetIndex = 0; i < lineText.length; ) {
-        const nextOffset =
-          unicodeOffsets === undefined
-            ? i + 1
-            : unicodeOffsets[offsetIndex + 1];
-        range.setStart(textNode, i);
-        range.setEnd(textNode, nextOffset);
-
-        // A new visual line starts whenever the character's top edge moves
-        // below the previous character's top edge.
-        const { left, top } = range.getBoundingClientRect();
-        if (top > lastTop) {
-          // Safari can report the first range on a wrapped visual line as
-          // starting one character past the visual line start. Use the previous
-          // offset so segment-local caret math begins at the actual wrap point.
-          const startsPastLineStart =
-            isSafari() &&
-            starts.length > 0 &&
-            left - wrapLineStartLeft > this.#metrics.ch / 2;
-          starts.push(startsPastLineStart ? previousOffset : i);
-          lastTop = top;
+      // A new visual line starts whenever a grapheme's top edge moves below
+      // the previous grapheme's top edge. Line breaking assigns graphemes to
+      // visual lines in logical order, so tops are non-decreasing with the
+      // text offset and each wrap point can be located by binary-searching for
+      // the first grapheme below the current visual line — O(wraps * log n)
+      // rect measurements instead of one per character.
+      starts.push(0);
+      let lastTop = measureGrapheme(0).top;
+      let searchStart = 1;
+      while (searchStart < graphemeCount) {
+        let low = searchStart;
+        let high = graphemeCount;
+        while (low < high) {
+          const mid = (low + high) >> 1;
+          if (measureGrapheme(mid).top > lastTop) {
+            high = mid;
+          } else {
+            low = mid + 1;
+          }
         }
-        previousOffset = i;
-        i = nextOffset;
-        offsetIndex++;
+        if (low >= graphemeCount) {
+          break;
+        }
+        const { left, top } = measureGrapheme(low);
+        // Safari can report the first range on a wrapped visual line as
+        // starting one character past the visual line start. Use the previous
+        // grapheme so segment-local caret math begins at the actual wrap point.
+        const startsPastLineStart =
+          isSafari() && left - wrapLineStartLeft > this.#metrics.ch / 2;
+        starts.push(graphemeStart(startsPastLineStart ? low - 1 : low));
+        lastTop = top;
+        searchStart = low + 1;
       }
 
       const offsets = new Uint32Array(starts.length + 1);

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -4705,7 +4705,11 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         }
       }
     }
-    if (this.#isWrap) {
+    // Wrap offsets persist while overflow is 'scroll' (the mode can toggle
+    // back before any width/font/document invalidation runs), so edits must
+    // invalidate them in every mode, not just while wrap is on. The size
+    // guard keeps edits free when nothing was ever measured.
+    if (this.#wrapLineOffsetsCache.size > 0) {
       // Lines outside the edited ranges keep both their text and their
       // numbering when no renumbering happened anywhere, so only the rewritten
       // lines need new wrap measurements. A net-zero lineDelta alone is not

--- a/packages/diffs/test/editorWrapCaretPosition.test.ts
+++ b/packages/diffs/test/editorWrapCaretPosition.test.ts
@@ -114,7 +114,12 @@ function restorePrototypeProperty(
 // #wrapLineText detects visual row starts by checking when a Range's top moves
 // downward. jsdom does not measure ranges, so this harness reports a new top
 // every `columns` UTF-16 offsets, making wrap offsets deterministic.
-function installWrapMeasurement(columns: number): { restore(): void } {
+// rangeMeasurements() exposes how many Range rects were taken so tests can
+// assert measurement cost and cache retention.
+function installWrapMeasurement(columns: number): {
+  rangeMeasurements(): number;
+  restore(): void;
+} {
   const rangeProto = Object.getPrototypeOf(document.createRange()) as object;
   const elementProto = HTMLElement.prototype;
   const originalRangeRect = Object.getOwnPropertyDescriptor(
@@ -126,9 +131,11 @@ function installWrapMeasurement(columns: number): { restore(): void } {
     'getBoundingClientRect'
   );
 
+  let rangeMeasurements = 0;
   Object.defineProperty(rangeProto, 'getBoundingClientRect', {
     configurable: true,
     value(this: Range): DOMRect {
+      rangeMeasurements++;
       const offset = this.startOffset;
       return rect((offset % columns) * 8, Math.floor(offset / columns) * ROW);
     },
@@ -141,6 +148,9 @@ function installWrapMeasurement(columns: number): { restore(): void } {
   });
 
   return {
+    rangeMeasurements(): number {
+      return rangeMeasurements;
+    },
     restore(): void {
       restorePrototypeProperty(
         rangeProto,
@@ -186,6 +196,7 @@ async function createWrapEditor(
   content: HTMLElement;
   editor: Editor<undefined>;
   fileContainer: HTMLElement;
+  rangeMeasurements(): number;
   window: EditorTestWindow;
 }> {
   const dom = installDom();
@@ -218,6 +229,7 @@ async function createWrapEditor(
     content,
     editor,
     fileContainer,
+    rangeMeasurements: wrapMeasurement.rangeMeasurements,
     window: dom.window as unknown as EditorTestWindow,
   };
 }
@@ -490,6 +502,67 @@ describe('editor wrap caret position', () => {
       editor.cleanUp();
       file.cleanUp();
       dom.cleanup();
+    }
+  });
+});
+
+describe('wrap measurement cost and cache retention', () => {
+  test('wrap points on a long line are found without measuring every character', async () => {
+    // 1000 chars at 100 columns = 10 visual rows. The per-character
+    // measurement loop this guards against took one Range rect per UTF-16
+    // unit per measurement pass; binary-searching each wrap point needs
+    // ~rows * log2(chars) rects, far under one per character even across
+    // several passes.
+    const LINE = 'x'.repeat(1000);
+    const { cleanup, editor, fileContainer, rangeMeasurements } =
+      await createWrapEditor(`${LINE}\nnext`, 100);
+    try {
+      setCaret(editor, 0, 950);
+      // Row 9, segment-relative column 50 — proves the measured wrap offsets
+      // are still correct.
+      expect(caretXY(fileContainer)).toEqual({ x: colX(50), y: 9 * ROW_H });
+      expect(rangeMeasurements()).toBeLessThan(LINE.length / 2);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('an edit that keeps the line count preserves wrap offsets of untouched lines', async () => {
+    const { cleanup, editor, fileContainer, rangeMeasurements } =
+      await createWrapEditor(`${'a'.repeat(20)}\n${'b'.repeat(20)}`, 10);
+    try {
+      // Prime line 1's wrap offsets: character 15 sits on its second visual
+      // row (the line element itself reports offsetTop 0 under jsdom).
+      setCaret(editor, 1, 15);
+      expect(caretXY(fileContainer)).toEqual({ x: colX(5), y: ROW_H });
+
+      // Park the caret on line 0 so the edit below only renders against line
+      // 0 — line 1's cached offsets are not re-primed as a side effect of the
+      // edit's own caret paint, which would mask stale-cache invalidation.
+      setCaret(editor, 0, 0);
+
+      // Grow line 0 without changing the line count. Only line 0's wrap
+      // offsets are invalidated; line 1 keeps both its number and its text.
+      editor.applyEdits([
+        {
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+          },
+          newText: 'x',
+        },
+      ]);
+      await wait(0);
+      const measurementsAfterEdit = rangeMeasurements();
+
+      // Moving the caret within line 1 must be served from the cache — before
+      // range-scoped invalidation, the edit dropped every line at or after
+      // line 0 and this re-measured line 1 from scratch.
+      setCaret(editor, 1, 5);
+      expect(caretXY(fileContainer)).toEqual({ x: colX(5), y: 0 });
+      expect(rangeMeasurements()).toBe(measurementsAfterEdit);
+    } finally {
+      cleanup();
     }
   });
 });

--- a/packages/diffs/test/editorWrapCaretPosition.test.ts
+++ b/packages/diffs/test/editorWrapCaretPosition.test.ts
@@ -195,6 +195,7 @@ async function createWrapEditor(
   cleanup(): void;
   content: HTMLElement;
   editor: Editor<undefined>;
+  file: File<undefined>;
   fileContainer: HTMLElement;
   rangeMeasurements(): number;
   window: EditorTestWindow;
@@ -228,6 +229,7 @@ async function createWrapEditor(
     },
     content,
     editor,
+    file,
     fileContainer,
     rangeMeasurements: wrapMeasurement.rangeMeasurements,
     window: dom.window as unknown as EditorTestWindow,
@@ -561,6 +563,41 @@ describe('wrap measurement cost and cache retention', () => {
       setCaret(editor, 1, 5);
       expect(caretXY(fileContainer)).toEqual({ x: colX(5), y: 0 });
       expect(rangeMeasurements()).toBe(measurementsAfterEdit);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('an edit made while overflow is scroll still invalidates wrap offsets', async () => {
+    const { cleanup, editor, file, fileContainer, rangeMeasurements } =
+      await createWrapEditor(`${'a'.repeat(20)}\nnext`, 10);
+    try {
+      // Prime line 0's wrap offsets in wrap mode.
+      setCaret(editor, 0, 15);
+      expect(caretXY(fileContainer)).toEqual({ x: colX(5), y: ROW_H });
+
+      // Toggle to scroll, edit line 0, toggle back. The wrap cache survives
+      // the whole round trip, and the edit runs while wrap is off — skipping
+      // invalidation here would leave offsets measured for the old text.
+      file.setOptions({ ...file.options, overflow: 'scroll' });
+      editor.applyEdits([
+        {
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+          },
+          newText: 'x',
+        },
+      ]);
+      await wait(0);
+      file.setOptions({ ...file.options, overflow: 'wrap' });
+
+      // Back in wrap mode, the edited line must be re-measured rather than
+      // served from offsets that predate the edit.
+      const beforeReturn = rangeMeasurements();
+      setCaret(editor, 0, 15);
+      expect(caretXY(fileContainer)).toEqual({ x: colX(5), y: ROW_H });
+      expect(rangeMeasurements()).toBeGreaterThan(beforeReturn);
     } finally {
       cleanup();
     }


### PR DESCRIPTION
Type or scroll in a wrapped file with long lines: every keystroke and scroll re-measured wrap points character by character for each line, one Range.getBoundingClientRect() per character, making minified or long-line files sluggish.

Three changes to wrap measurement and its caching:

- Find each wrap point by binary-searching for the first grapheme whose rect top drops to the next visual line (tops are non-decreasing with text offset), replacing the per-character scan: O(wraps * log chars) measurements instead of O(chars).
- On edits that renumber no lines, invalidate only the lines the edit rewrote instead of every line at or after it. Per-edit line deltas guard the multi-edit batch whose net delta cancels to zero while still shifting lines between the edits.
- Keep wrap offsets across render-range syncs: they depend on line text, font metrics, and content width, not on rendered rows. The sites where those inputs change (document swap, font load, width resize, cleanup) now clear the cache themselves, with a 10k-line cap since entries persist across scrolls.
 

Two regression tests in `editorWrapCaretPosition.test.ts`, backed by a
measurement counter added to the mock harness:

- A 10-row / 1000-char line resolves with `< 500` rect measurements while the
  caret still lands on the right visual row/column (old code: exactly 1000).
- After a same-line-count edit to line 0, moving the caret within line 1 adds
  zero measurements (old code re-measured line 1 from scratch).