### PR TITLE
[diffs/edit] Misc Fixes

### DIFF
--- a/apps/docs/app/(diffs)/_home/agent-ui.css
+++ b/apps/docs/app/(diffs)/_home/agent-ui.css
@@ -151,7 +151,7 @@ button.aui-dot.is-zoom:hover {
 
 .aui-body {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 380px;
+  grid-template-columns: minmax(0, 1fr) 340px;
   min-height: 0;
 }
 
@@ -433,6 +433,7 @@ button.aui-dot.is-zoom:hover {
   min-height: 0;
   overflow: auto;
   padding-top: 6px;
+  --trees-padding-inline-override: 6px;
 }
 
 /* --- Fullscreen variant (/edit/live) ------------------------------------- */

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -56,9 +56,11 @@ import {
 import { getFileRendererOptions } from '../utils/getFileRendererOptions';
 import { getLineAnnotationName } from '../utils/getLineAnnotationName';
 import { getOrCreateCodeNode } from '../utils/getOrCreateCodeNode';
+import { guardWebKitScrollDuringRebuild } from '../utils/guardWebKitScrollDuringRebuild';
 import { upsertHostThemeStyle } from '../utils/hostTheme';
 import { isFilePlainText } from '../utils/isFilePlainText';
 import { isStyleNode } from '../utils/isStyleNode';
+import { isSafari } from '../utils/platform';
 import { prerenderHTMLIfNecessary } from '../utils/prerenderHTMLIfNecessary';
 import { getMeasuredScrollbarGutter } from '../utils/scrollbarGutter';
 import { setPreNodeProperties } from '../utils/setWrapperNodeProps';
@@ -1099,24 +1101,39 @@ export class File<
     );
   }
 
+  // A boolean check to ensure that edit mode in WebKit doesn't cause potential
+  // scroll jumps to due bugs with WebKit. The workarounds have performance
+  // implications so we avoid running the workarounds on browsers or scenarios
+  // where they are not applicable
+  protected shouldGuardRebuildScroll(): boolean {
+    return this.editor != null && isSafari();
+  }
+
   private applyFullRender(result: FileRenderResult, pre: HTMLPreElement): void {
     this.cleanupErrorWrapper();
     this.applyPreNodeAttributes(pre, result);
-    this.code = getOrCreateCodeNode({ code: this.code });
+    const code = (this.code = getOrCreateCodeNode({ code: this.code }));
     const codeAst = this.fileRenderer.renderCodeAST(result);
     this.editor?.__captureFocusForDOMReplacement();
-    if (this.code.childElementCount >= 2) {
-      for (let i = 0; i < 2; i++) {
-        const domEl = this.code.children[i] as HTMLElement;
-        const astEl = codeAst[i] as HASTElement;
-        domEl.innerHTML = toHtml(astEl.children);
-        domEl.style.cssText = astEl.properties.style as string;
+    const applyColumns = () => {
+      if (code.childElementCount >= 2) {
+        for (let i = 0; i < 2; i++) {
+          const domEl = code.children[i] as HTMLElement;
+          const astEl = codeAst[i] as HASTElement;
+          domEl.innerHTML = toHtml(astEl.children);
+          domEl.style.cssText = astEl.properties.style as string;
+        }
+      } else {
+        code.innerHTML = toHtml(codeAst);
       }
+      if (!pre.contains(code)) {
+        pre.replaceChildren(code);
+      }
+    };
+    if (this.shouldGuardRebuildScroll()) {
+      guardWebKitScrollDuringRebuild(pre, applyColumns);
     } else {
-      this.code.innerHTML = toHtml(codeAst);
-    }
-    if (!pre.contains(this.code)) {
-      pre.replaceChildren(this.code);
+      applyColumns();
     }
     this.lastRowCount = result.rowCount;
   }

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -86,6 +86,7 @@ import { getDiffHunksRendererOptions } from '../utils/getDiffHunksRendererOption
 import { getHunkSideStartBoundary } from '../utils/getHunkSideBoundaries';
 import { getLineAnnotationName } from '../utils/getLineAnnotationName';
 import { getOrCreateCodeNode } from '../utils/getOrCreateCodeNode';
+import { guardWebKitScrollDuringRebuild } from '../utils/guardWebKitScrollDuringRebuild';
 import { upsertHostThemeStyle } from '../utils/hostTheme';
 import { hydratePartialDiff } from '../utils/hydratePartialDiff';
 import { isDefaultRenderRange } from '../utils/isDefaultRenderRange';
@@ -93,6 +94,7 @@ import { isDiffPlainText } from '../utils/isDiffPlainText';
 import { isStyleNode } from '../utils/isStyleNode';
 import { iterateOverDiff } from '../utils/iterateOverDiff';
 import { parseDiffFromFile } from '../utils/parseDiffFromFile';
+import { isSafari } from '../utils/platform';
 import { prerenderHTMLIfNecessary } from '../utils/prerenderHTMLIfNecessary';
 import { getMeasuredScrollbarGutter } from '../utils/scrollbarGutter';
 import { setPreNodeProperties } from '../utils/setWrapperNodeProps';
@@ -2242,7 +2244,28 @@ export class FileDiff<
     );
   }
 
+  // A boolean check to ensure that edit mode in WebKit doesn't cause potential
+  // scroll jumps to due bugs with WebKit. The workarounds have performance
+  // implications so we avoid running the workarounds on browsers or scenarios
+  // where they are not applicable
+  protected shouldGuardRebuildScroll(): boolean {
+    return this.editor != null && isSafari();
+  }
+
   private applyHunksToDOM(
+    pre: HTMLPreElement,
+    result: HunksRenderResult
+  ): void {
+    if (this.shouldGuardRebuildScroll()) {
+      guardWebKitScrollDuringRebuild(pre, () =>
+        this.replaceCodeColumns(pre, result)
+      );
+    } else {
+      this.replaceCodeColumns(pre, result);
+    }
+  }
+
+  private replaceCodeColumns(
     pre: HTMLPreElement,
     result: HunksRenderResult
   ): void {
@@ -2610,18 +2633,25 @@ export class FileDiff<
     const ast = this.hunksRenderer.renderCodeAST('unified', hunksResult);
     const gutterChildren = getElementChildren(ast?.[0]);
     const contentChildren = getElementChildren(ast?.[1]);
-    for (const [el, astChildren] of [
-      [columns.gutter, gutterChildren],
-      [columns.content, contentChildren],
-    ] as const) {
-      if (astChildren != null) {
-        el.innerHTML = toHtml(astChildren);
+    const applyColumns = () => {
+      for (const [el, astChildren] of [
+        [columns.gutter, gutterChildren],
+        [columns.content, contentChildren],
+      ] as const) {
+        if (astChildren != null) {
+          el.innerHTML = toHtml(astChildren);
+        }
       }
-    }
 
-    if (hunksResult.rowCount !== this.lastRowCount) {
-      this.applyRowSpan('unified', columns, hunksResult.rowCount);
-      this.lastRowCount = hunksResult.rowCount;
+      if (hunksResult.rowCount !== this.lastRowCount) {
+        this.applyRowSpan('unified', columns, hunksResult.rowCount);
+        this.lastRowCount = hunksResult.rowCount;
+      }
+    };
+    if (this.shouldGuardRebuildScroll()) {
+      guardWebKitScrollDuringRebuild(this.pre, applyColumns);
+    } else {
+      applyColumns();
     }
     this.renderSeparators(hunksResult.hunkData);
 

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -2265,6 +2265,38 @@ export class FileDiff<
     }
   }
 
+  // Renders a code column's AST into an existing elements without replacing
+  // the gutter and content parents. Identity matters in edit mode: the content
+  // element is the focused contenteditable, and replacing it ends the
+  // browser's editing session — focus tears down and restores, and iOS
+  // answers every session restart with an animated caret reveal.
+  //
+  // Returns false when the element has no column pair yet (initial render,
+  // or a diff-style switch built a fresh element); the caller then assigns
+  // the full innerHTML.
+  private applyCodeColumnsInPlace(
+    code: HTMLElement,
+    ast: ElementContent[],
+    rowCount: number
+  ): boolean {
+    const columns = this.getColumnPair(code);
+    if (columns == null) {
+      return false;
+    }
+    const gutterChildren = getElementChildren(ast[0]);
+    const contentChildren = getElementChildren(ast[1]);
+    if (gutterChildren == null || contentChildren == null) {
+      return false;
+    }
+    columns.gutter.innerHTML = toHtml(gutterChildren);
+    columns.content.innerHTML = toHtml(contentChildren);
+    if (rowCount !== this.lastRowCount) {
+      columns.gutter.style.setProperty('grid-row', `span ${rowCount}`);
+      columns.content.style.setProperty('grid-row', `span ${rowCount}`);
+    }
+    return true;
+  }
+
   private replaceCodeColumns(
     pre: HTMLPreElement,
     result: HunksRenderResult
@@ -2301,8 +2333,16 @@ export class FileDiff<
         rowSpan,
         containerSize,
       });
-      this.codeUnified.innerHTML =
-        this.hunksRenderer.renderPartialHTML(unifiedAST);
+      if (
+        !this.applyCodeColumnsInPlace(
+          this.codeUnified,
+          unifiedAST,
+          result.rowCount
+        )
+      ) {
+        this.codeUnified.innerHTML =
+          this.hunksRenderer.renderPartialHTML(unifiedAST);
+      }
       codeElements.push(this.codeUnified);
     } else if (deletionsAST != null || additionsAST != null) {
       if (deletionsAST != null) {
@@ -2318,8 +2358,16 @@ export class FileDiff<
           rowSpan,
           containerSize,
         });
-        this.codeDeletions.innerHTML =
-          this.hunksRenderer.renderPartialHTML(deletionsAST);
+        if (
+          !this.applyCodeColumnsInPlace(
+            this.codeDeletions,
+            deletionsAST,
+            result.rowCount
+          )
+        ) {
+          this.codeDeletions.innerHTML =
+            this.hunksRenderer.renderPartialHTML(deletionsAST);
+        }
         codeElements.push(this.codeDeletions);
       } else {
         // If we have no deletion column, lets clean it up if it exists
@@ -2343,8 +2391,16 @@ export class FileDiff<
           rowSpan,
           containerSize,
         });
-        this.codeAdditions.innerHTML =
-          this.hunksRenderer.renderPartialHTML(additionsAST);
+        if (
+          !this.applyCodeColumnsInPlace(
+            this.codeAdditions,
+            additionsAST,
+            result.rowCount
+          )
+        ) {
+          this.codeAdditions.innerHTML =
+            this.hunksRenderer.renderPartialHTML(additionsAST);
+        }
         codeElements.push(this.codeAdditions);
       } else {
         // If we have no addition column, lets clean it up if it exists
@@ -3012,6 +3068,25 @@ export class FileDiff<
     element.style.setProperty('min-height', `calc(${size} * 1lh)`);
   }
 
+  private getColumnPair(
+    code: HTMLElement | undefined
+  ): ColumnElements | undefined {
+    if (code == null) {
+      return undefined;
+    }
+    const gutter = code.children[0];
+    const content = code.children[1];
+    if (
+      !(gutter instanceof HTMLElement) ||
+      !(content instanceof HTMLElement) ||
+      gutter.dataset.gutter == null ||
+      content.dataset.content == null
+    ) {
+      return undefined;
+    }
+    return { gutter, content };
+  }
+
   private getCodeColumns(
     diffStyle: 'split' | 'unified',
     codeUnified: HTMLElement | undefined,
@@ -3021,30 +3096,11 @@ export class FileDiff<
     | [ColumnElements | undefined, ColumnElements | undefined]
     | ColumnElements
     | undefined {
-    function getColumns(
-      code: HTMLElement | undefined
-    ): ColumnElements | undefined {
-      if (code == null) {
-        return undefined;
-      }
-      const gutter = code.children[0];
-      const content = code.children[1];
-      if (
-        !(gutter instanceof HTMLElement) ||
-        !(content instanceof HTMLElement) ||
-        gutter.dataset.gutter == null ||
-        content.dataset.content == null
-      ) {
-        return undefined;
-      }
-      return { gutter, content };
-    }
-
     if (diffStyle === 'unified') {
-      return getColumns(codeUnified);
+      return this.getColumnPair(codeUnified);
     } else {
-      const deletions = getColumns(codeDeletions);
-      const additions = getColumns(codeAdditions);
+      const deletions = this.getColumnPair(codeDeletions);
+      const additions = this.getColumnPair(codeAdditions);
       return deletions != null || additions != null
         ? [deletions, additions]
         : undefined;

--- a/packages/diffs/src/components/VirtualizedFile.ts
+++ b/packages/diffs/src/components/VirtualizedFile.ts
@@ -792,6 +792,12 @@ export class VirtualizedFile<
     return this.isAdvancedMode() || super.shouldDisableVirtualizationBuffers();
   }
 
+  // This WebKit dom manipulation scroll fix is not applicable in virtualized
+  // environments, so we avoid the performance hit even on Webkit
+  protected override shouldGuardRebuildScroll(): boolean {
+    return false;
+  }
+
   private isSimpleMode(): boolean {
     return this.virtualizer.type === 'simple';
   }

--- a/packages/diffs/src/components/VirtualizedFileDiff.ts
+++ b/packages/diffs/src/components/VirtualizedFileDiff.ts
@@ -1313,6 +1313,12 @@ export class VirtualizedFileDiff<
     return this.isAdvancedMode() || super.shouldDisableVirtualizationBuffers();
   }
 
+  // This WebKit dom manipulation scroll fix is not applicable in virtualized
+  // environments, so we avoid the performance hit even on Webkit
+  protected override shouldGuardRebuildScroll(): boolean {
+    return false;
+  }
+
   private isSimpleMode(): boolean {
     return this.virtualizer.type === 'simple';
   }

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -1896,7 +1896,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         ) {
           const cursorMoveOptions: CursorMoveOptions = {
             getSoftLineOffsets: this.#isWrap
-              ? (line) => this.#wrapLineText(line)
+              ? (line) => this.#wrapLineTextOrWholeLine(line)
               : undefined,
             resolveRenderableLine: this.#resolveRenderableLine,
           };
@@ -4276,7 +4276,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     type: 'selection' | 'match' | 'marker' | 'bracketMatch',
     extraDataset?: string
   ) {
-    const wrapOffsets = this.#wrapLineText(line);
+    const wrapOffsets = this.#wrapLineTextOrWholeLine(line);
     const segmentCount = wrapOffsets.length - 1;
     // offsetLeft is the x of the content's left edge in overlay coordinates.
     // In a split diff with wrapping the content element is a grid item shifted
@@ -5031,7 +5031,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     }
     const getSoftLineStart = this.#isWrap
       ? (line: number, character: number) => {
-          const wrapOffsets = this.#wrapLineText(line);
+          const wrapOffsets = this.#wrapLineTextOrWholeLine(line);
           for (let w = 0; w + 1 < wrapOffsets.length; w++) {
             const segmentStart = wrapOffsets[w];
             const segmentEnd = wrapOffsets[w + 1];
@@ -5517,6 +5517,15 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         2 * this.#metrics.ch + this.#metrics.measureTextWidth(lineText);
       if (textWidth > contentWidth) {
         const wrapOffsets = this.#wrapLineText(line);
+        // undefined means the wrap offsets could not be measured — the
+        // content element is detached or has no layout (see #wrapLineText).
+        // Fall back to an unwrapped position, and return before the
+        // #lastAccessedCharX write below so nothing derived from the
+        // unmeasurable DOM gets memoized; the next call re-measures against
+        // live layout.
+        if (wrapOffsets == null) {
+          return [left + (this.#activeContentOffset?.left ?? 0), 0];
+        }
         for (let w = 0; w + 1 < wrapOffsets.length; w++) {
           const segmentStart = wrapOffsets[w];
           const segmentEnd = wrapOffsets[w + 1];
@@ -5557,7 +5566,17 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
 
   // Compute how a logical line of text is broken into visual lines when line
   // wrapping is enabled.
-  #wrapLineText(line: number): Uint32Array {
+  //
+  // Returns undefined when the offsets cannot be measured: measurement works
+  // by appending a hidden probe to #contentElement, so a detached or
+  // zero-width content element (both occur while a session re-render replaces
+  // the code columns) would report "never wraps" for any line. That result is
+  // never returned or cached — a cached wrong answer would keep placing
+  // carets at unwrapped positions until an unrelated edit evicted it. Callers
+  // that need best-effort segmentation use #wrapLineTextOrWholeLine;
+  // #getCharX propagates the undefined so its own memoization is skipped
+  // too.
+  #wrapLineText(line: number): Uint32Array | undefined {
     const cachedOffsets = this.#wrapLineOffsetsCache.get(line);
     if (cachedOffsets !== undefined) {
       return cachedOffsets;
@@ -5571,6 +5590,11 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
       const offsets = new Uint32Array([0]);
       this.#wrapLineOffsetsCache.set(line, offsets);
       return offsets;
+    }
+
+    const contentElement = this.#contentElement;
+    if (contentElement == null || !contentElement.isConnected) {
+      return undefined;
     }
 
     const div = h(
@@ -5592,16 +5616,19 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         },
         textContent: lineText,
       },
-      this.#contentElement
+      contentElement
     );
     const textNode = div.firstChild as Text;
     const range = document.createRange();
     const starts: number[] = [];
 
     try {
+      const divRect = div.getBoundingClientRect();
+      if (divRect.width === 0) {
+        return undefined;
+      }
       const unicodeOffsets = getUnicodeMeasurementOffsets(lineText);
-      const wrapLineStartLeft =
-        div.getBoundingClientRect().left + this.#metrics.ch;
+      const wrapLineStartLeft = divRect.left + this.#metrics.ch;
 
       // Measurement steps through grapheme clusters when the text needs
       // Unicode-aware boundaries, single UTF-16 units otherwise. Grapheme
@@ -5662,6 +5689,19 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
     } finally {
       div.remove();
     }
+  }
+
+  // #wrapLineText for callers that need usable offsets even when measurement
+  // is impossible (undefined): treats the line as one unwrapped segment.
+  // Safe because the fallback is never cached — once the content element is
+  // measurable again, the same call returns real offsets.
+  #wrapLineTextOrWholeLine(line: number): Uint32Array {
+    const offsets = this.#wrapLineText(line);
+    if (offsets !== undefined) {
+      return offsets;
+    }
+    const length = this.#textDocument?.getLineText(line)?.length ?? 0;
+    return Uint32Array.of(0, length);
   }
 
   // check if the web selection belongs to editor

--- a/packages/diffs/src/editor/platform.ts
+++ b/packages/diffs/src/editor/platform.ts
@@ -1,34 +1,11 @@
-let _isMacLike: boolean | undefined = undefined;
-let _isLinux: boolean | undefined = undefined;
-let _isSafari: boolean | undefined = undefined;
+import {
+  isLinux,
+  isMacLike,
+  isSafari,
+  resetPlatformDetection,
+} from '../utils/platform';
 
-/**
- * Clears the cached platform/browser detection. Detection is memoized on first
- * call, so a test process that swaps `navigator` (e.g. to exercise Linux or
- * Safari behavior) must reset it; otherwise the value cached by an earlier test
- * leaks across tests and no longer matches the active navigator.
- */
-export function resetPlatformDetectionForTests(): void {
-  _isMacLike = undefined;
-  _isLinux = undefined;
-  _isSafari = undefined;
-}
-
-export function isMacLike(): boolean {
-  return (_isMacLike ??= /macOS|MacIntel|iPhone|iPad|iPod/i.test(
-    getPlatform()
-  ));
-}
-
-export function isLinux(): boolean {
-  return (_isLinux ??= /Linux/i.test(getPlatform()));
-}
-
-export function isSafari(): boolean {
-  return (_isSafari ??=
-    ('safari' in window && 'pushNotification' in (window as any).safari) ||
-    /^((?!chrome|android).)*safari/i.test(navigator.userAgent));
-}
+export { isLinux, isMacLike, isSafari, resetPlatformDetection };
 
 export function isPrimaryModifier(
   { metaKey, ctrlKey }: MouseEvent | KeyboardEvent,
@@ -91,11 +68,4 @@ export function isMoveCursorShortcut(
   }
 
   return undefined;
-}
-
-function getPlatform(): string {
-  const navigator = globalThis.navigator as Navigator & {
-    userAgentData?: { platform?: string };
-  };
-  return navigator?.platform ?? navigator?.userAgentData?.platform ?? 'unknown';
 }

--- a/packages/diffs/src/utils/guardWebKitScrollDuringRebuild.ts
+++ b/packages/diffs/src/utils/guardWebKitScrollDuringRebuild.ts
@@ -1,0 +1,32 @@
+/**
+ * Runs a wholesale code-column rebuild with the pre element's height pinned,
+ * working around a WebKit bug (https://bugs.webkit.org/show_bug.cgi?id=308027):
+ * when the subtree of a `container-type: inline-size` element is rewritten in
+ * bulk (column innerHTML swaps, grid-row span rewrites), WebKit resolves the
+ * ancestor scroller's offset against a transiently collapsed interim layout
+ * and clamps scrollTop to 0 — the scroller visibly jumps to the top on every
+ * edit. Pinning `min-height` keeps that interim layout at full height so the
+ * scroll offset survives; the layout read before unpinning is required, since
+ * it materializes the interim layout while the pin is active.
+ *
+ * Both the pin height read and the pinned-layout read force a synchronous
+ * layout, so callers own the gating via shouldGuardRebuildScroll: Safari-only,
+ * edit-mode-only, and never inside CodeView's batched read/write render pass.
+ */
+export function guardWebKitScrollDuringRebuild(
+  pre: HTMLElement | undefined,
+  rebuild: () => void
+): void {
+  const height = pre?.offsetHeight ?? 0;
+  if (pre == null || height === 0) {
+    rebuild();
+    return;
+  }
+  pre.style.minHeight = `${height}px`;
+  try {
+    rebuild();
+    void pre.offsetHeight;
+  } finally {
+    pre.style.minHeight = '';
+  }
+}

--- a/packages/diffs/src/utils/platform.ts
+++ b/packages/diffs/src/utils/platform.ts
@@ -1,0 +1,39 @@
+let _isMacLike: boolean | undefined = undefined;
+let _isLinux: boolean | undefined = undefined;
+let _isSafari: boolean | undefined = undefined;
+
+/**
+ * Clears the cached platform/browser detection. Detection is memoized on first
+ * call, so a test process that swaps `navigator` (e.g. to exercise Linux or
+ * Safari behavior) must reset it; otherwise the value cached by an earlier test
+ * leaks across tests and no longer matches the active navigator.
+ */
+export function resetPlatformDetection(): void {
+  _isMacLike = undefined;
+  _isLinux = undefined;
+  _isSafari = undefined;
+}
+
+export function isMacLike(): boolean {
+  return (_isMacLike ??= /macOS|MacIntel|iPhone|iPad|iPod/i.test(
+    getPlatform()
+  ));
+}
+
+export function isLinux(): boolean {
+  return (_isLinux ??= /Linux/i.test(getPlatform()));
+}
+
+export function isSafari(): boolean {
+  return (_isSafari ??=
+    // oxlint-disable-next-line typescript/no-explicit-any
+    ('safari' in window && 'pushNotification' in (window as any).safari) ||
+    /^((?!chrome|android).)*safari/i.test(navigator.userAgent));
+}
+
+function getPlatform(): string {
+  const navigator = globalThis.navigator as Navigator & {
+    userAgentData?: { platform?: string };
+  };
+  return navigator?.platform ?? navigator?.userAgentData?.platform ?? 'unknown';
+}

--- a/packages/diffs/test/domHarness.ts
+++ b/packages/diffs/test/domHarness.ts
@@ -1,9 +1,9 @@
 import { JSDOM } from 'jsdom';
 
 import type { CodeView } from '../src/components/CodeView';
-import { resetPlatformDetection } from '../src/utils/platform';
 import { clearRenderQueue } from '../src/managers/UniversalRenderingManager';
 import type { CodeViewItem, FileContents } from '../src/types';
+import { resetPlatformDetection } from '../src/utils/platform';
 
 export interface InstallDomNavigatorOptions {
   maxTouchPoints?: number;

--- a/packages/diffs/test/domHarness.ts
+++ b/packages/diffs/test/domHarness.ts
@@ -1,7 +1,7 @@
 import { JSDOM } from 'jsdom';
 
 import type { CodeView } from '../src/components/CodeView';
-import { resetPlatformDetectionForTests } from '../src/editor/platform';
+import { resetPlatformDetection } from '../src/utils/platform';
 import { clearRenderQueue } from '../src/managers/UniversalRenderingManager';
 import type { CodeViewItem, FileContents } from '../src/types';
 
@@ -264,7 +264,7 @@ export function installDom(options: InstallDomOptions = {}): DomHandle {
   // Platform detection memoizes on first call; reset it so it re-runs against
   // the navigator just installed above rather than a value an earlier test
   // cached under a different platform.
-  resetPlatformDetectionForTests();
+  resetPlatformDetection();
 
   return {
     window: dom.window,

--- a/packages/diffs/test/e2e/e2e-globals.d.ts
+++ b/packages/diffs/test/e2e/e2e-globals.d.ts
@@ -79,6 +79,7 @@ interface Window {
   __editor?: E2EEditor;
   __forceEditorFullRender?: () => void;
   __moveEditorContainer?: () => void;
+  __syncCount?: number;
 
   // edit-collapsed.html helpers: rendered new-file line numbers in the
   // editable column, and the primary caret's zero-based line.

--- a/packages/diffs/test/e2e/edit.pw.ts
+++ b/packages/diffs/test/e2e/edit.pw.ts
@@ -36,10 +36,16 @@ async function clickIntoAdditions(page: Page): Promise<void> {
   await page.locator(ADDITIONS).click();
 }
 
+// Moves focus away from the editor at a controlled point inside a full
+// render, then lets the caller assert the editor does not reclaim it. A full
+// render keeps the editable element in place, so the two hook points are:
+// 'rebuild' — the column children were just swapped (the editor's deferred
+// focus/selection restore has not run yet) — and 'after-sync' — the editor
+// re-sync (which invokes the restore) has completed.
 async function moveFocusDuringFullRender(
   page: Page,
   target: 'background' | 'external-link' | 'host',
-  timing: 'replacement' | 'after-sync'
+  timing: 'rebuild' | 'after-sync'
 ): Promise<void> {
   await page.evaluate(
     ({ selector, target, timing }) =>
@@ -47,7 +53,6 @@ async function moveFocusDuringFullRender(
         const host = document.querySelector('diffs-container');
         const root = host?.shadowRoot;
         const content = root?.querySelector(selector);
-        const code = content?.parentElement;
         const externalLink = document.querySelector('[data-fixtures-index]');
         const focusTarget =
           target === 'host'
@@ -57,7 +62,7 @@ async function moveFocusDuringFullRender(
               : externalLink;
         if (
           !(host instanceof HTMLElement) ||
-          !(code instanceof HTMLElement) ||
+          !(content instanceof HTMLElement) ||
           !(focusTarget instanceof HTMLElement)
         ) {
           reject(new Error('missing editor or external focus target'));
@@ -66,16 +71,7 @@ async function moveFocusDuringFullRender(
         if (target === 'host') {
           host.tabIndex = -1;
         }
-        const observer = new MutationObserver(() => {
-          const replacement = root?.querySelector(selector);
-          if (
-            replacement === content ||
-            (timing === 'after-sync' &&
-              replacement?.getAttribute('contenteditable') !== 'true')
-          ) {
-            return;
-          }
-          observer.disconnect();
+        const moveFocus = () => {
           if (target === 'background') {
             focusTarget.dispatchEvent(
               new PointerEvent('pointerdown', {
@@ -83,6 +79,11 @@ async function moveFocusDuringFullRender(
                 composed: true,
               })
             );
+            // A synthetic pointerdown carries no default focus change; a real
+            // background press blurs the editor, so blur explicitly to match.
+            if (root?.activeElement instanceof HTMLElement) {
+              root.activeElement.blur();
+            }
           } else {
             focusTarget.focus();
             if (
@@ -94,10 +95,25 @@ async function moveFocusDuringFullRender(
             }
           }
           resolve();
+        };
+        if (timing === 'after-sync') {
+          const syncsBefore = window.__syncCount ?? 0;
+          const poll = () => {
+            if ((window.__syncCount ?? 0) > syncsBefore) {
+              moveFocus();
+              return;
+            }
+            requestAnimationFrame(poll);
+          };
+          window.__forceEditorFullRender?.();
+          poll();
+          return;
+        }
+        const observer = new MutationObserver(() => {
+          observer.disconnect();
+          moveFocus();
         });
-        observer.observe(code, {
-          attributes: true,
-          attributeFilter: ['contenteditable'],
+        observer.observe(content, {
           childList: true,
           subtree: true,
         });
@@ -105,6 +121,15 @@ async function moveFocusDuringFullRender(
       }),
     { selector: ADDITIONS, target, timing }
   );
+}
+
+// Kicks off a full render and resolves once the editor has re-synced to it.
+async function runFullRender(page: Page): Promise<void> {
+  const syncsBefore = await page.evaluate(() => window.__syncCount ?? 0);
+  await page.evaluate(() => window.__forceEditorFullRender?.());
+  await expect
+    .poll(() => page.evaluate(() => window.__syncCount ?? 0))
+    .toBeGreaterThan(syncsBefore);
 }
 
 test.describe('edit mode', () => {
@@ -174,16 +199,16 @@ test.describe('edit mode', () => {
       throw new Error('missing additions content');
     }
 
-    await page.evaluate(() => window.__forceEditorFullRender?.());
+    await runFullRender(page);
 
-    await expect
-      .poll(() =>
-        additions.evaluate(
-          (content, previous) => content !== previous,
-          previousContent
-        )
+    // The full render rebuilds the columns on the same editable element, so
+    // focus never leaves it and typing keeps flowing.
+    expect(
+      await additions.evaluate(
+        (content, previous) => content === previous,
+        previousContent
       )
-      .toBe(true);
+    ).toBe(true);
     await expect.poll(() => editorHasFocus(page)).toBe(true);
     await page.keyboard.type('Z');
     await expect(additions).toContainText('Z');
@@ -194,31 +219,23 @@ test.describe('edit mode', () => {
 
     const additions = page.locator(ADDITIONS);
     await additions.click();
+    // Start a second full render the moment the first one swaps the column
+    // children, so the second render races the first one's editor re-sync.
     await page.evaluate(
       (selector) =>
         new Promise<void>((resolve, reject) => {
           const root = document.querySelector('diffs-container')?.shadowRoot;
           const content = root?.querySelector(selector);
-          const code = content?.parentElement;
-          if (!(code instanceof HTMLElement)) {
+          if (!(content instanceof HTMLElement)) {
             reject(new Error('missing editor content'));
             return;
           }
           const observer = new MutationObserver(() => {
-            const replacement = root?.querySelector(selector);
-            if (
-              replacement === content ||
-              replacement?.getAttribute('contenteditable') !== 'true'
-            ) {
-              return;
-            }
             observer.disconnect();
             window.__forceEditorFullRender?.();
             resolve();
           });
-          observer.observe(code, {
-            attributes: true,
-            attributeFilter: ['contenteditable'],
+          observer.observe(content, {
             childList: true,
             subtree: true,
           });
@@ -232,7 +249,7 @@ test.describe('edit mode', () => {
     await expect(additions).toContainText('Z');
   });
 
-  test('focused editor without a selection survives a full render', async ({
+  test('focused editor without a selection survives a container move', async ({
     page,
   }) => {
     await openFixture(page);
@@ -243,7 +260,10 @@ test.describe('edit mode', () => {
     });
     await expect.poll(() => editorHasFocus(page)).toBe(true);
 
-    await page.evaluate(() => window.__forceEditorFullRender?.());
+    // A container move genuinely replaces the editable element (a full render
+    // rebuilds it in place), so focus restoration must work even with no
+    // selection to anchor the caret.
+    await page.evaluate(() => window.__moveEditorContainer?.());
 
     await expect.poll(() => editorHasFocus(page)).toBe(true);
   });
@@ -262,14 +282,14 @@ test.describe('edit mode', () => {
     await expect(additions).toContainText('Z');
   });
 
-  test('full render does not reclaim focus moved during replacement', async ({
+  test('full render does not reclaim focus moved during the rebuild', async ({
     page,
   }) => {
     await openFixture(page);
 
     await clickIntoAdditions(page);
     const fixturesLink = page.locator('[data-fixtures-index]');
-    await moveFocusDuringFullRender(page, 'external-link', 'replacement');
+    await moveFocusDuringFullRender(page, 'external-link', 'rebuild');
 
     await expect(fixturesLink).toBeFocused();
   });
@@ -280,12 +300,12 @@ test.describe('edit mode', () => {
     await openFixture(page);
 
     await clickIntoAdditions(page);
-    await moveFocusDuringFullRender(page, 'background', 'replacement');
+    await moveFocusDuringFullRender(page, 'background', 'rebuild');
 
     await expect.poll(() => editorHasFocus(page)).toBe(false);
   });
 
-  test('stopped background press that starts a full render does not restore focus', async ({
+  test('stopped background press that starts a full render leaves focus in place', async ({
     page,
   }) => {
     await openFixture(page);
@@ -311,7 +331,12 @@ test.describe('edit mode', () => {
         })
     );
 
-    await expect.poll(() => editorHasFocus(page)).toBe(false);
+    // The press never moved focus (its default was stopped) and the render
+    // keeps the editable element, so focus stays exactly where it was — the
+    // canceled restore must neither blur the editor nor steal focus back.
+    await expect.poll(() => editorHasFocus(page)).toBe(true);
+    await page.keyboard.type('Z');
+    await expect(page.locator(ADDITIONS)).toContainText('Z');
   });
 
   test('full render does not reclaim focus moved to its host', async ({
@@ -321,6 +346,7 @@ test.describe('edit mode', () => {
 
     await clickIntoAdditions(page);
     await moveFocusDuringFullRender(page, 'host', 'after-sync');
+
     await page.evaluate(
       () =>
         new Promise<void>((resolve) => {

--- a/packages/diffs/test/e2e/fixtures/edit.html
+++ b/packages/diffs/test/e2e/fixtures/edit.html
@@ -99,6 +99,18 @@ export default value;
 
       instance.render({ oldFile, newFile, containerWrapper: mount });
       editor.edit(instance);
+      // Counts completed editor re-syncs. A full render keeps the editable
+      // element in place, so specs can't detect completion by watching for a
+      // replacement element — they await this counter instead. By the time it
+      // increments, the render has landed and the editor's focus/selection
+      // restore has been invoked.
+      window.__syncCount = 0;
+      const originalSyncRenderView = editor.__syncRenderView;
+      editor.__syncRenderView = (...args) => {
+        const result = originalSyncRenderView.apply(editor, args);
+        window.__syncCount += 1;
+        return result;
+      };
       window.__forceEditorFullRender = () => {
         instance.setOptions({
           ...instance.options,

--- a/packages/diffs/test/editorCollapsedEdit.test.ts
+++ b/packages/diffs/test/editorCollapsedEdit.test.ts
@@ -314,6 +314,34 @@ describe('diff editor: collapsed regions during edit', () => {
     }
   });
 
+  test('a line-count edit rebuilds columns without replacing the content element', async () => {
+    const fixture = await createCollapsedEditFixture();
+    const { container, editor } = fixture;
+    try {
+      const contentBefore = findAdditionContent(container);
+      const gutterBefore = findAdditionGutter(container);
+      expect(contentBefore).toBeDefined();
+      const rowsBefore = contentBefore!.children.length;
+
+      // Enter at the end of the first hunk's changed line (index 9) — a
+      // line-count change, which rebuilds both columns wholesale.
+      typeAt(editor, 9, 'line 10 changed'.length, '\n');
+      await waitFor(
+        () =>
+          (findAdditionContent(container)?.children.length ?? 0) > rowsBefore
+      );
+
+      // The rebuild ran (a row was added) on the same column elements: the
+      // contenteditable keeps its identity, so the browser's editing session
+      // is never torn down and refocused (iOS answers a session restart with
+      // an animated caret reveal).
+      expect(findAdditionContent(container)).toBe(contentBefore);
+      expect(findAdditionGutter(container)).toBe(gutterBefore);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
   test('clicking a separator expand button mid-edit reveals rows and keeps edits', async () => {
     const fixture = await createCollapsedEditFixture();
     const { container, editor } = fixture;

--- a/packages/diffs/test/editorDisplayOptionResync.test.ts
+++ b/packages/diffs/test/editorDisplayOptionResync.test.ts
@@ -65,10 +65,16 @@ interface DisplayOptionFixture {
   // Toggles a display option and forces a re-render, exactly as the React bridge
   // does on any display-option change: setOptions(newOptions) then a forced
   // re-render. The bug report's headline trigger is the word-wrap toggle, but
-  // every display option (theme, diff style, line numbers, wrap) shares the same
-  // forced-render path; line numbers is used here because wrap measurement needs
-  // browser layout APIs jsdom lacks.
+  // display options (theme, line numbers, wrap) share the same forced-render
+  // path; line numbers is used here because wrap measurement needs browser
+  // layout APIs jsdom lacks. Display re-renders rebuild the columns in place,
+  // so the editable content element keeps its identity.
   toggleDisplayOption(): Promise<void>;
+  // Switches between split and unified rendering mid-edit. Unlike display
+  // options, a diff-style switch builds a fresh code element for the target
+  // style, so the editable content element is genuinely replaced — the case
+  // the replacement-focus test exercises.
+  toggleDiffStyle(): Promise<void>;
   cleanup(): Promise<void>;
 }
 
@@ -111,10 +117,12 @@ async function createFixture(
     editor,
     fileDiff,
     async toggleDisplayOption() {
-      const previousContent = findAdditionContent(container);
+      const disableLineNumbers = !(
+        fileDiff.options.disableLineNumbers ?? false
+      );
       fileDiff.setOptions({
         ...fileDiff.options,
-        disableLineNumbers: !(fileDiff.options.disableLineNumbers ?? false),
+        disableLineNumbers,
       });
       fileDiff.render({
         oldFile,
@@ -122,9 +130,34 @@ async function createFixture(
         fileContainer: container,
         forceRender: true,
       });
-      // The forced re-render replaces the additions column and re-syncs the
-      // editor through an async highlighter pass; wait for the replacement
+      // The forced re-render rebuilds the columns in place (the content
+      // element is retained) and re-syncs the editor through an async
+      // highlighter pass; wait for the option to land on the pre element
       // instead of a fixed sleep.
+      await waitFor(() => {
+        const pre = container.shadowRoot?.querySelector('pre');
+        return (
+          (pre?.hasAttribute('data-disable-line-numbers') ?? false) ===
+          disableLineNumbers
+        );
+      });
+      await wait(0);
+    },
+    async toggleDiffStyle() {
+      const previousContent = findAdditionContent(container);
+      fileDiff.setOptions({
+        ...fileDiff.options,
+        diffStyle: fileDiff.options.diffStyle === 'split' ? 'unified' : 'split',
+      });
+      fileDiff.render({
+        oldFile,
+        newFile,
+        fileContainer: container,
+        forceRender: true,
+      });
+      // The style switch builds a fresh code element, replacing the editable
+      // content; wait for the replacement to be re-marked editable by the
+      // async editor re-sync.
       await waitFor(() => {
         const content = findAdditionContent(container);
         return (
@@ -189,7 +222,9 @@ describe('diff editor: display-option toggle mid-edit', () => {
 
       // Firefox and WebKit can remove the focused shadow subtree without a
       // blur event, so replacement detection must preserve the focus intent.
-      await fixture.toggleDisplayOption();
+      // A diff-style switch is used because it genuinely replaces the
+      // editable element; display-option re-renders keep it in place.
+      await fixture.toggleDiffStyle();
 
       const replacement = findAdditionContent(container);
       expect(replacement == null).toBe(false);


### PR DESCRIPTION
This PR fixes a bunch of scroll-jumping bugs that showed up while editing diffs, mostly in Safari.

- **Safari: the view jumped to the top while editing.** Pressing Enter (or expanding hidden lines) rebuilds the diff's DOM, and a WebKit bug makes the scroll position clamp to the top whenever that happens (related: webkit.org/b/308027). We now pin the diff's height while rebuilding so the scroll position can't get lost. Safari-only, edit-mode-only; virtualized views aren't affected by the bug so they skip the guard.
- **iOS Safari: creating a new line did an annoying animated focus scroll.** Rebuilds used to throw away the editable element and create a fresh one, which iOS treats as "you started editing again" and animates the caret back into view every time. Rebuilds now reuse the existing elements and just swap out their contents, so the editing session never restarts. This also fixed a double scroll-jump on desktop for the same edits.
- **The caret could end up floating way off the text on wrapped lines.** If the editor measured line wrapping at the wrong moment (mid-rebuild), it concluded "this line doesn't wrap", cached that, and kept placing the caret at the wrong spot — even forcing the code area to scroll sideways. Measurements taken in that broken state are no longer cached, so the next render self-corrects.
- **Small refactor:** browser detection helpers (`isSafari` etc.) moved into shared utils so non-editor code can use them too.
- **Tests:** updated the tests that relied on the old "rebuild = new element" behavior, added coverage that the editable element survives edits, and corrected one expectation that flipped now that focus never gets torn down in the first place.
- Made a few smol improvements to the homepage edit demo
  - Tweaked the trees horizontal padding to match vertical padding
  - Made file tree column narrower, felt a bit too wide for the content it was showing.