### PR TITLE
[diffs/edit] Fix `resolveSystemThemeType` function of editor tokenizer

### DIFF
--- a/packages/diffs/src/editor/tokenizer.ts
+++ b/packages/diffs/src/editor/tokenizer.ts
@@ -245,11 +245,8 @@ export class EditorTokenizer {
     this.#onThemeChange?.();
   }
 
-  // Resolve `themeType: 'system'` the same way the MutationObserver does: from
-  // the host document's computed `color-scheme`. Apps often force a scheme via
-  // page CSS/classes while the OS `prefers-color-scheme` media query differs;
-  // using matchMedia here would flip tokens back to the OS preference on every
-  // render sync and fight the observer.
+  // Respect an explicit host color-scheme override. When the computed value
+  // advertises support for both schemes, let the OS preference choose one.
   #resolveSystemThemeType(): 'light' | 'dark' {
     try {
       if (
@@ -257,9 +254,16 @@ export class EditorTokenizer {
         typeof getComputedStyle === 'function' &&
         document.body != null
       ) {
-        return getComputedStyle(document.body).colorScheme === 'dark'
-          ? 'dark'
-          : 'light';
+        const colorSchemes = getComputedStyle(document.body).colorScheme.split(
+          /\s+/
+        );
+        const supportsDark = colorSchemes.includes('dark');
+        const supportsLight = colorSchemes.includes('light');
+        // A single host-forced scheme wins. `light dark` only declares support
+        // for both schemes, so the media query still selects the active one.
+        if (supportsDark !== supportsLight) {
+          return supportsDark ? 'dark' : 'light';
+        }
       }
     } catch {
       // jsdom and similar harnesses may lack getComputedStyle or throw; fall

--- a/packages/diffs/test/editorTokenizer.test.ts
+++ b/packages/diffs/test/editorTokenizer.test.ts
@@ -1886,11 +1886,9 @@ describe('EditorTokenizer', () => {
     }
   });
 
-  // Apps often force a scheme via page CSS/classes while the OS media query
-  // differs. syncTheme must use the same computed color-scheme source as the
-  // MutationObserver; otherwise a render sync flips tokens back to the OS
-  // preference and edited lines render the wrong theme colors.
-  test('syncTheme resolves system theme from host color-scheme, not OS media query', () => {
+  // Apps can force one scheme via page CSS/classes or advertise support for
+  // both. syncTheme must only use the OS preference in the latter case.
+  test('syncTheme resolves forced and preferred system themes', () => {
     const originalMatchMedia = globalThis.window.matchMedia;
     const originalGetComputedStyle = Reflect.get(
       globalThis,
@@ -1901,6 +1899,8 @@ describe('EditorTokenizer', () => {
       globalThis,
       'MutationObserver'
     );
+    let colorScheme = 'dark';
+    let prefersDark = false;
 
     globalThis.window.matchMedia = (() =>
       ({
@@ -1908,7 +1908,9 @@ describe('EditorTokenizer', () => {
         addListener: () => {},
         dispatchEvent: () => false,
         // OS prefers light, but the host document forces dark.
-        matches: false,
+        get matches() {
+          return prefersDark;
+        },
         media: '(prefers-color-scheme: dark)',
         onchange: null,
         removeEventListener: () => {},
@@ -1923,7 +1925,7 @@ describe('EditorTokenizer', () => {
       'getComputedStyle',
       (() =>
         ({
-          colorScheme: 'dark',
+          colorScheme,
         }) as CSSStyleDeclaration) as typeof getComputedStyle
     );
     Reflect.set(
@@ -1942,7 +1944,7 @@ describe('EditorTokenizer', () => {
       const grammar = {
         tokenizeLine2(lineText: string, ruleStack: StateStack) {
           return {
-            tokens: new Uint32Array([0, 0]),
+            tokens: new Uint32Array([0, 1 << 15]),
             ruleStack,
             stoppedEarly: false,
             lineText,
@@ -1954,6 +1956,9 @@ describe('EditorTokenizer', () => {
       const tokenizer = new EditorTokenizer({
         highlighter: createTestHighlighter({
           getLanguage: () => grammar,
+          setTheme: (theme: string) => ({
+            colorMap: ['', theme === 'dark-theme' ? '#dark' : '#light'],
+          }),
         }),
         textDocument,
         codeOptions: {
@@ -1969,6 +1974,25 @@ describe('EditorTokenizer', () => {
       // A later render sync must not flip back to the OS light preference.
       tokenizer.syncTheme({ theme: dualThemes, themeType: 'system' });
       expect(tokenizer.themeType).toBe('dark');
+
+      // A dual declaration advertises support rather than forcing light.
+      // Let the dark OS preference choose the active token color.
+      colorScheme = 'light dark';
+      prefersDark = true;
+      tokenizer.syncTheme({ theme: dualThemes, themeType: 'system' });
+      const dirtyLines = tokenizer.tokenize({
+        startLine: 0,
+        startCharacter: 0,
+        endCharacter: 0,
+        endLine: 0,
+        endedAtDocumentEnd: false,
+        previousLineCount: textDocument.lineCount,
+        lineCount: textDocument.lineCount,
+        lineDelta: 0,
+        changedLineRanges: [[0, 0]],
+      });
+      expect(tokenizer.themeType).toBe('dark');
+      expect(dirtyLines.get(0)?.[0]?.[1]).toBe('#dark');
 
       tokenizer.cleanUp();
     } finally {


### PR DESCRIPTION
Fix `resolveSystemThemeType` function of paring system color schemes. Before it returns `light` type in dark mode.