### PR TITLE
fix(diffs): keep scroll anchor stable when CodeView removes items

### DIFF
--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -2535,6 +2535,18 @@ export class CodeView<LAnnotation = undefined> {
       return;
     }
 
+    // Capture the scroll anchor against the outgoing items/layout before
+    // reassigning this.items below. Otherwise the next render's
+    // getScrollAnchor() reads renderState.firstIndex/lastIndex against
+    // already-reindexed items through stale top/height metrics, which is
+    // exactly wrong for removals and reorders. This must stay below the
+    // early return above: capturing unconditionally at the top of the
+    // method would strand a pending anchor on the instance after a
+    // no-op reconcile, since render() (which consumes/clears it) never
+    // runs when nothing changed, and some later unrelated render would
+    // then "correct" scroll against that stale anchor.
+    this.capturePendingLayoutAnchor();
+
     this.items = nextItems;
     this.idToItem = nextIdToItem;
     this.instanceToItem = nextInstanceToItem;

--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -651,6 +651,11 @@ type PendingScrollTarget =
   | PendingRangeTarget
   | PendingItemTarget;
 
+type CodeViewItemMap<LAnnotation> = Map<
+  string,
+  CodeViewContextItem<LAnnotation>
+>;
+
 export class CodeView<LAnnotation = undefined> {
   static __STOP = false;
   static __lastScrollPosition = 0;
@@ -662,7 +667,7 @@ export class CodeView<LAnnotation = undefined> {
     resizeDebugging: false,
   };
   private items: CodeViewContextItem<LAnnotation>[] = [];
-  private idToItem: Map<string, CodeViewContextItem<LAnnotation>> = new Map();
+  private idToItem: CodeViewItemMap<LAnnotation> = new Map();
   private selectedLines: CodeViewLineSelection | null = null;
   // One editor per edit-mode item, created lazily via options.createEditor.
   // Entries survive virtualization unmounts so a remounted item re-attaches
@@ -1706,9 +1711,10 @@ export class CodeView<LAnnotation = undefined> {
     }
   }
 
-  public capturePendingLayoutAnchor(): void {
+  public capturePendingLayoutAnchor(
+    nextItems: Readonly<CodeViewItemMap<LAnnotation>> = this.idToItem
+  ): void {
     if (
-      this.pendingLayoutAnchor != null ||
       this.root == null ||
       this.items.length === 0 ||
       this.pendingScrollTarget != null
@@ -1716,7 +1722,10 @@ export class CodeView<LAnnotation = undefined> {
       return;
     }
 
-    this.pendingLayoutAnchor = this.getScrollAnchor(this.getScrollTop());
+    this.pendingLayoutAnchor = this.getScrollAnchor(
+      this.getScrollTop(),
+      nextItems
+    );
   }
 
   public render(immediate = false): void {
@@ -2521,6 +2530,15 @@ export class CodeView<LAnnotation = undefined> {
       nextInstanceToItem.set(item.instance, item);
     }
 
+    if (firstDirtyIndex == null) {
+      if (removedItems.size === 0) {
+        return;
+      }
+      firstDirtyIndex = Math.max(nextItems.length - 1, 0);
+    }
+
+    this.capturePendingLayoutAnchor(nextIdToItem);
+
     for (let index = 0; index < previousItems.length; index++) {
       const removedItem = previousItems[index];
       if (removedItem == null || !removedItems.has(removedItem)) {
@@ -2530,22 +2548,6 @@ export class CodeView<LAnnotation = undefined> {
       const dirtyIndex = Math.max(nextItems.length - 1, 0);
       firstDirtyIndex = Math.min(firstDirtyIndex ?? dirtyIndex, dirtyIndex);
     }
-
-    if (firstDirtyIndex == null) {
-      return;
-    }
-
-    // Capture the scroll anchor against the outgoing items/layout before
-    // reassigning this.items below. Otherwise the next render's
-    // getScrollAnchor() reads renderState.firstIndex/lastIndex against
-    // already-reindexed items through stale top/height metrics, which is
-    // exactly wrong for removals and reorders. This must stay below the
-    // early return above: capturing unconditionally at the top of the
-    // method would strand a pending anchor on the instance after a
-    // no-op reconcile, since render() (which consumes/clears it) never
-    // runs when nothing changed, and some later unrelated render would
-    // then "correct" scroll against that stale anchor.
-    this.capturePendingLayoutAnchor();
 
     this.items = nextItems;
     this.idToItem = nextIdToItem;
@@ -3641,10 +3643,25 @@ export class CodeView<LAnnotation = undefined> {
    * A scroll anchor represents the first fully visible element (in other
    * words, the first file or first line who's top is fully in the viewport).
    */
-  private getScrollAnchor(scrollTop: number): ScrollAnchor | undefined {
-    // If we already have a pendingLayoutAnchor, let's use that.
-    if (this.pendingLayoutAnchor != null) {
-      return this.pendingLayoutAnchor;
+  private getScrollAnchor(
+    scrollTop: number,
+    availableItems: ReadonlyMap<string, CodeViewContextItem<LAnnotation>> = this
+      .idToItem
+  ): ScrollAnchor | undefined {
+    let skippedItem: CodeViewContextItem<LAnnotation> | undefined;
+
+    const { pendingLayoutAnchor } = this;
+    if (pendingLayoutAnchor != null) {
+      const pendingItem = this.idToItem.get(pendingLayoutAnchor.id);
+      if (
+        pendingItem != null &&
+        availableItems.get(pendingLayoutAnchor.id) === pendingItem
+      ) {
+        return pendingLayoutAnchor;
+      }
+      if (pendingItem != null) {
+        skippedItem = pendingItem;
+      }
     }
 
     // We shouldn't scroll anchor when at the top, this way if a custom header
@@ -3683,6 +3700,12 @@ export class CodeView<LAnnotation = undefined> {
         break;
       }
 
+      const itemIsAvailable = availableItems.get(item.item.id) === item;
+      if (!itemIsAvailable) {
+        skippedItem ??= item;
+        continue;
+      }
+
       if (absoluteItemTop >= scrollTop) {
         return {
           type: 'item',
@@ -3707,6 +3730,28 @@ export class CodeView<LAnnotation = undefined> {
           side: lineAnchor.side,
           viewportOffset: absoluteLineTop - scrollTop,
         };
+      }
+    }
+
+    // If we couldn't find an anchored item and we have a skipped item, lets
+    // attempt to anchor to the top of the item that came after it
+    if (skippedItem != null) {
+      for (
+        let index = skippedItem.index + 1;
+        index < this.items.length;
+        index++
+      ) {
+        const candidate = this.items[index];
+        if (
+          candidate != null &&
+          availableItems.get(candidate.item.id) === candidate
+        ) {
+          return {
+            type: 'item',
+            id: candidate.item.id,
+            viewportOffset: 0,
+          };
+        }
       }
     }
 

--- a/packages/diffs/test/CodeView.scrollAnchoring.test.ts
+++ b/packages/diffs/test/CodeView.scrollAnchoring.test.ts
@@ -314,6 +314,119 @@ describe('CodeView scroll anchoring', () => {
     }
   });
 
+  test('anchors the next item at the top when reconcileItems removes the only visible anchor', async () => {
+    const { cleanup } = installDom();
+    const viewer = new CodeView();
+    const root = createRoot({ height: ROOT_HEIGHT });
+    const removedId = 'diff:removed-anchor';
+    const nextId = 'file:after-anchor';
+    const items: CodeViewItem[] = [
+      makeFileItem('file:before-anchor', 120),
+      makeReplacementDiffItem(removedId, 240),
+      makeFileItem(nextId, 80),
+      ...Array.from({ length: 8 }, (_, index) =>
+        makeFileItem(`file:trailing-${index}`, 80)
+      ),
+    ];
+
+    try {
+      viewer.setup(root);
+      await renderItems(viewer, items);
+
+      viewer.scrollTo({
+        type: 'line',
+        id: removedId,
+        lineNumber: 80,
+        side: 'additions',
+        align: 'start',
+        behavior: 'instant',
+      });
+      viewer.render(true);
+      await wait(0);
+
+      // Keep the successor outside the old render window so reconciliation
+      // has to anchor its item header at the top instead of finding a visible
+      // survivor.
+      expect(viewer.getRenderedItems().some((item) => item.id === nextId)).toBe(
+        false
+      );
+
+      viewer.setItems(items.filter((item) => item.id !== removedId));
+      viewer.render(true);
+      await wait(0);
+
+      const nextTop = viewer.getTopForItem(nextId);
+      if (nextTop == null) {
+        throw new Error('expected the promoted successor');
+      }
+      expect(nextTop - viewer.getScrollTop()).toBe(0);
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+
+  test('skips a removed line anchor for a visible surviving item', async () => {
+    const { cleanup } = installDom();
+    const viewer = new CodeView();
+    const root = createRoot({ height: ROOT_HEIGHT });
+    const removedId = 'diff:visible-removed-anchor';
+    const nextId = 'file:visible-after-anchor';
+    const items: CodeViewItem[] = [
+      makeFileItem('file:visible-before-anchor', 100),
+      makeReplacementDiffItem(removedId, 12),
+      makeFileItem(nextId, 40),
+      makeFileItem('file:visible-trailing', 100),
+    ];
+
+    try {
+      viewer.setup(root);
+      await renderItems(viewer, items);
+
+      viewer.scrollTo({
+        type: 'line',
+        id: removedId,
+        lineNumber: 4,
+        side: 'additions',
+        align: 'start',
+        behavior: 'instant',
+      });
+      viewer.render(true);
+      await wait(0);
+
+      expect(viewer.getRenderedItems().some((item) => item.id === nextId)).toBe(
+        true
+      );
+      const nextTopBeforeRemoval = viewer.getTopForItem(nextId);
+      if (nextTopBeforeRemoval == null) {
+        throw new Error('expected the visible successor');
+      }
+      const nextViewportOffset =
+        DEFAULT_CODE_VIEW_LAYOUT.paddingTop +
+        nextTopBeforeRemoval -
+        viewer.getScrollTop();
+
+      viewer.setItems(items.filter((item) => item.id !== removedId));
+      viewer.render(true);
+      await wait(0);
+
+      const nextTopAfterRemoval = viewer.getTopForItem(nextId);
+      if (nextTopAfterRemoval == null) {
+        throw new Error('expected the surviving item');
+      }
+      expect(
+        DEFAULT_CODE_VIEW_LAYOUT.paddingTop +
+          nextTopAfterRemoval -
+          viewer.getScrollTop()
+      ).toBe(nextViewportOffset);
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+
   test('moves the physical spacer before applying a programmatic rebase jump', async () => {
     const { cleanup } = installDom();
     const viewer = new CodeView({

--- a/packages/diffs/test/CodeView.scrollAnchoring.test.ts
+++ b/packages/diffs/test/CodeView.scrollAnchoring.test.ts
@@ -5,6 +5,7 @@ import { DEFAULT_CODE_VIEW_LAYOUT } from '../src/constants';
 import type { CodeViewItem, FileContents } from '../src/types';
 import { parseDiffFromFile } from '../src/utils/parseDiffFromFile';
 import {
+  createRoot,
   dispatchScroll,
   installDom,
   makeFile,
@@ -244,6 +245,68 @@ describe('CodeView scroll anchoring', () => {
       expect(getRootMaxScrollTop(root)).toBeGreaterThan(
         SCROLL_REBASE_THRESHOLD
       );
+    } finally {
+      viewer.cleanUp();
+      await wait(0);
+      cleanup();
+    }
+  });
+
+  test('keeps a rendered item anchored when reconcileItems removes earlier items', async () => {
+    const { cleanup } = installDom();
+    const viewer = new CodeView();
+    const root = createRoot({ height: ROOT_HEIGHT });
+    const items = Array.from({ length: 60 }, (_, index) =>
+      makeFileItem(`file:${index}`, 5 + ((index * 7) % 15))
+    );
+    const anchorId = 'file:30';
+
+    try {
+      viewer.setup(root);
+      await renderItems(viewer, items);
+
+      viewer.scrollTo({
+        type: 'item',
+        id: anchorId,
+        align: 'start',
+        behavior: 'instant',
+      });
+      viewer.render(true);
+      await wait(0);
+
+      const anchorTopBeforeRemoval = viewer.getTopForItem(anchorId) ?? 0;
+      const scrollTopBeforeRemoval = viewer.getScrollTop();
+
+      // Remove several earlier items in one call, well outside the current
+      // render window but still shifting the index (and therefore the top
+      // offset) of every item at or after them, including the anchor. A
+      // single removal isn't enough here, even giving the removed item a
+      // very different height from its neighbors: the stale scan is off by
+      // exactly one slot, which almost always still resolves to the very
+      // next real item, and that item's own recomputed shift is identical
+      // regardless of what was removed, so the error cancels out. Only a
+      // shift big enough to carry the stale, off-by-N read past the old
+      // viewport/overscan bounds makes the search fail outright, which is
+      // what removing 10 items in one call reliably does.
+      const removedIds = new Set(
+        Array.from({ length: 10 }, (_, index) => `file:${index}`)
+      );
+      viewer.setItems(items.filter((item) => !removedIds.has(item.id)));
+      viewer.render(true);
+      await wait(0);
+
+      const anchorTopAfterRemoval = viewer.getTopForItem(anchorId) ?? 0;
+      const scrollTopAfterRemoval = viewer.getScrollTop();
+
+      // The anchor shifted up by the removed items' combined height. A
+      // correct anchor keeps it fixed in the viewport, so the scroll
+      // position must shift by the same delta. Without capturing the anchor
+      // before the reindex, the anchor scan instead finds nothing (it reads
+      // stale, not-yet-relaid-out positions through the new index mapping)
+      // and scrollTop is left stuck at its old value.
+      const anchorShift = anchorTopBeforeRemoval - anchorTopAfterRemoval;
+      expect(anchorShift).toBeGreaterThan(0);
+      expect(scrollTopBeforeRemoval - scrollTopAfterRemoval).toBe(anchorShift);
     } finally {
       viewer.cleanUp();
       await wait(0);


### PR DESCRIPTION
> This PR is fully authored by Opus 5 and Sonnet 5 using Claude Code harness.
> <details>
> <summary>Here's a message from Opus regarding this change</summary>
> 
> `CodeView.reconcileItems` reassigns `this.items` (and rebuilds `idToItem`)
> without first calling `capturePendingLayoutAnchor()`, unlike `setOptions`,
> which always captures one before a layout-affecting change. The next render's
> `getScrollAnchor()` call has nothing pending, so it scans
> `renderState.firstIndex..lastIndex` against the array `reconcileItems` just
> reindexed. Every index at or after a removal now points at a different
> logical item, read through `.top`/`.height` that `recomputeLayout` hasn't
> refreshed yet, so the search either returns the wrong item or, once the
> window is far enough into stale territory, finds nothing at all and leaves
> `scrollTop` stuck at its old value while the content underneath it has moved.
> 
> Measured against a 355-file list, removing one file from the middle:
> 
> - Unpatched: `scrollTop` stays at `400000` while content shifts underneath
>   it, landing the viewport on an unrelated item; `scrollHeight` drops from
>   `738888` to `735704`.
> - Patched: `scrollTop` moves `400000` → `398256`, tracking the same anchor
>   line, with `scrollHeight` shrinking by exactly the removed item's height
>   plus gap in one update and no resettle.
> 
> I first hit this in [fdarian/nisi](https://github.com/fdarian/nisi), a diff
> review app built on `@pierre/diffs`, via its "hide reviewed files" action
> (removes a card from the rendered list) on a ~206-file list: `scrollTop`
> collapsed to `0`, `scrollHeight` dropped from `10088` to `502`, then
> resettled ~600-900ms later at `4956`, on unrelated files.
> 
> Same-length updates are unaffected; this only hits removals and reorders.
> 
> The fix is one line: call `capturePendingLayoutAnchor()` in
> `reconcileItems`, placed after the method's existing no-op early return
> (`if (firstDirtyIndex == null) return;`) and before `this.items = nextItems`.
> Placement matters: capturing unconditionally at the top of the method would
> strand a pending anchor on the instance after every no-op `setItems` call,
> since a same-length update that changes nothing returns early without
> rendering, and render is what consumes/clears the pending anchor. Some later,
> unrelated render would then "correct" scroll against that stale anchor. I hit
> exactly that while testing the fix, so it's a real trap and not hypothetical.
> 
> Added a regression test in `CodeView.scrollAnchoring.test.ts` that scrolls
> into a 60-item list, removes 10 earlier items in one `setItems` call, and
> asserts the anchored item's scroll offset shifts by exactly the removed
> items' combined height. It fails on `main` (scroll position stuck) and
> passes with the fix.
> </details>

Fixes a scroll-position bug in `CodeView`'s virtualized list: removing or reordering items in the controlled `items` array destroys the user's scroll position instead of keeping their place.

This one-line patch was discovered after Opus-5-observed Sonnet 5 did three iterations to solve the following bug. As shown in the video, removing an item will break the scroll position:

https://github.com/user-attachments/assets/2f63478d-6466-4496-9709-e78fa597f9d2

Then here's after it [added the patch](https://github.com/fdarian/nisi/commit/3e7f649348be06d08a996c882dc429b3aed91c11):

https://github.com/user-attachments/assets/b4839b94-2d6f-4844-baa0-d5e2ff95c20c

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Documentation update

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/pierrecomputer/pierre/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project (`moon run root:lint`)
- [x] My code is formatted properly (`moon run root:format`)
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have added tests to cover my changes (if applicable)
- [x] All new and existing tests pass (`moonx diffs:test`)

### Related issues

Possibly related to #1030, which is the same symptom (scroll anchor failing
to recover) via a different trigger (markdown remount / transient estimated
heights) and a different code path; not claiming this fixes it.
