### PR TITLE
[diffs/edit] More Virtualization Edit Fixes

### DIFF
--- a/apps/docs/app/(diffs)/playground/PlaygroundClient.tsx
+++ b/apps/docs/app/(diffs)/playground/PlaygroundClient.tsx
@@ -119,8 +119,10 @@ const EMPTY_ANNOTATIONS: DiffLineAnnotation<PlaygroundAnnotationMetadata>[] =
 // on the annotation metadata generic, so a single annotation-agnostic type keeps
 // them assignable to FileDiff, VirtualizedFileDiff, and CodeView alike (spreading
 // a `<undefined>`-typed options object into an annotated FileDiff would otherwise
-// widen its annotation callbacks to `undefined`).
-type SharedRenderOptions = Pick<
+// widen its annotation callbacks to `undefined`). The Virtualizer views take
+// this as their options prop: it carries no callback keys, so it also spreads
+// cleanly into the plain-file FileOptions their README surface uses.
+export type SharedRenderOptions = Pick<
   FileDiffOptions<undefined>,
   | 'diffStyle'
   | 'diffIndicators'

--- a/apps/docs/app/(diffs)/playground/PlaygroundVirtualizerElementView.tsx
+++ b/apps/docs/app/(diffs)/playground/PlaygroundVirtualizerElementView.tsx
@@ -5,24 +5,31 @@ import {
   type DiffLineAnnotation,
   type FileDiffMetadata,
   type FileDiffOptions,
+  type FileOptions,
   isDiffAnnotationCollection,
   type SelectedLineRange,
 } from '@pierre/diffs';
 import type { EditorOptions } from '@pierre/diffs/edit';
-import { FileDiff, useStableCallback, Virtualizer } from '@pierre/diffs/react';
+import {
+  File,
+  FileDiff,
+  useStableCallback,
+  Virtualizer,
+} from '@pierre/diffs/react';
 import { IconCheckboxFill, IconSquircleLg } from '@pierre/icons';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { flushSync } from 'react-dom';
 
 import type { PlaygroundAnnotationMetadata } from './constants';
-import { ITEM_UNSAFE_CSS } from './constants';
+import { ITEM_UNSAFE_CSS, LONG_README_FILE } from './constants';
+import type { SharedRenderOptions } from './PlaygroundClient';
 import { CommentForm, CommentThread } from './PlaygroundComments';
 
 const SCROLL_REGION_STYLES = { height: '70vh', overflow: 'auto' } as const;
 
 interface PlaygroundVirtualizerElementViewProps {
   diffs: FileDiffMetadata[];
-  options: FileDiffOptions<PlaygroundAnnotationMetadata>;
+  options: SharedRenderOptions;
   enableLineSelection: boolean;
   enableGutterComments: boolean;
   showAnnotations: boolean;
@@ -33,7 +40,8 @@ interface PlaygroundVirtualizerElementViewProps {
 // fixed-height scroll region, in contrast to the window-scroll variant that
 // drives the vanilla Virtualizer against `document`. Any React <FileDiff>
 // nested under <Virtualizer> auto-virtualizes through context; no imperative
-// wiring is needed.
+// wiring is needed. The long README plain file leads the list (as in
+// CodeView), rendered through <File>, which virtualizes the same way.
 export function PlaygroundVirtualizerElementView({
   diffs,
   options,
@@ -46,6 +54,7 @@ export function PlaygroundVirtualizerElementView({
       className="border-border rounded-lg border"
       style={SCROLL_REGION_STYLES}
     >
+      <ElementVirtualizerFile options={options} />
       {diffs.map((fileDiff) => (
         <ElementVirtualizerDiff
           key={fileDiff.name}
@@ -57,6 +66,59 @@ export function PlaygroundVirtualizerElementView({
         />
       ))}
     </Virtualizer>
+  );
+}
+
+const FILE_EDITOR_OPTIONS: EditorOptions<undefined> = {
+  onAttach(editor) {
+    editor.focus({ lineNumber: 'first-visible', preventScroll: true });
+  },
+};
+
+// The long README plain-file surface leading the list. Carries the same
+// header Edit toggle as the diffs (the app-level EditProvider creates its
+// editor); no comment wiring, since the demo file has no annotations.
+function ElementVirtualizerFile({ options }: { options: SharedRenderOptions }) {
+  const [editing, setEditing] = useState(false);
+
+  const fileOptions = useMemo<FileOptions<undefined>>(
+    () => ({
+      ...options,
+      stickyHeader: true,
+      unsafeCSS: ITEM_UNSAFE_CSS,
+    }),
+    [options]
+  );
+
+  // Must NOT be a stable callback — see ElementVirtualizerDiff's
+  // renderHeaderMetadata for why a per-`editing` useCallback is required.
+  const renderHeaderMetadata = useCallback(() => {
+    return (
+      <button
+        type="button"
+        onClick={() => setEditing((current) => !current)}
+        aria-pressed={editing}
+        className="playground-edit-toggle"
+      >
+        <IconCheckboxFill
+          size={12}
+          className="playground-edit-toggle-icon-on"
+        />
+        <IconSquircleLg size={12} className="playground-edit-toggle-icon-off" />
+        <span className="playground-edit-toggle-label-on">Editing</span>
+        <span className="playground-edit-toggle-label-off">Edit</span>
+      </button>
+    );
+  }, [editing]);
+
+  return (
+    <File
+      file={LONG_README_FILE}
+      edit={editing}
+      options={fileOptions}
+      editorOptions={FILE_EDITOR_OPTIONS}
+      renderHeaderMetadata={renderHeaderMetadata}
+    />
   );
 }
 

--- a/apps/docs/app/(diffs)/playground/PlaygroundVirtualizerView.tsx
+++ b/apps/docs/app/(diffs)/playground/PlaygroundVirtualizerView.tsx
@@ -3,8 +3,8 @@
 import {
   type DiffLineAnnotation,
   type FileDiffMetadata,
-  type FileDiffOptions,
   isDiffAnnotationCollection,
+  VirtualizedFile,
   VirtualizedFileDiff,
   Virtualizer,
 } from '@pierre/diffs';
@@ -14,12 +14,13 @@ import { useEffect, useRef } from 'react';
 import { flushSync } from 'react-dom';
 import { createRoot, type Root } from 'react-dom/client';
 
-import { ITEM_UNSAFE_CSS } from './constants';
+import { ITEM_UNSAFE_CSS, LONG_README_FILE } from './constants';
+import type { SharedRenderOptions } from './PlaygroundClient';
 import { CommentForm, CommentThread } from './PlaygroundComments';
 
 interface PlaygroundVirtualizerViewProps {
   diffs: FileDiffMetadata[];
-  options: FileDiffOptions<VirtualizerAnnotationMetadata>;
+  options: SharedRenderOptions;
   enableLineSelection: boolean;
   enableGutterComments: boolean;
   showAnnotations: boolean;
@@ -105,6 +106,7 @@ export function PlaygroundVirtualizerView({
   const instancesRef = useRef<
     VirtualizedFileDiff<VirtualizerAnnotationMetadata>[]
   >([]);
+  const fileInstanceRef = useRef<VirtualizedFile | null>(null);
   const annotationsRef = useRef<VirtualizerAnnotation[][]>([]);
   const annotationRootsRef = useRef(new Map<string, Root>());
   const annotationKeyCounterRef = useRef(0);
@@ -134,6 +136,49 @@ export function PlaygroundVirtualizerView({
     const virtualizer = new Virtualizer();
     // Passing `document` makes the page/window the scroll container.
     virtualizer.setup(document);
+
+    // The long README plain file leads the window-scroll list (as in
+    // CodeView), driven by the vanilla VirtualizedFile. It carries the same
+    // header Edit toggle as the diffs below; no comment wiring, since the
+    // demo file has no annotations. Its container is appended first so it
+    // sits above the diffs in the page flow.
+    const readmeContainer = document.createElement('diffs-container');
+    readmeContainer.style.display = 'block';
+    content.appendChild(readmeContainer);
+    const readmeEditor = new Editor<undefined>({
+      onAttach(attachedEditor) {
+        attachedEditor.focus({
+          lineNumber: 'first-visible',
+          preventScroll: true,
+        });
+      },
+    });
+    const readmeToggle = createEditToggle();
+    const fileInstance = new VirtualizedFile(
+      {
+        ...options,
+        renderHeaderMetadata: () => readmeToggle,
+        stickyHeader: true,
+        unsafeCSS: VIRTUALIZER_CUSTOM_CSS,
+      },
+      virtualizer,
+      undefined,
+      pool
+    );
+    readmeToggle.addEventListener('click', () => {
+      const editing = readmeToggle.getAttribute('aria-pressed') !== 'true';
+      readmeToggle.setAttribute('aria-pressed', editing ? 'true' : 'false');
+      if (editing) {
+        readmeEditor.edit(fileInstance);
+      } else {
+        readmeEditor.cleanUp();
+      }
+    });
+    fileInstance.render({
+      file: LONG_README_FILE,
+      fileContainer: readmeContainer,
+    });
+    fileInstanceRef.current = fileInstance;
 
     annotationsRef.current = diffs.map(() => []);
     const editors: Editor<VirtualizerAnnotationMetadata>[] = [];
@@ -319,6 +364,9 @@ export function PlaygroundVirtualizerView({
       for (const instance of instances) {
         instance.cleanUp();
       }
+      readmeEditor.cleanUp();
+      fileInstance.cleanUp();
+      fileInstanceRef.current = null;
       for (const root of annotationRoots.values()) {
         setTimeout(() => root.unmount(), 0);
       }
@@ -344,6 +392,13 @@ export function PlaygroundVirtualizerView({
         ...options,
         enableLineSelection: enableLineSelection && !enableGutterComments,
         enableGutterUtility: enableGutterComments && showAnnotations,
+      });
+    }
+    const fileInstance = fileInstanceRef.current;
+    if (fileInstance != null) {
+      fileInstance.setOptions({
+        ...fileInstance.options,
+        ...options,
       });
     }
   }, [options, enableLineSelection, enableGutterComments, showAnnotations]);

--- a/apps/docs/app/(diffs)/playground/constants.ts
+++ b/apps/docs/app/(diffs)/playground/constants.ts
@@ -275,6 +275,12 @@ const user = await getUser('123');
 \`\`\`
 `;
 
+// The plain-file CodeView items ship the README repeated 10x so the file
+// surfaces are long enough to scroll on their own. Only the file items use
+// this — the diff fixtures keep their authored sizes (one long fixture plus
+// the shorter variants).
+const LONG_README_CONTENT = NEW_README_CONTENT.repeat(10);
+
 // Nested markup with meaningful indentation, for exercising edit-mode diff
 // alignment: wrapping/unwrapping containers, pushing lines around with
 // Enter, and re-indenting all reshape change blocks whose lines differ only
@@ -591,7 +597,7 @@ export const CODE_VIEW_ITEMS: CodeViewItem<PlaygroundAnnotationMetadata>[] = [
         {
           id: `file:${readmeName}`,
           type: 'file',
-          file: { name: readmeName, contents: NEW_README_CONTENT },
+          file: { name: readmeName, contents: LONG_README_CONTENT },
         },
         {
           id: `diff:${variantName(STYLES_BASE.name, index)}`,

--- a/apps/docs/app/(diffs)/playground/constants.ts
+++ b/apps/docs/app/(diffs)/playground/constants.ts
@@ -1,5 +1,6 @@
 import {
   type CodeViewItem,
+  type FileContents,
   type FileDiffMetadata,
   parseDiffFromFile,
 } from '@pierre/diffs';
@@ -275,11 +276,19 @@ const user = await getUser('123');
 \`\`\`
 `;
 
-// The plain-file CodeView items ship the README repeated 10x so the file
-// surfaces are long enough to scroll on their own. Only the file items use
-// this — the diff fixtures keep their authored sizes (one long fixture plus
-// the shorter variants).
+// The plain-file items ship the README repeated 10x so the file surfaces are
+// long enough to scroll on their own. Only the file items use this — the diff
+// fixtures keep their authored sizes (one long fixture plus the shorter
+// variants).
 const LONG_README_CONTENT = NEW_README_CONTENT.repeat(10);
+
+// The long README as a ready-made plain file: leads the CodeView items and
+// both Virtualizer lists. FileContents is never mutated by the library, so
+// one shared instance is fine across surfaces.
+export const LONG_README_FILE: FileContents = {
+  name: 'README.md',
+  contents: LONG_README_CONTENT,
+};
 
 // Nested markup with meaningful indentation, for exercising edit-mode diff
 // alignment: wrapping/unwrapping containers, pushing lines around with
@@ -569,11 +578,16 @@ export const VIRTUALIZER_FILE_DIFFS: FileDiffMetadata[] = [
   ).flat(),
 ];
 
-// Items rendered in the CodeView mode: the long single-file diff leads (as in
-// the Virtualizer list), then each variant contributes two diffs and a plain
-// file so the demo shows both item types scrolling within CodeView's own
-// scroll container.
+// Items rendered in the CodeView mode: the long README file item leads,
+// followed by the long single-file diff (as in the Virtualizer list), then
+// each variant contributes two diffs and a plain file so the demo shows both
+// item types scrolling within CodeView's own scroll container.
 export const CODE_VIEW_ITEMS: CodeViewItem<PlaygroundAnnotationMetadata>[] = [
+  {
+    id: 'file:README.md',
+    type: 'file',
+    file: LONG_README_FILE,
+  },
   {
     id: `diff:${LONG_FIXTURE_NAME}`,
     type: 'diff',
@@ -583,6 +597,18 @@ export const CODE_VIEW_ITEMS: CodeViewItem<PlaygroundAnnotationMetadata>[] = [
     { length: DIFF_VARIANT_COUNT },
     (_, index): CodeViewItem<PlaygroundAnnotationMetadata>[] => {
       const readmeName = variantName('README.md', index);
+      // Variant 0's README file is hoisted to the head of the list above, so
+      // only the later variants emit a file item here.
+      const readmeItems: CodeViewItem<PlaygroundAnnotationMetadata>[] =
+        index === 0
+          ? []
+          : [
+              {
+                id: `file:${readmeName}`,
+                type: 'file',
+                file: { name: readmeName, contents: LONG_README_CONTENT },
+              },
+            ];
       return [
         {
           id: `diff:${variantName(USERS_BASE.name, index)}`,
@@ -594,11 +620,7 @@ export const CODE_VIEW_ITEMS: CodeViewItem<PlaygroundAnnotationMetadata>[] = [
           type: 'diff',
           fileDiff: variantDiff(MARKUP_BASE, index),
         },
-        {
-          id: `file:${readmeName}`,
-          type: 'file',
-          file: { name: readmeName, contents: LONG_README_CONTENT },
-        },
+        ...readmeItems,
         {
           id: `diff:${variantName(STYLES_BASE.name, index)}`,
           type: 'diff',

--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -1706,8 +1706,9 @@ export class CodeView<LAnnotation = undefined> {
     }
   }
 
-  private capturePendingLayoutAnchor(): void {
+  public capturePendingLayoutAnchor(): void {
     if (
+      this.pendingLayoutAnchor != null ||
       this.root == null ||
       this.items.length === 0 ||
       this.pendingScrollTarget != null

--- a/packages/diffs/src/components/VirtualizedFile.ts
+++ b/packages/diffs/src/components/VirtualizedFile.ts
@@ -640,6 +640,10 @@ export class VirtualizedFile<
     shouldUpdateBuffer = false
   ): void {
     const { renderRange: previousRenderRange } = this;
+    // Capture the scroll anchor before the synchronous document swap and
+    // layout-cache wipe below; the host's next frame resolves it against the
+    // new geometry so on-screen rows do not shift.
+    this.getAdvancedVirtualizer()?.capturePendingLayoutAnchor();
     super.applyDocumentChange(textDocument, newLineAnnotations);
     this.getSimpleVirtualizer()?.markDOMDirty();
     this.resetLayoutCache(this.isSimpleMode(), false);
@@ -864,6 +868,10 @@ export class VirtualizedFile<
 
   private getSimpleVirtualizer(): Virtualizer | undefined {
     return this.virtualizer.type === 'simple' ? this.virtualizer : undefined;
+  }
+
+  private getAdvancedVirtualizer(): CodeView<LAnnotation> | undefined {
+    return this.virtualizer.type === 'advanced' ? this.virtualizer : undefined;
   }
 
   private isResizeDebuggingEnabled(): boolean {

--- a/packages/diffs/src/components/VirtualizedFile.ts
+++ b/packages/diffs/src/components/VirtualizedFile.ts
@@ -639,21 +639,20 @@ export class VirtualizedFile<
     newLineAnnotations?: LineAnnotation<LAnnotation>[],
     shouldUpdateBuffer = false
   ): void {
-    const previousRenderRange = this.renderRange;
-
+    const { renderRange: previousRenderRange } = this;
     super.applyDocumentChange(textDocument, newLineAnnotations);
-
-    // reset the layout cache
     this.getSimpleVirtualizer()?.markDOMDirty();
     this.resetLayoutCache(this.isSimpleMode(), false);
 
-    // Update the buffers caused by the line-count change to ensure the host
-    // scrolls to the correct position before re-rendering
-    if (
+    if (!this.isSimpleMode()) {
+      this.computeApproximateSize(true);
+    } else if (
       shouldUpdateBuffer &&
       previousRenderRange !== undefined &&
       this.file !== undefined
     ) {
+      // Update the buffers caused by the line-count change to ensure the host
+      // scrolls to the correct position before re-rendering.
       const windowSpecs = this.virtualizer.getWindowSpecs();
       const renderRange = this.computeRenderRangeFromWindow(
         this.file,
@@ -664,6 +663,9 @@ export class VirtualizedFile<
         this.updateBuffers(renderRange);
       }
     }
+
+    this.forceRenderOverride = true;
+    this.virtualizer.instanceChanged(this, true);
   }
 
   protected override renderPreparedFile({

--- a/packages/diffs/src/components/VirtualizedFileDiff.ts
+++ b/packages/diffs/src/components/VirtualizedFileDiff.ts
@@ -1025,6 +1025,10 @@ export class VirtualizedFileDiff<
     shouldUpdateBuffer = false
   ): void {
     const { renderRange: previousRenderRange } = this;
+    // Capture the scroll anchor before the synchronous hunk rebuild and
+    // measured-height wipe below; the host's next frame resolves it against
+    // the new geometry so on-screen rows do not shift.
+    this.getAdvancedVirtualizer()?.capturePendingLayoutAnchor();
     super.applyDocumentChange(textDocument, newLineAnnotations);
     this.getSimpleVirtualizer()?.markDOMDirty();
     this.resetLayoutCache({
@@ -1327,6 +1331,10 @@ export class VirtualizedFileDiff<
 
   private getSimpleVirtualizer(): Virtualizer | undefined {
     return this.virtualizer.type === 'simple' ? this.virtualizer : undefined;
+  }
+
+  private getAdvancedVirtualizer(): CodeView<LAnnotation> | undefined {
+    return this.virtualizer.type === 'advanced' ? this.virtualizer : undefined;
   }
 
   private isResizeDebuggingEnabled(): boolean {

--- a/packages/diffs/src/components/VirtualizedFileDiff.ts
+++ b/packages/diffs/src/components/VirtualizedFileDiff.ts
@@ -1024,28 +1024,24 @@ export class VirtualizedFileDiff<
     newLineAnnotations?: DiffLineAnnotation<LAnnotation>[],
     shouldUpdateBuffer = false
   ): void {
-    const previousRenderRange = this.renderRange;
-
+    const { renderRange: previousRenderRange } = this;
     super.applyDocumentChange(textDocument, newLineAnnotations);
-
     this.getSimpleVirtualizer()?.markDOMDirty();
     this.resetLayoutCache({
       forceSimpleRecompute: this.isSimpleMode(),
       includeEstimatedHeights: true,
       resetRenderRange: false,
     });
+
     if (!this.isSimpleMode()) {
       this.computeApproximateSize(true);
-    }
-
-    // Recompute the buffer spacer when the edit grew the document below the
-    // rendered window so scroll/caret positioning stays correct before the next
-    // virtualizer re-sync.
-    if (
+    } else if (
       shouldUpdateBuffer &&
       previousRenderRange !== undefined &&
       this.fileDiff !== undefined
     ) {
+      // Update the buffers caused by the line-count change to ensure the host
+      // scrolls to the correct position before re-rendering.
       const windowSpecs = this.virtualizer.getWindowSpecs();
       const renderRange = this.computeRenderRangeFromWindow(
         this.fileDiff,
@@ -1056,6 +1052,9 @@ export class VirtualizedFileDiff<
         this.updateBuffers(renderRange);
       }
     }
+
+    this.forceRenderOverride = true;
+    this.virtualizer.instanceChanged(this, true);
   }
 
   // Compute the approximate size from the cached baseline estimate plus any

--- a/packages/diffs/test/CodeView.edit.test.ts
+++ b/packages/diffs/test/CodeView.edit.test.ts
@@ -705,6 +705,93 @@ describe('CodeView item edit mode', () => {
     }
   });
 
+  test('a mid-session document change reconciles the file item layout', async () => {
+    const { cleanup } = installDom();
+    const { createEditor } = createEditorHarness();
+    const viewer = new CodeView({ createEditor });
+    const items: CodeViewItem<undefined>[] = [
+      makeEditFileItem('edited', true, 200),
+      makeEditFileItem('below', false, 10),
+    ];
+    try {
+      const root = createRoot();
+      viewer.setup(root);
+      await renderItems(viewer, items);
+      const heightBefore = viewer.getScrollHeight();
+      const belowTopBefore = viewer.getTopForItem('below');
+      if (belowTopBefore == null) {
+        throw new Error('Expected a layout top for the below item.');
+      }
+      expect(
+        viewer.getRenderedItems().some((rendered) => rendered.id === 'below')
+      ).toBe(false);
+
+      const edited = viewer.getRenderedItems()[0];
+      edited.instance.applyDocumentChange({
+        lineCount: 1,
+        getLineText: () => 'only line',
+        getText: () => 'only line',
+      });
+      await wait(0);
+
+      expect(viewer.getScrollHeight()).toBeLessThan(heightBefore);
+      expect(viewer.getTopForItem('below')).toBeLessThan(belowTopBefore);
+      // The shrunken item frees the window, so the next item mounts.
+      expect(
+        viewer.getRenderedItems().some((rendered) => rendered.id === 'below')
+      ).toBe(true);
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+
+  test('a mid-session document change reconciles a diff item that scrolls out', async () => {
+    const { cleanup } = installDom();
+    const { createEditor } = createEditorHarness();
+    const viewer = new CodeView({ createEditor });
+    const items: CodeViewItem<undefined>[] = [
+      makeEditDiffItem('edited', true),
+      ...Array.from({ length: 5 }, (_, index) =>
+        makeEditFileItem(`file-${index}`, false, 100)
+      ),
+    ];
+    try {
+      const root = createRoot();
+      viewer.setup(root);
+      await renderItems(viewer, items);
+      const heightBefore = viewer.getScrollHeight();
+
+      const lineCount = 40;
+      const documentText = Array.from(
+        { length: lineCount },
+        (_, i) => `edited ${i}`
+      ).join('\n');
+      const edited = viewer.getRenderedItems()[0];
+      edited.instance.applyDocumentChange({
+        lineCount,
+        getLineText: (lineNumber: number) => `edited ${lineNumber}`,
+        getText: () => documentText,
+      });
+      // Scroll the edited item out before any render pass reconciles it: the
+      // released item's cached layout height must still pick up the change.
+      root.scrollTop = 10_000;
+      dispatchScroll(root);
+      viewer.render(true);
+      await wait(0);
+
+      expect(
+        viewer.getRenderedItems().some((rendered) => rendered.id === 'edited')
+      ).toBe(false);
+      expect(viewer.getScrollHeight()).toBeGreaterThan(heightBefore);
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+
   test('remounts an edited file with the session text after a recycle', async () => {
     const { cleanup } = installDom();
     const { createEditor } = createEditorHarness();

--- a/packages/diffs/test/editorDisplayOptionResync.test.ts
+++ b/packages/diffs/test/editorDisplayOptionResync.test.ts
@@ -6,7 +6,7 @@ import { Editor } from '../src/editor/editor';
 import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
 import type { DiffsHighlighter, FileContents } from '../src/types';
 import { parseDiffFromFile } from '../src/utils/parseDiffFromFile';
-import { installDom, wait } from './domHarness';
+import { installDom, wait, waitFor } from './domHarness';
 
 afterAll(async () => {
   await disposeHighlighter();
@@ -96,19 +96,21 @@ async function createFixture(
   });
   editor.edit(fileDiff);
 
-  for (let attempt = 0; attempt < 40; attempt++) {
+  // Deadline-based: the first fixture in a file pays the shared highlighter's
+  // cold start, which can outlast any fixed number of macrotask turns on a
+  // slow runner. The editor assigns the contentEditable property, which jsdom
+  // does not reflect to the attribute, so poll the property.
+  await waitFor(() => {
     const content = findAdditionContent(container);
-    if (content != null && content.getAttribute('contenteditable') === 'true') {
-      break;
-    }
-    await wait(0);
-  }
+    return content?.contentEditable === 'true';
+  });
 
   return {
     container,
     editor,
     fileDiff,
     async toggleDisplayOption() {
+      const previousContent = findAdditionContent(container);
       fileDiff.setOptions({
         ...fileDiff.options,
         disableLineNumbers: !(fileDiff.options.disableLineNumbers ?? false),
@@ -119,8 +121,18 @@ async function createFixture(
         fileContainer: container,
         forceRender: true,
       });
-      // Let syncRenderViewToEditor's highlighter promise resolve.
-      await wait(10);
+      // The forced re-render replaces the additions column and re-syncs the
+      // editor through an async highlighter pass; wait for the replacement
+      // instead of a fixed sleep.
+      await waitFor(() => {
+        const content = findAdditionContent(container);
+        return (
+          content != null &&
+          content !== previousContent &&
+          content.contentEditable === 'true'
+        );
+      });
+      await wait(0);
     },
     async cleanup() {
       await wait(10);
@@ -159,13 +171,19 @@ describe('diff editor: display-option toggle mid-edit', () => {
     );
 
     try {
+      editor.focus({ lineNumber: 1, preventScroll: true });
+      // Focus can be deferred while the editor settles its first highlight
+      // pass, and a deferred background pass may replace the additions column
+      // once more before it lands — wait for focus to land on the current
+      // column, then capture that element as the pre-toggle baseline.
+      await waitFor(() => {
+        const current = findAdditionContent(container);
+        return current != null && focusTargets.at(-1) === current;
+      });
       const content = findAdditionContent(container);
       if (content == null) {
         throw new Error('missing editable additions content');
       }
-
-      editor.focus({ lineNumber: 1, preventScroll: true });
-      await wait(10);
       expect(focusTargets.at(-1) === content).toBe(true);
 
       // Firefox and WebKit can remove the focused shadow subtree without a
@@ -175,6 +193,9 @@ describe('diff editor: display-option toggle mid-edit', () => {
       const replacement = findAdditionContent(container);
       expect(replacement == null).toBe(false);
       expect(replacement === content).toBe(false);
+      // Focus restoration can trail the replacement by a deferred focus
+      // retry; wait for it to settle before asserting the final target.
+      await waitFor(() => focusTargets.at(-1) === replacement);
       expect(focusTargets.at(-1) === replacement).toBe(true);
     } finally {
       focusSpy.mockRestore();

--- a/packages/diffs/test/virtualizedApplyDocumentChange.test.ts
+++ b/packages/diffs/test/virtualizedApplyDocumentChange.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'bun:test';
+
+import { VirtualizedFile } from '../src/components/VirtualizedFile';
+import type {
+  DiffsTextDocument,
+  FileContents,
+  RenderRange,
+} from '../src/types';
+
+function createStubVirtualizer(type: 'simple' | 'advanced') {
+  return {
+    type,
+    config: {},
+    connect() {},
+    disconnect() {},
+    getWindowSpecs() {
+      return { top: 0, bottom: 1000 };
+    },
+    getOffsetInScrollContainer() {
+      return 0;
+    },
+    instanceChanged() {},
+    isInstanceVisible() {
+      return true;
+    },
+    markDOMDirty() {},
+    requestHeightReconcile() {},
+    render() {},
+  } as never;
+}
+
+function makeContents(lineCount: number): string {
+  return Array.from({ length: lineCount }, (_, i) => `line ${i + 1}`).join(
+    '\n'
+  );
+}
+
+function makeDocument(lineCount: number): DiffsTextDocument {
+  const text = makeContents(lineCount);
+  return {
+    lineCount,
+    getLineText: (lineNumber: number) => `line ${lineNumber + 1}`,
+    getText: () => text,
+  };
+}
+
+function makeFile(lineCount: number): FileContents {
+  return { name: 'a.txt', contents: makeContents(lineCount), lang: 'text' };
+}
+
+class BufferRecordingFile extends VirtualizedFile<undefined> {
+  public bufferUpdates = 0;
+
+  public seedRenderRange(renderRange: RenderRange): void {
+    this.renderRange = renderRange;
+  }
+
+  protected override updateBuffers(): void {
+    this.bufferUpdates += 1;
+  }
+}
+
+describe('applyDocumentChange buffer updates', () => {
+  test('the buffer spacer update only runs in simple mode', () => {
+    const seeded: RenderRange = {
+      startingLine: 0,
+      totalLines: 50,
+      bufferBefore: 0,
+      bufferAfter: 12_345,
+    };
+
+    const advancedInstance = new BufferRecordingFile(
+      {},
+      createStubVirtualizer('advanced')
+    );
+    advancedInstance.prepareCodeViewItem(makeFile(50), 0);
+    advancedInstance.seedRenderRange(seeded);
+    advancedInstance.applyDocumentChange(makeDocument(1), undefined, true);
+    expect(advancedInstance.bufferUpdates).toBe(0);
+
+    const simpleInstance = new BufferRecordingFile(
+      {},
+      createStubVirtualizer('simple')
+    );
+    simpleInstance.prepareCodeViewItem(makeFile(50), 0);
+    simpleInstance.seedRenderRange(seeded);
+    simpleInstance.applyDocumentChange(makeDocument(1), undefined, true);
+    expect(simpleInstance.bufferUpdates).toBe(1);
+  });
+});

--- a/packages/diffs/test/virtualizedApplyDocumentChange.test.ts
+++ b/packages/diffs/test/virtualizedApplyDocumentChange.test.ts
@@ -11,6 +11,7 @@ function createStubVirtualizer(type: 'simple' | 'advanced') {
   return {
     type,
     config: {},
+    capturePendingLayoutAnchor() {},
     connect() {},
     disconnect() {},
     getWindowSpecs() {


### PR DESCRIPTION
Found another couple virtualization bugs dealing with taller files.

1. Improved the playground to have these taller files to ensure the bugs were more obvious in the future if they regressed
2. There were some regression tests that we added as well

### File Content Deletion Bug

**BEFORE:**

https://github.com/user-attachments/assets/c852a3e6-7c6a-4359-a85a-37e8a51a1aa6

**AFTER:**

https://github.com/user-attachments/assets/5fb2ba2f-ce09-4514-94db-532ff8585635

### CodeView Deletion Scroll Jump Bug:

**BEFORE:**

https://github.com/user-attachments/assets/b7c4dc4f-ed25-4ad9-844f-f848b63b11ad

**AFTER:**

https://github.com/user-attachments/assets/5ff21a3e-72a5-49d7-a142-3b79e50be76e