### PR TITLE
diffs: add starlark file extensions

### DIFF
--- a/packages/diffs/src/utils/getFiletypeFromFileName.ts
+++ b/packages/diffs/src/utils/getFiletypeFromFileName.ts
@@ -243,6 +243,19 @@ export const EXTENSION_TO_FILE_FORMAT: ExtensionFormatMap = {
   py: 'python',
   pyw: 'python',
   pyi: 'python',
+  // FIXME: these should be changed to a Starlark file type if/when one
+  // appears in shiki. For now, Starlark is highlighted like the Python subset
+  // it is.
+  BUCK: 'python',
+  BUILD: 'python',
+  MODULE: 'python',
+  PACKAGE: 'python',
+  WORKSPACE: 'python',
+  bazel: 'python',
+  bxl: 'python',
+  bzl: 'python',
+  star: 'python',
+  sky: 'python',
   qml: 'qml',
   qmldir: 'qmldir',
   qss: 'qss',


### PR DESCRIPTION
If shiki ever grows Starlark support, this should be revised to use that starlark support, but Starlark is a strict subset of Python anyway.

ref for the file extensions:
https://bazel.build/concepts/build-ref
https://buck2.build/docs/rule_authors/package_files/
https://buck2.build/docs/bxl/

### Description

Add support for highlighting Starlark files like those from Bazel/Buck2/Copybara.

### Motivation & Context

I like my diffs for my build files to be readable.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality). You must have
      first discussed with the dev team and they should be aware that this PR is
      being opened
- [ ] Breaking change (fix or feature that would change existing functionality).
      You must have first discussed with the dev team and they should be aware
      that this PR is being opened
- [ ] Documentation update

### Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/pierrecomputer/pierre/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project (`moon run root:lint`)
- [x] My code is formatted properly (`moon run root:format`)
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have added tests to cover my changes (if applicable)
- [x] All new and existing tests pass (`moonx diffs:test`)

### How was AI used in generating this PR

wrote this with claude then realized it was all out of order and redid it by hand lmao

### Related issues

<!-- Please link any related issues here. -->
