### PR TITLE
Improvements to Edit API

### DIFF
--- a/apps/docs/app/(diffs)/docs/Edit/constants.ts
+++ b/apps/docs/app/(diffs)/docs/Edit/constants.ts
@@ -9,8 +9,8 @@ const options = {
   unsafeCSS: CustomScrollbarCSS,
 } as const;
 
-// The editor requires the token transformer, so enabling it in the server
-// render keeps hydration from rerendering the surface after the editor
+// Enabling the token transformer in the server render keeps the markup
+// editor-ready, so hydration does not rerender the surface when the editor
 // attaches. Mirrors `(diffs)/_edit/constants.ts`.
 const editableDemoOptions: FileOptions<undefined> = {
   theme: { dark: 'pierre-dark', light: 'pierre-light' },
@@ -860,6 +860,8 @@ const workerPool = getOrCreateWorkerPoolSingleton({
   poolOptions: { workerFactory },
   highlighterOptions: {
     theme: { dark: 'pierre-dark', light: 'pierre-light' },
+    // Optional: pool markup is then already editor-compatible, so entering
+    // edit mode skips a one-time re-render of the file.
     useTokenTransformer: true,
   },
 });
@@ -901,6 +903,8 @@ const file: FileContents = {
 const poolOptions = { workerFactory };
 const highlighterOptions = {
   theme: { dark: 'pierre-dark', light: 'pierre-light' },
+  // Optional: pool markup is then already editor-compatible, so entering
+  // edit mode skips a one-time re-render of the file.
   useTokenTransformer: true,
 } as const;
 

--- a/apps/docs/app/(diffs)/docs/Edit/content.mdx
+++ b/apps/docs/app/(diffs)/docs/Edit/content.mdx
@@ -420,9 +420,16 @@ Limit the stack size with `historyMaxEntries` in
 
 ### Using Worker Pool
 
-When you offload syntax highlighting to a worker pool, edit mode still needs the
-token transformer pipeline to re-highlight lines as you type. Set
-`useTokenTransformer: true` on the pool's `highlighterOptions`.
+Edit mode works with a worker pool out of the box: a file being edited renders
+on the main thread with the token metadata the editor needs, while the pool
+keeps rendering every other file on the page. Keystroke re-highlighting always
+runs on the main thread, with or without a pool.
+
+Setting `useTokenTransformer: true` on the pool's `highlighterOptions` is an
+optional optimization for edit-heavy apps: pool-rendered markup is then already
+editor-compatible, so entering edit mode skips a one-time re-render of that
+file. It costs larger DOM for every rendered file, which is why it is off by
+default.
 
 See [Worker Pool](#worker-pool) for worker factory setup and pool options. In
 vanilla JS, pass the pool as the second argument to `File` or `FileDiff`. In

--- a/apps/docs/app/(diffs)/docs/TokenHooks/content.mdx
+++ b/apps/docs/app/(diffs)/docs/TokenHooks/content.mdx
@@ -26,17 +26,23 @@ Shared behavior:
 - Whitespace-only tokens are excluded unless
   `enableTokenInteractionsOnWhitespace` is `true`.
 - `tokenElement` is usually the simplest way to apply temporary hover styles.
+- Attaching any token callback enables token metadata automatically for locally
+  rendered components — the markup the callbacks need to fire.
 - Set `useTokenTransformer: true` when you want token wrappers or experimental
   selectors like `data-char` without token callbacks.
 - Enabling token metadata increases DOM size because more token wrappers and
   attributes are preserved. On large files or many mounted diffs, this can have
   a noticeable performance cost.
 - If you are using a [Worker Pool](#worker-pool), set
-  `useTokenTransformer: true` on `WorkerPoolManager`. Worker pools can move
+  `useTokenTransformer: true` on `WorkerPoolManager` — pool-rendered surfaces
+  follow the pool's options, not component callbacks. Worker pools can move
   highlighting work off the main thread, but they do not reduce the extra DOM
   size created by token metadata.
-- If you are using [SSR](#ssr) don't forget to set `useTokenTransformer: true`
-  on your preload option configs
+- [SSR](#ssr) preloads honor token callbacks the same way the client does; set
+  `useTokenTransformer: true` on your preload option configs only when you want
+  token markup without callbacks.
+- [Edit mode](#edit-mode) enables token metadata automatically for the file
+  being edited; nothing needs to be configured.
 
 <TokenHookTabs
   reactExample={reactTokenHooks}

--- a/apps/docs/app/(diffs)/docs/WorkerPool/content.mdx
+++ b/apps/docs/app/(diffs)/docs/WorkerPool/content.mdx
@@ -135,6 +135,13 @@ move highlighting work off the main thread, but they do not reduce the extra DOM
 size created by token metadata. For token callback behavior and performance
 tradeoffs, see [Token Hooks](#token-hooks).
 
+[Edit mode](#edit-mode) needs no pool configuration: a file being edited renders
+on the main thread with the token metadata the editor needs, while the pool
+keeps rendering every other file. Enabling `useTokenTransformer: true` on the
+pool is an optional optimization for edit-heavy apps — pool markup is then
+already editor-compatible, so entering edit mode skips a one-time re-render of
+that file.
+
 If you need to control which Shiki engine is used, set `preferredHighlighter`
 when initializing the pool (`'shiki-js'` by default, `'shiki-wasm'` optional).
 

--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -322,16 +322,6 @@ export const CODE_VIEW_FILE_OPTION_KEYS = [
 
 type CodeViewFileOptionKeys = (typeof CODE_VIEW_FILE_OPTION_KEYS)[number];
 
-// Option values Editor.edit requires before it attaches to an instance. These
-// keys are excluded from the plain pass-through loops (defineItemOption
-// properties are non-configurable and cannot be redefined) so the prototypes
-// can define edit-aware getters that serve the editor-required value while an
-// item is in edit mode. Without this, Editor.edit would fall back to
-// instance.setOptions, which throws for CodeView-managed instances.
-const CODE_VIEW_EDIT_FORCED_OPTION_KEYS: ReadonlySet<string> = new Set([
-  'useTokenTransformer',
-]);
-
 type CodeViewPassThroughOptions<LAnnotation> = Pick<
   FileDiffOptions<LAnnotation>,
   CodeViewDiffOptionKeys
@@ -2015,21 +2005,6 @@ export class CodeView<LAnnotation = undefined> {
     return item.item.edit === true && item.item.collapsed !== true;
   }
 
-  // True when the receiving item options belong to an item currently in edit
-  // mode. The edit-forced option getters use this to serve editor-required
-  // values (see CODE_VIEW_EDIT_FORCED_OPTION_KEYS).
-  private isReceiverEdited<TMode extends CodeViewMode>(
-    receiver: CodeViewModeOptions<LAnnotation, TMode>,
-    mode: TMode
-  ): boolean {
-    const state = getItemOptionsState(receiver);
-    if (state == null) {
-      return false;
-    }
-    const item = this.getItemOptions(state, mode);
-    return item != null && this.isItemInEditMode(item);
-  }
-
   /**
    * Attach (or lazily create) the editor for a mounted edit-mode item. Called
    * from the render loop so every mounted item passes through it: fresh
@@ -2179,9 +2154,6 @@ export class CodeView<LAnnotation = undefined> {
     const prototype = {} as FileOptions<LAnnotation>;
 
     for (const key of CODE_VIEW_FILE_OPTION_KEYS) {
-      if (CODE_VIEW_EDIT_FORCED_OPTION_KEYS.has(key)) {
-        continue;
-      }
       defineItemOption<FileOptions<LAnnotation>, CodeViewFileOptionKeys>(
         prototype,
         key,
@@ -2189,14 +2161,8 @@ export class CodeView<LAnnotation = undefined> {
       );
     }
 
-    // Edit-forced options: while the item is in edit mode these serve the
-    // values Editor.edit requires so it never falls back to
-    // instance.setOptions (which throws for CodeView-managed instances).
-    defineItemOption(prototype, 'useTokenTransformer', (receiver) =>
-      this.isReceiverEdited(receiver, 'file')
-        ? true
-        : this.options.useTokenTransformer
-    );
+    // Mapped options: served from CodeView-level names or per-item state
+    // that the plain pass-through loop cannot express.
     defineItemOption(
       prototype,
       'stickyHeader',
@@ -2224,9 +2190,6 @@ export class CodeView<LAnnotation = undefined> {
     const prototype = {} as FileDiffOptions<LAnnotation>;
 
     for (const key of CODE_VIEW_DIFF_OPTION_KEYS) {
-      if (CODE_VIEW_EDIT_FORCED_OPTION_KEYS.has(key)) {
-        continue;
-      }
       defineItemOption<FileDiffOptions<LAnnotation>, CodeViewDiffOptionKeys>(
         prototype,
         key,
@@ -2234,14 +2197,8 @@ export class CodeView<LAnnotation = undefined> {
       );
     }
 
-    // Edit-forced options: while the item is in edit mode these serve the
-    // values Editor.edit requires so it never falls back to
-    // instance.setOptions (which throws for CodeView-managed instances).
-    defineItemOption(prototype, 'useTokenTransformer', (receiver) =>
-      this.isReceiverEdited(receiver, 'diff')
-        ? true
-        : this.options.useTokenTransformer
-    );
+    // Mapped options: served from CodeView-level names or per-item state
+    // that the plain pass-through loop cannot express.
     defineItemOption(
       prototype,
       'stickyHeader',

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -547,6 +547,7 @@ export class File<
   public attachEditor(editor: DiffsEditor<LAnnotation>): () => void {
     this.editor?.cleanUp();
     this.editor = editor;
+    this.fileRenderer.beginEditSession();
     const preparedFile =
       this.file == null ? undefined : editor.__prepareFile?.(this.file);
     if (preparedFile !== undefined && preparedFile !== this.file) {
@@ -561,6 +562,7 @@ export class File<
     }
     return () => {
       this.editor = undefined;
+      this.fileRenderer.endEditSession();
     };
   }
 

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -557,8 +557,13 @@ export class File<
         preventEmit: true,
         renderRange: this.renderRange,
       });
-    } else {
+    } else if (this.fileRenderer.editorRenderReady()) {
       this.syncRenderViewToEditor();
+    } else {
+      // The current markup is missing the editor's token metadata, or its
+      // highlight is still pending: render through the session, which also
+      // syncs the render view once it paints.
+      this.rerender();
     }
     return () => {
       this.editor = undefined;

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -1359,7 +1359,14 @@ export class FileDiff<
     if (this.fileDiff?.isPartial === true) {
       this.loadFilesIfNecessary();
     }
-    this.syncRenderViewToEditor();
+    if (this.hunksRenderer.editorRenderReady()) {
+      this.syncRenderViewToEditor();
+    } else {
+      // The current markup is missing the editor's token metadata, or its
+      // highlight is still pending: render through the session, which also
+      // syncs the render view once it paints.
+      this.rerender();
+    }
     return (recycle?: boolean) => {
       this.editor = undefined;
       // A recycle detach is a virtualized unmount mid-session: the session

--- a/packages/diffs/src/components/UnresolvedFile.ts
+++ b/packages/diffs/src/components/UnresolvedFile.ts
@@ -26,6 +26,7 @@ import {
   parseMergeConflictDiffFromFile,
 } from '../utils/parseMergeConflictDiffFromFile';
 import { resolveConflict as resolveConflictDiff } from '../utils/resolveConflict';
+import { shouldUseTokenTransformer } from '../utils/shouldUseTokenTransformer';
 import { splitFileContents } from '../utils/splitFileContents';
 import type { WorkerPoolManager } from '../worker';
 import {
@@ -865,9 +866,10 @@ export function getUnresolvedDiffHunksRendererOptions<LAnnotation>(
   options?: UnresolvedFileOptions<LAnnotation>,
   baseOptions?: UnresolvedFileOptions<LAnnotation>
 ): UnresolvedFileHunksRendererOptions {
+  const merged = { ...baseOptions, ...options };
   return {
-    ...baseOptions,
-    ...options,
+    ...merged,
+    useTokenTransformer: shouldUseTokenTransformer<'diff'>(merged),
     hunkSeparators:
       typeof options?.hunkSeparators === 'function'
         ? 'custom'

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -3351,7 +3351,10 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       // call focus in a request animation frame to prevent conflict with
       // the `setBaseAndExtent` method
       queueRender(() => {
-        if (shouldFocus?.() === false) {
+        // #contentHasFocus was marked eagerly above; a blur (or cleanup) in
+        // the deferred gap cedes focus, and this stale frame must not pull
+        // it back into the current — possibly replaced — content.
+        if (shouldFocus?.() === false || !this.#contentHasFocus) {
           this.#shouldIgnoreSelectionChange = false;
           return;
         }

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -464,13 +464,6 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       }
     }
     this.#invalidateOnAttach();
-    if (fileInstance.options.useTokenTransformer !== true) {
-      fileInstance.setOptions({
-        ...fileInstance.options,
-        useTokenTransformer: true,
-      });
-      fileInstance.rerender();
-    }
     this.#fileInstance = fileInstance;
     this.#initialize();
     this.#detach = fileInstance.attachEditor(this);

--- a/packages/diffs/src/react/utils/useFileDiffInstance.ts
+++ b/packages/diffs/src/react/utils/useFileDiffInstance.ts
@@ -76,9 +76,7 @@ export function useFileDiffInstance<LAnnotation>({
         instanceRef.current = new VirtualizedFileDiff(
           mergeFileDiffOptions({
             controlledSelection,
-            edit,
             hasCustomHeader,
-            hasEditor: createEditor !== undefined,
             hasGutterRenderUtility,
             options,
           }),
@@ -91,9 +89,7 @@ export function useFileDiffInstance<LAnnotation>({
         instanceRef.current = new FileDiff(
           mergeFileDiffOptions({
             controlledSelection,
-            edit,
             hasCustomHeader,
-            hasEditor: createEditor !== undefined,
             hasGutterRenderUtility,
             options,
           }),
@@ -123,13 +119,16 @@ export function useFileDiffInstance<LAnnotation>({
     if (instance == null) return;
     const newOptions = mergeFileDiffOptions({
       controlledSelection,
-      edit,
       hasCustomHeader,
-      hasEditor: createEditor !== undefined,
       hasGutterRenderUtility,
       options,
     });
-    const forceRender = !areOptionsEqual(instance.options, newOptions);
+    // setOptions(undefined) is a no-op, so an undefined merge result never
+    // requires a forced render — comparing it against the instance's
+    // constructor-default options would force a full render on every commit.
+    const forceRender =
+      newOptions !== undefined &&
+      !areOptionsEqual(instance.options, newOptions);
     instance.setOptions(newOptions);
     void instance.render({
       forceRender,
@@ -176,8 +175,6 @@ export function useFileDiffInstance<LAnnotation>({
 
 interface MergeFileDiffOptionsProps<LAnnotation> {
   controlledSelection: boolean;
-  edit: boolean;
-  hasEditor: boolean;
   hasCustomHeader: boolean;
   hasGutterRenderUtility: boolean;
   options: FileDiffOptions<LAnnotation> | undefined;
@@ -186,34 +183,26 @@ interface MergeFileDiffOptionsProps<LAnnotation> {
 function mergeFileDiffOptions<LAnnotation>({
   options,
   controlledSelection,
-  edit,
   hasCustomHeader,
-  hasEditor,
   hasGutterRenderUtility,
 }: MergeFileDiffOptionsProps<LAnnotation>):
   | FileDiffOptions<LAnnotation>
   | undefined {
-  const needsEditorOverrides = edit && hasEditor;
   const needsReactOverrides =
     controlledSelection || hasGutterRenderUtility || hasCustomHeader;
 
-  if (!needsReactOverrides && !needsEditorOverrides) {
+  if (!needsReactOverrides) {
     return options;
   }
 
   return {
     ...options,
-    ...(needsReactOverrides
-      ? {
-          controlledSelection,
-          renderCustomHeader: hasCustomHeader
-            ? noopRender
-            : options?.renderCustomHeader,
-          renderGutterUtility: hasGutterRenderUtility
-            ? noopRender
-            : options?.renderGutterUtility,
-        }
-      : null),
-    ...(needsEditorOverrides ? { useTokenTransformer: true } : null),
+    controlledSelection,
+    renderCustomHeader: hasCustomHeader
+      ? noopRender
+      : options?.renderCustomHeader,
+    renderGutterUtility: hasGutterRenderUtility
+      ? noopRender
+      : options?.renderGutterUtility,
   };
 }

--- a/packages/diffs/src/react/utils/useFileInstance.ts
+++ b/packages/diffs/src/react/utils/useFileInstance.ts
@@ -80,9 +80,7 @@ export function useFileInstance<LAnnotation>({
         instanceRef.current = new VirtualizedFile(
           mergeFileOptions({
             controlledSelection,
-            edit,
             hasCustomHeader,
-            hasEditor: createEditor !== undefined,
             hasGutterRenderUtility,
             options,
           }),
@@ -95,9 +93,7 @@ export function useFileInstance<LAnnotation>({
         instanceRef.current = new File(
           mergeFileOptions({
             controlledSelection,
-            edit,
             hasCustomHeader,
-            hasEditor: createEditor !== undefined,
             hasGutterRenderUtility,
             options,
           }),
@@ -124,16 +120,16 @@ export function useFileInstance<LAnnotation>({
     if (instanceRef.current == null) return;
     const newOptions = mergeFileOptions({
       controlledSelection,
-      edit,
       hasCustomHeader,
-      hasEditor: createEditor !== undefined,
       hasGutterRenderUtility,
       options,
     });
-    const forceRender = !areOptionsEqual(
-      instanceRef.current.options,
-      newOptions
-    );
+    // setOptions(undefined) is a no-op, so an undefined merge result never
+    // requires a forced render — comparing it against the instance's
+    // constructor-default options would force a full render on every commit.
+    const forceRender =
+      newOptions !== undefined &&
+      !areOptionsEqual(instanceRef.current.options, newOptions);
     instanceRef.current.setOptions(newOptions);
     void instanceRef.current.render({ file, lineAnnotations, forceRender });
     if (selectedLines !== undefined) {
@@ -173,8 +169,6 @@ export function useFileInstance<LAnnotation>({
 interface MergeFileOptionsProps<LAnnotation> {
   options: FileOptions<LAnnotation> | undefined;
   controlledSelection: boolean;
-  edit: boolean;
-  hasEditor: boolean;
   hasGutterRenderUtility: boolean;
   hasCustomHeader: boolean;
 }
@@ -182,37 +176,24 @@ interface MergeFileOptionsProps<LAnnotation> {
 function mergeFileOptions<LAnnotation>({
   options,
   controlledSelection,
-  edit,
   hasCustomHeader,
-  hasEditor,
   hasGutterRenderUtility,
 }: MergeFileOptionsProps<LAnnotation>): FileOptions<LAnnotation> | undefined {
-  const needsEditorOverrides = edit && hasEditor;
   const needsReactOverrides =
     controlledSelection || hasGutterRenderUtility || hasCustomHeader;
 
-  if (!needsReactOverrides && !needsEditorOverrides) {
+  if (!needsReactOverrides) {
     return options;
   }
 
-  let merged: FileOptions<LAnnotation> = { ...options };
-
-  if (needsReactOverrides) {
-    merged = {
-      ...merged,
-      controlledSelection,
-      renderCustomHeader: hasCustomHeader
-        ? noopRender
-        : options?.renderCustomHeader,
-      renderGutterUtility: hasGutterRenderUtility
-        ? noopRender
-        : options?.renderGutterUtility,
-    };
-  }
-
-  if (needsEditorOverrides) {
-    merged = { ...merged, useTokenTransformer: true };
-  }
-
-  return merged;
+  return {
+    ...options,
+    controlledSelection,
+    renderCustomHeader: hasCustomHeader
+      ? noopRender
+      : options?.renderCustomHeader,
+    renderGutterUtility: hasGutterRenderUtility
+      ? noopRender
+      : options?.renderGutterUtility,
+  };
 }

--- a/packages/diffs/src/react/utils/useUnresolvedFileInstance.ts
+++ b/packages/diffs/src/react/utils/useUnresolvedFileInstance.ts
@@ -148,7 +148,12 @@ export function useUnresolvedFileInstance<LAnnotation>({
       onMergeConflictAction,
       options,
     });
-    const forceRender = !areOptionsEqual(instance.options, newOptions);
+    // setOptions(undefined) is a no-op, so an undefined merge result never
+    // requires a forced render — comparing it against the instance's
+    // constructor-default options would force a full render on every commit.
+    const forceRender =
+      newOptions !== undefined &&
+      !areOptionsEqual(instance.options, newOptions);
     instance.setOptions(newOptions);
     void instance.render({
       fileDiff,

--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -79,7 +79,6 @@ import { isDiffPlainText } from '../utils/isDiffPlainText';
 import type { DiffLineMetadata } from '../utils/iterateOverDiff';
 import { iterateOverDiff } from '../utils/iterateOverDiff';
 import { renderDiffWithHighlighter } from '../utils/renderDiffWithHighlighter';
-import { shouldUseTokenTransformer } from '../utils/shouldUseTokenTransformer';
 import {
   recomputeDiffHunksForEdit,
   recomputeEmptyDocumentDiff,
@@ -291,6 +290,17 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
   /** Leave edit-session mode. The exit recompute is the host's concern. */
   public endEditSession(): void {
     this.editSessionActive = false;
+  }
+
+  /**
+   * Ensures that the DOM is compatible with editor render updates
+   */
+  public editorRenderReady(): boolean {
+    return (
+      this.renderCache?.options.useTokenTransformer === true &&
+      this.renderCache.highlighted &&
+      this.renderCache.result != null
+    );
   }
 
   /**
@@ -843,7 +853,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
       return {
         theme,
         useTokenTransformer:
-          this.editSessionActive || shouldUseTokenTransformer(this.options),
+          this.editSessionActive || this.options.useTokenTransformer === true,
         tokenizeMaxLineLength,
         lineDiffType,
         maxLineDiffLength,

--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -787,7 +787,9 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
     this.highlighter = await getSharedHighlighter(
       getHighlighterOptions(this.computedLang, {
         theme: this.getLocalHighlightTheme(),
-        preferredHighlighter: this.options.preferredHighlighter,
+        preferredHighlighter:
+          this.workerManager?.getPreferredHighlighter() ??
+          this.options.preferredHighlighter,
       })
     );
     return this.highlighter;

--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -238,7 +238,11 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
   private renderCache: RenderedDiffASTCache | undefined;
 
   // Edit-session state: while active, hunk updates go through the frozen
-  // region skeleton (editSessionHunks) instead of the full recompute.
+  // region skeleton (editSessionHunks) instead of the full recompute, and
+  // rendering stays on the main thread with editor-compatible token markup —
+  // the editor's caret/selection mapping needs the token transformer, and
+  // the pool's global options are not guaranteed to produce it. The pool
+  // keeps serving every surface without a session.
   private editSessionActive = false;
 
   constructor(
@@ -275,8 +279,10 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
 
   /**
    * Enter edit-session mode: hunk updates preserve the current region
-   * skeleton instead of recomputing hunks. Called on every editor attach,
-   * including a re-attach after recycle.
+   * skeleton instead of recomputing hunks, and rendering happens locally
+   * with the token transformer forced on (worker-pool requests/results are
+   * suspended for this renderer). Called on every editor attach, including
+   * a re-attach after recycle.
    */
   public beginEditSession(): void {
     this.editSessionActive = true;
@@ -310,7 +316,11 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
     const { workerManager } = this;
     // The pool's diff cache is keyed by cacheKey, so a worker refresh needs
     // one; a keyless diff uses the local highlighter fallback below instead.
-    if (workerManager?.isWorkingPool() === true && diff.cacheKey != null) {
+    if (
+      !this.editSessionActive &&
+      workerManager?.isWorkingPool() === true &&
+      diff.cacheKey != null
+    ) {
       workerManager.evictDiffFromCache(diff.cacheKey);
       return workerManager
         .primeDiffHighlightCache(diff)
@@ -765,7 +775,10 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
 
   public async initializeHighlighter(): Promise<DiffsHighlighter> {
     this.highlighter = await getSharedHighlighter(
-      getHighlighterOptions(this.computedLang, this.options)
+      getHighlighterOptions(this.computedLang, {
+        theme: this.getLocalHighlightTheme(),
+        preferredHighlighter: this.options.preferredHighlighter,
+      })
     );
     return this.highlighter;
   }
@@ -788,7 +801,10 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
       result: massiveDiff ? undefined : cache?.result,
       renderRange: undefined,
     };
-    if (this.workerManager?.isWorkingPool() === true) {
+    if (
+      !this.editSessionActive &&
+      this.workerManager?.isWorkingPool() === true
+    ) {
       if (this.renderCache.result == null && !massiveDiff) {
         // We should only kick off a preload of the AST if we have a WorkerPool
         this.workerManager.highlightDiffAST(this, this.diff);
@@ -801,16 +817,33 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
     }
   }
 
+  private getLocalHighlightTheme(): RenderDiffOptions['theme'] {
+    return (
+      this.workerManager?.getDiffRenderOptions().theme ??
+      this.options.theme ??
+      DEFAULT_THEMES
+    );
+  }
+
   private getRenderOptions(diff: FileDiffMetadata): GetRenderOptionsReturn {
     const options: RenderDiffOptions = (() => {
       if (this.workerManager?.isWorkingPool() === true) {
-        return this.workerManager.getDiffRenderOptions();
+        const poolOptions = this.workerManager.getDiffRenderOptions();
+        // Active edit sessions require `useTokenTransformer: true`
+        if (
+          this.editSessionActive &&
+          poolOptions.useTokenTransformer !== true
+        ) {
+          return { ...poolOptions, useTokenTransformer: true };
+        }
+        return poolOptions;
       }
       const { theme, tokenizeMaxLineLength, lineDiffType, maxLineDiffLength } =
         this.getOptionsWithDefaults();
       return {
         theme,
-        useTokenTransformer: shouldUseTokenTransformer(this.options),
+        useTokenTransformer:
+          this.editSessionActive || shouldUseTokenTransformer(this.options),
         tokenizeMaxLineLength,
         lineDiffType,
         maxLineDiffLength,
@@ -868,7 +901,10 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
       this.renderCache.renderRange,
       renderRange
     );
-    if (this.workerManager?.isWorkingPool() === true) {
+    if (
+      !this.editSessionActive &&
+      this.workerManager?.isWorkingPool() === true
+    ) {
       // An already-highlighted view is waiting on a fresh highlight for the
       // same diff. Returning no result keeps the host's current content in
       // place instead of downgrading it to a plain AST; the pending
@@ -968,7 +1004,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
           if (this.renderCache != null) {
             this.renderCache.highlighted = false;
           }
-          this.onHighlightSuccess(diff, result, options, !forcePlainText);
+          this.applyHighlightResult(diff, result, options, !forcePlainText);
         });
       }
     }
@@ -1017,7 +1053,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
       : (diff.lang ?? getFiletypeFromFileName(diff.name));
     const hasThemes =
       this.highlighter != null &&
-      areThemesAttached(this.options.theme ?? DEFAULT_THEMES);
+      areThemesAttached(this.getLocalHighlightTheme());
     const hasLangs =
       forcePlainText ||
       (this.highlighter != null && areLanguagesAttached(this.computedLang));
@@ -1054,6 +1090,18 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
     options: RenderDiffOptions,
     highlighted = true
   ): void {
+    if (this.editSessionActive) {
+      return;
+    }
+    this.applyHighlightResult(diff, result, options, highlighted);
+  }
+
+  private applyHighlightResult(
+    diff: FileDiffMetadata,
+    result: ThemedDiffResult,
+    options: RenderDiffOptions,
+    highlighted = true
+  ): void {
     // NOTE(amadeus): This is a bad assumption, and I should figure out
     // something better... If renderCache was blown away, we can assume we've
     // run cleanUp()
@@ -1083,6 +1131,9 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
     diff: FileDiffMetadata,
     options: RenderDiffOptions
   ): RenderDiffResult | undefined {
+    if (this.editSessionActive) {
+      return undefined;
+    }
     const cache = this.workerManager?.getDiffResultCache(diff);
     if (cache == null || !areDiffRenderOptionsEqual(options, cache.options)) {
       return undefined;

--- a/packages/diffs/src/renderers/FileRenderer.ts
+++ b/packages/diffs/src/renderers/FileRenderer.ts
@@ -881,7 +881,9 @@ export class FileRenderer<LAnnotation = undefined> {
     this.highlighter = await getSharedHighlighter(
       getHighlighterOptions(this.computedLang, {
         theme: this.getLocalHighlightTheme(),
-        preferredHighlighter: this.options.preferredHighlighter,
+        preferredHighlighter:
+          this.workerManager?.getPreferredHighlighter() ??
+          this.options.preferredHighlighter,
       })
     );
     return this.highlighter;

--- a/packages/diffs/src/renderers/FileRenderer.ts
+++ b/packages/diffs/src/renderers/FileRenderer.ts
@@ -55,7 +55,6 @@ import {
 } from '../utils/includesFileAnnotations';
 import { isFilePlainText } from '../utils/isFilePlainText';
 import { renderFileWithHighlighter } from '../utils/renderFileWithHighlighter';
-import { shouldUseTokenTransformer } from '../utils/shouldUseTokenTransformer';
 import type { WorkerPoolManager } from '../worker';
 
 type AnnotationLineMap<LAnnotation> = Record<
@@ -171,6 +170,17 @@ export class FileRenderer<LAnnotation = undefined> {
   /** Leave edit-session mode. Rendering returns to the pool when one works. */
   public endEditSession(): void {
     this.editSessionActive = false;
+  }
+
+  /**
+   * Ensures that the DOM is compatible with editor render updates
+   */
+  public editorRenderReady(): boolean {
+    return (
+      this.renderCache?.options.useTokenTransformer === true &&
+      this.renderCache.highlighted &&
+      this.renderCache.result != null
+    );
   }
 
   public recycle(): void {
@@ -303,7 +313,7 @@ export class FileRenderer<LAnnotation = undefined> {
       return {
         theme: this.getLocalHighlightTheme(),
         useTokenTransformer:
-          this.editSessionActive || shouldUseTokenTransformer(this.options),
+          this.editSessionActive || this.options.useTokenTransformer === true,
         tokenizeMaxLineLength,
       };
     })();

--- a/packages/diffs/src/renderers/FileRenderer.ts
+++ b/packages/diffs/src/renderers/FileRenderer.ts
@@ -114,6 +114,13 @@ export class FileRenderer<LAnnotation = undefined> {
   private pendingStructuralRows: Map<number, HASTElement> | undefined;
   private textDocumentCache = new WeakMap<FileContents, DiffsTextDocument>();
 
+  // Edit-session state: while active, this renderer stays on the main thread
+  // with editor-compatible token markup — the editor's caret/selection
+  // mapping needs the token transformer, and the pool's global options are
+  // not guaranteed to produce it. The pool keeps serving every surface
+  // without a session.
+  private editSessionActive = false;
+
   constructor(
     public options: FileRendererOptions = { theme: DEFAULT_THEMES },
     private onRenderUpdate?: () => unknown,
@@ -151,11 +158,28 @@ export class FileRenderer<LAnnotation = undefined> {
     this.onRenderUpdate = undefined;
   }
 
+  /**
+   * Enter edit-session mode: rendering happens locally with the token
+   * transformer forced on, and worker-pool requests/results are suspended
+   * for this renderer. Called on every editor attach, including a re-attach
+   * after recycle.
+   */
+  public beginEditSession(): void {
+    this.editSessionActive = true;
+  }
+
+  /** Leave edit-session mode. Rendering returns to the pool when one works. */
+  public endEditSession(): void {
+    this.editSessionActive = false;
+  }
+
   public recycle(): void {
     this.clearRenderCache();
     this.highlighter = undefined;
     this.workerManager?.cleanUpTasks(this);
     this.lineCache = undefined;
+    // The session flag re-seeds on the next editor attach (beginEditSession).
+    this.endEditSession();
     // The edited-document cache is only coherent alongside the render cache
     // it patched. Keeping it across a recycle would let getLineCount report
     // edit-session line counts (keyed by the long-lived file object) against
@@ -238,7 +262,10 @@ export class FileRenderer<LAnnotation = undefined> {
       // FIXME(amadeus): Add support for renderRanges
       renderRange: undefined,
     };
-    if (this.workerManager?.isWorkingPool() === true) {
+    if (
+      !this.editSessionActive &&
+      this.workerManager?.isWorkingPool() === true
+    ) {
       if (this.renderCache.result == null && !massiveFile) {
         // We should only kick off a preload of the AST if we have a WorkerPool
         this.workerManager.highlightFileAST(this, file);
@@ -251,16 +278,32 @@ export class FileRenderer<LAnnotation = undefined> {
     }
   }
 
+  private getLocalHighlightTheme(): RenderFileOptions['theme'] {
+    return (
+      this.workerManager?.getFileRenderOptions().theme ??
+      this.options.theme ??
+      DEFAULT_THEMES
+    );
+  }
+
   private getRenderOptions(file: FileContents): GetRenderOptionsReturn {
     const options: RenderFileOptions = (() => {
       if (this.workerManager?.isWorkingPool() === true) {
-        return this.workerManager.getFileRenderOptions();
+        const poolOptions = this.workerManager.getFileRenderOptions();
+        // Active edit sessions require `useTokenTransformer: true`
+        if (
+          this.editSessionActive &&
+          poolOptions.useTokenTransformer !== true
+        ) {
+          return { ...poolOptions, useTokenTransformer: true };
+        }
+        return poolOptions;
       }
-      const { theme = DEFAULT_THEMES, tokenizeMaxLineLength = 1000 } =
-        this.options;
+      const { tokenizeMaxLineLength = 1000 } = this.options;
       return {
-        theme,
-        useTokenTransformer: shouldUseTokenTransformer(this.options),
+        theme: this.getLocalHighlightTheme(),
+        useTokenTransformer:
+          this.editSessionActive || shouldUseTokenTransformer(this.options),
         tokenizeMaxLineLength,
       };
     })();
@@ -495,6 +538,18 @@ export class FileRenderer<LAnnotation = undefined> {
       this.textDocumentCache = new WeakMap();
     }
     let { options, forceHighlight } = this.getRenderOptions(file);
+    // A dirty edit-session cache must not be superseded by a render with
+    // different options (e.g. a session ending and returning to pool
+    // options): persist the session text into the file and evict the stale
+    // pool cache entry first (clearRenderCache does both) so the rebuild
+    // below uses the edited contents instead of resurrecting pre-edit
+    // markup.
+    if (
+      this.renderCache?.isDirty === true &&
+      !areFileRenderOptionsEqual(options, this.renderCache.options)
+    ) {
+      this.clearRenderCache();
+    }
     const cache = this.getMatchingWorkerResultCache(file, options);
     if (cache != null && !this.hasHighlightedRenderCache(file, options)) {
       this.renderCache = {
@@ -523,7 +578,10 @@ export class FileRenderer<LAnnotation = undefined> {
       this.renderCache.renderRange,
       renderRange
     );
-    if (this.workerManager?.isWorkingPool() === true) {
+    if (
+      !this.editSessionActive &&
+      this.workerManager?.isWorkingPool() === true
+    ) {
       // Cache invalidation based on renderRange comparison
       if (
         forcePlainText ||
@@ -600,7 +658,7 @@ export class FileRenderer<LAnnotation = undefined> {
           if (this.renderCache != null) {
             this.renderCache.highlighted = false;
           }
-          this.onHighlightSuccess(file, result, options, !forcePlainText);
+          this.applyHighlightResult(file, result, options, !forcePlainText);
         });
       }
     }
@@ -633,7 +691,7 @@ export class FileRenderer<LAnnotation = undefined> {
       : (file.lang ?? getFiletypeFromFileName(file.name));
     const hasThemes =
       this.highlighter != null &&
-      hasResolvedThemes(getThemes(this.options.theme));
+      hasResolvedThemes(getThemes(this.getLocalHighlightTheme()));
     const hasLangs =
       forcePlainText ||
       (this.highlighter != null && areLanguagesAttached(this.computedLang));
@@ -811,12 +869,27 @@ export class FileRenderer<LAnnotation = undefined> {
 
   public async initializeHighlighter(): Promise<DiffsHighlighter> {
     this.highlighter = await getSharedHighlighter(
-      getHighlighterOptions(this.computedLang, this.options)
+      getHighlighterOptions(this.computedLang, {
+        theme: this.getLocalHighlightTheme(),
+        preferredHighlighter: this.options.preferredHighlighter,
+      })
     );
     return this.highlighter;
   }
 
   public onHighlightSuccess(
+    file: FileContents,
+    result: ThemedFileResult,
+    options: RenderFileOptions,
+    highlighted = true
+  ): void {
+    if (this.editSessionActive) {
+      return;
+    }
+    this.applyHighlightResult(file, result, options, highlighted);
+  }
+
+  private applyHighlightResult(
     file: FileContents,
     result: ThemedFileResult,
     options: RenderFileOptions,
@@ -847,6 +920,9 @@ export class FileRenderer<LAnnotation = undefined> {
     file: FileContents,
     options: RenderFileOptions
   ): RenderFileResult | undefined {
+    if (this.editSessionActive) {
+      return undefined;
+    }
     const cache = this.workerManager?.getFileResultCache(file);
     if (cache == null || !areFileRenderOptionsEqual(options, cache.options)) {
       return undefined;

--- a/packages/diffs/src/ssr/preloadDiffs.ts
+++ b/packages/diffs/src/ssr/preloadDiffs.ts
@@ -25,6 +25,7 @@ import { getDiffFileInput } from '../utils/getDiffFileInput';
 import { getSingularPatch } from '../utils/getSingularPatch';
 import { parseDiffFromFile } from '../utils/parseDiffFromFile';
 import { parseMergeConflictDiffFromFile } from '../utils/parseMergeConflictDiffFromFile';
+import { shouldUseTokenTransformer } from '../utils/shouldUseTokenTransformer';
 import { renderHTML } from './renderHTML';
 
 interface PreloadDiffBaseOptions<LAnnotation> {
@@ -274,6 +275,9 @@ function getHunksRendererOptions<LAnnotation>(
 ): DiffHunksRendererOptions {
   return {
     ...options,
+    // Match the client's option snapshot: token callbacks imply the
+    // transformer, so server markup hydrates into identical client renders.
+    useTokenTransformer: shouldUseTokenTransformer<'diff'>(options),
     headerRenderMode:
       options?.renderCustomHeader != null ? 'custom' : 'default',
     hunkSeparators:

--- a/packages/diffs/src/ssr/preloadFile.ts
+++ b/packages/diffs/src/ssr/preloadFile.ts
@@ -6,6 +6,7 @@ import {
   createThemeStyleElement,
 } from '../utils/createStyleElement';
 import { wrapThemeCSS } from '../utils/cssWrappers';
+import { shouldUseTokenTransformer } from '../utils/shouldUseTokenTransformer';
 import { renderHTML } from './renderHTML';
 
 export type PreloadFileOptions<LAnnotation> = {
@@ -28,6 +29,9 @@ export async function preloadFile<LAnnotation = undefined>({
 }: PreloadFileOptions<LAnnotation>): Promise<PreloadedFileResult<LAnnotation>> {
   const fileRenderer = new FileRenderer<LAnnotation>({
     ...options,
+    // Match the client's option snapshot: token callbacks imply the
+    // transformer, so server markup hydrates into identical client renders.
+    useTokenTransformer: shouldUseTokenTransformer(options),
     headerRenderMode:
       options?.renderCustomHeader != null ? 'custom' : 'default',
   });

--- a/packages/diffs/src/utils/getDiffHunksRendererOptions.ts
+++ b/packages/diffs/src/utils/getDiffHunksRendererOptions.ts
@@ -1,5 +1,6 @@
 import type { FileDiffOptions } from '../components/FileDiff';
 import type { DiffHunksRendererOptions } from '../renderers/DiffHunksRenderer';
+import { shouldUseTokenTransformer } from './shouldUseTokenTransformer';
 
 // Build the renderer option snapshot with direct property reads. CodeView item
 // options may inherit prototype getters, so object spread can miss values.
@@ -16,7 +17,7 @@ export function getDiffHunksRendererOptions<LAnnotation>(
     stickyHeader: options?.stickyHeader,
     preferredHighlighter: options?.preferredHighlighter,
     useCSSClasses: options?.useCSSClasses,
-    useTokenTransformer: options?.useTokenTransformer,
+    useTokenTransformer: shouldUseTokenTransformer<'diff'>(options),
     tokenizeMaxLineLength: options?.tokenizeMaxLineLength,
     tokenizeMaxLength: options?.tokenizeMaxLength,
     diffStyle: options?.diffStyle,

--- a/packages/diffs/src/utils/getFileRendererOptions.ts
+++ b/packages/diffs/src/utils/getFileRendererOptions.ts
@@ -1,5 +1,6 @@
 import type { FileOptions } from '../components/File';
 import type { FileRendererOptions } from '../renderers/FileRenderer';
+import { shouldUseTokenTransformer } from './shouldUseTokenTransformer';
 
 // Build the renderer option snapshot with direct property reads. CodeView item
 // options may inherit prototype getters, so object spread can miss values.
@@ -17,7 +18,7 @@ export function getFileRendererOptions<LAnnotation>(
     stickyHeader: options?.stickyHeader,
     preferredHighlighter: options?.preferredHighlighter,
     useCSSClasses: options?.useCSSClasses,
-    useTokenTransformer: options?.useTokenTransformer,
+    useTokenTransformer: shouldUseTokenTransformer(options),
     tokenizeMaxLineLength: options?.tokenizeMaxLineLength,
     tokenizeMaxLength: options?.tokenizeMaxLength,
     unsafeCSS: options?.unsafeCSS,

--- a/packages/diffs/src/utils/shouldUseTokenTransformer.ts
+++ b/packages/diffs/src/utils/shouldUseTokenTransformer.ts
@@ -1,15 +1,24 @@
-import type { InteractionManagerBaseOptions } from '../managers/InteractionManager';
+import type {
+  InteractionManagerMode,
+  OnTokenEventProps,
+} from '../managers/InteractionManager';
 
-// Token metadata is only needed when token-level interactions are enabled.
-export function shouldUseTokenTransformer<TMode extends 'file' | 'diff'>(
-  options: InteractionManagerBaseOptions<TMode> & {
-    useTokenTransformer?: boolean;
-  }
-): boolean {
+interface ShouldUseTokenTransformerProps<TMode extends InteractionManagerMode> {
+  onTokenClick?(props: OnTokenEventProps<TMode>, event: MouseEvent): unknown;
+  onTokenEnter?(props: OnTokenEventProps<TMode>, event: PointerEvent): unknown;
+  onTokenLeave?(props: OnTokenEventProps<TMode>, event: PointerEvent): unknown;
+  useTokenTransformer?: boolean;
+}
+
+// Token interaction callbacks require token metadata in the markup to fire at
+// all, so attaching any token callback enables the transformer;
+export function shouldUseTokenTransformer<
+  TMode extends 'file' | 'diff' = 'file',
+>(options: ShouldUseTokenTransformerProps<TMode> | undefined): boolean {
   return (
-    options.useTokenTransformer === true ||
-    options.onTokenClick != null ||
-    options.onTokenEnter != null ||
-    options.onTokenLeave != null
+    options?.useTokenTransformer === true ||
+    options?.onTokenClick != null ||
+    options?.onTokenEnter != null ||
+    options?.onTokenLeave != null
   );
 }

--- a/packages/diffs/src/worker/WorkerPoolManager.ts
+++ b/packages/diffs/src/worker/WorkerPoolManager.ts
@@ -275,6 +275,10 @@ export class WorkerPoolManager {
     }
   }
 
+  public getPreferredHighlighter(): HighlighterTypes {
+    return this.preferredHighlighter;
+  }
+
   public getFileRenderOptions(): RenderFileOptions {
     const { tokenizeMaxLineLength, theme, useTokenTransformer } =
       this.renderOptions;

--- a/packages/diffs/test/CodeView.edit.test.ts
+++ b/packages/diffs/test/CodeView.edit.test.ts
@@ -326,7 +326,7 @@ describe('CodeView item edit mode', () => {
     }
   });
 
-  test('only overrides the token transformer while items are edited', async () => {
+  test('edited items keep pass-through options untouched', async () => {
     const { cleanup } = installDom();
     const { createEditor } = createEditorHarness();
     const viewer = new CodeView({
@@ -347,9 +347,10 @@ describe('CodeView item edit mode', () => {
       ]);
 
       const [renderedA, renderedB, renderedC] = viewer.getRenderedItems();
-      // Edited items force only the transformer and retain interaction options.
+      // Edited items keep the pass-through options untouched; the edit
+      // session supplies token markup without rewriting them.
       for (const rendered of [renderedA, renderedB]) {
-        expect(rendered.instance.options.useTokenTransformer).toBe(true);
+        expect(rendered.instance.options.useTokenTransformer).toBe(false);
         expect(rendered.instance.options.enableLineSelection).toBe(true);
         expect(rendered.instance.options.enableGutterUtility).toBe(true);
         expect(rendered.instance.options.lineHoverHighlight).toBe('both');
@@ -357,8 +358,8 @@ describe('CodeView item edit mode', () => {
       if (renderedB.type !== 'diff') {
         throw new Error('expected a rendered diff item');
       }
-      // expandUnchanged is not edit-forced: collapsed unchanged regions stay
-      // collapsed during editing, so the item serves the pass-through value.
+      // Collapsed unchanged regions stay collapsed during editing; the item
+      // serves the pass-through value.
       expect(renderedB.instance.options.expandUnchanged).toBe(false);
       // ...while non-edited siblings keep the parent options.
       expect(renderedC.instance.options.useTokenTransformer).toBe(false);

--- a/packages/diffs/test/CodeView.optionPrototype.test.ts
+++ b/packages/diffs/test/CodeView.optionPrototype.test.ts
@@ -43,8 +43,8 @@ describe('CodeView item option prototypes', () => {
 
       // Every declared pass-through key must resolve to an enumerable
       // accessor on its prototype — whether the plain loops define it or a
-      // hand-written getter does (e.g. the edit-forced options). A key that
-      // is skipped from the loops without a replacement getter fails here.
+      // hand-written getter does. A key that is skipped from the loops
+      // without a replacement getter fails here.
       const fileKeys = Object.keys(fileOptionsPrototype);
       for (const key of CODE_VIEW_FILE_OPTION_KEYS) {
         expect(fileKeys).toContain(key);

--- a/packages/diffs/test/CodeView.workerPoolReady.test.ts
+++ b/packages/diffs/test/CodeView.workerPoolReady.test.ts
@@ -2,7 +2,11 @@ import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test';
 
 import { CodeView } from '../src/components/CodeView';
 import { DEFAULT_THEMES } from '../src/constants';
-import type { RenderDiffOptions, RenderFileOptions } from '../src/types';
+import type {
+  HighlighterTypes,
+  RenderDiffOptions,
+  RenderFileOptions,
+} from '../src/types';
 import type { WorkerPoolManager, WorkerStats } from '../src/worker';
 import { createRoot, installDom, makeFileItem, wait } from './domHarness';
 
@@ -67,7 +71,11 @@ class FakeWorkerPoolManager {
   }
 
   // The real manager reports its configured render options regardless of
-  // pool health; renderers read the local-fallback theme from here.
+  // pool health; renderers read the local-fallback theme and engine here.
+  public getPreferredHighlighter(): HighlighterTypes {
+    return 'shiki-js';
+  }
+
   public getFileRenderOptions(): RenderFileOptions {
     return {
       theme: DEFAULT_THEMES,

--- a/packages/diffs/test/CodeView.workerPoolReady.test.ts
+++ b/packages/diffs/test/CodeView.workerPoolReady.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test';
 
 import { CodeView } from '../src/components/CodeView';
+import { DEFAULT_THEMES } from '../src/constants';
+import type { RenderDiffOptions, RenderFileOptions } from '../src/types';
 import type { WorkerPoolManager, WorkerStats } from '../src/worker';
 import { createRoot, installDom, makeFileItem, wait } from './domHarness';
 
@@ -62,6 +64,24 @@ class FakeWorkerPoolManager {
 
   public getFileResultCache(): undefined {
     return undefined;
+  }
+
+  // The real manager reports its configured render options regardless of
+  // pool health; renderers read the local-fallback theme from here.
+  public getFileRenderOptions(): RenderFileOptions {
+    return {
+      theme: DEFAULT_THEMES,
+      useTokenTransformer: false,
+      tokenizeMaxLineLength: 1000,
+    };
+  }
+
+  public getDiffRenderOptions(): RenderDiffOptions {
+    return {
+      ...this.getFileRenderOptions(),
+      lineDiffType: 'word-alt',
+      maxLineDiffLength: 1000,
+    };
   }
 
   public markInitialized(): void {

--- a/packages/diffs/test/UnresolvedFile.sequentialResolve.test.ts
+++ b/packages/diffs/test/UnresolvedFile.sequentialResolve.test.ts
@@ -175,3 +175,53 @@ describe('UnresolvedFile sequential conflict resolution', () => {
     }
   });
 });
+
+describe('UnresolvedFile token callbacks', () => {
+  test('token callbacks alone produce data-char markup', async () => {
+    const { cleanup } = installDom();
+    const fileContainer = document.createElement('div');
+    document.body.appendChild(fileContainer);
+    const state = parseMergeConflictDiffFromFile(TWO_CONFLICT_FILE);
+    // No explicit useTokenTransformer: the unresolved option builder must
+    // resolve the callback implication itself (it spreads options wholesale
+    // instead of using the File/FileDiff snapshots).
+    const instance = new UnresolvedFile(
+      {
+        theme: DEFAULT_THEMES,
+        mergeConflictActionsType: 'default',
+        onMergeConflictAction: () => undefined,
+        onTokenClick: () => undefined,
+      },
+      undefined,
+      true
+    );
+    try {
+      instance.hydrate({
+        fileDiff: state.fileDiff,
+        actions: state.actions,
+        markerRows: state.markerRows,
+        fileContainer,
+      });
+      instance.render({
+        fileDiff: state.fileDiff,
+        actions: state.actions,
+        markerRows: state.markerRows,
+      });
+      const dataCharCount = () =>
+        (fileContainer.shadowRoot ?? fileContainer).querySelectorAll(
+          '[data-char]'
+        ).length;
+      const deadline = Date.now() + 4000;
+      while (dataCharCount() === 0 && Date.now() < deadline) {
+        await wait(10);
+      }
+      expect(dataCharCount()).toBeGreaterThan(0);
+    } finally {
+      instance.cleanUp();
+      document.body.innerHTML = '';
+      await wait(0);
+      cleanup();
+      await disposeHighlighter();
+    }
+  });
+});

--- a/packages/diffs/test/WorkerPoolManager.test.ts
+++ b/packages/diffs/test/WorkerPoolManager.test.ts
@@ -3,63 +3,24 @@ import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { parseDiffFromFile } from '../src';
 import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
 import type { FileContents, FileDiffMetadata } from '../src/types';
-import type {
-  DiffRendererInstance,
-  InitializeWorkerRequest,
-  RenderDiffRequest,
-  RenderFileRequest,
-  WorkerRequest,
-  WorkerResponse,
-} from '../src/worker/types';
-import { WorkerPoolManager } from '../src/worker/WorkerPoolManager';
+import type { DiffRendererInstance } from '../src/worker/types';
+import {
+  createInitializedManager,
+  createInitializingManager,
+  installAnimationFramePolyfill,
+  respondToDiffRequest,
+  respondToFileRequest,
+  withTimeout,
+} from './workerPoolHarness';
 
-const originalRequestAnimationFrame =
-  typeof globalThis.requestAnimationFrame === 'function'
-    ? globalThis.requestAnimationFrame
-    : undefined;
-const originalCancelAnimationFrame =
-  typeof globalThis.cancelAnimationFrame === 'function'
-    ? globalThis.cancelAnimationFrame
-    : undefined;
-let nextFrameId = 0;
-const frames = new Map<number, ReturnType<typeof setTimeout>>();
+let restoreAnimationFrame: (() => void) | undefined;
 
 beforeAll(() => {
-  globalThis.requestAnimationFrame = ((callback) => {
-    const id = ++nextFrameId;
-    const timeout = setTimeout(() => {
-      frames.delete(id);
-      callback(performance.now());
-    }, 0);
-    frames.set(id, timeout);
-    return id;
-  }) as typeof requestAnimationFrame;
-
-  globalThis.cancelAnimationFrame = ((id) => {
-    const timeout = frames.get(id);
-    if (timeout != null) {
-      clearTimeout(timeout);
-      frames.delete(id);
-    }
-  }) as typeof cancelAnimationFrame;
+  restoreAnimationFrame = installAnimationFramePolyfill();
 });
 
 afterAll(async () => {
-  for (const timeout of frames.values()) {
-    clearTimeout(timeout);
-  }
-  frames.clear();
-
-  if (originalRequestAnimationFrame != null) {
-    globalThis.requestAnimationFrame = originalRequestAnimationFrame;
-  } else {
-    Reflect.deleteProperty(globalThis, 'requestAnimationFrame');
-  }
-  if (originalCancelAnimationFrame != null) {
-    globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
-  } else {
-    Reflect.deleteProperty(globalThis, 'cancelAnimationFrame');
-  }
+  restoreAnimationFrame?.();
   await disposeHighlighter();
 });
 
@@ -245,46 +206,6 @@ describe('WorkerPoolManager cache priming', () => {
   });
 });
 
-function createInitializingManager(): {
-  initialization: Promise<void>;
-  manager: WorkerPoolManager;
-  worker: TestWorker;
-} {
-  const worker = new TestWorker();
-  const manager = new WorkerPoolManager(
-    {
-      poolSize: 1,
-      workerFactory: () => worker as unknown as Worker,
-    },
-    {
-      langs: [],
-      preferredHighlighter: 'shiki-js',
-      theme: 'github-dark',
-    }
-  );
-  return {
-    initialization: manager.initialize(),
-    manager,
-    worker,
-  };
-}
-
-async function createInitializedManager(): Promise<{
-  manager: WorkerPoolManager;
-  worker: TestWorker;
-}> {
-  const { initialization, manager, worker } = createInitializingManager();
-  const request = await worker.waitForInitializeRequest();
-  worker.respond({
-    type: 'success',
-    requestType: 'initialize',
-    id: request.id,
-    sentAt: Date.now(),
-  });
-  await withTimeout(initialization);
-  return { manager, worker };
-}
-
 function createCacheableDiff(): FileDiffMetadata {
   const oldFile = createCacheableFile('file:old', 'const value = "old";\n');
   const newFile = createCacheableFile('file:new', 'const value = "new";\n');
@@ -300,141 +221,4 @@ function createCacheableFile(
     contents,
     cacheKey,
   };
-}
-
-function respondToDiffRequest(
-  manager: WorkerPoolManager,
-  worker: TestWorker,
-  request: RenderDiffRequest
-): void {
-  worker.respond({
-    type: 'success',
-    requestType: 'diff',
-    id: request.id,
-    result: {
-      code: { additionLines: [], deletionLines: [] },
-      themeStyles: '',
-      baseThemeType: undefined,
-    },
-    options: manager.getDiffRenderOptions(),
-    sentAt: Date.now(),
-  });
-}
-
-function respondToFileRequest(
-  manager: WorkerPoolManager,
-  worker: TestWorker,
-  request: RenderFileRequest
-): void {
-  worker.respond({
-    type: 'success',
-    requestType: 'file',
-    id: request.id,
-    result: {
-      code: [],
-      themeStyles: '',
-      baseThemeType: undefined,
-    },
-    options: manager.getFileRenderOptions(),
-    sentAt: Date.now(),
-  });
-}
-
-class TestWorker {
-  terminated = false;
-  private diffRequests: RenderDiffRequest[] = [];
-  private diffRequestResolve:
-    | ((request: RenderDiffRequest) => void)
-    | undefined;
-  private fileRequests: RenderFileRequest[] = [];
-  private fileRequestResolve:
-    | ((request: RenderFileRequest) => void)
-    | undefined;
-  private initializeRequest: InitializeWorkerRequest | undefined;
-  private initializeRequestResolve:
-    | ((request: InitializeWorkerRequest) => void)
-    | undefined;
-  private readonly initializeRequestPromise =
-    new Promise<InitializeWorkerRequest>((resolve) => {
-      this.initializeRequestResolve = resolve;
-    });
-  private readonly messageListeners = new Set<
-    (event: MessageEvent<WorkerResponse>) => void
-  >();
-
-  addEventListener(
-    type: string,
-    listener: (event: MessageEvent<WorkerResponse>) => void
-  ): void {
-    if (type === 'message') {
-      this.messageListeners.add(listener);
-    }
-  }
-
-  postMessage(request: WorkerRequest): void {
-    // Browser workers synchronously clone a message before returning.
-    const clonedRequest = structuredClone(request);
-    if (clonedRequest.type === 'initialize') {
-      this.initializeRequest = clonedRequest;
-      this.initializeRequestResolve?.(clonedRequest);
-    } else if (clonedRequest.type === 'diff') {
-      this.diffRequests.push(clonedRequest);
-      this.diffRequestResolve?.(clonedRequest);
-      this.diffRequestResolve = undefined;
-    } else if (clonedRequest.type === 'file') {
-      this.fileRequests.push(clonedRequest);
-      this.fileRequestResolve?.(clonedRequest);
-      this.fileRequestResolve = undefined;
-    }
-  }
-
-  terminate(): void {
-    this.terminated = true;
-  }
-
-  async waitForInitializeRequest(): Promise<InitializeWorkerRequest> {
-    return this.initializeRequest ?? this.initializeRequestPromise;
-  }
-
-  get diffRequestCount(): number {
-    return this.diffRequests.length;
-  }
-
-  async waitForDiffRequest(): Promise<RenderDiffRequest> {
-    const request = this.diffRequests.at(-1);
-    if (request != null) {
-      return request;
-    }
-    return new Promise<RenderDiffRequest>((resolve) => {
-      this.diffRequestResolve = resolve;
-    });
-  }
-
-  async waitForFileRequest(): Promise<RenderFileRequest> {
-    const request = this.fileRequests.at(-1);
-    if (request != null) {
-      return request;
-    }
-    return new Promise<RenderFileRequest>((resolve) => {
-      this.fileRequestResolve = resolve;
-    });
-  }
-
-  respond(response: WorkerResponse): void {
-    for (const listener of this.messageListeners) {
-      listener({ data: response } as MessageEvent<WorkerResponse>);
-    }
-  }
-}
-
-function withTimeout<T>(promise: Promise<T>): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      reject(new Error('Timed out waiting for promise to settle'));
-    }, 5_000);
-
-    promise.then(resolve, reject).finally(() => {
-      clearTimeout(timeout);
-    });
-  });
 }

--- a/packages/diffs/test/editorCollapsedEdit.test.ts
+++ b/packages/diffs/test/editorCollapsedEdit.test.ts
@@ -5,7 +5,7 @@ import { DEFAULT_THEMES } from '../src/constants';
 import { Editor } from '../src/editor/editor';
 import { PieceTable } from '../src/editor/pieceTable';
 import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
-import { installDom, wait } from './domHarness';
+import { installDom, wait, waitFor } from './domHarness';
 
 afterAll(async () => {
   await disposeHighlighter();
@@ -131,14 +131,14 @@ function typeAt(
   );
 }
 
-describe('diff editor: attach-time option normalization', () => {
-  test('only enables the token transformer when attaching', async () => {
+describe('diff editor: attach-time markup normalization', () => {
+  test('renders editor token markup without mutating component options', async () => {
     const dom = installDom();
     const container = document.createElement('div');
     document.body.appendChild(container);
-    // useTokenTransformer: false triggers Editor.edit's setOptions fallback,
-    // which replaces options wholesale. Every other option must flow through
-    // unchanged.
+    // useTokenTransformer: false means the attach-time session render must
+    // supply the editor's token markup; public options stay untouched.
+    let updates = 0;
     const fileDiff = new FileDiff<undefined>({
       disableFileHeader: true,
       theme: DEFAULT_THEMES,
@@ -148,6 +148,9 @@ describe('diff editor: attach-time option normalization', () => {
       enableGutterUtility: true,
       enableLineSelection: true,
       lineHoverHighlight: 'both',
+      onPostRender: (_node, _instance, phase) => {
+        if (phase === 'update') updates++;
+      },
     });
     const editor = new Editor<undefined>();
     try {
@@ -157,10 +160,29 @@ describe('diff editor: attach-time option normalization', () => {
         fileContainer: container,
         forceRender: true,
       });
-      editor.edit(fileDiff);
-      await wait(10);
+      // Let the initial (non-transformer) highlight settle so the attach
+      // render below is the only render left to count. Styled token spans
+      // only exist once the async highlight has painted.
+      await waitFor(
+        () =>
+          (container.shadowRoot?.querySelectorAll('[data-content] span[style]')
+            .length ?? 0) > 0,
+        { timeout: 4000 }
+      );
+      const updatesBefore = updates;
 
-      expect(fileDiff.options.useTokenTransformer).toBe(true);
+      editor.edit(fileDiff);
+      await waitFor(
+        () =>
+          (container.shadowRoot?.querySelectorAll('[data-char]').length ?? 0) >
+          0,
+        { timeout: 4000 }
+      );
+
+      // Exactly one logical re-render: the attach-time session render (the
+      // loaded highlighter re-highlights synchronously within it).
+      expect(updates - updatesBefore).toBe(1);
+      expect(fileDiff.options.useTokenTransformer).toBe(false);
       expect(fileDiff.options.expandUnchanged).toBe(true);
       expect(fileDiff.options.enableGutterUtility).toBe(true);
       expect(fileDiff.options.enableLineSelection).toBe(true);

--- a/packages/diffs/test/editorRecycle.test.ts
+++ b/packages/diffs/test/editorRecycle.test.ts
@@ -229,6 +229,10 @@ describe('Editor onAttach lifecycle', () => {
       onContentFocus: (content) => focusTargets.push(content),
     });
     try {
+      // A queued host rerender (theme change, async highlight, hydration)
+      // replaces the shadow DOM while the attach sync is still pending;
+      // onAttach must wait for the replacement to synchronize.
+      component.rerender();
       editor.edit(component);
       await wait(20);
 

--- a/packages/diffs/test/editorRecycle.test.ts
+++ b/packages/diffs/test/editorRecycle.test.ts
@@ -496,6 +496,33 @@ describe('Editor recycle cleanUp', () => {
     }
   });
 
+  test('a blur during the deferred attach-focus frame cancels the stale focus', async () => {
+    const dom = installDom();
+    const restoredFocus = mock((_options?: FocusOptions) => {});
+    const onAttach = mock((attachedEditor: Editor<undefined>) => {
+      // The positional focus defers its real focus() call to a rAF. A blur
+      // plus a host rerender landing in that gap must cancel the stale
+      // frame instead of pulling focus into the replaced content.
+      attachedEditor.focus({ lineNumber: 2, preventScroll: true });
+      component.contentElement.dispatchEvent(new Event('blur'));
+      component.rerender();
+      component.contentElement.focus = restoredFocus;
+    });
+    const editor = new Editor<undefined>({ onAttach });
+    const component = new TestEditableComponent(createFile());
+    try {
+      editor.edit(component);
+      await wait(20);
+
+      expect(onAttach).toHaveBeenCalledTimes(1);
+      expect(restoredFocus).not.toHaveBeenCalled();
+    } finally {
+      editor.cleanUp();
+      component.cleanUp();
+      dom.cleanup();
+    }
+  });
+
   test('recycled re-attach recreates a tokenizer so edits still paint', () => {
     const dom = installDom();
     try {

--- a/packages/diffs/test/editorWorkerPool.test.ts
+++ b/packages/diffs/test/editorWorkerPool.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { afterAll, beforeAll, describe, expect, spyOn, test } from 'bun:test';
 import type { ElementContent } from 'hast';
 import { toHtml } from 'hast-util-to-html';
 
@@ -925,6 +925,42 @@ describe('editor attach entry', () => {
       instance.cleanUp();
     } finally {
       dom.cleanup();
+    }
+  });
+});
+
+describe('local highlighter engine', () => {
+  // The shared highlighter keeps the engine selected by its first caller, so
+  // a local initialization on a pool-backed surface must consult the pool's
+  // configured engine instead of seeding the singleton from component
+  // defaults.
+  test('local highlighter initialization consults the pool engine preference', async () => {
+    const { manager } = await createInitializedManager({
+      theme: 'pierre-dark',
+    });
+    try {
+      const preferred = spyOn(manager, 'getPreferredHighlighter');
+      const fileRenderer = new FileRenderer(
+        { theme: 'pierre-dark' },
+        undefined,
+        manager
+      );
+      await fileRenderer.initializeHighlighter();
+      expect(preferred).toHaveBeenCalled();
+      fileRenderer.cleanUp();
+
+      preferred.mockClear();
+      const diffRenderer = new DiffHunksRenderer(
+        { theme: 'pierre-dark' },
+        undefined,
+        manager
+      );
+      await diffRenderer.initializeHighlighter();
+      expect(preferred).toHaveBeenCalled();
+      diffRenderer.cleanUp();
+      preferred.mockRestore();
+    } finally {
+      manager.terminate();
     }
   });
 });

--- a/packages/diffs/test/editorWorkerPool.test.ts
+++ b/packages/diffs/test/editorWorkerPool.test.ts
@@ -5,10 +5,18 @@ import { toHtml } from 'hast-util-to-html';
 import { parseDiffFromFile } from '../src';
 import { File } from '../src/components/File';
 import { FileDiff } from '../src/components/FileDiff';
-import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
+import { VirtualizedFileDiff } from '../src/components/VirtualizedFileDiff';
+import { Editor } from '../src/editor/editor';
+import {
+  disposeHighlighter,
+  getSharedHighlighter,
+} from '../src/highlighter/shared_highlighter';
 import { DiffHunksRenderer } from '../src/renderers/DiffHunksRenderer';
 import { FileRenderer } from '../src/renderers/FileRenderer';
 import type { DiffsEditor, FileContents } from '../src/types';
+import { getDiffHunksRendererOptions } from '../src/utils/getDiffHunksRendererOptions';
+import { renderDiffWithHighlighter } from '../src/utils/renderDiffWithHighlighter';
+import { renderFileWithHighlighter } from '../src/utils/renderFileWithHighlighter';
 import { installDom, wait } from './domHarness';
 import {
   createInitializedManager,
@@ -56,9 +64,12 @@ function plainFileCode(contents: string): ElementContent[] {
   }));
 }
 
+// Budget stays below bun's 5s test timeout so a failing poll rejects (and
+// the test's finally-cleanup runs) before bun abandons the test — a zombie
+// cleanup firing mid-way through a later test tears down its DOM globals.
 async function waitFor(
   assertion: () => void,
-  timeoutMs = 5_000
+  timeoutMs = 4_000
 ): Promise<void> {
   const start = Date.now();
   for (;;) {
@@ -501,6 +512,418 @@ describe('FileDiff component edit session', () => {
       instance.cleanUp();
     } finally {
       manager.terminate();
+      dom.cleanup();
+    }
+  });
+});
+
+function createEditorStub(): DiffsEditor<undefined> {
+  return {
+    cleanUp: () => undefined,
+    __syncRenderView: () => undefined,
+    __postponeBgTokenizeToNextFrame: () => undefined,
+    __captureFocusForDOMReplacement: () => undefined,
+  } as unknown as DiffsEditor<undefined>;
+}
+
+// Renders `file` the way a transformer-configured pool worker would, so
+// tests can settle a pool highlight with genuine editor-compatible markup.
+async function respondWithRealFileHighlight(
+  manager: Awaited<ReturnType<typeof createInitializedManager>>['manager'],
+  worker: Awaited<ReturnType<typeof createInitializedManager>>['worker'],
+  file: FileContents
+): Promise<void> {
+  const request = await withTimeout(worker.waitForFileRequest());
+  const highlighter = await getSharedHighlighter({
+    themes: ['pierre-dark'],
+    langs: ['typescript'],
+    preferredHighlighter: 'shiki-js',
+  });
+  worker.respond({
+    type: 'success',
+    requestType: 'file',
+    id: request.id,
+    result: renderFileWithHighlighter(
+      file,
+      highlighter,
+      manager.getFileRenderOptions()
+    ),
+    options: manager.getFileRenderOptions(),
+    sentAt: Date.now(),
+  });
+}
+
+describe('editor attach entry', () => {
+  test('attaching to a settled transformer-pool render needs no re-render', async () => {
+    const dom = installDom();
+    const { manager, worker } = await createInitializedManager({
+      theme: 'pierre-dark',
+      useTokenTransformer: true,
+    });
+    try {
+      let updates = 0;
+      const instance = new File(
+        {
+          theme: 'pierre-dark',
+          disableFileHeader: true,
+          onPostRender: (_node, _instance, phase) => {
+            if (phase === 'update') updates++;
+          },
+        },
+        manager
+      );
+      const fileContainer = document.createElement('div');
+      fileContainer.attachShadow({ mode: 'open' });
+      const file = createFile('file:entry-ready');
+
+      instance.render({ file, fileContainer, forceRender: true });
+      await respondWithRealFileHighlight(manager, worker, file);
+      await waitFor(() => {
+        expect(fileContainer.shadowRoot?.innerHTML ?? '').toContain(
+          'data-char'
+        );
+      });
+
+      const updatesBefore = updates;
+      const lineBefore =
+        fileContainer.shadowRoot?.querySelector('[data-line="1"]');
+      const detach = instance.attachEditor(createEditorStub());
+      await wait(50);
+
+      expect(updates).toBe(updatesBefore);
+      expect(
+        fileContainer.shadowRoot?.querySelector('[data-line="1"]') ===
+          lineBefore
+      ).toBe(true);
+      expect(worker.fileRequestCount).toBe(1);
+      detach();
+      instance.cleanUp();
+    } finally {
+      manager.terminate();
+      dom.cleanup();
+    }
+  });
+
+  test('a non-transformer pool render gets one session render at attach; siblings untouched', async () => {
+    const dom = installDom();
+    const { manager, worker } = await createInitializedManager({
+      theme: 'pierre-dark',
+    });
+    try {
+      let updates = 0;
+      let siblingUpdates = 0;
+      const instance = new File(
+        {
+          theme: 'pierre-dark',
+          disableFileHeader: true,
+          onPostRender: (_node, _instance, phase) => {
+            if (phase === 'update') updates++;
+          },
+        },
+        manager
+      );
+      const sibling = new File(
+        {
+          theme: 'pierre-dark',
+          disableFileHeader: true,
+          onPostRender: (_node, _instance, phase) => {
+            if (phase === 'update') siblingUpdates++;
+          },
+        },
+        manager
+      );
+      const fileContainer = document.createElement('div');
+      fileContainer.attachShadow({ mode: 'open' });
+      const siblingContainer = document.createElement('div');
+      siblingContainer.attachShadow({ mode: 'open' });
+      const file = createFile('file:entry-plain');
+      const siblingFile = createFile('file:entry-sibling');
+
+      instance.render({ file, fileContainer, forceRender: true });
+      respondToFileRequest(
+        manager,
+        worker,
+        await withTimeout(worker.waitForFileRequest()),
+        plainFileCode(FILE_CONTENTS)
+      );
+      sibling.render({
+        file: siblingFile,
+        fileContainer: siblingContainer,
+        forceRender: true,
+      });
+      respondToFileRequest(
+        manager,
+        worker,
+        await withTimeout(worker.waitForFileRequest()),
+        plainFileCode(FILE_CONTENTS)
+      );
+      await wait(50);
+
+      const updatesBefore = updates;
+      const siblingUpdatesBefore = siblingUpdates;
+      const detach = instance.attachEditor(createEditorStub());
+      await waitFor(() => {
+        expect(fileContainer.shadowRoot?.innerHTML ?? '').toContain(
+          'data-char'
+        );
+      });
+
+      // One session render at attach plus its async highlight completion.
+      expect(updates - updatesBefore).toBe(2);
+      expect(siblingUpdates).toBe(siblingUpdatesBefore);
+      expect(siblingContainer.shadowRoot?.innerHTML ?? '').not.toContain(
+        'data-char'
+      );
+      expect(worker.fileRequestCount).toBe(2);
+      detach();
+      instance.cleanUp();
+      sibling.cleanUp();
+    } finally {
+      manager.terminate();
+      dom.cleanup();
+    }
+  });
+
+  test('attaching while the pool highlight is in flight starts the local highlight immediately', async () => {
+    const dom = installDom();
+    const { manager, worker } = await createInitializedManager({
+      theme: 'pierre-dark',
+      useTokenTransformer: true,
+    });
+    try {
+      const instance = new File(
+        { theme: 'pierre-dark', disableFileHeader: true },
+        manager
+      );
+      const fileContainer = document.createElement('div');
+      fileContainer.attachShadow({ mode: 'open' });
+      const file = createFile('file:entry-inflight');
+
+      instance.render({ file, fileContainer, forceRender: true });
+      const request = await withTimeout(worker.waitForFileRequest());
+
+      const detach = instance.attachEditor(createEditorStub());
+      // The local highlight lands without the pool ever answering. The plain
+      // pool AST already carries data-char (transformer-shaped), so only the
+      // highlight colors prove the attach-time session render ran.
+      await waitFor(() => {
+        const html = fileContainer.shadowRoot?.innerHTML ?? '';
+        expect(html).toContain('data-char');
+        expect(html).toContain('color:');
+      });
+
+      // The late pool result is refused silently and replaces nothing.
+      respondToFileRequest(manager, worker, request, [
+        {
+          type: 'element',
+          tagName: 'div',
+          properties: { 'data-line': 1, 'data-pool-result': '' },
+          children: [],
+        },
+      ]);
+      await wait(50);
+      expect(fileContainer.shadowRoot?.innerHTML ?? '').toContain('data-char');
+      expect(fileContainer.shadowRoot?.innerHTML ?? '').not.toContain(
+        'data-pool-result'
+      );
+      expect(worker.fileRequestCount).toBe(1);
+      detach();
+      instance.cleanUp();
+    } finally {
+      manager.terminate();
+      dom.cleanup();
+    }
+  });
+
+  test('first edit of a settled virtualized diff replaces nothing (playground repro)', async () => {
+    const dom = installDom();
+    const { manager, worker } = await createInitializedManager({
+      theme: 'pierre-dark',
+      useTokenTransformer: true,
+    });
+    let attaches = 0;
+    const editor = new Editor<undefined>({ onAttach: () => attaches++ });
+    try {
+      const root = document.createElement('div');
+      document.body.appendChild(root);
+      let instanceChangedCalls = 0;
+      const virtualizer = {
+        type: 'simple',
+        config: {},
+        connect() {},
+        disconnect() {},
+        getRoot: () => root,
+        getWindowSpecs: () => ({ top: 0, bottom: 800 }),
+        getOffsetInScrollContainer: () => 0,
+        instanceChanged(target: { onRender(dirty: boolean): boolean }) {
+          instanceChangedCalls++;
+          target.onRender(true);
+        },
+        isInstanceVisible: () => true,
+        markDOMDirty() {},
+        requestHeightReconcile() {},
+      } as never;
+      const instance = new VirtualizedFileDiff<undefined>(
+        { theme: 'pierre-dark', disableFileHeader: true },
+        virtualizer,
+        undefined,
+        manager
+      );
+      const fileContainer = document.createElement('div');
+      root.appendChild(fileContainer);
+      const fileDiff = parseDiffFromFile(
+        {
+          name: 'demo.ts',
+          contents: 'const value = "old";\n',
+          cacheKey: 'vr:old',
+        },
+        {
+          name: 'demo.ts',
+          contents: 'const value = "new";\n',
+          cacheKey: 'vr:new',
+        }
+      );
+
+      instance.render({ fileDiff, fileContainer, forceRender: true });
+      const request = await withTimeout(worker.waitForDiffRequest());
+      // Deliver a genuine transformer-shaped highlight, as a configured
+      // pool worker would.
+      const highlighter = await getSharedHighlighter({
+        themes: ['pierre-dark'],
+        langs: ['typescript'],
+        preferredHighlighter: 'shiki-js',
+      });
+      worker.respond({
+        type: 'success',
+        requestType: 'diff',
+        id: request.id,
+        result: renderDiffWithHighlighter(
+          fileDiff,
+          highlighter,
+          manager.getDiffRenderOptions()
+        ),
+        options: manager.getDiffRenderOptions(),
+        sentAt: Date.now(),
+      });
+      await waitFor(() => {
+        expect(fileContainer.shadowRoot?.innerHTML ?? '').toContain(
+          'data-char'
+        );
+      });
+
+      const contentBefore =
+        fileContainer.shadowRoot?.querySelector('[data-content]');
+      const lineBefore =
+        fileContainer.shadowRoot?.querySelector('[data-line="1"]');
+      const callsBefore = instanceChangedCalls;
+
+      const detach = editor.edit(instance);
+      // The zero-render path must still deliver a working attachment.
+      await waitFor(() => expect(attaches).toBe(1));
+
+      expect(instanceChangedCalls).toBe(callsBefore);
+      expect(
+        fileContainer.shadowRoot?.querySelector('[data-content]') ===
+          contentBefore
+      ).toBe(true);
+      expect(
+        fileContainer.shadowRoot?.querySelector('[data-line="1"]') ===
+          lineBefore
+      ).toBe(true);
+      expect(instance.options.useTokenTransformer).toBeUndefined();
+      expect(worker.diffRequestCount).toBe(1);
+      detach();
+      instance.cleanUp();
+    } finally {
+      editor.cleanUp();
+      manager.terminate();
+      dom.cleanup();
+    }
+  });
+
+  test('a settled no-pool transformer render attaches with zero re-renders', async () => {
+    const dom = installDom();
+    try {
+      let updates = 0;
+      const instance = new File({
+        theme: 'pierre-dark',
+        disableFileHeader: true,
+        useTokenTransformer: true,
+        onPostRender: (_node, _instance, phase) => {
+          if (phase === 'update') updates++;
+        },
+      });
+      const fileContainer = document.createElement('div');
+      fileContainer.attachShadow({ mode: 'open' });
+      const file = createFile('file:nopool-explicit');
+
+      instance.render({ file, fileContainer, forceRender: true });
+      await waitFor(() => {
+        const html = fileContainer.shadowRoot?.innerHTML ?? '';
+        expect(html).toContain('data-char');
+        expect(html).toContain('color:');
+      });
+
+      const updatesBefore = updates;
+      const lineBefore =
+        fileContainer.shadowRoot?.querySelector('[data-line="1"]');
+      const detach = instance.attachEditor(createEditorStub());
+      await wait(50);
+
+      expect(updates).toBe(updatesBefore);
+      expect(
+        fileContainer.shadowRoot?.querySelector('[data-line="1"]') ===
+          lineBefore
+      ).toBe(true);
+      detach();
+      instance.cleanUp();
+    } finally {
+      dom.cleanup();
+    }
+  });
+
+  // The option snapshots map shouldUseTokenTransformer, so token callbacks
+  // alone give a no-pool render its data-char markup — which also means an
+  // editor can attach to it without triggering a re-render.
+  test('token callbacks alone produce data-char markup, so an editor attaches without re-rendering', async () => {
+    const dom = installDom();
+    try {
+      let updates = 0;
+      const instance = new File({
+        theme: 'pierre-dark',
+        disableFileHeader: true,
+        onTokenClick: () => undefined,
+        onPostRender: (_node, _instance, phase) => {
+          if (phase === 'update') updates++;
+        },
+      });
+      const fileContainer = document.createElement('div');
+      fileContainer.attachShadow({ mode: 'open' });
+      const file = createFile('file:nopool-callbacks');
+
+      instance.render({ file, fileContainer, forceRender: true });
+      await waitFor(() => {
+        const html = fileContainer.shadowRoot?.innerHTML ?? '';
+        expect(html).toContain('data-char');
+        expect(html).toContain('color:');
+      });
+
+      const updatesBefore = updates;
+      const detach = instance.attachEditor(createEditorStub());
+      await wait(50);
+
+      expect(updates).toBe(updatesBefore);
+      expect(instance.options.useTokenTransformer).toBeUndefined();
+      // The diff snapshot applies the same implication.
+      expect(
+        getDiffHunksRendererOptions({
+          theme: 'pierre-dark',
+          onTokenClick: () => undefined,
+        }).useTokenTransformer
+      ).toBe(true);
+      detach();
+      instance.cleanUp();
+    } finally {
       dom.cleanup();
     }
   });

--- a/packages/diffs/test/editorWorkerPool.test.ts
+++ b/packages/diffs/test/editorWorkerPool.test.ts
@@ -1,0 +1,507 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import type { ElementContent } from 'hast';
+import { toHtml } from 'hast-util-to-html';
+
+import { parseDiffFromFile } from '../src';
+import { File } from '../src/components/File';
+import { FileDiff } from '../src/components/FileDiff';
+import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
+import { DiffHunksRenderer } from '../src/renderers/DiffHunksRenderer';
+import { FileRenderer } from '../src/renderers/FileRenderer';
+import type { DiffsEditor, FileContents } from '../src/types';
+import { installDom, wait } from './domHarness';
+import {
+  createInitializedManager,
+  installAnimationFramePolyfill,
+  respondToDiffRequest,
+  respondToFileRequest,
+  withTimeout,
+} from './workerPoolHarness';
+
+// During an edit session (begun at editor attach), File/FileDiff renderers
+// stay on the main thread: renders use editor-compatible token-transformer
+// markup, no worker requests are issued for the edited surface, and pool
+// results that were already in flight are refused. These tests cover that
+// behavior at the renderer level plus the component wiring.
+
+let restoreAnimationFrame: (() => void) | undefined;
+
+beforeAll(() => {
+  restoreAnimationFrame = installAnimationFramePolyfill();
+});
+
+afterAll(async () => {
+  restoreAnimationFrame?.();
+  await disposeHighlighter();
+});
+
+const FILE_CONTENTS = 'const a = 1;\n\nconst b = 2;\n';
+
+function createFile(cacheKey: string): FileContents {
+  return { name: 'demo.ts', contents: FILE_CONTENTS, cacheKey };
+}
+
+// A structurally valid plain (non-transformer) worker result for `contents`:
+// one line element per line, the shape processFileResult requires.
+function plainFileCode(contents: string): ElementContent[] {
+  return contents.split('\n').map((text, index) => ({
+    type: 'element',
+    tagName: 'div',
+    properties: {
+      'data-line': index + 1,
+      'data-line-type': 'context',
+      'data-line-index': index,
+    },
+    children: [{ type: 'text', value: text.length > 0 ? text : '\n' }],
+  }));
+}
+
+async function waitFor(
+  assertion: () => void,
+  timeoutMs = 5_000
+): Promise<void> {
+  const start = Date.now();
+  for (;;) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      if (Date.now() - start > timeoutMs) {
+        throw error;
+      }
+      await wait(10);
+    }
+  }
+}
+
+describe('FileRenderer edit session', () => {
+  test('a session render skips the pool and produces token markup', async () => {
+    const { manager, worker } = await createInitializedManager({
+      theme: 'pierre-dark',
+    });
+    try {
+      let renderUpdates = 0;
+      const renderer = new FileRenderer(
+        { theme: 'pierre-dark' },
+        () => renderUpdates++,
+        manager
+      );
+      const file = createFile('file:session');
+
+      renderer.renderFile(file);
+      await withTimeout(worker.waitForFileRequest());
+      expect(worker.fileRequestCount).toBe(1);
+
+      renderer.beginEditSession();
+      renderer.renderFile(file);
+
+      await waitFor(() => expect(renderUpdates).toBeGreaterThan(0));
+      const result = renderer.renderFile(file);
+      if (result == null) {
+        throw new Error('expected a render result');
+      }
+      const html = toHtml(result.contentAST);
+      expect(html).toContain('data-char');
+      expect(html).toContain('<br>');
+      expect(worker.fileRequestCount).toBe(1);
+    } finally {
+      manager.terminate();
+    }
+  });
+
+  test('a pool result that lands after attach is dropped', async () => {
+    const { manager, worker } = await createInitializedManager({
+      theme: 'pierre-dark',
+    });
+    try {
+      let renderUpdates = 0;
+      const renderer = new FileRenderer(
+        { theme: 'pierre-dark' },
+        () => renderUpdates++,
+        manager
+      );
+      const file = createFile('file:late');
+
+      renderer.renderFile(file);
+      const request = await withTimeout(worker.waitForFileRequest());
+
+      renderer.beginEditSession();
+      const poolMarker: ElementContent[] = [
+        {
+          type: 'element',
+          tagName: 'div',
+          properties: { 'data-line': 1, 'data-pool-result': '' },
+          children: [],
+        },
+      ];
+      respondToFileRequest(manager, worker, request, poolMarker);
+      // Refused outright: nothing is applied and nothing is requested — the
+      // session render issued at editor attach supplies the highlight.
+      await wait(50);
+      expect(renderUpdates).toBe(0);
+
+      const result = renderer.renderFile(file);
+      if (result == null) {
+        throw new Error('expected a render result');
+      }
+      expect(toHtml(result.contentAST)).not.toContain('data-pool-result');
+    } finally {
+      manager.terminate();
+    }
+  });
+
+  test('a pool with the transformer enabled cannot bypass the session through its cache', async () => {
+    const { manager, worker } = await createInitializedManager({
+      theme: 'pierre-dark',
+      useTokenTransformer: true,
+    });
+    try {
+      let renderUpdates = 0;
+      const renderer = new FileRenderer(
+        { theme: 'pierre-dark' },
+        () => renderUpdates++,
+        manager
+      );
+      const file = createFile('file:pool-transformer');
+
+      renderer.renderFile(file);
+      const request = await withTimeout(worker.waitForFileRequest());
+
+      renderer.beginEditSession();
+      const poolMarker: ElementContent[] = [
+        {
+          type: 'element',
+          tagName: 'div',
+          properties: { 'data-line': 1, 'data-pool-result': '' },
+          children: [],
+        },
+      ];
+      // With useTokenTransformer already on, the pool's options equal the
+      // session options — the refused result must not sneak back in through
+      // the manager's result cache on the next session render.
+      respondToFileRequest(manager, worker, request, poolMarker);
+      await wait(50);
+      expect(renderUpdates).toBe(0);
+
+      // The session render issued at editor attach stays local: no adoption
+      // of the refused result, and the local highlight lands when ready.
+      let result = renderer.renderFile(file);
+      if (result == null) {
+        throw new Error('expected a render result');
+      }
+      expect(toHtml(result.contentAST)).not.toContain('data-pool-result');
+
+      await waitFor(() => expect(renderUpdates).toBeGreaterThan(0));
+      result = renderer.renderFile(file);
+      if (result == null) {
+        throw new Error('expected a render result');
+      }
+      const html = toHtml(result.contentAST);
+      expect(html).not.toContain('data-pool-result');
+      expect(html).toContain('data-char');
+      expect(html).toContain('color:');
+      expect(worker.fileRequestCount).toBe(1);
+    } finally {
+      manager.terminate();
+    }
+  });
+
+  test('an in-session hydrate does not preload from the pool', async () => {
+    const { manager, worker } = await createInitializedManager({
+      theme: 'pierre-dark',
+    });
+    try {
+      const renderer = new FileRenderer(
+        { theme: 'pierre-dark' },
+        undefined,
+        manager
+      );
+      renderer.beginEditSession();
+      renderer.hydrate(createFile('file:hydrate'));
+      await wait(50);
+      expect(worker.fileRequestCount).toBe(0);
+    } finally {
+      manager.terminate();
+    }
+  });
+
+  test('a dirty edit session ends without resurrecting pre-edit pool markup', async () => {
+    const { manager, worker } = await createInitializedManager({
+      theme: 'pierre-dark',
+    });
+    try {
+      let renderUpdates = 0;
+      const renderer = new FileRenderer(
+        { theme: 'pierre-dark' },
+        () => renderUpdates++,
+        manager
+      );
+      const file = createFile('file:dirty');
+
+      // Pool render settles (and populates the manager cache) before the
+      // editor attaches.
+      renderer.renderFile(file);
+      respondToFileRequest(
+        manager,
+        worker,
+        await withTimeout(worker.waitForFileRequest()),
+        plainFileCode(FILE_CONTENTS)
+      );
+
+      renderer.beginEditSession();
+      renderer.renderFile(file);
+      await waitFor(() => expect(renderUpdates).toBeGreaterThan(1));
+
+      // Simulate an editor keystroke: line 0 rewritten, cache marked dirty.
+      renderer.updateRenderCache(
+        new Map([[0, [[0, '#ffffff', 'const edited = 1;']]]]),
+        'dark'
+      );
+
+      renderer.endEditSession();
+      const result = renderer.renderFile(file);
+      if (result == null) {
+        throw new Error('expected a render result');
+      }
+      // Ending the session persists the session text into the file and
+      // evicts the stale pool cache instead of adopting pre-edit markup.
+      expect(file.contents).toContain('const edited = 1;');
+      expect(toHtml(result.contentAST)).toContain('const edited = 1;');
+    } finally {
+      manager.terminate();
+    }
+  });
+
+  test('ending the session returns rendering to the pool', async () => {
+    const { manager, worker } = await createInitializedManager({
+      theme: 'pierre-dark',
+    });
+    try {
+      let renderUpdates = 0;
+      const renderer = new FileRenderer(
+        { theme: 'pierre-dark' },
+        () => renderUpdates++,
+        manager
+      );
+      renderer.beginEditSession();
+      const file = createFile('file:detach');
+
+      renderer.renderFile(file);
+      await waitFor(() => expect(renderUpdates).toBeGreaterThan(0));
+      expect(worker.fileRequestCount).toBe(0);
+
+      renderer.endEditSession();
+      renderer.renderFile(file);
+      await withTimeout(worker.waitForFileRequest());
+      expect(worker.fileRequestCount).toBe(1);
+    } finally {
+      manager.terminate();
+    }
+  });
+});
+
+describe('DiffHunksRenderer edit session', () => {
+  test('a session render skips the pool and drops late pool results', async () => {
+    const { manager, worker } = await createInitializedManager({
+      theme: 'pierre-dark',
+    });
+    try {
+      let renderUpdates = 0;
+      const renderer = new DiffHunksRenderer(
+        { theme: 'pierre-dark' },
+        () => renderUpdates++,
+        manager
+      );
+      const diff = parseDiffFromFile(
+        {
+          name: 'demo.ts',
+          contents: 'const value = "old";\n',
+          cacheKey: 'd:old',
+        },
+        {
+          name: 'demo.ts',
+          contents: 'const value = "new";\n',
+          cacheKey: 'd:new',
+        }
+      );
+
+      renderer.renderDiff(diff);
+      const request = await withTimeout(worker.waitForDiffRequest());
+      expect(worker.diffRequestCount).toBe(1);
+
+      renderer.beginEditSession();
+      respondToDiffRequest(manager, worker, request);
+      // Refused outright: nothing is applied and nothing is requested — the
+      // session render issued at editor attach supplies the highlight.
+      await wait(50);
+      expect(renderUpdates).toBe(0);
+
+      // The session render stays local and completes the highlight with
+      // editor-compatible markup.
+      renderer.renderDiff(diff);
+      expect(worker.diffRequestCount).toBe(1);
+      await waitFor(() => expect(renderUpdates).toBeGreaterThan(0));
+      const result = renderer.renderDiff(diff);
+      if (result == null) {
+        throw new Error('expected a render result');
+      }
+      const html = toHtml([
+        ...(result.unifiedContentAST ?? []),
+        ...(result.additionsContentAST ?? []),
+        ...(result.deletionsContentAST ?? []),
+      ]);
+      expect(html).toContain('data-char');
+      expect(worker.diffRequestCount).toBe(1);
+    } finally {
+      manager.terminate();
+    }
+  });
+
+  test('an in-session refresh re-highlights locally instead of through the pool', async () => {
+    const { manager, worker } = await createInitializedManager({
+      theme: 'pierre-dark',
+    });
+    try {
+      let renderUpdates = 0;
+      const renderer = new DiffHunksRenderer(
+        { theme: 'pierre-dark' },
+        () => renderUpdates++,
+        manager
+      );
+      renderer.beginEditSession();
+      const diff = parseDiffFromFile(
+        {
+          name: 'demo.ts',
+          contents: 'const value = "old";\n',
+          cacheKey: 'r:old',
+        },
+        {
+          name: 'demo.ts',
+          contents: 'const value = "new";\n',
+          cacheKey: 'r:new',
+        }
+      );
+
+      renderer.renderDiff(diff);
+      await waitFor(() => expect(renderUpdates).toBeGreaterThan(0));
+      expect(worker.diffRequestCount).toBe(0);
+
+      await renderer.refreshHighlightedResult();
+      expect(worker.diffRequestCount).toBe(0);
+    } finally {
+      manager.terminate();
+    }
+  });
+});
+
+describe('File component edit session', () => {
+  test('attaching an editor starts the session; detaching ends it', async () => {
+    const dom = installDom();
+    const { manager, worker } = await createInitializedManager({
+      theme: 'pierre-dark',
+    });
+    try {
+      const instance = new File(
+        { theme: 'pierre-dark', disableFileHeader: true },
+        manager
+      );
+      const fileContainer = document.createElement('div');
+      fileContainer.attachShadow({ mode: 'open' });
+      const file = createFile('file:component');
+
+      instance.render({ file, fileContainer, forceRender: true });
+      const request = await withTimeout(worker.waitForFileRequest());
+      expect(worker.fileRequestCount).toBe(1);
+      // Resolve the pool highlight before attaching so the session phase
+      // starts from settled pool markup and an idle task queue — a session
+      // render that leaked to the pool would then show up as request #2.
+      respondToFileRequest(
+        manager,
+        worker,
+        request,
+        plainFileCode(FILE_CONTENTS)
+      );
+
+      const editorStub = {
+        cleanUp: () => undefined,
+        __syncRenderView: () => undefined,
+        __postponeBgTokenizeToNextFrame: () => undefined,
+        __captureFocusForDOMReplacement: () => undefined,
+      } as unknown as DiffsEditor<undefined>;
+      const detach = instance.attachEditor(editorStub);
+      instance.rerender();
+      await waitFor(() => {
+        expect(fileContainer.shadowRoot?.innerHTML ?? '').toContain(
+          'data-char'
+        );
+      });
+      expect(worker.fileRequestCount).toBe(1);
+
+      // With the session over, the next render adopts the pool's cached
+      // (non-transformer) result: pool markup replaces the editor markup.
+      detach();
+      instance.rerender();
+      await waitFor(() => {
+        expect(fileContainer.shadowRoot?.innerHTML ?? '').not.toContain(
+          'data-char'
+        );
+      });
+      expect(worker.fileRequestCount).toBe(1);
+      instance.cleanUp();
+    } finally {
+      manager.terminate();
+      dom.cleanup();
+    }
+  });
+});
+
+describe('FileDiff component edit session', () => {
+  test('an attached editor renders the diff locally with token markup', async () => {
+    const dom = installDom();
+    const { manager, worker } = await createInitializedManager({
+      theme: 'pierre-dark',
+    });
+    try {
+      const instance = new FileDiff(
+        { theme: 'pierre-dark', disableFileHeader: true },
+        manager
+      );
+      const fileContainer = document.createElement('div');
+      fileContainer.attachShadow({ mode: 'open' });
+      const fileDiff = parseDiffFromFile(
+        {
+          name: 'demo.ts',
+          contents: 'const value = "old";\n',
+          cacheKey: 'fd:old',
+        },
+        {
+          name: 'demo.ts',
+          contents: 'const value = "new";\n',
+          cacheKey: 'fd:new',
+        }
+      );
+
+      instance.render({ fileDiff, fileContainer, forceRender: true });
+      await withTimeout(worker.waitForDiffRequest());
+      expect(worker.diffRequestCount).toBe(1);
+
+      const editorStub = {
+        cleanUp: () => undefined,
+        __syncRenderView: () => undefined,
+        __postponeBgTokenizeToNextFrame: () => undefined,
+        __captureFocusForDOMReplacement: () => undefined,
+      } as unknown as DiffsEditor<undefined>;
+      instance.attachEditor(editorStub);
+      instance.rerender();
+      await waitFor(() => {
+        expect(fileContainer.shadowRoot?.innerHTML ?? '').toContain(
+          'data-char'
+        );
+      });
+      instance.cleanUp();
+    } finally {
+      manager.terminate();
+      dom.cleanup();
+    }
+  });
+});

--- a/packages/diffs/test/reactEditorOptions.test.ts
+++ b/packages/diffs/test/reactEditorOptions.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, mock, test } from 'bun:test';
+import { afterAll, describe, expect, mock, spyOn, test } from 'bun:test';
 import {
   act,
   type ComponentType,
@@ -232,14 +232,26 @@ function createEditableSurfaceElement(
   });
 }
 
-describe('React Edit surface option normalization', () => {
-  test('File enables the token transformer while editing', async () => {
+// Custom elements isolate rendered markup behind a shadow root; find it
+// under the React container for markup assertions.
+function shadowHTML(container: HTMLElement): string {
+  for (const el of Array.from(container.querySelectorAll('*'))) {
+    if (el.shadowRoot != null) {
+      return el.shadowRoot.innerHTML;
+    }
+  }
+  return '';
+}
+
+describe('React edit surfaces', () => {
+  test('File renders editor token markup without mutating options', async () => {
     const { cleanup } = installDom();
     const cleanupActEnvironment = installReactActEnvironment();
     const container = document.createElement('div');
     document.body.appendChild(container);
     let instance: FileInstance<undefined> | undefined;
     let root: Root | undefined;
+    let updates = 0;
     const options: FileOptions<undefined> = {
       disableFileHeader: true,
       theme: DEFAULT_THEMES,
@@ -247,6 +259,9 @@ describe('React Edit surface option normalization', () => {
       onPostRender(_node, current, phase) {
         if (phase !== 'unmount') {
           instance = current;
+        }
+        if (phase === 'update') {
+          updates++;
         }
       },
     };
@@ -269,7 +284,17 @@ describe('React Edit surface option normalization', () => {
       });
 
       expect(instance).toBeDefined();
-      expect(instance!.options.useTokenTransformer).toBe(true);
+      // The attach-time session render supplies the token markup; public
+      // options are never rewritten for the editor.
+      await waitFor(() => shadowHTML(container).includes('data-char'), {
+        timeout: 4000,
+      });
+      // waitFor times out silently; this is the real assertion.
+      expect(shadowHTML(container)).toContain('data-char');
+      expect(instance!.options.useTokenTransformer).toBe(false);
+      // Mounting straight into edit renders once without a session and again
+      // at editor attach — the accepted pre-paint cost of mount-into-edit.
+      expect(updates).toBeGreaterThanOrEqual(1);
     } finally {
       await unmountRoot(root);
       cleanupActEnvironment();
@@ -277,7 +302,7 @@ describe('React Edit surface option normalization', () => {
     }
   });
 
-  test('FileDiff enables the token transformer while editing', async () => {
+  test('FileDiff renders editor token markup without mutating options', async () => {
     const { cleanup } = installDom();
     const cleanupActEnvironment = installReactActEnvironment();
     const container = document.createElement('div');
@@ -317,8 +342,63 @@ describe('React Edit surface option normalization', () => {
       });
 
       expect(instance).toBeDefined();
-      expect(instance!.options.useTokenTransformer).toBe(true);
+      // The attach-time session render supplies the token markup; public
+      // options are never rewritten for the editor.
+      await waitFor(() => shadowHTML(container).includes('data-char'), {
+        timeout: 4000,
+      });
+      // waitFor times out silently; this is the real assertion.
+      expect(shadowHTML(container)).toContain('data-char');
+      expect(instance!.options.useTokenTransformer).toBe(false);
     } finally {
+      await unmountRoot(root);
+      cleanupActEnvironment();
+      cleanup();
+    }
+  });
+
+  test('an unchanged commit does not force-render an optionless edit surface', async () => {
+    const { cleanup } = installDom();
+    const cleanupActEnvironment = installReactActEnvironment();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const renderSpy = spyOn(FileInstance.prototype, 'render');
+    let root: Root | undefined;
+    const file = { name: 'edit.ts', contents: 'const value = 1;\n' };
+    // A fresh element per commit: rendering an identical element reference
+    // makes React bail out entirely, which would skip the layout effects
+    // this test exists to observe.
+    const makeElement = () =>
+      createElement(
+        EditProviderComponent,
+        { createEditor },
+        createElement(ReactFileComponent, {
+          disableWorkerPool: true,
+          edit: true,
+          file,
+        })
+      );
+    try {
+      root = createReactRoot(container);
+      await act(async () => {
+        root!.render(makeElement());
+        await wait(10);
+      });
+      await wait(50);
+      const forcedRenders = () =>
+        renderSpy.mock.calls.filter((call) => call[0]?.forceRender === true)
+          .length;
+      const forcedBefore = forcedRenders();
+
+      // With no options prop the merged options are undefined every commit;
+      // that must compare clean instead of force-rendering the edited file.
+      await act(async () => {
+        root!.render(makeElement());
+        await wait(10);
+      });
+      expect(forcedRenders()).toBe(forcedBefore);
+    } finally {
+      renderSpy.mockRestore();
       await unmountRoot(root);
       cleanupActEnvironment();
       cleanup();

--- a/packages/diffs/test/workerPoolHarness.ts
+++ b/packages/diffs/test/workerPoolHarness.ts
@@ -1,0 +1,253 @@
+import type { ElementContent } from 'hast';
+
+import type {
+  InitializeWorkerRequest,
+  RenderDiffRequest,
+  RenderFileRequest,
+  WorkerInitializationRenderOptions,
+  WorkerRequest,
+  WorkerResponse,
+} from '../src/worker/types';
+import { WorkerPoolManager } from '../src/worker/WorkerPoolManager';
+
+// WorkerPoolManager schedules its broadcasts through requestAnimationFrame,
+// which Bun's test environment does not provide. Installs a setTimeout-backed
+// substitute and returns a restore function for afterAll.
+export function installAnimationFramePolyfill(): () => void {
+  const originalRequestAnimationFrame =
+    typeof globalThis.requestAnimationFrame === 'function'
+      ? globalThis.requestAnimationFrame
+      : undefined;
+  const originalCancelAnimationFrame =
+    typeof globalThis.cancelAnimationFrame === 'function'
+      ? globalThis.cancelAnimationFrame
+      : undefined;
+  let nextFrameId = 0;
+  const frames = new Map<number, ReturnType<typeof setTimeout>>();
+
+  globalThis.requestAnimationFrame = ((callback) => {
+    const id = ++nextFrameId;
+    const timeout = setTimeout(() => {
+      frames.delete(id);
+      callback(performance.now());
+    }, 0);
+    frames.set(id, timeout);
+    return id;
+  }) as typeof requestAnimationFrame;
+
+  globalThis.cancelAnimationFrame = ((id) => {
+    const timeout = frames.get(id);
+    if (timeout != null) {
+      clearTimeout(timeout);
+      frames.delete(id);
+    }
+  }) as typeof cancelAnimationFrame;
+
+  return () => {
+    for (const timeout of frames.values()) {
+      clearTimeout(timeout);
+    }
+    frames.clear();
+    if (originalRequestAnimationFrame != null) {
+      globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    } else {
+      Reflect.deleteProperty(globalThis, 'requestAnimationFrame');
+    }
+    if (originalCancelAnimationFrame != null) {
+      globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+    } else {
+      Reflect.deleteProperty(globalThis, 'cancelAnimationFrame');
+    }
+  };
+}
+
+// A plain object substituted for a browser Worker through `workerFactory`.
+// Records posted requests by type and delivers responses to the manager's
+// message listeners on demand, so tests fully control response timing.
+export class TestWorker {
+  terminated = false;
+  private diffRequests: RenderDiffRequest[] = [];
+  private diffRequestResolve:
+    | ((request: RenderDiffRequest) => void)
+    | undefined;
+  private fileRequests: RenderFileRequest[] = [];
+  private fileRequestResolve:
+    | ((request: RenderFileRequest) => void)
+    | undefined;
+  private initializeRequest: InitializeWorkerRequest | undefined;
+  private initializeRequestResolve:
+    | ((request: InitializeWorkerRequest) => void)
+    | undefined;
+  private readonly initializeRequestPromise =
+    new Promise<InitializeWorkerRequest>((resolve) => {
+      this.initializeRequestResolve = resolve;
+    });
+  private readonly messageListeners = new Set<
+    (event: MessageEvent<WorkerResponse>) => void
+  >();
+
+  addEventListener(
+    type: string,
+    listener: (event: MessageEvent<WorkerResponse>) => void
+  ): void {
+    if (type === 'message') {
+      this.messageListeners.add(listener);
+    }
+  }
+
+  postMessage(request: WorkerRequest): void {
+    // Browser workers synchronously clone a message before returning.
+    const clonedRequest = structuredClone(request);
+    if (clonedRequest.type === 'initialize') {
+      this.initializeRequest = clonedRequest;
+      this.initializeRequestResolve?.(clonedRequest);
+    } else if (clonedRequest.type === 'diff') {
+      this.diffRequests.push(clonedRequest);
+      this.diffRequestResolve?.(clonedRequest);
+      this.diffRequestResolve = undefined;
+    } else if (clonedRequest.type === 'file') {
+      this.fileRequests.push(clonedRequest);
+      this.fileRequestResolve?.(clonedRequest);
+      this.fileRequestResolve = undefined;
+    }
+  }
+
+  terminate(): void {
+    this.terminated = true;
+  }
+
+  async waitForInitializeRequest(): Promise<InitializeWorkerRequest> {
+    return this.initializeRequest ?? this.initializeRequestPromise;
+  }
+
+  get diffRequestCount(): number {
+    return this.diffRequests.length;
+  }
+
+  get fileRequestCount(): number {
+    return this.fileRequests.length;
+  }
+
+  async waitForDiffRequest(): Promise<RenderDiffRequest> {
+    const request = this.diffRequests.at(-1);
+    if (request != null) {
+      return request;
+    }
+    return new Promise<RenderDiffRequest>((resolve) => {
+      this.diffRequestResolve = resolve;
+    });
+  }
+
+  async waitForFileRequest(): Promise<RenderFileRequest> {
+    const request = this.fileRequests.at(-1);
+    if (request != null) {
+      return request;
+    }
+    return new Promise<RenderFileRequest>((resolve) => {
+      this.fileRequestResolve = resolve;
+    });
+  }
+
+  respond(response: WorkerResponse): void {
+    for (const listener of this.messageListeners) {
+      listener({ data: response } as MessageEvent<WorkerResponse>);
+    }
+  }
+}
+
+export function createInitializingManager(
+  initOptions: Partial<WorkerInitializationRenderOptions> = {}
+): {
+  initialization: Promise<void>;
+  manager: WorkerPoolManager;
+  worker: TestWorker;
+} {
+  const worker = new TestWorker();
+  const manager = new WorkerPoolManager(
+    {
+      poolSize: 1,
+      workerFactory: () => worker as unknown as Worker,
+    },
+    {
+      langs: [],
+      preferredHighlighter: 'shiki-js',
+      theme: 'github-dark',
+      ...initOptions,
+    }
+  );
+  return {
+    initialization: manager.initialize(),
+    manager,
+    worker,
+  };
+}
+
+export async function createInitializedManager(
+  initOptions: Partial<WorkerInitializationRenderOptions> = {}
+): Promise<{
+  manager: WorkerPoolManager;
+  worker: TestWorker;
+}> {
+  const { initialization, manager, worker } =
+    createInitializingManager(initOptions);
+  const request = await worker.waitForInitializeRequest();
+  worker.respond({
+    type: 'success',
+    requestType: 'initialize',
+    id: request.id,
+    sentAt: Date.now(),
+  });
+  await withTimeout(initialization);
+  return { manager, worker };
+}
+
+export function respondToDiffRequest(
+  manager: WorkerPoolManager,
+  worker: TestWorker,
+  request: RenderDiffRequest
+): void {
+  worker.respond({
+    type: 'success',
+    requestType: 'diff',
+    id: request.id,
+    result: {
+      code: { additionLines: [], deletionLines: [] },
+      themeStyles: '',
+      baseThemeType: undefined,
+    },
+    options: manager.getDiffRenderOptions(),
+    sentAt: Date.now(),
+  });
+}
+
+export function respondToFileRequest(
+  manager: WorkerPoolManager,
+  worker: TestWorker,
+  request: RenderFileRequest,
+  code: ElementContent[] = []
+): void {
+  worker.respond({
+    type: 'success',
+    requestType: 'file',
+    id: request.id,
+    result: {
+      code,
+      themeStyles: '',
+      baseThemeType: undefined,
+    },
+    options: manager.getFileRenderOptions(),
+    sentAt: Date.now(),
+  });
+}
+
+export function withTimeout<T>(promise: Promise<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('Timed out waiting for promise to settle'));
+    }, 5_000);
+
+    promise.then(resolve, reject).finally(() => {
+      clearTimeout(timeout);
+    });
+  });
+}


### PR DESCRIPTION
So the idea of this PR is to improve the develop experience around editing.

Editing a file requires `useTokenTransform` enabled and I was not a fan of having that be a requirement that developers have to manage given it can really balloon dom node count and has a measurable highlighting impact.

However, after doing a bit more digging and thinking about it, I realized that all highlighting for edit already goes through the main thread highlighter, and that particular highlighter can easily take whatever customization props we need (vs WorkerPool which tries to save rendering options and has to re-highlight all visible files whenever a setting changes.

Because of this, I came up with the idea that we can stop requiring this prop to be set by the developer, and just silently send it through when in edit mode. If the file was previously highlighted without `useTokenTransform`, we can just kick off a new highlight using the main thread highlighter to rectify the DOM and then do our normal edit highlight infrastructure. Devs can still force the prop to be always on to avoid the initial re-highlight of the file on edit.

This does mean that while in edit mode on a file or diff, it's ALWAYS using the main thread highlighter, regardless. I think this is actually a good thing anyways, because we get into potentially weird territory with trying to allow the edit highlighter AND the worker pool at the same time, and we ensure they don't fight with each other.

So in summary: `useTokenTransform` becomes an internal edit mode responsibility. Devs don't have to think about it, and all the weird previous architecture that was forcing new options is no longer needed.