### PR TITLE
[diffs/edit] Virtualization Edit Bug

### DIFF
--- a/apps/docs/app/(diffs)/playground/constants.ts
+++ b/apps/docs/app/(diffs)/playground/constants.ts
@@ -402,17 +402,178 @@ function variantDiff(base: BaseDiff, index: number): FileDiffMetadata {
   );
 }
 
-// Diffs rendered as a list in the Virtualizer (window/body scroll) mode.
-export const VIRTUALIZER_FILE_DIFFS: FileDiffMetadata[] = Array.from(
-  { length: DIFF_VARIANT_COUNT },
-  (_, index) => BASE_DIFFS.map((base) => variantDiff(base, index))
-).flat();
+// -----------------------------------------------------------------------------
+// Long single-file fixture
+//
+// One diff tall enough to scroll through on its own: a generated "resource
+// registry" module with a get/list helper pair per table. Edits land in every
+// pair, so the rendered diff stays fully expanded (no collapsed unchanged
+// regions) and runs 600+ rows top to bottom.
+// -----------------------------------------------------------------------------
 
-// Items rendered in the CodeView mode: each variant contributes two diffs and a
-// plain file so the demo shows both item types scrolling within CodeView's own
+const LONG_FIXTURE_NAME = 'api/resources.ts';
+
+// Each table yields a ~14-line (old) / ~18-line (new) helper pair; 30 tables
+// keep the generated file past 500 lines. Every name pluralizes with a bare
+// `s`, which is how the table accessor and list-helper names are derived.
+const LONG_FIXTURE_TABLES = [
+  'account',
+  'project',
+  'repo',
+  'commit',
+  'issue',
+  'comment',
+  'label',
+  'milestone',
+  'review',
+  'deployment',
+  'webhook',
+  'token',
+  'session',
+  'team',
+  'invite',
+  'notification',
+  'tag',
+  'release',
+  'artifact',
+  'pipeline',
+  'job',
+  'runner',
+  'secret',
+  'environment',
+  'alert',
+  'dashboard',
+  'report',
+  'audit',
+  'changelog',
+  'snapshot',
+];
+
+// Builds the old/new contents of the long fixture. The new side rewrites each
+// helper pair — `get*` gains a missing-record throw (and drops `| null`),
+// `list*` gains a default limit and an `orderBy` — so a change lands at least
+// every ~6 lines. With the widened diff context in `longFixtureDiff`, that
+// density keeps the whole file in a single hunk with every line visible.
+function buildLongFixtureContents(): {
+  oldContents: string;
+  newContents: string;
+} {
+  const oldLines: string[] = [
+    '/**',
+    ' * Resource registry – CRUD helpers for every synced table.',
+    ' * @module api/resources',
+    ' */',
+    '',
+    "import { db } from './database';",
+    '',
+    'export interface Resource {',
+    '  id: string;',
+    '  createdAt: Date;',
+    '}',
+    '',
+  ];
+  const newLines: string[] = [
+    '/**',
+    ' * Resource registry – CRUD helpers for every synced table.',
+    ' * @module api/resources',
+    ' */',
+    '',
+    "import { db } from './database';",
+    "import { NotFoundError } from './errors';",
+    '',
+    'export interface Resource {',
+    '  id: string;',
+    '  createdAt: Date;',
+    '  updatedAt: Date;',
+    '}',
+    '',
+  ];
+
+  LONG_FIXTURE_TABLES.forEach((table, index) => {
+    const single = table.charAt(0).toUpperCase() + table.slice(1);
+    const plural = `${table}s`;
+    const defaultLimit = 20 + (index % 4) * 10;
+
+    oldLines.push(
+      `/** CRUD helpers for the \`${plural}\` table. */`,
+      `export async function get${single}(id: string): Promise<Resource | null> {`,
+      `  const record = await db.${plural}.findUnique({`,
+      '    where: { id },',
+      '  });',
+      '  return record;',
+      '}',
+      '',
+      `export async function list${single}s(limit: number): Promise<Resource[]> {`,
+      `  return db.${plural}.findMany({`,
+      '    take: limit,',
+      '  });',
+      '}',
+      ''
+    );
+    newLines.push(
+      `/** CRUD helpers for the \`${plural}\` table. */`,
+      `export async function get${single}(id: string): Promise<Resource> {`,
+      `  const record = await db.${plural}.findUnique({`,
+      '    where: { id },',
+      '  });',
+      '  if (record === null) {',
+      `    throw new NotFoundError('${table}', id);`,
+      '  }',
+      '  return record;',
+      '}',
+      '',
+      `export async function list${single}s(limit = ${defaultLimit}): Promise<Resource[]> {`,
+      `  return db.${plural}.findMany({`,
+      '    take: limit,',
+      "    orderBy: { createdAt: 'desc' },",
+      '  });',
+      '}',
+      ''
+    );
+  });
+
+  return {
+    oldContents: oldLines.join('\n'),
+    newContents: newLines.join('\n'),
+  };
+}
+
+const LONG_FIXTURE_CONTENTS = buildLongFixtureContents();
+
+// Fresh parse per call so each surface (Virtualizer list, CodeView items) gets
+// its own FileDiffMetadata instance, matching how `variantDiff` builds the
+// replicated fixtures. `context: 8` widens jsdiff's default of 4 so the added
+// import near the top keeps line 1 inside the first hunk instead of leaving a
+// two-line collapsed region above it.
+function longFixtureDiff(): FileDiffMetadata {
+  return parseDiffFromFile(
+    { name: LONG_FIXTURE_NAME, contents: LONG_FIXTURE_CONTENTS.oldContents },
+    { name: LONG_FIXTURE_NAME, contents: LONG_FIXTURE_CONTENTS.newContents },
+    { context: 8 }
+  );
+}
+
+// Diffs rendered as a list in the Virtualizer (window/body scroll) mode. The
+// long single-file fixture leads so scroll-heavy behavior inside one file is
+// reachable without paging through the shorter variants first.
+export const VIRTUALIZER_FILE_DIFFS: FileDiffMetadata[] = [
+  longFixtureDiff(),
+  ...Array.from({ length: DIFF_VARIANT_COUNT }, (_, index) =>
+    BASE_DIFFS.map((base) => variantDiff(base, index))
+  ).flat(),
+];
+
+// Items rendered in the CodeView mode: the long single-file diff leads (as in
+// the Virtualizer list), then each variant contributes two diffs and a plain
+// file so the demo shows both item types scrolling within CodeView's own
 // scroll container.
-export const CODE_VIEW_ITEMS: CodeViewItem<PlaygroundAnnotationMetadata>[] =
-  Array.from(
+export const CODE_VIEW_ITEMS: CodeViewItem<PlaygroundAnnotationMetadata>[] = [
+  {
+    id: `diff:${LONG_FIXTURE_NAME}`,
+    type: 'diff',
+    fileDiff: longFixtureDiff(),
+  },
+  ...Array.from(
     { length: DIFF_VARIANT_COUNT },
     (_, index): CodeViewItem<PlaygroundAnnotationMetadata>[] => {
       const readmeName = variantName('README.md', index);
@@ -439,7 +600,8 @@ export const CODE_VIEW_ITEMS: CodeViewItem<PlaygroundAnnotationMetadata>[] =
         },
       ];
     }
-  ).flat();
+  ).flat(),
+];
 
 export const ITEM_UNSAFE_CSS = `${CustomScrollbarCSS}
 [data-diffs-header] {

--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -2253,6 +2253,19 @@ function withContentProperties(
   };
 }
 
+// Number of entries in a split-line array that hold document content. A
+// document ending in a line break is represented two ways during a session:
+// the parsed-diff shape (`splitFileContents`) has no entry for the empty line
+// that final break implies, while the editor-document shape
+// (`getEditorDocumentLines`) exposes it as a trailing `''` entry. Only that
+// representational tail is ever `''` — every other entry keeps its line break
+// or is the raw final line — so trimming it yields comparable content lines.
+function contentLineCount(lines: string[]): number {
+  return lines.length > 0 && lines[lines.length - 1] === ''
+    ? lines.length - 1
+    : lines.length;
+}
+
 // Realigns the cached per-line addition HAST array with an edited document.
 // Cached entries are looked up by line index, so a line inserted or removed
 // mid-document must shift the surviving entries to their new indexes —
@@ -2260,13 +2273,21 @@ function withContentProperties(
 // line's stale tokens once they become visible. Entries outside the changed
 // window keep their highlighted content; entries inside it become plain-text
 // elements that the editor re-tokenizes on its next background pass.
+//
+// The bottom-up scan runs over content lines only: a session's first
+// line-count edit still has `previousLines` in the parsed-diff shape while
+// `nextLines` is editor-shaped, and comparing the raw tails would mismatch on
+// the representational trailing `''`, zero out the suffix, and plain-fill
+// every line below the tokenizer's render window.
 function realignAdditionHastLines(
   previousLines: string[],
   nextLines: string[],
   hastLines: ElementContent[],
   textDocument: DiffsTextDocument
 ): ElementContent[] {
-  const maxShared = Math.min(previousLines.length, nextLines.length);
+  const previousContentLength = contentLineCount(previousLines);
+  const nextContentLength = contentLineCount(nextLines);
+  const maxShared = Math.min(previousContentLength, nextContentLength);
   let prefix = 0;
   while (prefix < maxShared && previousLines[prefix] === nextLines[prefix]) {
     prefix++;
@@ -2274,8 +2295,8 @@ function realignAdditionHastLines(
   let suffix = 0;
   while (
     suffix < maxShared - prefix &&
-    previousLines[previousLines.length - 1 - suffix] ===
-      nextLines[nextLines.length - 1 - suffix]
+    previousLines[previousContentLength - 1 - suffix] ===
+      nextLines[nextContentLength - 1 - suffix]
   ) {
     suffix++;
   }
@@ -2285,15 +2306,22 @@ function realignAdditionHastLines(
     realigned[index] = hastLines[index];
   }
   for (let offset = 0; offset < suffix; offset++) {
-    realigned[nextLines.length - 1 - offset] =
-      hastLines[previousLines.length - 1 - offset];
+    realigned[nextContentLength - 1 - offset] =
+      hastLines[previousContentLength - 1 - offset];
+  }
+  // A trailing empty entry present on both sides keeps its cached row.
+  if (
+    previousContentLength < previousLines.length &&
+    nextContentLength < nextLines.length
+  ) {
+    realigned[nextLines.length - 1] = hastLines[previousLines.length - 1];
   }
   // Deferred tokenization can write entries past the previous line count;
   // those were produced with post-edit indexes and are already in place.
   for (let index = previousLines.length; index < nextLines.length; index++) {
     realigned[index] ??= hastLines[index];
   }
-  for (let index = prefix; index < nextLines.length - suffix; index++) {
+  for (let index = prefix; index < nextLines.length; index++) {
     realigned[index] ??= createPlainAdditionLineElement(index, textDocument);
   }
   return realigned;

--- a/packages/diffs/test/DiffHunksRendererRecompute.test.ts
+++ b/packages/diffs/test/DiffHunksRendererRecompute.test.ts
@@ -363,6 +363,84 @@ describe('DiffHunksRenderer edit-session hunk updates', () => {
     ]);
   });
 
+  test('a bounded-window line-count edit keeps highlighted rows below the window', async () => {
+    // Virtualized surfaces tokenize only the visible render window on a
+    // structural edit; rows below it rely on realignAdditionHastLines
+    // shifting their cached highlighted entries into place. The session's
+    // first line-count edit compares parsed-diff-shaped additionLines (no
+    // trailing empty entry) against the editor-shaped document (which gains
+    // one when the file ends in a line break) — the bottom-up scan must not
+    // mismatch on that representational tail, or every row below the window
+    // is plain-filled and stays unhighlighted for the rest of the session.
+    const lineText = (n: number) => `const value${n} = ${n};`;
+    const totalLines = 30;
+    const oldLines = Array.from({ length: totalLines }, (_, index) =>
+      lineText(index + 1)
+    );
+    const newLines = [...oldLines];
+    newLines[0] = 'const changed = 0;';
+    const renderer = new DiffHunksRenderer({
+      theme: 'github-light',
+      diffStyle: 'split',
+    });
+    // Full-context parse so every line renders as a row (no collapsed
+    // context), mirroring the playground's fully expanded long diff.
+    const diff = parseDiffFromFile(
+      { name: 'window.ts', contents: oldLines.join('\n') + '\n' },
+      { name: 'window.ts', contents: newLines.join('\n') + '\n' },
+      { context: totalLines }
+    );
+    await renderer.asyncRender(diff);
+    renderer.renderDiff(diff);
+    renderer.beginEditSession();
+
+    const styledRowTexts = (result: ReturnType<typeof renderer.renderDiff>) =>
+      collectAllElements(result?.additionsContentAST ?? [])
+        .filter(
+          (node) =>
+            node.properties?.['data-line'] != null &&
+            JSON.stringify(node).includes('color:')
+        )
+        .map((node) => hastTextContent(node).replace(/\n$/, ''));
+    expect(styledRowTexts(renderer.renderDiff(diff))).toContain(
+      lineText(totalLines)
+    );
+
+    // Delete new-file lines 2-3: every following line shifts up two indexes.
+    const editedLines = [...newLines];
+    editedLines.splice(1, 2);
+    // The foreground tokenize pass covers a [0, 10) render window and writes
+    // post-edit contents at post-edit indexes before the realign runs.
+    const windowEnd = 10;
+    renderer.updateRenderCache(
+      makeDirtyLines(
+        editedLines
+          .slice(1, windowEnd)
+          .map((text, offset): [number, string] => [1 + offset, text])
+      ),
+      'light',
+      true
+    );
+    renderer.applyDocumentChange(
+      makeTextDocumentFromText(editedLines.join('\n') + '\n')
+    );
+
+    let styled = styledRowTexts(renderer.renderDiff(diff));
+    expect(styled).toContain(lineText(windowEnd + 5));
+    expect(styled).toContain(lineText(totalLines));
+
+    // A later structural edit realigns editor-shaped lines on both sides;
+    // rows below the edit must keep riding their shifted cache entries.
+    editedLines.splice(1, 1);
+    renderer.applyDocumentChange(
+      makeTextDocumentFromText(editedLines.join('\n') + '\n')
+    );
+
+    styled = styledRowTexts(renderer.renderDiff(diff));
+    expect(styled).toContain(lineText(windowEnd + 5));
+    expect(styled).toContain(lineText(totalLines));
+  });
+
   test('reverting a hunk keeps it as a context-only region', async () => {
     const { renderer, diff } = await createSessionRenderer();
     const boundsBefore = diff.hunks.map((hunk) => ({


### PR DESCRIPTION
While doing some testing with longer virtualized files, I came across an issue where deleting a few lines of text, and then scrolling down would trigger the bunch of new lines rendered as you scroll to come in as plain text.

It's a bug that's been around for a bit, it's just unfortunate that we never really caught it in the playground because none of the virtualized files were long enough to exhibit this.

So this PR adds a longer file example to make it easier for us to catch these issues in the future, and fixes the bug.

**BEFORE:**

https://github.com/user-attachments/assets/1c41c05c-f14e-4019-afbc-52494ecf4c69

**AFTER:**

https://github.com/user-attachments/assets/50c4d486-5c6e-4561-8c65-6bdb81bc683c