### PR TITLE
Expose internal imperative navigation API as a public API

### DIFF
--- a/apps/docs/app/(trees)/docs/Reference/ReactAPI/content.mdx
+++ b/apps/docs/app/(trees)/docs/Reference/ReactAPI/content.mdx
@@ -95,6 +95,10 @@ Typical write paths are:
 - focus and selection methods on the model or item handles. This includes
   `scrollToPath(...)`, which reveals a path without moving DOM focus and makes
   optional model focus changes.
+- visible-tree traversal through `focusFirstItem()`, `focusLastItem()`,
+  `focusNextItem()`, `focusPreviousItem()`, and `focusParentItem()`.
+- visible row inspection through `getFocusedIndex()`, `getVisibleCount()`, and
+  `getVisibleRows(start, end)` when surrounding UI needs custom navigation.
 - search methods such as `setSearch(...)` and `openSearch(...)`
 - mutation methods such as `add(...)`, `remove(...)`, `move(...)`, `batch(...)`,
   and `resetPaths(...)`

--- a/apps/docs/app/(trees)/docs/Reference/VanillaAPI/content.mdx
+++ b/apps/docs/app/(trees)/docs/Reference/VanillaAPI/content.mdx
@@ -52,6 +52,9 @@ Common read methods are:
 - `getItem(path)`
 - `getFocusedItem()`
 - `getFocusedPath()`
+- `getFocusedIndex()`
+- `getVisibleCount()`
+- `getVisibleRows(start, end)`
 - `getSelectedPaths()`
 - `getComposition()`
 - `isSearchOpen()`
@@ -85,12 +88,19 @@ Focus and selection control:
 
 - `focusPath(path)`
 - `focusNearestPath(path | null)`
+- `focusFirstItem()` / `focusLastItem()`
+- `focusNextItem()` / `focusPreviousItem()`
+- `focusParentItem()`
 - `scrollToPath(path, { offset: 'top' | 'center' | 'nearest', focus?: boolean })`
 - `startRenaming(path?)`
 - item-handle selection and focus methods
 
 `scrollToPath(...)` scrolls the virtualizer without moving DOM focus. It updates
 model focus by default. Pass `focus: false` to keep model focus unchanged.
+
+The traversal methods follow the current visible tree, including its active
+expansion and search state. `getVisibleRows(start, end)` uses inclusive row
+indexes and returns path-first row metadata for building custom navigation.
 
 Search control:
 

--- a/packages/trees/src/render/FileTree.ts
+++ b/packages/trees/src/render/FileTree.ts
@@ -49,6 +49,7 @@ import type {
   FileTreeSearchSessionHandle,
   FileTreeSelectionChangeListener,
   FileTreeSsrPayload,
+  FileTreeVisibleRow,
 } from '../model/publicTypes';
 import {
   FILE_TREE_DEFAULT_ITEM_HEIGHT,
@@ -304,6 +305,21 @@ export class FileTree
     return this.#controller.getFocusedPath();
   }
 
+  public getFocusedIndex(): number {
+    return this.#controller.getFocusedIndex();
+  }
+
+  public getVisibleCount(): number {
+    return this.#controller.getVisibleCount();
+  }
+
+  public getVisibleRows(
+    start: number,
+    end: number
+  ): readonly FileTreeVisibleRow[] {
+    return this.#controller.getVisibleRows(start, end);
+  }
+
   public getSelectedPaths(): readonly string[] {
     return this.#controller.getSelectedPaths();
   }
@@ -338,6 +354,26 @@ export class FileTree
 
   public focusPath(path: string): void {
     this.#controller.focusPath(path);
+  }
+
+  public focusFirstItem(): void {
+    this.#controller.focusFirstItem();
+  }
+
+  public focusLastItem(): void {
+    this.#controller.focusLastItem();
+  }
+
+  public focusNextItem(): void {
+    this.#controller.focusNextItem();
+  }
+
+  public focusPreviousItem(): void {
+    this.#controller.focusPreviousItem();
+  }
+
+  public focusParentItem(): void {
+    this.#controller.focusParentItem();
   }
 
   public scrollToPath(

--- a/packages/trees/test/file-tree-public-navigation.test.ts
+++ b/packages/trees/test/file-tree-public-navigation.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test';
+
+import { FileTree } from '../src/render/FileTree';
+
+describe('FileTree public navigation', () => {
+  test('traverses rows in the current visible tree order', () => {
+    const fileTree = new FileTree({
+      flattenEmptyDirectories: false,
+      initialExpansion: 'open',
+      paths: ['README.md', 'src/index.ts', 'src/lib/util.ts'],
+    });
+
+    expect(fileTree.getVisibleCount()).toBe(5);
+    expect(
+      fileTree
+        .getVisibleRows(0, fileTree.getVisibleCount() - 1)
+        .map((row) => [row.path, row.kind])
+    ).toEqual([
+      ['src/', 'directory'],
+      ['src/lib/', 'directory'],
+      ['src/lib/util.ts', 'file'],
+      ['src/index.ts', 'file'],
+      ['README.md', 'file'],
+    ]);
+
+    expect(fileTree.getFocusedIndex()).toBe(0);
+    fileTree.focusNextItem();
+    expect(fileTree.getFocusedPath()).toBe('src/lib/');
+    expect(fileTree.getFocusedIndex()).toBe(1);
+
+    fileTree.focusLastItem();
+    expect(fileTree.getFocusedPath()).toBe('README.md');
+    fileTree.focusPreviousItem();
+    expect(fileTree.getFocusedPath()).toBe('src/index.ts');
+
+    fileTree.focusParentItem();
+    expect(fileTree.getFocusedPath()).toBe('src/');
+    fileTree.focusFirstItem();
+    expect(fileTree.getFocusedPath()).toBe('src/');
+
+    fileTree.cleanUp();
+  });
+
+  test('visible rows reflect directory expansion changes', () => {
+    const fileTree = new FileTree({
+      flattenEmptyDirectories: false,
+      initialExpansion: 'open',
+      paths: ['README.md', 'src/index.ts', 'src/lib/util.ts'],
+    });
+    const src = fileTree.getItem('src');
+    if (src == null || !('collapse' in src)) {
+      throw new Error('expected src directory');
+    }
+
+    src.collapse();
+
+    expect(fileTree.getVisibleCount()).toBe(2);
+    expect(fileTree.getVisibleRows(0, 1).map((row) => row.path)).toEqual([
+      'src/',
+      'README.md',
+    ]);
+    fileTree.focusLastItem();
+    fileTree.focusNextItem();
+    expect(fileTree.getFocusedPath()).toBe('README.md');
+
+    fileTree.cleanUp();
+  });
+});


### PR DESCRIPTION
### Description

Exposes the private imperative navigation API  in Pierre's Trees library as a public API. 

### Motivation & Context

Pierre's Diffs library has a public imperative navigation API. This is very useful for building keyboard- and hotkey-first experiences on the Diff library. 

While integrating the Trees library into HumanLayer, I noticed that unlike the Diffs library, the Trees library's imperative navigation API is internal/private. 

This PR makes that private API Public. 

### Type of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality). You must have
      first discussed with the dev team and they should be aware that this PR is
      being opened
- [ ] Breaking change (fix or feature that would change existing functionality).
      You must have first discussed with the dev team and they should be aware
      that this PR is being opened
- [x] Documentation update

### Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/pierrecomputer/pierre/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project (`moon run root:lint`)
- [x] My code is formatted properly (`moon run root:format`)
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have added tests to cover my changes (if applicable)
- [x] All new and existing tests pass (`moonx diffs:test`)

### How was AI used in generating this PR

1. Used HumanLayer (humanlayer.com) to conduct codebase research and identify the relevant parts of the codebase and APIs (artifact [here](https://cloud.dev.codelayer.gg/shared/artifacts/019f8fe8-d315-773b-b144-692b4e99907c?key=67c042e0-1995-4afd-986c-2e5fd2dcd706)] 
2. Created a [concise design document](https://cloud.dev.codelayer.gg/shared/artifacts/019f72ad-c901-7d0a-8d23-306d515c5752?key=877f69dd-4cde-41d0-bd91-177151a701ad) that was shared with the Pierre team via slack to request feedback

-> received feedback from @SlexAxton 

> my first thought reading the goals section was that trees should likely just support this mode natively
> but i also think the rest of the imperative stuff would likely end up useful anyways
> so i'd be down for both

3. Used HumanLayer to implement & test changes and to review the Contributing guide before opening an upstream PR (per the guide, this description has been written by hand by me) 

