### PR TITLE
feat(trees): Keep file-tree search open and interactive

### DIFF
--- a/packages/trees/src/model/FileTreeController.ts
+++ b/packages/trees/src/model/FileTreeController.ts
@@ -258,6 +258,7 @@ export class FileTreeController
   #renamingPath: string | null = null;
   #renamingValue = '';
   #removeRenamingPathIfCanceled = false;
+  #searchCollapsedOverrides = new Set<string>();
   #searchMatchPathSet = new Set<string>();
   #searchMatchingPaths: readonly string[] = [];
   #searchMode: FileTreeSearchMode;
@@ -697,6 +698,17 @@ export class FileTreeController
     const directoryPath = this.resolveMountedDirectoryPathFromInput(path);
     if (directoryPath == null) {
       return;
+    }
+
+    // During a search, record when the user collapses a matched directory so
+    // the search keeps it collapsed. A second toggle of the same directory
+    // clears the override and returns the directory to the search default.
+    if (this.#searchValue != null && this.#searchValue.length > 0) {
+      if (this.#searchCollapsedOverrides.has(directoryPath)) {
+        this.#searchCollapsedOverrides.delete(directoryPath);
+      } else if (this.#store.isExpanded(directoryPath)) {
+        this.#searchCollapsedOverrides.add(directoryPath);
+      }
     }
 
     this.#toggleDirectory(directoryPath);
@@ -1716,7 +1728,6 @@ export class FileTreeController
 
   #syncSearchVisibilityState(): void {
     if (this.#searchValue == null || this.#searchValue.length === 0) {
-      this.#searchMatchingPaths = [];
       this.#searchVisibleIndices = null;
       this.#searchVisiblePaths = null;
       this.#searchVisibleIndexByPath = null;
@@ -1725,10 +1736,6 @@ export class FileTreeController
     }
 
     const currentVisiblePaths = this.#projectionPaths;
-    this.#searchMatchingPaths = currentVisiblePaths.filter((path) =>
-      this.#searchMatchPathSet.has(path)
-    );
-
     if (
       this.#searchMode !== 'hide-non-matches' ||
       this.#searchMatchPathSet.size === 0
@@ -1743,8 +1750,9 @@ export class FileTreeController
     const visibleIndices: number[] = [];
     const visiblePaths: string[] = [];
     const visibleIndexByPath = new Map<string, number>();
+    const searchVisiblePathSet = this.#searchVisiblePathSet;
     for (const [index, path] of currentVisiblePaths.entries()) {
-      if (this.#searchVisiblePathSet?.has(path) !== true) {
+      if (searchVisiblePathSet?.has(path) !== true) {
         continue;
       }
 
@@ -1822,14 +1830,18 @@ export class FileTreeController
     this.#searchValue = normalizedValue;
 
     if (normalizedValue == null) {
+      this.#searchCollapsedOverrides.clear();
       this.#restoreSearchExpandedPaths(true);
       this.#searchPreviousExpandedPaths = null;
       this.#searchMatchPathSet.clear();
+      this.#searchMatchingPaths = [];
       this.#searchVisiblePathSet = null;
       this.#rebuildVisibleProjection(this.#focusedPath, true);
     } else if (normalizedValue.length === 0) {
+      this.#searchCollapsedOverrides.clear();
       this.#restoreSearchExpandedPaths(false);
       this.#searchMatchPathSet.clear();
+      this.#searchMatchingPaths = [];
       this.#searchVisiblePathSet = null;
       this.#rebuildVisibleProjection(this.#focusedPath, true);
     } else {
@@ -1846,9 +1858,11 @@ export class FileTreeController
   #refreshActiveSearchState(): string | null {
     if (this.#searchValue == null || this.#searchValue.length === 0) {
       this.#searchMatchPathSet.clear();
+      this.#searchMatchingPaths = [];
       return this.#focusedPath;
     }
 
+    this.#pruneStaleSearchCollapsedOverrides();
     const searchValue = this.#searchValue;
     const listedPaths = this.#getListedPaths();
     const listedPathsLowerCase = this.#getListedPathsLowerCase();
@@ -1888,6 +1902,7 @@ export class FileTreeController
     }
 
     this.#searchMatchPathSet = matchingPathSet;
+    this.#searchMatchingPaths = matchingPaths;
     const searchVisiblePathSet =
       this.#searchMode === 'hide-non-matches' && matchingPaths.length > 0
         ? new Set<string>()
@@ -1908,6 +1923,19 @@ export class FileTreeController
       for (const ancestorPath of getAncestorDirectoryPaths(matchingPath)) {
         expandedPaths.add(ancestorPath);
         if (searchVisiblePathSet != null) {
+          searchVisiblePathSet.add(ancestorPath);
+        }
+      }
+    }
+
+    // For each directory the user collapsed during the search, remove it from
+    // the expanded set. Keep the directory and its ancestors visible, so the
+    // user can expand it again.
+    for (const collapsedPath of this.#searchCollapsedOverrides) {
+      expandedPaths.delete(collapsedPath);
+      if (searchVisiblePathSet != null) {
+        searchVisiblePathSet.add(collapsedPath);
+        for (const ancestorPath of getAncestorDirectoryPaths(collapsedPath)) {
           searchVisiblePathSet.add(ancestorPath);
         }
       }
@@ -2056,12 +2084,62 @@ export class FileTreeController
     this.#rebuildVisibleProjection(this.#focusedPath, true);
   }
 
+  // Each collapsed-directory override is a directory path. Drop any override
+  // when its directory no longer exists or is no longer a directory. A stale
+  // entry must not affect a later search.
+  #pruneStaleSearchCollapsedOverrides(): void {
+    if (this.#searchCollapsedOverrides.size === 0) {
+      return;
+    }
+
+    for (const collapsedPath of [...this.#searchCollapsedOverrides]) {
+      if (
+        this.resolveMountedDirectoryPathFromInput(collapsedPath) !==
+        collapsedPath
+      ) {
+        this.#searchCollapsedOverrides.delete(collapsedPath);
+      }
+    }
+  }
+
+  // A tree mutation can rename or move the directories that the overrides use.
+  // Remap each collapsed path through the mutation. Keep only the paths that
+  // still resolve to a live directory.
+  #remapSearchCollapsedOverridesThroughMutation(
+    event: Extract<
+      PathStoreEvent,
+      { operation: 'add' | 'remove' | 'move' | 'batch' }
+    >
+  ): void {
+    if (this.#searchCollapsedOverrides.size === 0) {
+      return;
+    }
+
+    const nextOverrides = new Set<string>();
+    for (const collapsedPath of this.#searchCollapsedOverrides) {
+      const remappedPath = remapPathThroughMutation(collapsedPath, event);
+      if (remappedPath == null) {
+        continue;
+      }
+
+      const canonicalPath = this.#store.getPathInfo(remappedPath)?.path ?? null;
+      if (canonicalPath == null || !canonicalPath.endsWith('/')) {
+        continue;
+      }
+
+      nextOverrides.add(canonicalPath);
+    }
+
+    this.#searchCollapsedOverrides = nextOverrides;
+  }
+
   #applyMutationState(
     event: Extract<
       PathStoreEvent,
       { operation: 'add' | 'remove' | 'move' | 'batch' }
     >
   ): string | null {
+    this.#remapSearchCollapsedOverridesThroughMutation(event);
     const nextRenamingPath = remapPathThroughMutation(
       this.#renamingPath,
       event
@@ -2119,12 +2197,22 @@ export class FileTreeController
       const focusPathCandidate = isPathMutationEvent(event)
         ? this.#applyMutationState(event)
         : this.#focusedPath;
-      const searchFocusCandidate =
-        this.#searchValue != null && this.#searchValue.length > 0
-          ? this.#refreshActiveSearchState()
-          : this.#searchValue === ''
+      // Keep the current focus if it is still a visible search row after the
+      // mutation. If it is not, use the refreshed best match. This keeps the
+      // focus on a row the user revealed and prevents an unwanted focus move.
+      let searchFocusCandidate: string | null;
+      if (this.#searchValue != null && this.#searchValue.length > 0) {
+        const refreshedSearchFocusCandidate = this.#refreshActiveSearchState();
+        searchFocusCandidate =
+          this.#focusedPath != null &&
+          this.#searchVisiblePathSet?.has(this.#focusedPath) === true
             ? this.#focusedPath
-            : focusPathCandidate;
+            : refreshedSearchFocusCandidate;
+      } else if (this.#searchValue === '') {
+        searchFocusCandidate = this.#focusedPath;
+      } else {
+        searchFocusCandidate = focusPathCandidate;
+      }
       const shouldBuildFullProjection =
         this.#searchValue != null ||
         (event.operation !== 'expand' && event.operation !== 'collapse');

--- a/packages/trees/src/render/FileTreeView.tsx
+++ b/packages/trees/src/render/FileTreeView.tsx
@@ -2216,27 +2216,12 @@ export function FileTreeView({
         restoreTreeFocusViewportOffsetRef.current = null;
         controller.closeSearch();
       } else if (event.key === 'Enter') {
+        // Enter selects the focused match. Enter keeps the search open. The
+        // user can then select more matches without a new search.
         const currentFocusedPath = controller.getFocusedPath();
         if (currentFocusedPath != null) {
           controller.selectOnlyPath(currentFocusedPath);
         }
-        const scrollElement = scrollRef.current;
-        const viewportHeight = readMeasuredViewportHeight(
-          scrollElement,
-          resolvedViewportHeight
-        );
-        restoreTreeFocusViewportOffsetRef.current =
-          focusedIndex < 0 || scrollElement == null
-            ? null
-            : Math.max(
-                0,
-                Math.min(
-                  focusedIndex * itemHeight - scrollElement.scrollTop,
-                  Math.max(0, viewportHeight - itemHeight)
-                )
-              );
-        restoreTreeFocusAfterSearchCloseRef.current = true;
-        controller.closeSearch();
       } else if (event.key === 'ArrowDown') {
         controller.focusNextSearchMatch();
       } else if (event.key === 'ArrowUp') {

--- a/packages/trees/src/render/rowClickPlan.ts
+++ b/packages/trees/src/render/rowClickPlan.ts
@@ -28,7 +28,7 @@ export type FileTreeRowClickPlanInput = {
 export function computeFileTreeRowClickPlan(
   input: FileTreeRowClickPlanInput
 ): FileTreeRowClickPlan {
-  const { event, mode, isSearchOpen, isDirectory } = input;
+  const { event, mode, isDirectory } = input;
   const additive = event.ctrlKey || event.metaKey;
   const hasModifier = event.shiftKey || additive;
 
@@ -41,7 +41,10 @@ export function computeFileTreeRowClickPlan(
   // Sticky rows are aria-hidden mirrors of in-flow rows, so every sticky click
   // must hand off to the canonical row even when modifiers suppress toggling.
   return {
-    closeSearch: isSearchOpen,
+    // A row click does not close an open search. The user can then refine the
+    // search and select results. Keep this field on the plan. It gives the
+    // close decision one place to change later.
+    closeSearch: false,
     revealCanonical: mode === 'sticky',
     selection,
     toggleDirectory: !hasModifier && isDirectory,

--- a/packages/trees/test/e2e/file-tree-search.pw.ts
+++ b/packages/trees/test/e2e/file-tree-search.pw.ts
@@ -143,7 +143,7 @@ test.describe('file-tree search proof', () => {
     );
   });
 
-  test('Enter selects the focused match and returns focus to the tree item', async ({
+  test('Enter selects the focused match and keeps search open', async ({
     page,
   }) => {
     await page.goto('/test/e2e/fixtures/file-tree-search.html');
@@ -181,8 +181,9 @@ test.describe('file-tree search proof', () => {
       'data-item-path',
       focusedPathBeforeSubmit ?? ''
     );
-    await expect(searchInput).not.toBeFocused();
-    await expect(selectedRow).toBeFocused();
+    // Enter keeps the search open. The input keeps focus and its value.
+    await expect(searchInput).toBeFocused();
+    await expect(searchInput).toHaveValue('worker');
   });
 
   test('Enter immediately after ArrowDown still selects the latest focused match', async ({
@@ -231,11 +232,6 @@ test.describe('file-tree search proof', () => {
           key: 'ArrowDown',
         })
       );
-      const focusedBeforeSubmit = shadow.querySelector<HTMLButtonElement>(
-        'button[data-item-focused="true"]'
-      );
-      const focusedTopBefore =
-        focusedBeforeSubmit?.getBoundingClientRect().top ?? null;
       input.dispatchEvent(
         new KeyboardEvent('keydown', {
           bubbles: true,
@@ -249,29 +245,17 @@ test.describe('file-tree search proof', () => {
         'button[data-item-selected="true"]'
       );
       const active = shadow.activeElement as HTMLElement | null;
-      const scrollElement = shadow.querySelector<HTMLElement>(
-        '[data-file-tree-virtualized-scroll="true"]'
-      );
-      const selectedTopAfter = selected?.getBoundingClientRect().top ?? null;
       return {
-        activePath: active?.getAttribute('data-item-path') ?? null,
-        focusedTopBefore,
         inputFocused: active === input,
-        scrollTop: scrollElement?.scrollTop ?? null,
         selectedPath: selected?.getAttribute('data-item-path') ?? null,
-        selectedTopAfter,
       };
     });
 
     expect(result).not.toBeNull();
+    // Enter selects the match that ArrowDown moved to. This is true even when
+    // the two keys arrive together with no render between them.
     expect(result?.selectedPath).toBe('src/utils/worker/index.ts');
-    expect(result?.activePath).toBe('src/utils/worker/index.ts');
-    expect(result?.inputFocused).toBe(false);
-    expect(result?.scrollTop).toBeGreaterThan(0);
-    expect(
-      Math.abs(
-        (result?.selectedTopAfter ?? 0) - (result?.focusedTopBefore ?? 0)
-      )
-    ).toBeLessThan(2);
+    // Enter keeps the search open. Focus stays in the search input.
+    expect(result?.inputFocused).toBe(true);
   });
 });

--- a/packages/trees/test/file-tree-row-click-plan.test.ts
+++ b/packages/trees/test/file-tree-row-click-plan.test.ts
@@ -95,7 +95,7 @@ describe('computeFileTreeRowClickPlan', () => {
     expect(plan.toggleDirectory).toBe(false);
   });
 
-  test('an open search closes on every click', () => {
+  test('an open search stays open on every click', () => {
     const plain = computeFileTreeRowClickPlan({
       ...baseInput,
       isSearchOpen: true,
@@ -105,8 +105,8 @@ describe('computeFileTreeRowClickPlan', () => {
       event: { ctrlKey: false, metaKey: false, shiftKey: true },
       isSearchOpen: true,
     });
-    expect(plain.closeSearch).toBe(true);
-    expect(shift.closeSearch).toBe(true);
+    expect(plain.closeSearch).toBe(false);
+    expect(shift.closeSearch).toBe(false);
   });
 
   test('sticky mode clicks ask the caller to reveal the canonical row', () => {

--- a/packages/trees/test/file-tree-search-manual-collapse.test.ts
+++ b/packages/trees/test/file-tree-search-manual-collapse.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'bun:test';
+
+import { loadFileTreeController } from './helpers/loadFileTree';
+
+const FILES = [
+  'README.md',
+  'src/utils/worker.ts',
+  'src/utils/stream.ts',
+] as const;
+
+function getVisiblePaths(
+  controller: import('../src/model/FileTreeController').FileTreeController
+): string[] {
+  return controller
+    .getVisibleRows(0, controller.getVisibleCount())
+    .map((row) => row.path);
+}
+
+// These tests drive the controller directly. They exercise the manual collapse
+// override for a hide-non-matches search. A row click collapses a matched
+// directory to hide its matches. `toggleMountedDirectoryFromInput` is the entry
+// point the row click handler uses.
+describe('file-tree search manual collapse overrides', () => {
+  test('collapsing a matched directory hides its match but keeps the directory visible', async () => {
+    const FileTreeController = await loadFileTreeController();
+
+    const controller = new FileTreeController({
+      fileTreeSearchMode: 'hide-non-matches',
+      flattenEmptyDirectories: false,
+      initialExpansion: 'open',
+      paths: FILES,
+    });
+
+    controller.setSearch('worker.ts');
+    expect(getVisiblePaths(controller)).toContain('src/utils/');
+    expect(getVisiblePaths(controller)).toContain('src/utils/worker.ts');
+
+    // Collapse the directory that holds the match. The directory stays visible.
+    // The search hides the match until the override clears.
+    controller.toggleMountedDirectoryFromInput('src/utils/');
+    expect(getVisiblePaths(controller)).toContain('src/utils/');
+    expect(getVisiblePaths(controller)).not.toContain('src/utils/worker.ts');
+
+    // The match set does not change. Only the visible rows change.
+    expect(controller.getSearchMatchingPaths()).toContain(
+      'src/utils/worker.ts'
+    );
+
+    // A second toggle of the same directory clears the override. The default
+    // search layout returns.
+    controller.toggleMountedDirectoryFromInput('src/utils/');
+    expect(getVisiblePaths(controller)).toContain('src/utils/worker.ts');
+
+    controller.destroy();
+  });
+
+  test('clearing the search discards manual collapse overrides', async () => {
+    const FileTreeController = await loadFileTreeController();
+
+    const controller = new FileTreeController({
+      fileTreeSearchMode: 'hide-non-matches',
+      flattenEmptyDirectories: false,
+      initialExpansion: 'open',
+      paths: FILES,
+    });
+
+    controller.setSearch('worker.ts');
+    controller.toggleMountedDirectoryFromInput('src/utils/');
+    expect(getVisiblePaths(controller)).not.toContain('src/utils/worker.ts');
+
+    // Close the search and run the same query again. The tree starts from the
+    // default layout, not the previous override.
+    controller.setSearch(null);
+    controller.setSearch('worker.ts');
+    expect(getVisiblePaths(controller)).toContain('src/utils/worker.ts');
+
+    controller.destroy();
+  });
+});

--- a/packages/trees/test/file-tree-search.test.ts
+++ b/packages/trees/test/file-tree-search.test.ts
@@ -488,7 +488,7 @@ describe('file-tree search', () => {
     }
   });
 
-  test('Enter selects the focused search match and closes search', async () => {
+  test('Enter selects the focused search match and keeps search open', async () => {
     const { cleanup, dom } = installDom();
     try {
       const FileTree = await loadFileTree();
@@ -537,8 +537,8 @@ describe('file-tree search', () => {
       });
       await flushDom();
 
-      expect(fileTree.isSearchOpen()).toBe(false);
-      expect(fileTree.getSearchValue()).toBe('');
+      expect(fileTree.isSearchOpen()).toBe(true);
+      expect(fileTree.getSearchValue()).toBe('worker');
       expect(fileTree.getSelectedPaths()).toEqual(
         focusedPathBeforeSubmit == null ? [] : [focusedPathBeforeSubmit]
       );
@@ -548,7 +548,9 @@ describe('file-tree search', () => {
       expect(selectedRow?.getAttribute('data-item-path')).toBe(
         focusedPathBeforeSubmit
       );
-      expect(shadowRoot?.activeElement).toBe(selectedRow);
+      // Search stays open. Focus stays in the search input. Focus does not move
+      // to the selected tree row.
+      expect(shadowRoot?.activeElement).toBe(searchInput);
 
       fileTree.cleanUp();
     } finally {
@@ -556,7 +558,7 @@ describe('file-tree search', () => {
     }
   });
 
-  test('Enter immediately after ArrowDown still returns focus to the selected row', async () => {
+  test('Enter after ArrowDown selects the navigated match and keeps search open', async () => {
     const { cleanup, dom } = installDom();
     try {
       const FileTree = await loadFileTree();
@@ -613,88 +615,14 @@ describe('file-tree search', () => {
       const selectedRow = shadowRoot?.querySelector<HTMLButtonElement>(
         'button[data-item-selected="true"]'
       );
-      expect(fileTree.isSearchOpen()).toBe(false);
+      expect(fileTree.isSearchOpen()).toBe(true);
       expect(selectedRow).not.toBeNull();
       expect(selectedRow?.getAttribute('data-item-path')).toBe(
         'src/utils/worker/match-1.ts'
       );
-      expect(shadowRoot?.activeElement).toBe(selectedRow);
-
-      fileTree.cleanUp();
-    } finally {
-      cleanup();
-    }
-  });
-
-  test('closing search scrolls a newly selected offscreen row back toward the viewport center', async () => {
-    const { cleanup, dom } = installDom();
-    try {
-      const FileTree = await loadFileTree();
-      const mount = dom.window.document.createElement('div');
-      dom.window.document.body.appendChild(mount);
-
-      const offscreenWorkerFiles = [
-        'README.md',
-        ...Array.from({ length: 24 }, (_unused, index) => {
-          return `src/generated/file-${String(index)}.ts`;
-        }),
-        ...Array.from({ length: 24 }, (_unused, index) => {
-          return `src/utils/worker/match-${String(index)}.ts`;
-        }),
-      ];
-
-      const fileTree = new FileTree({
-        fileTreeSearchMode: 'hide-non-matches',
-        flattenEmptyDirectories: false,
-        id: 'pst-search-center-selected-row',
-        initialExpansion: 'open',
-        overscan: 0,
-        paths: offscreenWorkerFiles,
-        search: true,
-        initialVisibleRowCount: 44 / 30,
-      });
-
-      fileTree.render({ containerWrapper: mount });
-      await flushDom();
-
-      const shadowRoot = fileTree.getFileTreeContainer()?.shadowRoot;
-      const scrollElement = shadowRoot?.querySelector<HTMLElement>(
-        '[data-file-tree-virtualized-scroll="true"]'
-      );
-      const firstButton = shadowRoot?.querySelector<HTMLButtonElement>(
-        'button[data-type="item"]'
-      );
-      const searchInput = shadowRoot?.querySelector<HTMLInputElement>(
-        'input[data-file-tree-search-input]'
-      );
-      expect(scrollElement).not.toBeNull();
-      expect(firstButton).not.toBeNull();
-      expect(searchInput).not.toBeNull();
-
-      firstButton?.focus();
-      pressKey(firstButton as HTMLButtonElement, dom, 'w');
-      await flushDom();
-
-      setInputValue(searchInput as HTMLInputElement, dom, 'worker');
-      await flushDom();
-
-      pressKey(searchInput as HTMLInputElement, dom, 'ArrowDown', {
-        code: 'ArrowDown',
-      });
-      pressKey(searchInput as HTMLInputElement, dom, 'Enter', {
-        code: 'Enter',
-      });
-      await flushDom();
-      await flushDom();
-
-      const selectedRow = shadowRoot?.querySelector<HTMLButtonElement>(
-        'button[data-item-selected="true"]'
-      );
-      expect(scrollElement?.scrollTop).toBeGreaterThan(0);
-      expect(selectedRow?.getAttribute('data-item-path')).toBe(
-        'src/utils/worker/match-1.ts'
-      );
-      expect(shadowRoot?.activeElement).toBe(selectedRow);
+      // Search stays open. Focus stays in the search input. Focus does not move
+      // to the selected tree row.
+      expect(shadowRoot?.activeElement).toBe(searchInput);
 
       fileTree.cleanUp();
     } finally {


### PR DESCRIPTION
Before, a file-tree search was a temporary mode. It closed as soon as the user clicked a row or pressed Enter, and the user could not change which directories the search expanded. Now the search stays open, and the user can work inside the results.

## What the user can now do

- **Click a row and keep the search open.** A click selects the row and leaves the search open. The user can select several results and refine the query.
- **Press Enter and keep the search open.** Enter selects the focused match and leaves the search open. Focus stays in the search input, so the user can select more matches without a new search.
- **Collapse a directory in the results.** During a hide-non-matches search, the user can collapse a matched directory to hide its matches. The search keeps that choice until the user clears the search.

## How it works

Each commit is a self-contained change:

1. **Keep search open after a row click** — the click plan returns `closeSearch: false`.
2. **Keep search open when the user presses Enter** — the Enter handler selects the focused match and no longer closes the search. The inline rename path (F2) still closes the search and restores the scroll.
3. **Let the user collapse directories during search** — the controller keeps a set of the directories the user collapsed. Each search refresh keeps them collapsed but still visible, filters the visible rows from that state, prunes stale directories, remaps them through tree mutations, and clears the set when the search closes. The controller now tracks matches outside the visibility pass, so match navigation still uses the full match set.

## Source of the change

These commits port the `@pierre/trees` patch from the diffy project into the TypeScript source. The original patch changed the built `dist/`, so this PR applies the same behavior to `src/`. The upstream patch also carried an `expand`/reveal override, but @suveshmoza confirmed it is not needed, so this PR drops it and keeps only the reachable collapse behavior. This PR also updates the affected tests and adds a controller test for the collapse override.

## Test plan

- `moon run root:format root:lint`
- `moonx trees:typecheck`
- `moonx trees:test`
- `moonx trees:test-e2e`
