### PR TITLE
[diffs/edit] fix editor state persisting

### DIFF
--- a/apps/docs/app/(diffs)/_home/AgentUi.tsx
+++ b/apps/docs/app/(diffs)/_home/AgentUi.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { DEFAULT_THEMES, type FileDiffMetadata } from '@pierre/diffs';
-import type { EditorOptions } from '@pierre/diffs/edit';
-import { File, FileDiff } from '@pierre/diffs/react';
+import { Editor, type EditorOptions } from '@pierre/diffs/edit';
+import { EditProvider, File, FileDiff, Virtualizer } from '@pierre/diffs/react';
 import {
   IconArrow,
   IconChevronSm,
@@ -21,7 +21,6 @@ import {
   type CSSProperties,
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -41,11 +40,6 @@ import {
   getSessionGitStatus,
   getSessionPaths,
 } from './mockData';
-// Runs as a layout effect in the browser (so DOM reads/writes land before the
-// next paint) but falls back to useEffect during SSR, where useLayoutEffect
-// would warn. The demo is server-rendered, so the fallback matters.
-const useIsomorphicLayoutEffect =
-  typeof window === 'undefined' ? useEffect : useLayoutEffect;
 
 // Added/removed line totals for a single file's diff.
 interface DiffStats {
@@ -1114,9 +1108,18 @@ export function AgentUi({
         // Changes tree's +/- totals reflect the live edits.
         recordEditedStatsRef.current(target, file.contents);
       },
+      persistState: true,
       __debug: true,
     }),
     [addSnippet]
+  );
+  const editor = useMemo(() => new Editor<undefined>(), []);
+  const createEditor = useCallback(
+    (options: EditorOptions<undefined>) => {
+      editor.setOptions(options);
+      return editor;
+    },
+    [editor]
   );
 
   const openFile = useCallback((path: string) => {
@@ -1167,30 +1170,19 @@ export function AgentUi({
   // Re-adopt the jade/red line-number override whenever the diff surface is
   // rebuilt (each file switch remounts the diffs-container with a fresh shadow
   // root).
-  const surfaceWrapRef = useRef<HTMLDivElement | null>(null);
+  const surfaceHostRef = useRef<HTMLElement | null>(null);
   useEffect(() => {
     const sheet = getLineNumberColorSheet();
     if (sheet == null) {
       return;
     }
-    const container = surfaceWrapRef.current?.querySelector('.aui-surface');
+    const container = surfaceHostRef.current?.querySelector('.aui-surface');
     const shadowRoot = container?.shadowRoot;
     if (shadowRoot == null) {
       return;
     }
     if (!shadowRoot.adoptedStyleSheets.includes(sheet)) {
       shadowRoot.adoptedStyleSheets = [...shadowRoot.adoptedStyleSheets, sheet];
-    }
-  }, [activePath]);
-
-  // `key={activePath}` remounts the FileDiff or File surface for each file while
-  // `.aui-surface-wrap` remains mounted and retains its scroll offset. Reset the
-  // outer host after the new surface is laid out but before paint. Editing a
-  // file does not change `activePath`, so this never disturbs a session.
-  useIsomorphicLayoutEffect(() => {
-    const wrap = surfaceWrapRef.current;
-    if (wrap != null) {
-      wrap.scrollTop = 0;
     }
   }, [activePath]);
 
@@ -1234,7 +1226,7 @@ export function AgentUi({
             />
           </aside>
         )}
-        <section className="aui-center">
+        <section className="aui-center" ref={surfaceHostRef}>
           <header className="aui-center-header">
             {/* The windowed card has no left sidebar, so its window controls
              * sit just left of the breadcrumb. */}
@@ -1268,46 +1260,49 @@ export function AgentUi({
             </nav>
           </header>
 
-          <div className="aui-surface-wrap" ref={surfaceWrapRef}>
-            {activeFile != null && fileDiff != null ? (
-              <FileDiff
-                key={activePath}
-                fileDiff={fileDiff}
-                className="aui-surface"
-                options={{ ...AUI_DIFF_OPTIONS, theme }}
-                prerenderedHTML={activePrerenderedHTML}
-                edit
-                editorOptions={editorOptions}
-              />
-            ) : placeholderContents != null && activePath != null ? (
-              // Editable view for explorer files that aren't part of the change
-              // set (e.g. the root README or a generated stub). The app-level
-              // provider creates an independent editor for this keyed surface.
-              // Caller-owned `editsRef` seeds its contents when revisited.
-              // Highlighted on the main thread since this File is mounted
-              // dynamically outside the editable surface's worker pool.
-              <File
-                key={activePath}
-                file={{
-                  name: activePath,
-                  contents:
-                    editsRef.current.get(activePath) ?? placeholderContents,
-                }}
-                className="aui-surface"
-                options={{
-                  theme,
-                  themeType: 'dark',
-                  disableFileHeader: true,
-                  overflow: 'wrap',
-                }}
-                disableWorkerPool
-                edit
-                editorOptions={editorOptions}
-              />
-            ) : (
-              <div className="aui-empty">Select a file to review.</div>
-            )}
-          </div>
+          <EditProvider createEditor={createEditor}>
+            <Virtualizer className="aui-surface-wrap">
+              {activeFile != null && fileDiff != null ? (
+                <FileDiff
+                  key={activePath}
+                  fileDiff={fileDiff}
+                  className="aui-surface"
+                  options={{ ...AUI_DIFF_OPTIONS, theme }}
+                  prerenderedHTML={activePrerenderedHTML}
+                  edit
+                  editorOptions={editorOptions}
+                />
+              ) : placeholderContents != null && activePath != null ? (
+                // Editable view for explorer files that aren't part of the
+                // change set (e.g. the root README or a generated stub). The
+                // local provider reuses one editor so path-keyed File state
+                // survives keyed surface remounts. Highlighted on the main
+                // thread since this File is mounted dynamically outside the
+                // editable surface's worker pool.
+                <File
+                  key={activePath}
+                  file={{
+                    name: activePath,
+                    contents:
+                      editsRef.current.get(activePath) ?? placeholderContents,
+                    cacheKey: activePath,
+                  }}
+                  className="aui-surface"
+                  options={{
+                    theme,
+                    themeType: 'dark',
+                    disableFileHeader: true,
+                    overflow: 'wrap',
+                  }}
+                  disableWorkerPool
+                  edit
+                  editorOptions={editorOptions}
+                />
+              ) : (
+                <div className="aui-empty">Select a file to review.</div>
+              )}
+            </Virtualizer>
+          </EditProvider>
 
           <div className="aui-composer">
             {snippets.length > 0 && (

--- a/apps/docs/app/(diffs)/docs/Edit/constants.ts
+++ b/apps/docs/app/(diffs)/docs/Edit/constants.ts
@@ -1092,14 +1092,14 @@ const file: FileContents | undefined = editor.getFile();
 // Full document text, or '' when nothing is attached.
 const text: string = editor.getText();
 
-// Snapshot selections and horizontal code position for explicit restoration.
+// Snapshot selections and viewport scroll position for explicit restoration.
 const state: EditorState = editor.getState();
 // EditorState = {
 //   selections?: EditorSelection[];
-//   view?: { scrollLeft: number };
+//   view?: { scrollTop: number; scrollLeft: number };
 // }
 
-// Restore selections and horizontal code position after re-rendering.
+// Restore selections and viewport scroll position after re-rendering.
 editor.setState(state);
 
 // Replace all cursors and ranges programmatically. Positions are zero-based;

--- a/apps/docs/app/(diffs)/docs/Edit/content.mdx
+++ b/apps/docs/app/(diffs)/docs/Edit/content.mdx
@@ -330,17 +330,23 @@ Ranges use zero-based line and character positions.
 #### Persisting file state
 
 State persistence is disabled by default. Set `persistState: true` to preserve
-an editable `File`'s text document, undo history, selections, and horizontal
-code scroll position when the attached file renders a different file and later
-returns. This currently applies to `File` and `VirtualizedFile` surfaces; diff
-surfaces do not use the persistence cache.
+an editable surface's text document, undo history, and selections when the
+attached surface renders a different file and later returns. It applies to every
+editable surface: `File`, `FileDiff`, and their virtualized variants. Persisting
+the viewport scroll position (`scrollTop` and `scrollLeft`) additionally
+requires a virtualized surface: inside a `Virtualizer` the whole scroll viewport
+is saved (and resets to the origin when a cache key has no stored state yet),
+while `CodeView` items keep only their item-local horizontal code scroll.
+Standalone surfaces do not persist scroll offsets.
 
 Every editable file must provide an explicit, non-empty `file.cacheKey` while
 `persistState` is enabled. The editor throws if it encounters an unkeyed file;
-it does not fall back to `file.name`. Cache keys must be unique and stable
-within the persistence storage namespace. Reuse the same key when a rename or
-move should resume the same editing session; change it when new incoming
-contents should start a fresh document.
+it does not fall back to `file.name`. Diff surfaces are keyed by
+`fileDiff.cacheKey`; a diff without one falls back to a key derived from its
+file names. Cache keys must be unique and stable within the persistence storage
+namespace. Reuse the same key when a rename or move should resume the same
+editing session; change it when new incoming contents should start a fresh
+document.
 
 ```ts
 import type { EditorState, FileContents } from '@pierre/diffs';

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -300,13 +300,13 @@ export class File<
     });
   }
 
-  public getCodeScrollLeft(): number {
-    return this.code?.scrollLeft ?? 0;
+  public getViewportScroll(): { top: number; left: number } | undefined {
+    return { top: 0, left: this.code?.scrollLeft ?? 0 };
   }
 
-  public setCodeScrollLeft(position: number): void {
+  public setViewportScroll(position: { top: number; left: number }): void {
     if (this.code != null) {
-      this.code.scrollLeft = position;
+      this.code.scrollLeft = position.left;
     }
   }
 

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -14,6 +14,7 @@ import {
   THEME_CSS_ATTRIBUTE,
   UNSAFE_CSS_ATTRIBUTE,
 } from '../constants';
+import { isSafari } from '../editor/platform';
 import {
   type GetHoveredLineResult,
   type GetLineIndexUtility,
@@ -2613,12 +2614,31 @@ export class FileDiff<
     const ast = this.hunksRenderer.renderCodeAST('unified', hunksResult);
     const gutterChildren = getElementChildren(ast?.[0]);
     const contentChildren = getElementChildren(ast?.[1]);
+
+    // Replacing both column subtrees within a single layout pass makes WebKit
+    // scroll the viewport on its own during that layout: while typing in a
+    // unified diff with collapsed regions, Safari yanked the editor toward the
+    // top of the render window on every debounced refresh. Forcing a layout
+    // after each column replacement keeps the passes separated, which
+    // empirically suppresses that scroll entirely; the snapshot below is a
+    // second line of defense that puts the viewport back if a WebKit build
+    // still moves it. Both are scoped to Safari so other engines never pay
+    // the extra layout nor risk clobbering a concurrent user scroll.
+    const restoreViewportScroll = isSafari();
+    const viewportScroll = restoreViewportScroll
+      ? this.getViewportScroll()
+      : undefined;
+
     for (const [el, astChildren] of [
       [columns.gutter, gutterChildren],
       [columns.content, contentChildren],
     ] as const) {
       if (astChildren != null) {
         el.innerHTML = toHtml(astChildren);
+        if (restoreViewportScroll) {
+          // force a layout(reflow)
+          void el.offsetHeight;
+        }
       }
     }
 
@@ -2633,6 +2653,21 @@ export class FileDiff<
 
     // sync the render view to the editor
     this.syncRenderViewToEditor();
+
+    if (viewportScroll != null) {
+      // WebKit's scroll happens at the first layout after this task, so check
+      // from a frame callback: reading the scroll position forces that layout,
+      // making any jump observable (and restorable) before paint.
+      requestAnimationFrame(() => {
+        const current = this.getViewportScroll();
+        if (current != null && current.top !== viewportScroll.top) {
+          this.setViewportScroll({
+            top: viewportScroll.top,
+            left: current.left,
+          });
+        }
+      });
+    }
   }
 
   private renderPartialColumn(

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -609,23 +609,26 @@ export class FileDiff<
     );
   }
 
-  public getCodeScrollLeft(): number {
-    return Math.max(
-      this.codeUnified?.scrollLeft ?? 0,
-      this.codeDeletions?.scrollLeft ?? 0,
-      this.codeAdditions?.scrollLeft ?? 0
-    );
+  public getViewportScroll(): { top: number; left: number } | undefined {
+    return {
+      top: 0,
+      left: Math.max(
+        this.codeUnified?.scrollLeft ?? 0,
+        this.codeDeletions?.scrollLeft ?? 0,
+        this.codeAdditions?.scrollLeft ?? 0
+      ),
+    };
   }
 
-  public setCodeScrollLeft(position: number): void {
+  public setViewportScroll(position: { top: number; left: number }): void {
     if (this.codeUnified != null) {
-      this.codeUnified.scrollLeft = position;
+      this.codeUnified.scrollLeft = position.left;
     }
     if (this.codeAdditions != null) {
-      this.codeAdditions.scrollLeft = position;
+      this.codeAdditions.scrollLeft = position.left;
     }
     if (this.codeDeletions != null) {
-      this.codeDeletions.scrollLeft = position;
+      this.codeDeletions.scrollLeft = position.left;
     }
   }
 

--- a/packages/diffs/src/components/VirtualizedFile.ts
+++ b/packages/diffs/src/components/VirtualizedFile.ts
@@ -406,6 +406,27 @@ export class VirtualizedFile<
       : this.virtualizer.getContainerElement();
   }
 
+  public override getViewportScroll():
+    | { top: number; left: number }
+    | undefined {
+    const virtualizer = this.getSimpleVirtualizer();
+    return virtualizer != null
+      ? { top: virtualizer.getScrollTop(), left: virtualizer.getScrollLeft() }
+      : super.getViewportScroll();
+  }
+
+  public override setViewportScroll(position: {
+    top: number;
+    left: number;
+  }): void {
+    const virtualizer = this.getSimpleVirtualizer();
+    if (virtualizer != null) {
+      virtualizer.scrollTo({ top: position.top, left: position.left });
+    } else {
+      super.setViewportScroll(position);
+    }
+  }
+
   public getNumericScrollAnchor(
     localViewportTop: number
   ): NumericScrollLineAnchor | undefined {

--- a/packages/diffs/src/components/VirtualizedFileDiff.ts
+++ b/packages/diffs/src/components/VirtualizedFileDiff.ts
@@ -618,6 +618,27 @@ export class VirtualizedFileDiff<
       : this.virtualizer.getContainerElement();
   }
 
+  public override getViewportScroll():
+    | { top: number; left: number }
+    | undefined {
+    const virtualizer = this.getSimpleVirtualizer();
+    return virtualizer != null
+      ? { top: virtualizer.getScrollTop(), left: virtualizer.getScrollLeft() }
+      : super.getViewportScroll();
+  }
+
+  public override setViewportScroll(position: {
+    top: number;
+    left: number;
+  }): void {
+    const virtualizer = this.getSimpleVirtualizer();
+    if (virtualizer != null) {
+      virtualizer.scrollTo(position);
+    } else {
+      super.setViewportScroll(position);
+    }
+  }
+
   public getNumericScrollAnchor(
     localViewportTop: number
   ): NumericScrollLineAnchor | undefined {

--- a/packages/diffs/src/components/Virtualizer.ts
+++ b/packages/diffs/src/components/Virtualizer.ts
@@ -37,6 +37,7 @@ export interface VirtualizerConfig {
 
 export interface VirtualizerScrollOptions {
   top: number;
+  left?: number;
   behavior?: ScrollBehavior;
 }
 
@@ -639,18 +640,33 @@ export class Virtualizer {
     return scrollTop;
   }
 
-  /** Scroll to a logical vertical position and queue the normal render pass. */
-  public scrollTo({ top, behavior = 'auto' }: VirtualizerScrollOptions): void {
+  public getScrollLeft(): number {
+    if (this.root instanceof Document) {
+      return window.scrollX;
+    }
+    return this.root?.scrollLeft ?? 0;
+  }
+
+  /** Scroll to a logical position and queue the normal render pass. */
+  public scrollTo({
+    top,
+    left,
+    behavior = 'auto',
+  }: VirtualizerScrollOptions): void {
     const { root } = this;
     if (root == null) {
       return;
     }
 
     const scrollTop = this.clampScrollTop(top);
+    const position: ScrollToOptions = { top: scrollTop, behavior };
+    if (left !== undefined) {
+      position.left = left;
+    }
     if (root instanceof Document) {
-      window.scrollTo({ top: scrollTop, behavior });
+      window.scrollTo(position);
     } else {
-      root.scrollTo({ top: scrollTop, behavior });
+      root.scrollTo(position);
     }
     this.scrollDirty = true;
     queueRender(this.computeRenderRangeAndEmit);

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -585,13 +585,14 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   }
 
   getState(): EditorState {
-    const fileInstance = this.#fileInstance;
+    const scroll = this.#fileInstance?.getViewportScroll();
     return {
       selections: this.#selections,
       view:
-        fileInstance != null
+        scroll !== undefined
           ? {
-              scrollLeft: fileInstance.getCodeScrollLeft(),
+              scrollLeft: scroll.left,
+              scrollTop: scroll.top,
             }
           : undefined,
     };
@@ -607,7 +608,10 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     // the caret into view afterward would overwrite them whenever the caret
     // sits outside that viewport (e.g. TreeApp remount restore).
     if (view != null) {
-      this.#fileInstance.setCodeScrollLeft(view.scrollLeft);
+      this.#fileInstance.setViewportScroll({
+        top: view.scrollTop,
+        left: view.scrollLeft,
+      });
       return;
     }
     this.#scrollToPrimaryCaret();
@@ -727,7 +731,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       this.#attachState.delivered = false;
     }
     const hadFileInstance = this.#fileInstance != null;
-    const shouldRestoreState = this.#isStatePersistenceEnabled;
+    const shouldRestoreState = this.#options.persistState === true;
     this.#stateRestoreGeneration++;
     this.#persistCurrentState();
     if (hadFileInstance) {
@@ -930,9 +934,10 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       this.#fileInfo.name !== fileOrDiff.name ||
       this.#fileInfo.lang !== fileOrDiff.lang ||
       this.#fileInfo.cacheKey !== fileOrDiff.cacheKey;
-    const persistedCacheKey = this.#isStatePersistenceEnabled
-      ? requirePersistedCacheKey(fileOrDiff)
-      : undefined;
+    const persistedCacheKey =
+      this.#options.persistState === true
+        ? requirePersistedCacheKey(fileOrDiff)
+        : undefined;
 
     let persistedStateTarget:
       | { cacheKey: string; textDocument: TextDocument<LAnnotation> }
@@ -1154,12 +1159,6 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     this.#scheduleOnAttach(fileInstance);
   };
 
-  get #isStatePersistenceEnabled(): boolean {
-    return (
-      this.#options.persistState === true && this.#fileInstance?.type === 'file'
-    );
-  }
-
   #getCachedTextDocument(
     file: FileContents | FileDiffMetadata,
     cacheKey: string
@@ -1170,13 +1169,13 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
   }
 
   #getStateStorage(): IStateStorage {
-    const option = this.#options.persistStateStorage ?? 'inMemory';
+    const stateStorage = this.#options.persistStateStorage ?? 'inMemory';
     if (
       this.#stateStorage === undefined ||
-      this.#stateStorageOption !== option
+      this.#stateStorageOption !== stateStorage
     ) {
-      this.#stateStorage = createStateStorage(option);
-      this.#stateStorageOption = option;
+      this.#stateStorage = createStateStorage(stateStorage);
+      this.#stateStorageOption = stateStorage;
     }
     return this.#stateStorage;
   }
@@ -1185,7 +1184,8 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     const fileInfo = this.#fileInfo;
     const textDocument = this.#textDocument;
     if (
-      !this.#isStatePersistenceEnabled ||
+      this.#options.persistState !== true ||
+      this.#fileInstance === undefined ||
       fileInfo === undefined ||
       textDocument === undefined
     ) {
@@ -1211,7 +1211,8 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       if (
         textDocument.version === pendingRestore.documentVersion &&
         this.#selections === pendingRestore.selections &&
-        state.view?.scrollLeft === pendingRestore.view?.scrollLeft
+        state.view?.scrollLeft === pendingRestore.view?.scrollLeft &&
+        state.view?.scrollTop === pendingRestore.view?.scrollTop
       ) {
         return;
       }
@@ -1276,15 +1277,19 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     const applyState = (state: EditorState | undefined): void => {
       const currentView = this.getState().view;
       if (
-        state === undefined ||
         generation !== this.#stateRestoreGeneration ||
         this.#textDocument !== textDocument ||
         textDocument.version !== documentVersion ||
         this.#selections !== selections ||
         currentView?.scrollLeft !== view?.scrollLeft ||
+        currentView?.scrollTop !== view?.scrollTop ||
         this.#fileInfo === undefined ||
         requirePersistedCacheKey(this.#fileInfo) !== cacheKey
       ) {
+        return;
+      }
+      if (state === undefined) {
+        this.#fileInstance?.setViewportScroll({ top: 0, left: 0 });
         return;
       }
       this.setState(cloneEditorState(state));

--- a/packages/diffs/src/types.ts
+++ b/packages/diffs/src/types.ts
@@ -1038,10 +1038,10 @@ export interface DiffsEditableComponent<
     lineNumber: number | null,
     options?: EditorActiveLineOptions
   ) => void;
-  /** Return the horizontal code scroll position (`scrollLeft`). */
-  getCodeScrollLeft: () => number;
-  /** Set the horizontal code scroll position (`scrollLeft`). */
-  setCodeScrollLeft: (position: number) => void;
+  /** Return the scroll position owned by this editable viewport, if present. */
+  getViewportScroll: () => { top: number; left: number } | undefined;
+  /** Restore the scroll position owned by this editable viewport. */
+  setViewportScroll: (position: { top: number; left: number }) => void;
   /**
    * Return the position and height of a one-based line relative to this component.
    * The host uses it to scroll to virtualized lines before their DOM nodes exist.
@@ -1254,7 +1254,7 @@ export interface EditorSelection extends Range {
 }
 
 export interface EditorViewState {
-  /** Horizontal position owned by the current editable code scroller. */
+  scrollTop: number;
   scrollLeft: number;
 }
 

--- a/packages/diffs/test/Virtualizer.scrollState.test.ts
+++ b/packages/diffs/test/Virtualizer.scrollState.test.ts
@@ -14,16 +14,25 @@ describe('Virtualizer scroll state', () => {
       value: 5_000,
     });
     root.scrollTop = 1_200;
+    root.scrollLeft = 320;
     const scrollCalls: ScrollToOptions[] = [];
     root.scrollTo = (options?: ScrollToOptions | number, y?: number) => {
       const top =
         typeof options === 'number'
           ? (y ?? root.scrollTop)
           : (options?.top ?? root.scrollTop);
+      const left =
+        typeof options === 'number'
+          ? root.scrollLeft
+          : (options?.left ?? root.scrollLeft);
       root.scrollTop = top;
+      root.scrollLeft = left;
       scrollCalls.push({
         behavior: typeof options === 'number' ? undefined : options?.behavior,
         top,
+        ...(typeof options !== 'number' && options?.left !== undefined
+          ? { left }
+          : {}),
       });
     };
     const virtualizer = new Virtualizer();
@@ -32,11 +41,14 @@ describe('Virtualizer scroll state', () => {
       virtualizer.setup(root, content);
       await wait(0);
       expect(virtualizer.getScrollTop()).toBe(1_200);
+      expect(virtualizer.getScrollLeft()).toBe(320);
 
-      virtualizer.scrollTo({ top: 2_500, behavior: 'instant' });
+      virtualizer.scrollTo({ top: 2_500, left: 640, behavior: 'instant' });
       expect(virtualizer.getScrollTop()).toBe(2_500);
+      expect(virtualizer.getScrollLeft()).toBe(640);
       expect(scrollCalls.at(-1)).toEqual({
         behavior: 'instant',
+        left: 640,
         top: 2_500,
       });
       await wait(0);
@@ -72,16 +84,27 @@ describe('Virtualizer scroll state', () => {
       configurable: true,
       get: () => scrollY,
     });
+    let scrollX = 320;
+    Object.defineProperty(dom.window, 'scrollX', {
+      configurable: true,
+      get: () => scrollX,
+    });
     const scrollCalls: ScrollToOptions[] = [];
     dom.window.scrollTo = (options?: ScrollToOptions | number, y?: number) => {
       const top =
         typeof options === 'number'
           ? (y ?? scrollY)
           : (options?.top ?? scrollY);
+      const left =
+        typeof options === 'number' ? scrollX : (options?.left ?? scrollX);
       scrollY = top;
+      scrollX = left;
       scrollCalls.push({
         behavior: typeof options === 'number' ? undefined : options?.behavior,
         top,
+        ...(typeof options !== 'number' && options?.left !== undefined
+          ? { left }
+          : {}),
       });
     };
     const virtualizer = new Virtualizer();
@@ -90,11 +113,14 @@ describe('Virtualizer scroll state', () => {
       virtualizer.setup(document);
       await wait(0);
       expect(virtualizer.getScrollTop()).toBe(1_200);
+      expect(virtualizer.getScrollLeft()).toBe(320);
 
-      virtualizer.scrollTo({ top: 2_500, behavior: 'instant' });
+      virtualizer.scrollTo({ top: 2_500, left: 640, behavior: 'instant' });
       expect(virtualizer.getScrollTop()).toBe(2_500);
+      expect(virtualizer.getScrollLeft()).toBe(640);
       expect(scrollCalls.at(-1)).toEqual({
         behavior: 'instant',
+        left: 640,
         top: 2_500,
       });
       await wait(0);

--- a/packages/diffs/test/editorClipboard.test.ts
+++ b/packages/diffs/test/editorClipboard.test.ts
@@ -147,11 +147,11 @@ class TestEditableComponent implements DiffsEditableComponent<undefined> {
     return this.options;
   }
 
-  getCodeScrollLeft(): number {
-    return 0;
+  getViewportScroll(): undefined {
+    return undefined;
   }
 
-  setCodeScrollLeft(): void {}
+  setViewportScroll(): void {}
 
   render({
     file,

--- a/packages/diffs/test/editorRecycle.test.ts
+++ b/packages/diffs/test/editorRecycle.test.ts
@@ -79,11 +79,11 @@ class TestEditableComponent implements DiffsEditableComponent<undefined> {
     return this.options;
   }
 
-  getCodeScrollLeft(): number {
-    return 0;
+  getViewportScroll(): undefined {
+    return undefined;
   }
 
-  setCodeScrollLeft(): void {}
+  setViewportScroll(): void {}
 
   render({
     file,

--- a/packages/diffs/test/editorState.test.ts
+++ b/packages/diffs/test/editorState.test.ts
@@ -36,8 +36,8 @@ class TestEditableComponent implements DiffsEditableComponent<undefined> {
   #editor?: DiffsEditor<undefined>;
   #lineAnnotations?: DiffLineAnnotation<undefined>[];
   #renderRange?: RenderRange;
-  codeScrollLeft = 0;
-  restoredCodeScrollLefts: number[] = [];
+  viewportScroll: { top: number; left: number } | undefined;
+  restoredViewportScrolls: { top: number; left: number }[] = [];
 
   constructor(private file: FileContents) {
     this.#renderShadowDom();
@@ -55,13 +55,13 @@ class TestEditableComponent implements DiffsEditableComponent<undefined> {
     return this.options;
   }
 
-  getCodeScrollLeft(): number {
-    return this.codeScrollLeft;
+  getViewportScroll(): { top: number; left: number } | undefined {
+    return this.viewportScroll;
   }
 
-  setCodeScrollLeft(position: number): void {
-    this.codeScrollLeft = position;
-    this.restoredCodeScrollLefts.push(position);
+  setViewportScroll(position: { top: number; left: number }): void {
+    this.viewportScroll = position;
+    this.restoredViewportScrolls.push(position);
   }
 
   render({
@@ -147,7 +147,7 @@ class TestEditableComponent implements DiffsEditableComponent<undefined> {
 }
 
 describe('Editor state', () => {
-  test('getState captures horizontal state from the code scroller', () => {
+  test('getState captures viewport scroll state', () => {
     const dom = installDom();
     const editor = new Editor<undefined>();
     const component = new TestEditableComponent({
@@ -157,9 +157,12 @@ describe('Editor state', () => {
 
     try {
       editor.edit(component);
-      component.codeScrollLeft = 24;
+      component.viewportScroll = { top: 128, left: 24 };
 
-      expect(editor.getState().view).toEqual({ scrollLeft: 24 });
+      expect(editor.getState().view).toEqual({
+        scrollTop: 128,
+        scrollLeft: 24,
+      });
     } finally {
       editor.cleanUp();
       component.cleanUp();
@@ -177,9 +180,38 @@ describe('Editor state', () => {
 
     try {
       editor.edit(component);
-      editor.setState({ view: { scrollLeft: 24 } });
+      editor.setState({ view: { scrollLeft: 24, scrollTop: 128 } });
 
-      expect(component.restoredCodeScrollLefts).toEqual([24]);
+      expect(component.restoredViewportScrolls).toEqual([
+        { top: 128, left: 24 },
+      ]);
+    } finally {
+      editor.cleanUp();
+      component.cleanUp();
+      dom.cleanup();
+    }
+  });
+
+  test('missing persisted state resets view scroll offsets', () => {
+    const dom = installDom();
+    const editor = new Editor<undefined>({
+      persistState: true,
+      persistStateStorage: {
+        get: () => undefined,
+        set() {},
+      },
+    });
+    const component = new TestEditableComponent({
+      name: 'state.ts',
+      contents: 'alpha\nbravo',
+      cacheKey: 'state.ts',
+    });
+    component.viewportScroll = { top: 128, left: 24 };
+
+    try {
+      editor.edit(component);
+
+      expect(component.restoredViewportScrolls).toEqual([{ top: 0, left: 0 }]);
     } finally {
       editor.cleanUp();
       component.cleanUp();
@@ -210,10 +242,10 @@ describe('Editor state', () => {
 
     try {
       editor.edit(component);
-      component.codeScrollLeft = 24;
+      component.viewportScroll = { top: 128, left: 24 };
       editor.cleanUp();
 
-      expect(storedState?.view).toEqual({ scrollLeft: 24 });
+      expect(storedState?.view).toEqual({ scrollLeft: 24, scrollTop: 128 });
     } finally {
       editor.cleanUp();
       component.cleanUp();
@@ -249,10 +281,12 @@ describe('Editor state', () => {
             direction: 0,
           },
         ],
-        view: { scrollLeft: 12 },
+        view: { scrollTop: 40, scrollLeft: 12 },
       });
 
-      expect(component.restoredCodeScrollLefts).toEqual([12]);
+      expect(component.restoredViewportScrolls).toEqual([
+        { top: 40, left: 12 },
+      ]);
       expect(scrollIntoViewCalls).toBe(0);
       expect(editor.getState().selections).toEqual([
         {

--- a/packages/diffs/test/editorVirtualizedEdit.test.ts
+++ b/packages/diffs/test/editorVirtualizedEdit.test.ts
@@ -387,7 +387,7 @@ describe('Editor selections in a virtualized window', () => {
             direction: DirectionForward,
           },
         ],
-        view: { scrollLeft: 0 },
+        view: { scrollTop: 0, scrollLeft: 0 },
       });
 
       expect(

--- a/packages/diffs/test/editorVirtualizedReveal.test.ts
+++ b/packages/diffs/test/editorVirtualizedReveal.test.ts
@@ -65,11 +65,11 @@ class VirtualizedEditableComponent implements DiffsEditableComponent<undefined> 
     return this.options;
   }
 
-  getCodeScrollLeft(): number {
-    return 0;
+  getViewportScroll(): undefined {
+    return undefined;
   }
 
-  setCodeScrollLeft(): void {}
+  setViewportScroll(): void {}
 
   render(): void {
     this.rerender();

--- a/packages/diffs/test/virtualizedEditorViewport.test.ts
+++ b/packages/diffs/test/virtualizedEditorViewport.test.ts
@@ -2,12 +2,13 @@ import { describe, expect, test } from 'bun:test';
 
 import { VirtualizedFile } from '../src/components/VirtualizedFile';
 import { VirtualizedFileDiff } from '../src/components/VirtualizedFileDiff';
-import { DEFAULT_THEMES } from '../src/constants';
-import type { DiffsEditor } from '../src/types';
-import { parseDiffFromFile } from '../src/utils/parseDiffFromFile';
-import { installDom, waitFor } from './domHarness';
+import { installDom } from './domHarness';
 
-function createSimpleVirtualizer(root: HTMLElement) {
+function createSimpleVirtualizer(
+  root: HTMLElement,
+  scrollTop = 0,
+  scrollLeft = 0
+) {
   return {
     type: 'simple',
     config: {},
@@ -16,67 +17,19 @@ function createSimpleVirtualizer(root: HTMLElement) {
     getRoot: () => root,
     getWindowSpecs: () => ({ top: 0, bottom: 800 }),
     getOffsetInScrollContainer: () => 0,
+    getScrollLeft: () => scrollLeft,
+    getScrollTop: () => scrollTop,
     instanceChanged(instance: { onRender(dirty: boolean): boolean }) {
       instance.onRender(true);
     },
     isInstanceVisible: () => true,
     markDOMDirty() {},
     requestHeightReconcile() {},
+    scrollTo(options: { top: number; left: number }) {
+      scrollLeft = options.left;
+      scrollTop = options.top;
+    },
   } as never;
-}
-
-async function renderFile(
-  file: VirtualizedFile<undefined>,
-  root: HTMLElement
-): Promise<HTMLElement> {
-  const fileContainer = document.createElement('div');
-  root.appendChild(fileContainer);
-  file.render({
-    file: { name: 'state.txt', contents: 'alpha\nbravo\n', lang: 'text' },
-    fileContainer,
-    forceRender: true,
-  });
-  await waitFor(
-    () =>
-      fileContainer.shadowRoot?.querySelector('[data-code]') instanceof
-      HTMLElement
-  );
-  const code = fileContainer.shadowRoot?.querySelector('[data-code]');
-  expect(code).toBeInstanceOf(HTMLElement);
-  return code as HTMLElement;
-}
-
-async function renderFileDiff(
-  fileDiff: VirtualizedFileDiff<undefined>,
-  root: HTMLElement
-): Promise<{ additions: HTMLElement; deletions?: HTMLElement }> {
-  const fileContainer = document.createElement('div');
-  root.appendChild(fileContainer);
-  fileDiff.render({
-    fileDiff: parseDiffFromFile(
-      { name: 'state.txt', contents: 'alpha\nbravo\n', lang: 'text' },
-      { name: 'state.txt', contents: 'alpha\ncharlie\n', lang: 'text' }
-    ),
-    fileContainer,
-    forceRender: true,
-  });
-  await waitFor(
-    () =>
-      fileContainer.shadowRoot?.querySelector(
-        '[data-code]:not([data-deletions])'
-      ) instanceof HTMLElement
-  );
-  const additions = fileContainer.shadowRoot?.querySelector(
-    '[data-code]:not([data-deletions])'
-  );
-  const deletions = fileContainer.shadowRoot?.querySelector(
-    '[data-code][data-deletions]'
-  );
-  expect(additions).toBeInstanceOf(HTMLElement);
-  return {
-    additions: additions as HTMLElement,
-    deletions: deletions instanceof HTMLElement ? deletions : undefined,
-  };
 }
 
 describe('virtualized editor viewport', () => {
@@ -120,111 +73,48 @@ describe('virtualized editor viewport', () => {
     }
   });
 
-  test('reads and restores File horizontal state from the code scroller', async () => {
+  test('reads and restores viewport state only for the simple Virtualizer', () => {
     const dom = installDom();
     const root = document.createElement('div');
-    root.scrollLeft = 900;
-    const virtualizer = createSimpleVirtualizer(root);
-    const file = new VirtualizedFile(
-      { disableFileHeader: true, theme: DEFAULT_THEMES },
-      virtualizer
-    );
+    const virtualizer = createSimpleVirtualizer(root, 128, 32);
+    const file = new VirtualizedFile({}, virtualizer);
+    const fileDiff = new VirtualizedFileDiff({}, virtualizer);
 
     try {
-      const code = await renderFile(file, root);
-      code.scrollLeft = 60;
+      expect(file.getViewportScroll()).toEqual({ top: 128, left: 32 });
+      expect(fileDiff.getViewportScroll()).toEqual({ top: 128, left: 32 });
 
-      expect(file.getCodeScrollLeft()).toBe(60);
-      file.setCodeScrollLeft(61);
-      expect(code.scrollLeft).toBe(61);
-
-      let recyclePosition: number | undefined;
-      file.attachEditor({
-        __captureFocusForDOMReplacement() {},
-        __postponeBgTokenizeToNextFrame() {},
-        __syncRenderView() {},
-        edit: () => () => {},
-        cleanUp() {
-          recyclePosition = file.getCodeScrollLeft();
-        },
-      } as DiffsEditor<undefined>);
-      code.scrollLeft = 62;
-      file.cleanUp(true);
-      expect(recyclePosition).toBe(62);
+      fileDiff.setViewportScroll({ top: 256, left: 64 });
+      expect(file.getViewportScroll()).toEqual({ top: 256, left: 64 });
     } finally {
       file.cleanUp();
+      fileDiff.cleanUp();
       dom.cleanup();
     }
   });
 
-  for (const diffStyle of ['unified', 'split'] as const) {
-    test(`reads ${diffStyle} FileDiff horizontal state from active code columns`, async () => {
-      const dom = installDom();
-      const root = document.createElement('div');
-      root.scrollLeft = 900;
-      const virtualizer = createSimpleVirtualizer(root);
-      const fileDiff = new VirtualizedFileDiff(
-        {
-          diffStyle,
-          disableFileHeader: true,
-          theme: DEFAULT_THEMES,
-        },
-        virtualizer
-      );
-
-      try {
-        const code = await renderFileDiff(fileDiff, root);
-        code.additions.scrollLeft = 40;
-        if (code.deletions !== undefined) {
-          code.deletions.scrollLeft = 60;
-        }
-
-        expect(fileDiff.getCodeScrollLeft()).toBe(
-          diffStyle === 'split' ? 60 : 40
-        );
-      } finally {
-        fileDiff.cleanUp();
-        dom.cleanup();
-      }
-    });
-  }
-
-  test('restores split FileDiff horizontal state to both code columns', async () => {
+  test('ignores vertical viewport state for CodeView', () => {
     const dom = installDom();
-    const root = document.createElement('div');
-    const virtualizer = createSimpleVirtualizer(root);
-    const fileDiff = new VirtualizedFileDiff(
-      {
-        diffStyle: 'split',
-        disableFileHeader: true,
-        theme: DEFAULT_THEMES,
+    let scrollCalls = 0;
+    const codeView = {
+      type: 'advanced',
+      getScrollTop: () => 128,
+      scrollTo: () => {
+        scrollCalls++;
       },
-      virtualizer
-    );
+    } as never;
+    const file = new VirtualizedFile({}, codeView);
+    const fileDiff = new VirtualizedFileDiff({}, codeView);
 
     try {
-      const code = await renderFileDiff(fileDiff, root);
-      expect(code.deletions).toBeDefined();
+      expect(file.getViewportScroll()).toEqual({ top: 0, left: 0 });
+      expect(fileDiff.getViewportScroll()).toEqual({ top: 0, left: 0 });
 
-      fileDiff.setCodeScrollLeft(60);
-
-      expect(code.additions.scrollLeft).toBe(60);
-      expect(code.deletions?.scrollLeft).toBe(60);
-
-      let recyclePosition: number | undefined;
-      fileDiff.attachEditor({
-        __captureFocusForDOMReplacement() {},
-        __postponeBgTokenizeToNextFrame() {},
-        __syncRenderView() {},
-        edit: () => () => {},
-        cleanUp() {
-          recyclePosition = fileDiff.getCodeScrollLeft();
-        },
-      } as DiffsEditor<undefined>);
-      code.deletions!.scrollLeft = 64;
-      fileDiff.cleanUp(true);
-      expect(recyclePosition).toBe(64);
+      file.setViewportScroll({ top: 256, left: 64 });
+      fileDiff.setViewportScroll({ top: 256, left: 64 });
+      expect(scrollCalls).toBe(0);
     } finally {
+      file.cleanUp();
       fileDiff.cleanUp();
       dom.cleanup();
     }


### PR DESCRIPTION
**Scroll position and selections are persisted in he Agent UI demo in home page.**

- Persist both `scrollTop`(been deleted in 517a4d17) and `scrollLeft` for `Virtualizer`.
- Keep `CodeView` persistence horizontal-only.
- Reset the viewport to `{ top: 0, left: 0 }` when persistence is enabled but no stored state exists.
- Restore persisted state for editable `FileDiff` surface as well, before only support `File` instance.

https://github.com/user-attachments/assets/7f868d85-ca07-4a1f-ac81-d56d67c040f8

**Fix safari scroll bug on unified diffs layout.**

https://github.com/user-attachments/assets/ae16a84b-72a7-4dbd-a515-d5c4d76771d6

