### PR TITLE
fix(diffs): Wrap annotation content in every overflow mode

### DIFF
--- a/apps/docs/app/(diffs)/_examples/Annotations/Annotations.tsx
+++ b/apps/docs/app/(diffs)/_examples/Annotations/Annotations.tsx
@@ -182,7 +182,6 @@ function CommentForm({
         <div
           className="max-w-[95%] sm:max-w-[70%]"
           style={{
-            whiteSpace: 'normal',
             margin: 20,
             fontFamily: 'Geist',
           }}
@@ -230,7 +229,6 @@ function Thread() {
     <div
       className="max-w-[95%] sm:max-w-[70%]"
       style={{
-        whiteSpace: 'normal',
         margin: 20,
         fontFamily: 'Geist',
       }}

--- a/packages/diffs/src/style.css
+++ b/packages/diffs/src/style.css
@@ -1398,9 +1398,15 @@
   }
 
   [data-overflow='wrap'] {
-    [data-line],
-    [data-annotation-content] {
+    [data-line] {
       white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    /* Annotations wrap in every overflow mode (see the base
+     * [data-annotation-content] rule). In wrap mode, also break long words so
+     * they do not overflow the wrapped column. */
+    [data-annotation-content] {
       word-break: break-word;
     }
   }
@@ -1647,6 +1653,12 @@
     z-index: 2;
     min-width: 0;
     isolation: isolate;
+    /* Annotations contain prose, not code. The text must wrap in every
+     * overflow mode. Slotted annotation content inherits this white-space
+     * value. In scroll mode without this rule, the text inherits
+     * `white-space: pre` from the `pre` element. Then long text does not
+     * wrap. */
+    white-space: normal;
   }
 
   /* Sticky positioning has a composite costs, so we should _only_ pay it if we

--- a/packages/diffs/test/e2e/annotations.pw.ts
+++ b/packages/diffs/test/e2e/annotations.pw.ts
@@ -22,4 +22,21 @@ test.describe('line annotations', () => {
     await expect(content).toBeVisible();
     await expect(content).toHaveText('note on line 2');
   });
+
+  test('annotation content wraps in the default scroll overflow mode', async ({
+    page,
+  }) => {
+    await openFixture(page);
+
+    // Annotations contain prose, so the content must wrap in every overflow
+    // mode. Slotted light-DOM content inherits `white-space` from the
+    // shadow-DOM `[data-annotation-content]` parent. So that parent must set
+    // `white-space: normal`, even in the default `scroll` overflow where code
+    // lines stay `pre`. Before the fix, the parent inherited `pre` and long
+    // annotation text did not wrap.
+    const whiteSpace = await page
+      .locator('[data-annotation-content]')
+      .evaluate((el) => getComputedStyle(el).whiteSpace);
+    expect(whiteSpace).toBe('normal');
+  });
 });


### PR DESCRIPTION
Annotation prose did not wrap in the default scroll overflow mode. React consumers had to add `white-space: normal` to each annotation by hand, or the text overflowed the diff column.

The diffs stylesheet lives in the shadow root, so slotted annotation content gets its white-space by inheritance from the shadow-DOM `[data-annotation-content]` parent. That parent normalized white-space only under `[data-overflow="wrap"]`. In scroll mode it inherited `white-space: pre` from the `pre` element, so the slotted prose did not wrap.

Set `white-space: normal` on `[data-annotation-content]` in every overflow mode. Annotations hold prose, not code, so they never need `pre`. One rule fixes every render path (React, imperative, SSR) and keeps them consistent.

Also remove the now-unnecessary `white-space: normal` workaround from the docs annotations demo, and add a browser regression test for the computed white-space in scroll mode.