### PR TITLE
fix(diffshub): use Bun cached blob (one-liner)

### DIFF
--- a/apps/diffshub/app/api/diff/route.ts
+++ b/apps/diffshub/app/api/diff/route.ts
@@ -24,6 +24,11 @@ const GITHUB_PULL_TAB_PATH_PATTERN =
 
 const CACHED_BLOBS = new Map<string, string>([
   [
+    '/oven-sh/bun/pull/30412',
+    'https://diffshub.pierrecdn.com/patches/30412.diff',
+  ],
+  // Preserve the CSS benchmark route across its base and test SHAs.
+  [
     '/nodejs/oven-sh/bun/pull/30412',
     'https://diffshub.pierrecdn.com/patches/30412.diff',
   ],

--- a/apps/diffshub/app/api/diff/route.ts
+++ b/apps/diffshub/app/api/diff/route.ts
@@ -27,11 +27,6 @@ const CACHED_BLOBS = new Map<string, string>([
     '/oven-sh/bun/pull/30412',
     'https://diffshub.pierrecdn.com/patches/30412.diff',
   ],
-  // Preserve the CSS benchmark route across its base and test SHAs.
-  [
-    '/nodejs/oven-sh/bun/pull/30412',
-    'https://diffshub.pierrecdn.com/patches/30412.diff',
-  ],
   [
     '/nodejs/node/pull/59805',
     'https://diffshub.pierrecdn.com/patches/59805.diff',

--- a/packages/diffs/benchmarks/CSS_PERFORMANCE_BENCHMARK.md
+++ b/packages/diffs/benchmarks/CSS_PERFORMANCE_BENCHMARK.md
@@ -192,7 +192,7 @@ virtualized scrolling but stable before tracing starts.
 Default route:
 
 ```text
-/nodejs/oven-sh/bun/pull/30412
+/oven-sh/bun/pull/30412
 ```
 
 Before recording, wait until all of these are true:


### PR DESCRIPTION
### Description

Fix the cached blob key for oven-sh/bun#30412 so DiffsHub uses the CDN blob.

### Type of changes

- [x] Bug fix

### Verification

- DiffsHub tests and typecheck
- Root format and lint

### How was AI used in generating this PR

Codex made the one-line fix and ran verification.