### PR TITLE
feat(theme): Export palette and theme colors as Figma variables

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -46,6 +46,7 @@
     "apps/docs/next-env.d.ts",
     "packages/theme/themes/*.json",
     "packages/theme/zed/themes/*.json",
+    "packages/theme/figma/**/*.json",
     "packages/tree-test-data/*-files.json",
     "*.patch",
     "README"

--- a/packages/theme/.vscodeignore
+++ b/packages/theme/.vscodeignore
@@ -6,6 +6,7 @@ preview/**
 .github/**
 .vscode/**
 zed/**
+figma/**
 
 ACCESSIBILITY.md
 CONTRIBUTING.md

--- a/packages/theme/CONTRIBUTING.md
+++ b/packages/theme/CONTRIBUTING.md
@@ -93,11 +93,25 @@ For visual proofing, `moonx theme:preview --ignore-ci-checks` writes
 `preview/*.html`: the palette scales, the Display-P3 conversions, and a
 normal-vs-simulated CVD proof sheet.
 
+## Figma variables
+
+`theme:build` also writes `figma/`, a Figma-importable copy of the same colors
+in DTCG token format (`src/createFigmaTokens.ts`). `figma/primitives.json` holds
+every palette step, and each `figma/semantic/*.json` is one theme variant that
+aliases those primitives — Figma turns each of those files into a mode. Commit
+the regenerated files alongside `themes/*.json`; see the README for the import
+steps.
+
+Semantic tokens are matched back to primitives by hex, so a role value that is
+not in any palette scale fails the build. That is deliberate: it catches roles
+drifting away from the palette. If a role genuinely needs a standalone literal,
+add its hex to `UNALIASED_ROLE_COLORS`.
+
 ## Scripts
 
 | Script                                        | Description                                                                                             |
 | --------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `moonx theme:build`                           | Builds the theme `.json` files in `./themes` and ESM modules in `./dist`                                |
+| `moonx theme:build`                           | Builds the theme `.json` files in `./themes`, Figma variables in `./figma`, and ESM modules in `./dist` |
 | `moonx theme:test`                            | Runs validation tests + the CVD accessibility gate after build                                          |
 | `moonx theme:preview --ignore-ci-checks`      | Writes preview HTML files from `src/previews` into `preview/`                                           |
 | `moonx theme:package-vsix --ignore-ci-checks` | Temporarily applies the VSIX package name/README shim, then writes the `.vsix` file at the project root |

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -43,6 +43,19 @@ Usage:
  Zed:
   Install "Pierre" from the Zed extension registry
 
+ Figma:
+  Variables ship as DTCG design tokens under figma/
+
+  1. Variables view > create a collection named exactly "Pierre Primitives",
+     then drag in figma/primitives.json
+  2. Create a second collection, then drag in all of figma/semantic/*.json
+     together — each file becomes a mode, and its values link back to the
+     primitives collection from step 1
+  3. Drag light.json in first so Light lands in the left-most column and
+     becomes the collection's default mode
+
+  The Vibrant variants are not exported: Figma imports sRGB and HSL only.
+
 ```
 
 ## Agent skill

--- a/packages/theme/figma/primitives.json
+++ b/packages/theme/figma/primitives.json
@@ -1,0 +1,3281 @@
+{
+  "gray": {
+    "020": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.984314,
+          0.984314,
+          0.984314
+        ],
+        "alpha": 1,
+        "hex": "#fbfbfb"
+      }
+    },
+    "040": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.976471,
+          0.976471,
+          0.976471
+        ],
+        "alpha": 1,
+        "hex": "#f9f9f9"
+      }
+    },
+    "060": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.972549,
+          0.972549,
+          0.972549
+        ],
+        "alpha": 1,
+        "hex": "#f8f8f8"
+      }
+    },
+    "080": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.94902,
+          0.94902,
+          0.952941
+        ],
+        "alpha": 1,
+        "hex": "#f2f2f3"
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.933333,
+          0.933333,
+          0.937255
+        ],
+        "alpha": 1,
+        "hex": "#eeeeef"
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.858824,
+          0.858824,
+          0.866667
+        ],
+        "alpha": 1,
+        "hex": "#dbdbdd"
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.776471,
+          0.776471,
+          0.784314
+        ],
+        "alpha": 1,
+        "hex": "#c6c6c8"
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.678431,
+          0.678431,
+          0.694118
+        ],
+        "alpha": 1,
+        "hex": "#adadb1"
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.556863,
+          0.556863,
+          0.584314
+        ],
+        "alpha": 1,
+        "hex": "#8e8e95"
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.517647,
+          0.517647,
+          0.541176
+        ],
+        "alpha": 1,
+        "hex": "#84848a"
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.47451,
+          0.47451,
+          0.498039
+        ],
+        "alpha": 1,
+        "hex": "#79797f"
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.423529,
+          0.423529,
+          0.443137
+        ],
+        "alpha": 1,
+        "hex": "#6c6c71"
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.290196,
+          0.290196,
+          0.305882
+        ],
+        "alpha": 1,
+        "hex": "#4a4a4e"
+      }
+    },
+    "920": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.258824,
+          0.258824,
+          0.270588
+        ],
+        "alpha": 1,
+        "hex": "#424245"
+      }
+    },
+    "940": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.223529,
+          0.223529,
+          0.235294
+        ],
+        "alpha": 1,
+        "hex": "#39393c"
+      }
+    },
+    "960": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.180392,
+          0.180392,
+          0.188235
+        ],
+        "alpha": 1,
+        "hex": "#2e2e30"
+      }
+    },
+    "980": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.121569,
+          0.121569,
+          0.129412
+        ],
+        "alpha": 1,
+        "hex": "#1f1f21"
+      }
+    },
+    "1000": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.078431,
+          0.078431,
+          0.082353
+        ],
+        "alpha": 1,
+        "hex": "#141415"
+      }
+    },
+    "1020": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.043137,
+          0.043137,
+          0.047059
+        ],
+        "alpha": 1,
+        "hex": "#0b0b0c"
+      }
+    },
+    "1040": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.027451,
+          0.027451,
+          0.027451
+        ],
+        "alpha": 1,
+        "hex": "#070707"
+      }
+    }
+  },
+  "neutral": {
+    "020": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.980392,
+          0.980392,
+          0.980392
+        ],
+        "alpha": 1,
+        "hex": "#fafafa"
+      }
+    },
+    "040": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.968627,
+          0.968627,
+          0.968627
+        ],
+        "alpha": 1,
+        "hex": "#f7f7f7"
+      }
+    },
+    "060": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.960784,
+          0.960784,
+          0.960784
+        ],
+        "alpha": 1,
+        "hex": "#f5f5f5"
+      }
+    },
+    "080": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.929412,
+          0.929412,
+          0.929412
+        ],
+        "alpha": 1,
+        "hex": "#ededed"
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.898039,
+          0.898039,
+          0.898039
+        ],
+        "alpha": 1,
+        "hex": "#e5e5e5"
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.831373,
+          0.831373,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#d4d4d4"
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.737255,
+          0.737255,
+          0.737255
+        ],
+        "alpha": 1,
+        "hex": "#bcbcbc"
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.639216,
+          0.639216,
+          0.639216
+        ],
+        "alpha": 1,
+        "hex": "#a3a3a3"
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.541176,
+          0.541176,
+          0.541176
+        ],
+        "alpha": 1,
+        "hex": "#8a8a8a"
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.45098,
+          0.45098,
+          0.45098
+        ],
+        "alpha": 1,
+        "hex": "#737373"
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.388235,
+          0.388235,
+          0.388235
+        ],
+        "alpha": 1,
+        "hex": "#636363"
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.321569,
+          0.321569,
+          0.321569
+        ],
+        "alpha": 1,
+        "hex": "#525252"
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.25098,
+          0.25098,
+          0.25098
+        ],
+        "alpha": 1,
+        "hex": "#404040"
+      }
+    },
+    "920": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.211765,
+          0.211765,
+          0.211765
+        ],
+        "alpha": 1,
+        "hex": "#363636"
+      }
+    },
+    "940": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.172549,
+          0.172549,
+          0.172549
+        ],
+        "alpha": 1,
+        "hex": "#2c2c2c"
+      }
+    },
+    "960": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.14902,
+          0.14902,
+          0.14902
+        ],
+        "alpha": 1,
+        "hex": "#262626"
+      }
+    },
+    "980": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      }
+    },
+    "1000": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.090196,
+          0.090196,
+          0.090196
+        ],
+        "alpha": 1,
+        "hex": "#171717"
+      }
+    },
+    "1020": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.062745,
+          0.062745,
+          0.062745
+        ],
+        "alpha": 1,
+        "hex": "#101010"
+      }
+    },
+    "1040": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.039216,
+          0.039216,
+          0.039216
+        ],
+        "alpha": 1,
+        "hex": "#0a0a0a"
+      }
+    }
+  },
+  "red": {
+    "050": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.929412,
+          0.917647
+        ],
+        "alpha": 1,
+        "hex": "#ffedea"
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.858824,
+          0.839216
+        ],
+        "alpha": 1,
+        "hex": "#ffdbd6"
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.717647,
+          0.682353
+        ],
+        "alpha": 1,
+        "hex": "#ffb7ae"
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.568627,
+          0.529412
+        ],
+        "alpha": 1,
+        "hex": "#ff9187"
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.403922,
+          0.384314
+        ],
+        "alpha": 1,
+        "hex": "#ff6762"
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.180392,
+          0.247059
+        ],
+        "alpha": 1,
+        "hex": "#ff2e3f"
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.835294,
+          0.172549,
+          0.211765
+        ],
+        "alpha": 1,
+        "hex": "#d52c36"
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.678431,
+          0.160784,
+          0.180392
+        ],
+        "alpha": 1,
+        "hex": "#ad292e"
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.52549,
+          0.141176,
+          0.145098
+        ],
+        "alpha": 1,
+        "hex": "#862425"
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.380392,
+          0.117647,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#611e1d"
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.243137,
+          0.090196,
+          0.082353
+        ],
+        "alpha": 1,
+        "hex": "#3e1715"
+      }
+    }
+  },
+  "vermillion": {
+    "050": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.941176,
+          0.917647
+        ],
+        "alpha": 1,
+        "hex": "#fff0ea"
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.886275,
+          0.839216
+        ],
+        "alpha": 1,
+        "hex": "#ffe2d6"
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.768627,
+          0.678431
+        ],
+        "alpha": 1,
+        "hex": "#ffc4ad"
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.65098,
+          0.521569
+        ],
+        "alpha": 1,
+        "hex": "#ffa685"
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.521569,
+          0.368627
+        ],
+        "alpha": 1,
+        "hex": "#ff855e"
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.364706,
+          0.211765
+        ],
+        "alpha": 1,
+        "hex": "#ff5d36"
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.835294,
+          0.317647,
+          0.184314
+        ],
+        "alpha": 1,
+        "hex": "#d5512f"
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.678431,
+          0.270588,
+          0.160784
+        ],
+        "alpha": 1,
+        "hex": "#ad4529"
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.52549,
+          0.219608,
+          0.133333
+        ],
+        "alpha": 1,
+        "hex": "#863822"
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.380392,
+          0.168627,
+          0.105882
+        ],
+        "alpha": 1,
+        "hex": "#612b1b"
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.243137,
+          0.117647,
+          0.078431
+        ],
+        "alpha": 1,
+        "hex": "#3e1e14"
+      }
+    }
+  },
+  "orange": {
+    "050": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.952941,
+          0.917647
+        ],
+        "alpha": 1,
+        "hex": "#fff3ea"
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.909804,
+          0.835294
+        ],
+        "alpha": 1,
+        "hex": "#ffe8d5"
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.819608,
+          0.670588
+        ],
+        "alpha": 1,
+        "hex": "#ffd1ab"
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.729412,
+          0.509804
+        ],
+        "alpha": 1,
+        "hex": "#ffba82"
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.639216,
+          0.34902
+        ],
+        "alpha": 1,
+        "hex": "#ffa359"
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.996078,
+          0.54902,
+          0.172549
+        ],
+        "alpha": 1,
+        "hex": "#fe8c2c"
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.831373,
+          0.462745,
+          0.156863
+        ],
+        "alpha": 1,
+        "hex": "#d47628"
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.67451,
+          0.376471,
+          0.137255
+        ],
+        "alpha": 1,
+        "hex": "#ac6023"
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.521569,
+          0.298039,
+          0.117647
+        ],
+        "alpha": 1,
+        "hex": "#854c1e"
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.376471,
+          0.219608,
+          0.098039
+        ],
+        "alpha": 1,
+        "hex": "#603819"
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.239216,
+          0.145098,
+          0.07451
+        ],
+        "alpha": 1,
+        "hex": "#3d2513"
+      }
+    }
+  },
+  "amber": {
+    "050": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.964706,
+          0.917647
+        ],
+        "alpha": 1,
+        "hex": "#fff6ea"
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.933333,
+          0.835294
+        ],
+        "alpha": 1,
+        "hex": "#ffeed5"
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.866667,
+          0.670588
+        ],
+        "alpha": 1,
+        "hex": "#ffddab"
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.8,
+          0.505882
+        ],
+        "alpha": 1,
+        "hex": "#ffcc81"
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.737255,
+          0.337255
+        ],
+        "alpha": 1,
+        "hex": "#ffbc56"
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.670588,
+          0.086275
+        ],
+        "alpha": 1,
+        "hex": "#ffab16"
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.835294,
+          0.564706,
+          0.109804
+        ],
+        "alpha": 1,
+        "hex": "#d5901c"
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.67451,
+          0.454902,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#ac741d"
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.521569,
+          0.356863,
+          0.105882
+        ],
+        "alpha": 1,
+        "hex": "#855b1b"
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.376471,
+          0.258824,
+          0.094118
+        ],
+        "alpha": 1,
+        "hex": "#604218"
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.239216,
+          0.168627,
+          0.07451
+        ],
+        "alpha": 1,
+        "hex": "#3d2b13"
+      }
+    }
+  },
+  "yellow": {
+    "050": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.976471,
+          0.917647
+        ],
+        "alpha": 1,
+        "hex": "#fff9ea"
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.956863,
+          0.835294
+        ],
+        "alpha": 1,
+        "hex": "#fff4d5"
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.913725,
+          0.670588
+        ],
+        "alpha": 1,
+        "hex": "#ffe9ab"
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.870588,
+          0.501961
+        ],
+        "alpha": 1,
+        "hex": "#ffde80"
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.831373,
+          0.321569
+        ],
+        "alpha": 1,
+        "hex": "#ffd452"
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.792157,
+          0
+        ],
+        "alpha": 1,
+        "hex": "#ffca00"
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.835294,
+          0.662745,
+          0.062745
+        ],
+        "alpha": 1,
+        "hex": "#d5a910"
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.67451,
+          0.533333,
+          0.086275
+        ],
+        "alpha": 1,
+        "hex": "#ac8816"
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.521569,
+          0.415686,
+          0.090196
+        ],
+        "alpha": 1,
+        "hex": "#856a17"
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.376471,
+          0.298039,
+          0.086275
+        ],
+        "alpha": 1,
+        "hex": "#604c16"
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.239216,
+          0.192157,
+          0.070588
+        ],
+        "alpha": 1,
+        "hex": "#3d3112"
+      }
+    }
+  },
+  "lime": {
+    "050": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.964706,
+          0.976471,
+          0.92549
+        ],
+        "alpha": 1,
+        "hex": "#f6f9ec"
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.929412,
+          0.956863,
+          0.847059
+        ],
+        "alpha": 1,
+        "hex": "#edf4d8"
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.854902,
+          0.909804,
+          0.694118
+        ],
+        "alpha": 1,
+        "hex": "#dae8b1"
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.776471,
+          0.862745,
+          0.541176
+        ],
+        "alpha": 1,
+        "hex": "#c6dc8a"
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.686275,
+          0.815686,
+          0.384314
+        ],
+        "alpha": 1,
+        "hex": "#afd062"
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.52549,
+          0.768627,
+          0.152941
+        ],
+        "alpha": 1,
+        "hex": "#86c427"
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.466667,
+          0.643137,
+          0.164706
+        ],
+        "alpha": 1,
+        "hex": "#77a42a"
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.396078,
+          0.521569,
+          0.152941
+        ],
+        "alpha": 1,
+        "hex": "#658527"
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.317647,
+          0.403922,
+          0.137255
+        ],
+        "alpha": 1,
+        "hex": "#516723"
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.243137,
+          0.294118,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#3e4b1d"
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.164706,
+          0.188235,
+          0.086275
+        ],
+        "alpha": 1,
+        "hex": "#2a3016"
+      }
+    }
+  },
+  "green": {
+    "050": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.929412,
+          0.976471,
+          0.929412
+        ],
+        "alpha": 1,
+        "hex": "#edf9ed"
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.854902,
+          0.952941,
+          0.858824
+        ],
+        "alpha": 1,
+        "hex": "#daf3db"
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.705882,
+          0.905882,
+          0.717647
+        ],
+        "alpha": 1,
+        "hex": "#b4e7b7"
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.54902,
+          0.854902,
+          0.580392
+        ],
+        "alpha": 1,
+        "hex": "#8cda94"
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.368627,
+          0.8,
+          0.443137
+        ],
+        "alpha": 1,
+        "hex": "#5ecc71"
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.05098,
+          0.745098,
+          0.305882
+        ],
+        "alpha": 1,
+        "hex": "#0dbe4e"
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.098039,
+          0.623529,
+          0.262745
+        ],
+        "alpha": 1,
+        "hex": "#199f43"
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.505882,
+          0.219608
+        ],
+        "alpha": 1,
+        "hex": "#1d8138"
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.392157,
+          0.180392
+        ],
+        "alpha": 1,
+        "hex": "#1d642e"
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.105882,
+          0.286275,
+          0.137255
+        ],
+        "alpha": 1,
+        "hex": "#1b4923"
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.086275,
+          0.184314,
+          0.098039
+        ],
+        "alpha": 1,
+        "hex": "#162f19"
+      }
+    }
+  },
+  "jade": {
+    "050": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.929412,
+          0.980392,
+          0.94902
+        ],
+        "alpha": 1,
+        "hex": "#edfaf2"
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.858824,
+          0.956863,
+          0.898039
+        ],
+        "alpha": 1,
+        "hex": "#dbf4e5"
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.713725,
+          0.913725,
+          0.796078
+        ],
+        "alpha": 1,
+        "hex": "#b6e9cb"
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.556863,
+          0.866667,
+          0.698039
+        ],
+        "alpha": 1,
+        "hex": "#8eddb2"
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.376471,
+          0.819608,
+          0.6
+        ],
+        "alpha": 1,
+        "hex": "#60d199"
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.027451,
+          0.768627,
+          0.501961
+        ],
+        "alpha": 1,
+        "hex": "#07c480"
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.094118,
+          0.643137,
+          0.423529
+        ],
+        "alpha": 1,
+        "hex": "#18a46c"
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.521569,
+          0.345098
+        ],
+        "alpha": 1,
+        "hex": "#1d8558"
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.117647,
+          0.403922,
+          0.27451
+        ],
+        "alpha": 1,
+        "hex": "#1e6746"
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.109804,
+          0.294118,
+          0.203922
+        ],
+        "alpha": 1,
+        "hex": "#1c4b34"
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.086275,
+          0.188235,
+          0.137255
+        ],
+        "alpha": 1,
+        "hex": "#163023"
+      }
+    }
+  },
+  "mint": {
+    "050": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.929412,
+          0.980392,
+          0.968627
+        ],
+        "alpha": 1,
+        "hex": "#edfaf7"
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.858824,
+          0.960784,
+          0.937255
+        ],
+        "alpha": 1,
+        "hex": "#dbf5ef"
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.717647,
+          0.921569,
+          0.87451
+        ],
+        "alpha": 1,
+        "hex": "#b7ebdf"
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.560784,
+          0.878431,
+          0.815686
+        ],
+        "alpha": 1,
+        "hex": "#8fe0d0"
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.380392,
+          0.835294,
+          0.752941
+        ],
+        "alpha": 1,
+        "hex": "#61d5c0"
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.792157,
+          0.694118
+        ],
+        "alpha": 1,
+        "hex": "#00cab1"
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.086275,
+          0.662745,
+          0.580392
+        ],
+        "alpha": 1,
+        "hex": "#16a994"
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.537255,
+          0.470588
+        ],
+        "alpha": 1,
+        "hex": "#1d8978"
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.117647,
+          0.415686,
+          0.368627
+        ],
+        "alpha": 1,
+        "hex": "#1e6a5e"
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.109804,
+          0.301961,
+          0.266667
+        ],
+        "alpha": 1,
+        "hex": "#1c4d44"
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.086275,
+          0.192157,
+          0.172549
+        ],
+        "alpha": 1,
+        "hex": "#16312c"
+      }
+    }
+  },
+  "teal": {
+    "050": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.933333,
+          0.976471,
+          0.980392
+        ],
+        "alpha": 1,
+        "hex": "#eef9fa"
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.866667,
+          0.956863,
+          0.964706
+        ],
+        "alpha": 1,
+        "hex": "#ddf4f6"
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.72549,
+          0.909804,
+          0.929412
+        ],
+        "alpha": 1,
+        "hex": "#b9e8ed"
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.572549,
+          0.866667,
+          0.894118
+        ],
+        "alpha": 1,
+        "hex": "#92dde4"
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.392157,
+          0.819608,
+          0.858824
+        ],
+        "alpha": 1,
+        "hex": "#64d1db"
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.772549,
+          0.823529
+        ],
+        "alpha": 1,
+        "hex": "#00c5d2"
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.090196,
+          0.647059,
+          0.686275
+        ],
+        "alpha": 1,
+        "hex": "#17a5af"
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.117647,
+          0.521569,
+          0.556863
+        ],
+        "alpha": 1,
+        "hex": "#1e858e"
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.121569,
+          0.407843,
+          0.431373
+        ],
+        "alpha": 1,
+        "hex": "#1f686e"
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.294118,
+          0.309804
+        ],
+        "alpha": 1,
+        "hex": "#1d4b4f"
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.090196,
+          0.188235,
+          0.2
+        ],
+        "alpha": 1,
+        "hex": "#173033"
+      }
+    }
+  },
+  "cyan": {
+    "050": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.937255,
+          0.976471,
+          0.996078
+        ],
+        "alpha": 1,
+        "hex": "#eff9fe"
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.870588,
+          0.94902,
+          0.988235
+        ],
+        "alpha": 1,
+        "hex": "#def2fc"
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.737255,
+          0.901961,
+          0.976471
+        ],
+        "alpha": 1,
+        "hex": "#bce6f9"
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.588235,
+          0.85098,
+          0.964706
+        ],
+        "alpha": 1,
+        "hex": "#96d9f6"
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.407843,
+          0.803922,
+          0.94902
+        ],
+        "alpha": 1,
+        "hex": "#68cdf2"
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.031373,
+          0.752941,
+          0.937255
+        ],
+        "alpha": 1,
+        "hex": "#08c0ef"
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.109804,
+          0.631373,
+          0.780392
+        ],
+        "alpha": 1,
+        "hex": "#1ca1c7"
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.129412,
+          0.509804,
+          0.631373
+        ],
+        "alpha": 1,
+        "hex": "#2182a1"
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.133333,
+          0.396078,
+          0.486275
+        ],
+        "alpha": 1,
+        "hex": "#22657c"
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.117647,
+          0.286275,
+          0.34902
+        ],
+        "alpha": 1,
+        "hex": "#1e4959"
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.094118,
+          0.184314,
+          0.219608
+        ],
+        "alpha": 1,
+        "hex": "#182f38"
+      }
+    }
+  },
+  "blue": {
+    "050": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.937255,
+          0.960784,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#eff5ff"
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.87451,
+          0.921569,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#dfebff"
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.741176,
+          0.843137,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#bdd7ff"
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.592157,
+          0.768627,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#97c4ff"
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.411765,
+          0.694118,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#69b1ff"
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.623529,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#009fff"
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.101961,
+          0.521569,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#1a85d4"
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.129412,
+          0.423529,
+          0.670588
+        ],
+        "alpha": 1,
+        "hex": "#216cab"
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.129412,
+          0.333333,
+          0.517647
+        ],
+        "alpha": 1,
+        "hex": "#215584"
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.121569,
+          0.243137,
+          0.368627
+        ],
+        "alpha": 1,
+        "hex": "#1f3e5e"
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.098039,
+          0.156863,
+          0.235294
+        ],
+        "alpha": 1,
+        "hex": "#19283c"
+      }
+    }
+  },
+  "indigo": {
+    "050": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.960784,
+          0.92549,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#f5ecff"
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.917647,
+          0.85098,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#ead9ff"
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.827451,
+          0.705882,
+          0.996078
+        ],
+        "alpha": 1,
+        "hex": "#d3b4fe"
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.729412,
+          0.560784,
+          0.992157
+        ],
+        "alpha": 1,
+        "hex": "#ba8ffd"
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.615686,
+          0.415686,
+          0.984314
+        ],
+        "alpha": 1,
+        "hex": "#9d6afb"
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.482353,
+          0.262745,
+          0.972549
+        ],
+        "alpha": 1,
+        "hex": "#7b43f8"
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.411765,
+          0.227451,
+          0.811765
+        ],
+        "alpha": 1,
+        "hex": "#693acf"
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.341176,
+          0.192157,
+          0.654902
+        ],
+        "alpha": 1,
+        "hex": "#5731a7"
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.27451,
+          0.160784,
+          0.505882
+        ],
+        "alpha": 1,
+        "hex": "#462981"
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.207843,
+          0.12549,
+          0.360784
+        ],
+        "alpha": 1,
+        "hex": "#35205c"
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.141176,
+          0.090196,
+          0.227451
+        ],
+        "alpha": 1,
+        "hex": "#24173a"
+      }
+    }
+  },
+  "violet": {
+    "050": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.972549,
+          0.929412,
+          0.996078
+        ],
+        "alpha": 1,
+        "hex": "#f8edfe"
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.945098,
+          0.854902,
+          0.992157
+        ],
+        "alpha": 1,
+        "hex": "#f1dafd"
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.882353,
+          0.709804,
+          0.980392
+        ],
+        "alpha": 1,
+        "hex": "#e1b5fa"
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.807843,
+          0.564706,
+          0.968627
+        ],
+        "alpha": 1,
+        "hex": "#ce90f7"
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.72549,
+          0.411765,
+          0.952941
+        ],
+        "alpha": 1,
+        "hex": "#b969f3"
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.631373,
+          0.235294,
+          0.933333
+        ],
+        "alpha": 1,
+        "hex": "#a13cee"
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.533333,
+          0.211765,
+          0.780392
+        ],
+        "alpha": 1,
+        "hex": "#8836c7"
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.435294,
+          0.180392,
+          0.631373
+        ],
+        "alpha": 1,
+        "hex": "#6f2ea1"
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.345098,
+          0.156863,
+          0.486275
+        ],
+        "alpha": 1,
+        "hex": "#58287c"
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.254902,
+          0.12549,
+          0.34902
+        ],
+        "alpha": 1,
+        "hex": "#412059"
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.168627,
+          0.090196,
+          0.219608
+        ],
+        "alpha": 1,
+        "hex": "#2b1738"
+      }
+    }
+  },
+  "purple": {
+    "050": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.984314,
+          0.929412,
+          0.992157
+        ],
+        "alpha": 1,
+        "hex": "#fbedfd"
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.968627,
+          0.858824,
+          0.984314
+        ],
+        "alpha": 1,
+        "hex": "#f7dbfb"
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.933333,
+          0.713725,
+          0.964706
+        ],
+        "alpha": 1,
+        "hex": "#eeb6f6"
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.886275,
+          0.564706,
+          0.941176
+        ],
+        "alpha": 1,
+        "hex": "#e290f0"
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.835294,
+          0.407843,
+          0.917647
+        ],
+        "alpha": 1,
+        "hex": "#d568ea"
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.776471,
+          0.207843,
+          0.894118
+        ],
+        "alpha": 1,
+        "hex": "#c635e4"
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.65098,
+          0.192157,
+          0.745098
+        ],
+        "alpha": 1,
+        "hex": "#a631be"
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.529412,
+          0.168627,
+          0.603922
+        ],
+        "alpha": 1,
+        "hex": "#872b9a"
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.411765,
+          0.14902,
+          0.466667
+        ],
+        "alpha": 1,
+        "hex": "#692677"
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.301961,
+          0.121569,
+          0.337255
+        ],
+        "alpha": 1,
+        "hex": "#4d1f56"
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.196078,
+          0.090196,
+          0.211765
+        ],
+        "alpha": 1,
+        "hex": "#321736"
+      }
+    }
+  },
+  "magenta": {
+    "050": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.992157,
+          0.929412,
+          0.968627
+        ],
+        "alpha": 1,
+        "hex": "#fdedf7"
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.984314,
+          0.858824,
+          0.933333
+        ],
+        "alpha": 1,
+        "hex": "#fbdbee"
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.968627,
+          0.717647,
+          0.866667
+        ],
+        "alpha": 1,
+        "hex": "#f7b7dd"
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.945098,
+          0.568627,
+          0.8
+        ],
+        "alpha": 1,
+        "hex": "#f191cc"
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.917647,
+          0.407843,
+          0.737255
+        ],
+        "alpha": 1,
+        "hex": "#ea68bc"
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.882353,
+          0.188235,
+          0.67451
+        ],
+        "alpha": 1,
+        "hex": "#e130ac"
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.741176,
+          0.180392,
+          0.564706
+        ],
+        "alpha": 1,
+        "hex": "#bd2e90"
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6,
+          0.164706,
+          0.458824
+        ],
+        "alpha": 1,
+        "hex": "#992a75"
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.466667,
+          0.145098,
+          0.356863
+        ],
+        "alpha": 1,
+        "hex": "#77255b"
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.337255,
+          0.121569,
+          0.262745
+        ],
+        "alpha": 1,
+        "hex": "#561f43"
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.219608,
+          0.090196,
+          0.168627
+        ],
+        "alpha": 1,
+        "hex": "#38172b"
+      }
+    }
+  },
+  "pink": {
+    "050": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.929412,
+          0.941176
+        ],
+        "alpha": 1,
+        "hex": "#ffedf0"
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.858824,
+          0.882353
+        ],
+        "alpha": 1,
+        "hex": "#ffdbe1"
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.717647,
+          0.768627
+        ],
+        "alpha": 1,
+        "hex": "#ffb7c4"
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.568627,
+          0.658824
+        ],
+        "alpha": 1,
+        "hex": "#ff91a8"
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.403922,
+          0.552941
+        ],
+        "alpha": 1,
+        "hex": "#ff678d"
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.988235,
+          0.168627,
+          0.45098
+        ],
+        "alpha": 1,
+        "hex": "#fc2b73"
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.827451,
+          0.164706,
+          0.380392
+        ],
+        "alpha": 1,
+        "hex": "#d32a61"
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.666667,
+          0.156863,
+          0.313725
+        ],
+        "alpha": 1,
+        "hex": "#aa2850"
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.517647,
+          0.141176,
+          0.247059
+        ],
+        "alpha": 1,
+        "hex": "#84243f"
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.372549,
+          0.117647,
+          0.184314
+        ],
+        "alpha": 1,
+        "hex": "#5f1e2f"
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.239216,
+          0.090196,
+          0.12549
+        ],
+        "alpha": 1,
+        "hex": "#3d1720"
+      }
+    }
+  },
+  "rose": {
+    "050": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.929412,
+          0.929412
+        ],
+        "alpha": 1,
+        "hex": "#ffeded"
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.858824,
+          0.862745
+        ],
+        "alpha": 1,
+        "hex": "#ffdbdc"
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.717647,
+          0.72549
+        ],
+        "alpha": 1,
+        "hex": "#ffb7b9"
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.568627,
+          0.596078
+        ],
+        "alpha": 1,
+        "hex": "#ff9198"
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.403922,
+          0.470588
+        ],
+        "alpha": 1,
+        "hex": "#ff6778"
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.996078,
+          0.176471,
+          0.34902
+        ],
+        "alpha": 1,
+        "hex": "#fe2d59"
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.831373,
+          0.168627,
+          0.298039
+        ],
+        "alpha": 1,
+        "hex": "#d42b4c"
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.67451,
+          0.160784,
+          0.247059
+        ],
+        "alpha": 1,
+        "hex": "#ac293f"
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.521569,
+          0.141176,
+          0.196078
+        ],
+        "alpha": 1,
+        "hex": "#852432"
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.376471,
+          0.117647,
+          0.14902
+        ],
+        "alpha": 1,
+        "hex": "#601e26"
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.243137,
+          0.090196,
+          0.105882
+        ],
+        "alpha": 1,
+        "hex": "#3e171b"
+      }
+    }
+  },
+  "brown": {
+    "050": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.972549,
+          0.94902,
+          0.933333
+        ],
+        "alpha": 1,
+        "hex": "#f8f2ee"
+      }
+    },
+    "100": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.945098,
+          0.894118,
+          0.866667
+        ],
+        "alpha": 1,
+        "hex": "#f1e4dd"
+      }
+    },
+    "200": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.890196,
+          0.792157,
+          0.733333
+        ],
+        "alpha": 1,
+        "hex": "#e3cabb"
+      }
+    },
+    "300": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.827451,
+          0.694118,
+          0.607843
+        ],
+        "alpha": 1,
+        "hex": "#d3b19b"
+      }
+    },
+    "400": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.764706,
+          0.596078,
+          0.482353
+        ],
+        "alpha": 1,
+        "hex": "#c3987b"
+      }
+    },
+    "500": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.698039,
+          0.498039,
+          0.360784
+        ],
+        "alpha": 1,
+        "hex": "#b27f5c"
+      }
+    },
+    "600": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.584314,
+          0.419608,
+          0.309804
+        ],
+        "alpha": 1,
+        "hex": "#956b4f"
+      }
+    },
+    "700": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.478431,
+          0.345098,
+          0.254902
+        ],
+        "alpha": 1,
+        "hex": "#7a5841"
+      }
+    },
+    "800": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.372549,
+          0.270588,
+          0.203922
+        ],
+        "alpha": 1,
+        "hex": "#5f4534"
+      }
+    },
+    "900": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.270588,
+          0.2,
+          0.152941
+        ],
+        "alpha": 1,
+        "hex": "#453327"
+      }
+    },
+    "950": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.176471,
+          0.133333,
+          0.105882
+        ],
+        "alpha": 1,
+        "hex": "#2d221b"
+      }
+    }
+  }
+}

--- a/packages/theme/figma/semantic/dark-protanopia-deuteranopia.json
+++ b/packages/theme/figma/semantic/dark-protanopia-deuteranopia.json
@@ -1,0 +1,1118 @@
+{
+  "bg": {
+    "editor": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.039216,
+          0.039216,
+          0.039216
+        ],
+        "alpha": 1,
+        "hex": "#0a0a0a"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1040"
+        }
+      }
+    },
+    "window": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.090196,
+          0.090196,
+          0.090196
+        ],
+        "alpha": 1,
+        "hex": "#171717"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1000"
+        }
+      }
+    },
+    "inset": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/980"
+        }
+      }
+    },
+    "elevated": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.062745,
+          0.062745,
+          0.062745
+        ],
+        "alpha": 1,
+        "hex": "#101010"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1020"
+        }
+      }
+    }
+  },
+  "fg": {
+    "base": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.980392,
+          0.980392,
+          0.980392
+        ],
+        "alpha": 1,
+        "hex": "#fafafa"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/020"
+        }
+      }
+    },
+    "fg1": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.831373,
+          0.831373,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#d4d4d4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/200"
+        }
+      }
+    },
+    "fg2": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.639216,
+          0.639216,
+          0.639216
+        ],
+        "alpha": 1,
+        "hex": "#a3a3a3"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/400"
+        }
+      }
+    },
+    "fg3": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.45098,
+          0.45098,
+          0.45098
+        ],
+        "alpha": 1,
+        "hex": "#737373"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/600"
+        }
+      }
+    },
+    "fg4": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.388235,
+          0.388235,
+          0.388235
+        ],
+        "alpha": 1,
+        "hex": "#636363"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/700"
+        }
+      }
+    }
+  },
+  "border": {
+    "window": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.039216,
+          0.039216,
+          0.039216
+        ],
+        "alpha": 1,
+        "hex": "#0a0a0a"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1040"
+        }
+      }
+    },
+    "editor": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/980"
+        }
+      }
+    },
+    "indentGuide": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/980"
+        }
+      }
+    },
+    "indentGuideActive": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.14902,
+          0.14902,
+          0.14902
+        ],
+        "alpha": 1,
+        "hex": "#262626"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/960"
+        }
+      }
+    },
+    "inset": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/980"
+        }
+      }
+    },
+    "elevated": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/980"
+        }
+      }
+    }
+  },
+  "accent": {
+    "primary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.623529,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#009fff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/500"
+        }
+      }
+    },
+    "link": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.623529,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#009fff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/500"
+        }
+      }
+    },
+    "subtle": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.098039,
+          0.156863,
+          0.235294
+        ],
+        "alpha": 1,
+        "hex": "#19283c"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/950"
+        }
+      }
+    },
+    "contrastOnAccent": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.039216,
+          0.039216,
+          0.039216
+        ],
+        "alpha": 1,
+        "hex": "#0a0a0a"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1040"
+        }
+      }
+    }
+  },
+  "states": {
+    "success": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.592157,
+          0.768627,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#97c4ff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/300"
+        }
+      }
+    },
+    "danger": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.996078,
+          0.54902,
+          0.172549
+        ],
+        "alpha": 1,
+        "hex": "#fe8c2c"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "orange/500"
+        }
+      }
+    },
+    "warn": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.870588,
+          0.501961
+        ],
+        "alpha": 1,
+        "hex": "#ffde80"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "yellow/300"
+        }
+      }
+    },
+    "info": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.407843,
+          0.803922,
+          0.94902
+        ],
+        "alpha": 1,
+        "hex": "#68cdf2"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/400"
+        }
+      }
+    },
+    "merge": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.72549,
+          0.411765,
+          0.952941
+        ],
+        "alpha": 1,
+        "hex": "#b969f3"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "violet/400"
+        }
+      }
+    }
+  },
+  "syntax": {
+    "comment": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.45098,
+          0.45098,
+          0.45098
+        ],
+        "alpha": 1,
+        "hex": "#737373"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/600"
+        }
+      }
+    },
+    "string": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.592157,
+          0.768627,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#97c4ff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/300"
+        }
+      }
+    },
+    "number": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.588235,
+          0.85098,
+          0.964706
+        ],
+        "alpha": 1,
+        "hex": "#96d9f6"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/300"
+        }
+      }
+    },
+    "keyword": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.72549,
+          0.411765,
+          0.952941
+        ],
+        "alpha": 1,
+        "hex": "#b969f3"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "violet/400"
+        }
+      }
+    },
+    "regexp": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.407843,
+          0.803922,
+          0.94902
+        ],
+        "alpha": 1,
+        "hex": "#68cdf2"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/400"
+        }
+      }
+    },
+    "func": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.729412,
+          0.560784,
+          0.992157
+        ],
+        "alpha": 1,
+        "hex": "#ba8ffd"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "indigo/300"
+        }
+      }
+    },
+    "type": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.886275,
+          0.564706,
+          0.941176
+        ],
+        "alpha": 1,
+        "hex": "#e290f0"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "purple/300"
+        }
+      }
+    },
+    "variable": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.639216,
+          0.34902
+        ],
+        "alpha": 1,
+        "hex": "#ffa359"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "orange/400"
+        }
+      }
+    },
+    "operator": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.031373,
+          0.752941,
+          0.937255
+        ],
+        "alpha": 1,
+        "hex": "#08c0ef"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/500"
+        }
+      }
+    },
+    "punctuation": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.388235,
+          0.388235,
+          0.388235
+        ],
+        "alpha": 1,
+        "hex": "#636363"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/700"
+        }
+      }
+    },
+    "constant": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.8,
+          0.505882
+        ],
+        "alpha": 1,
+        "hex": "#ffcc81"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "amber/300"
+        }
+      }
+    },
+    "parameter": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.639216,
+          0.639216,
+          0.639216
+        ],
+        "alpha": 1,
+        "hex": "#a3a3a3"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/400"
+        }
+      }
+    },
+    "namespace": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.737255,
+          0.337255
+        ],
+        "alpha": 1,
+        "hex": "#ffbc56"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "amber/400"
+        }
+      }
+    },
+    "decorator": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.411765,
+          0.694118,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#69b1ff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/400"
+        }
+      }
+    },
+    "escape": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.392157,
+          0.819608,
+          0.858824
+        ],
+        "alpha": 1,
+        "hex": "#64d1db"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/400"
+        }
+      }
+    },
+    "invalid": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.980392,
+          0.980392,
+          0.980392
+        ],
+        "alpha": 1,
+        "hex": "#fafafa"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/020"
+        }
+      }
+    },
+    "tag": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.639216,
+          0.34902
+        ],
+        "alpha": 1,
+        "hex": "#ffa359"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "orange/400"
+        }
+      }
+    },
+    "attribute": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.737255,
+          0.337255
+        ],
+        "alpha": 1,
+        "hex": "#ffbc56"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "amber/400"
+        }
+      }
+    }
+  },
+  "ansi": {
+    "black": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.090196,
+          0.090196,
+          0.090196
+        ],
+        "alpha": 1,
+        "hex": "#171717"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1000"
+        }
+      }
+    },
+    "red": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.639216,
+          0.34902
+        ],
+        "alpha": 1,
+        "hex": "#ffa359"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "orange/400"
+        }
+      }
+    },
+    "green": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.411765,
+          0.694118,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#69b1ff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/400"
+        }
+      }
+    },
+    "yellow": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.831373,
+          0.321569
+        ],
+        "alpha": 1,
+        "hex": "#ffd452"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "yellow/400"
+        }
+      }
+    },
+    "blue": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.623529,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#009fff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/500"
+        }
+      }
+    },
+    "magenta": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.72549,
+          0.411765,
+          0.952941
+        ],
+        "alpha": 1,
+        "hex": "#b969f3"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "violet/400"
+        }
+      }
+    },
+    "cyan": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.407843,
+          0.803922,
+          0.94902
+        ],
+        "alpha": 1,
+        "hex": "#68cdf2"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/400"
+        }
+      }
+    },
+    "white": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.737255,
+          0.737255,
+          0.737255
+        ],
+        "alpha": 1,
+        "hex": "#bcbcbc"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/300"
+        }
+      }
+    },
+    "brightBlack": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.090196,
+          0.090196,
+          0.090196
+        ],
+        "alpha": 1,
+        "hex": "#171717"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1000"
+        }
+      }
+    },
+    "brightRed": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.729412,
+          0.509804
+        ],
+        "alpha": 1,
+        "hex": "#ffba82"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "orange/300"
+        }
+      }
+    },
+    "brightGreen": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.592157,
+          0.768627,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#97c4ff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/300"
+        }
+      }
+    },
+    "brightYellow": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.870588,
+          0.501961
+        ],
+        "alpha": 1,
+        "hex": "#ffde80"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "yellow/300"
+        }
+      }
+    },
+    "brightBlue": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.411765,
+          0.694118,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#69b1ff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/400"
+        }
+      }
+    },
+    "brightMagenta": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.807843,
+          0.564706,
+          0.968627
+        ],
+        "alpha": 1,
+        "hex": "#ce90f7"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "violet/300"
+        }
+      }
+    },
+    "brightCyan": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.588235,
+          0.85098,
+          0.964706
+        ],
+        "alpha": 1,
+        "hex": "#96d9f6"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/300"
+        }
+      }
+    },
+    "brightWhite": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.737255,
+          0.737255,
+          0.737255
+        ],
+        "alpha": 1,
+        "hex": "#bcbcbc"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/300"
+        }
+      }
+    }
+  }
+}

--- a/packages/theme/figma/semantic/dark-soft.json
+++ b/packages/theme/figma/semantic/dark-soft.json
@@ -1,0 +1,1118 @@
+{
+  "bg": {
+    "editor": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.090196,
+          0.090196,
+          0.090196
+        ],
+        "alpha": 1,
+        "hex": "#171717"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1000"
+        }
+      }
+    },
+    "window": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.062745,
+          0.062745,
+          0.062745
+        ],
+        "alpha": 1,
+        "hex": "#101010"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1020"
+        }
+      }
+    },
+    "inset": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.14902,
+          0.14902,
+          0.14902
+        ],
+        "alpha": 1,
+        "hex": "#262626"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/960"
+        }
+      }
+    },
+    "elevated": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/980"
+        }
+      }
+    }
+  },
+  "fg": {
+    "base": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.831373,
+          0.831373,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#d4d4d4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/200"
+        }
+      }
+    },
+    "fg1": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.737255,
+          0.737255,
+          0.737255
+        ],
+        "alpha": 1,
+        "hex": "#bcbcbc"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/300"
+        }
+      }
+    },
+    "fg2": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.541176,
+          0.541176,
+          0.541176
+        ],
+        "alpha": 1,
+        "hex": "#8a8a8a"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/500"
+        }
+      }
+    },
+    "fg3": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.388235,
+          0.388235,
+          0.388235
+        ],
+        "alpha": 1,
+        "hex": "#636363"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/700"
+        }
+      }
+    },
+    "fg4": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.321569,
+          0.321569,
+          0.321569
+        ],
+        "alpha": 1,
+        "hex": "#525252"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/800"
+        }
+      }
+    }
+  },
+  "border": {
+    "window": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/980"
+        }
+      }
+    },
+    "editor": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.172549,
+          0.172549,
+          0.172549
+        ],
+        "alpha": 1,
+        "hex": "#2c2c2c"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/940"
+        }
+      }
+    },
+    "indentGuide": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.14902,
+          0.14902,
+          0.14902
+        ],
+        "alpha": 1,
+        "hex": "#262626"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/960"
+        }
+      }
+    },
+    "indentGuideActive": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.172549,
+          0.172549,
+          0.172549
+        ],
+        "alpha": 1,
+        "hex": "#2c2c2c"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/940"
+        }
+      }
+    },
+    "inset": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.172549,
+          0.172549,
+          0.172549
+        ],
+        "alpha": 1,
+        "hex": "#2c2c2c"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/940"
+        }
+      }
+    },
+    "elevated": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.14902,
+          0.14902,
+          0.14902
+        ],
+        "alpha": 1,
+        "hex": "#262626"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/960"
+        }
+      }
+    }
+  },
+  "accent": {
+    "primary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.411765,
+          0.694118,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#69b1ff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/400"
+        }
+      }
+    },
+    "link": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.411765,
+          0.694118,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#69b1ff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/400"
+        }
+      }
+    },
+    "subtle": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.121569,
+          0.243137,
+          0.368627
+        ],
+        "alpha": 1,
+        "hex": "#1f3e5e"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/900"
+        }
+      }
+    },
+    "contrastOnAccent": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.090196,
+          0.090196,
+          0.090196
+        ],
+        "alpha": 1,
+        "hex": "#171717"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1000"
+        }
+      }
+    }
+  },
+  "states": {
+    "merge": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.615686,
+          0.415686,
+          0.984314
+        ],
+        "alpha": 1,
+        "hex": "#9d6afb"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "indigo/400"
+        }
+      }
+    },
+    "success": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.376471,
+          0.819608,
+          0.6
+        ],
+        "alpha": 1,
+        "hex": "#60d199"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "jade/400"
+        }
+      }
+    },
+    "danger": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.403922,
+          0.384314
+        ],
+        "alpha": 1,
+        "hex": "#ff6762"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "red/400"
+        }
+      }
+    },
+    "warn": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.831373,
+          0.321569
+        ],
+        "alpha": 1,
+        "hex": "#ffd452"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "yellow/400"
+        }
+      }
+    },
+    "info": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.407843,
+          0.803922,
+          0.94902
+        ],
+        "alpha": 1,
+        "hex": "#68cdf2"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/400"
+        }
+      }
+    }
+  },
+  "syntax": {
+    "comment": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.388235,
+          0.388235,
+          0.388235
+        ],
+        "alpha": 1,
+        "hex": "#636363"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/700"
+        }
+      }
+    },
+    "string": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.54902,
+          0.854902,
+          0.580392
+        ],
+        "alpha": 1,
+        "hex": "#8cda94"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "green/300"
+        }
+      }
+    },
+    "number": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.588235,
+          0.85098,
+          0.964706
+        ],
+        "alpha": 1,
+        "hex": "#96d9f6"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/300"
+        }
+      }
+    },
+    "keyword": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.568627,
+          0.658824
+        ],
+        "alpha": 1,
+        "hex": "#ff91a8"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "pink/300"
+        }
+      }
+    },
+    "regexp": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.572549,
+          0.866667,
+          0.894118
+        ],
+        "alpha": 1,
+        "hex": "#92dde4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/300"
+        }
+      }
+    },
+    "func": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.729412,
+          0.560784,
+          0.992157
+        ],
+        "alpha": 1,
+        "hex": "#ba8ffd"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "indigo/300"
+        }
+      }
+    },
+    "type": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.886275,
+          0.564706,
+          0.941176
+        ],
+        "alpha": 1,
+        "hex": "#e290f0"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "purple/300"
+        }
+      }
+    },
+    "variable": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.729412,
+          0.509804
+        ],
+        "alpha": 1,
+        "hex": "#ffba82"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "orange/300"
+        }
+      }
+    },
+    "operator": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.407843,
+          0.803922,
+          0.94902
+        ],
+        "alpha": 1,
+        "hex": "#68cdf2"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/400"
+        }
+      }
+    },
+    "punctuation": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.45098,
+          0.45098,
+          0.45098
+        ],
+        "alpha": 1,
+        "hex": "#737373"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/600"
+        }
+      }
+    },
+    "constant": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.870588,
+          0.501961
+        ],
+        "alpha": 1,
+        "hex": "#ffde80"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "yellow/300"
+        }
+      }
+    },
+    "parameter": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.541176,
+          0.541176,
+          0.541176
+        ],
+        "alpha": 1,
+        "hex": "#8a8a8a"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/500"
+        }
+      }
+    },
+    "namespace": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.737255,
+          0.337255
+        ],
+        "alpha": 1,
+        "hex": "#ffbc56"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "amber/400"
+        }
+      }
+    },
+    "decorator": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.592157,
+          0.768627,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#97c4ff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/300"
+        }
+      }
+    },
+    "escape": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.560784,
+          0.878431,
+          0.815686
+        ],
+        "alpha": 1,
+        "hex": "#8fe0d0"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "mint/300"
+        }
+      }
+    },
+    "invalid": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.831373,
+          0.831373,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#d4d4d4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/200"
+        }
+      }
+    },
+    "tag": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.65098,
+          0.521569
+        ],
+        "alpha": 1,
+        "hex": "#ffa685"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "vermillion/300"
+        }
+      }
+    },
+    "attribute": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.556863,
+          0.866667,
+          0.698039
+        ],
+        "alpha": 1,
+        "hex": "#8eddb2"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "jade/300"
+        }
+      }
+    }
+  },
+  "ansi": {
+    "black": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.090196,
+          0.090196,
+          0.090196
+        ],
+        "alpha": 1,
+        "hex": "#171717"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1000"
+        }
+      }
+    },
+    "red": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.180392,
+          0.247059
+        ],
+        "alpha": 1,
+        "hex": "#ff2e3f"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "red/500"
+        }
+      }
+    },
+    "green": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.05098,
+          0.745098,
+          0.305882
+        ],
+        "alpha": 1,
+        "hex": "#0dbe4e"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "green/500"
+        }
+      }
+    },
+    "yellow": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.792157,
+          0
+        ],
+        "alpha": 1,
+        "hex": "#ffca00"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "yellow/500"
+        }
+      }
+    },
+    "blue": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.623529,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#009fff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/500"
+        }
+      }
+    },
+    "magenta": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.882353,
+          0.188235,
+          0.67451
+        ],
+        "alpha": 1,
+        "hex": "#e130ac"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "magenta/500"
+        }
+      }
+    },
+    "cyan": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.031373,
+          0.752941,
+          0.937255
+        ],
+        "alpha": 1,
+        "hex": "#08c0ef"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/500"
+        }
+      }
+    },
+    "white": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.737255,
+          0.737255,
+          0.737255
+        ],
+        "alpha": 1,
+        "hex": "#bcbcbc"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/300"
+        }
+      }
+    },
+    "brightBlack": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.090196,
+          0.090196,
+          0.090196
+        ],
+        "alpha": 1,
+        "hex": "#171717"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1000"
+        }
+      }
+    },
+    "brightRed": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.180392,
+          0.247059
+        ],
+        "alpha": 1,
+        "hex": "#ff2e3f"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "red/500"
+        }
+      }
+    },
+    "brightGreen": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.52549,
+          0.768627,
+          0.152941
+        ],
+        "alpha": 1,
+        "hex": "#86c427"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "lime/500"
+        }
+      }
+    },
+    "brightYellow": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.792157,
+          0
+        ],
+        "alpha": 1,
+        "hex": "#ffca00"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "yellow/500"
+        }
+      }
+    },
+    "brightBlue": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.623529,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#009fff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/500"
+        }
+      }
+    },
+    "brightMagenta": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.882353,
+          0.188235,
+          0.67451
+        ],
+        "alpha": 1,
+        "hex": "#e130ac"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "magenta/500"
+        }
+      }
+    },
+    "brightCyan": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.031373,
+          0.752941,
+          0.937255
+        ],
+        "alpha": 1,
+        "hex": "#08c0ef"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/500"
+        }
+      }
+    },
+    "brightWhite": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.737255,
+          0.737255,
+          0.737255
+        ],
+        "alpha": 1,
+        "hex": "#bcbcbc"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/300"
+        }
+      }
+    }
+  }
+}

--- a/packages/theme/figma/semantic/dark-tritanopia.json
+++ b/packages/theme/figma/semantic/dark-tritanopia.json
@@ -1,0 +1,1118 @@
+{
+  "bg": {
+    "editor": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.039216,
+          0.039216,
+          0.039216
+        ],
+        "alpha": 1,
+        "hex": "#0a0a0a"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1040"
+        }
+      }
+    },
+    "window": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.090196,
+          0.090196,
+          0.090196
+        ],
+        "alpha": 1,
+        "hex": "#171717"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1000"
+        }
+      }
+    },
+    "inset": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/980"
+        }
+      }
+    },
+    "elevated": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.062745,
+          0.062745,
+          0.062745
+        ],
+        "alpha": 1,
+        "hex": "#101010"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1020"
+        }
+      }
+    }
+  },
+  "fg": {
+    "base": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.980392,
+          0.980392,
+          0.980392
+        ],
+        "alpha": 1,
+        "hex": "#fafafa"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/020"
+        }
+      }
+    },
+    "fg1": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.831373,
+          0.831373,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#d4d4d4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/200"
+        }
+      }
+    },
+    "fg2": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.639216,
+          0.639216,
+          0.639216
+        ],
+        "alpha": 1,
+        "hex": "#a3a3a3"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/400"
+        }
+      }
+    },
+    "fg3": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.45098,
+          0.45098,
+          0.45098
+        ],
+        "alpha": 1,
+        "hex": "#737373"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/600"
+        }
+      }
+    },
+    "fg4": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.388235,
+          0.388235,
+          0.388235
+        ],
+        "alpha": 1,
+        "hex": "#636363"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/700"
+        }
+      }
+    }
+  },
+  "border": {
+    "window": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.039216,
+          0.039216,
+          0.039216
+        ],
+        "alpha": 1,
+        "hex": "#0a0a0a"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1040"
+        }
+      }
+    },
+    "editor": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/980"
+        }
+      }
+    },
+    "indentGuide": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/980"
+        }
+      }
+    },
+    "indentGuideActive": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.14902,
+          0.14902,
+          0.14902
+        ],
+        "alpha": 1,
+        "hex": "#262626"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/960"
+        }
+      }
+    },
+    "inset": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/980"
+        }
+      }
+    },
+    "elevated": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/980"
+        }
+      }
+    }
+  },
+  "accent": {
+    "primary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.623529,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#009fff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/500"
+        }
+      }
+    },
+    "link": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.623529,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#009fff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/500"
+        }
+      }
+    },
+    "subtle": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.098039,
+          0.156863,
+          0.235294
+        ],
+        "alpha": 1,
+        "hex": "#19283c"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/950"
+        }
+      }
+    },
+    "contrastOnAccent": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.039216,
+          0.039216,
+          0.039216
+        ],
+        "alpha": 1,
+        "hex": "#0a0a0a"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1040"
+        }
+      }
+    }
+  },
+  "states": {
+    "success": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.572549,
+          0.866667,
+          0.894118
+        ],
+        "alpha": 1,
+        "hex": "#92dde4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/300"
+        }
+      }
+    },
+    "danger": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.521569,
+          0.368627
+        ],
+        "alpha": 1,
+        "hex": "#ff855e"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "vermillion/400"
+        }
+      }
+    },
+    "warn": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.737255,
+          0.337255
+        ],
+        "alpha": 1,
+        "hex": "#ffbc56"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "amber/400"
+        }
+      }
+    },
+    "info": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.411765,
+          0.694118,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#69b1ff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/400"
+        }
+      }
+    },
+    "merge": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.917647,
+          0.407843,
+          0.737255
+        ],
+        "alpha": 1,
+        "hex": "#ea68bc"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "magenta/400"
+        }
+      }
+    }
+  },
+  "syntax": {
+    "comment": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.45098,
+          0.45098,
+          0.45098
+        ],
+        "alpha": 1,
+        "hex": "#737373"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/600"
+        }
+      }
+    },
+    "string": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.572549,
+          0.866667,
+          0.894118
+        ],
+        "alpha": 1,
+        "hex": "#92dde4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/300"
+        }
+      }
+    },
+    "number": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.411765,
+          0.694118,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#69b1ff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/400"
+        }
+      }
+    },
+    "keyword": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.835294,
+          0.407843,
+          0.917647
+        ],
+        "alpha": 1,
+        "hex": "#d568ea"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "purple/400"
+        }
+      }
+    },
+    "regexp": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.392157,
+          0.819608,
+          0.858824
+        ],
+        "alpha": 1,
+        "hex": "#64d1db"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/400"
+        }
+      }
+    },
+    "func": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.592157,
+          0.768627,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#97c4ff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/300"
+        }
+      }
+    },
+    "type": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.917647,
+          0.407843,
+          0.737255
+        ],
+        "alpha": 1,
+        "hex": "#ea68bc"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "magenta/400"
+        }
+      }
+    },
+    "variable": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.521569,
+          0.368627
+        ],
+        "alpha": 1,
+        "hex": "#ff855e"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "vermillion/400"
+        }
+      }
+    },
+    "operator": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.772549,
+          0.823529
+        ],
+        "alpha": 1,
+        "hex": "#00c5d2"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/500"
+        }
+      }
+    },
+    "punctuation": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.388235,
+          0.388235,
+          0.388235
+        ],
+        "alpha": 1,
+        "hex": "#636363"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/700"
+        }
+      }
+    },
+    "constant": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.8,
+          0.505882
+        ],
+        "alpha": 1,
+        "hex": "#ffcc81"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "amber/300"
+        }
+      }
+    },
+    "parameter": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.639216,
+          0.639216,
+          0.639216
+        ],
+        "alpha": 1,
+        "hex": "#a3a3a3"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/400"
+        }
+      }
+    },
+    "namespace": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.521569,
+          0.368627
+        ],
+        "alpha": 1,
+        "hex": "#ff855e"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "vermillion/400"
+        }
+      }
+    },
+    "decorator": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.411765,
+          0.694118,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#69b1ff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/400"
+        }
+      }
+    },
+    "escape": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.392157,
+          0.819608,
+          0.858824
+        ],
+        "alpha": 1,
+        "hex": "#64d1db"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/400"
+        }
+      }
+    },
+    "invalid": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.980392,
+          0.980392,
+          0.980392
+        ],
+        "alpha": 1,
+        "hex": "#fafafa"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/020"
+        }
+      }
+    },
+    "tag": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.521569,
+          0.368627
+        ],
+        "alpha": 1,
+        "hex": "#ff855e"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "vermillion/400"
+        }
+      }
+    },
+    "attribute": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.392157,
+          0.819608,
+          0.858824
+        ],
+        "alpha": 1,
+        "hex": "#64d1db"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/400"
+        }
+      }
+    }
+  },
+  "ansi": {
+    "black": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.090196,
+          0.090196,
+          0.090196
+        ],
+        "alpha": 1,
+        "hex": "#171717"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1000"
+        }
+      }
+    },
+    "red": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.521569,
+          0.368627
+        ],
+        "alpha": 1,
+        "hex": "#ff855e"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "vermillion/400"
+        }
+      }
+    },
+    "green": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.392157,
+          0.819608,
+          0.858824
+        ],
+        "alpha": 1,
+        "hex": "#64d1db"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/400"
+        }
+      }
+    },
+    "yellow": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.737255,
+          0.337255
+        ],
+        "alpha": 1,
+        "hex": "#ffbc56"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "amber/400"
+        }
+      }
+    },
+    "blue": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.411765,
+          0.694118,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#69b1ff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/400"
+        }
+      }
+    },
+    "magenta": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.917647,
+          0.407843,
+          0.737255
+        ],
+        "alpha": 1,
+        "hex": "#ea68bc"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "magenta/400"
+        }
+      }
+    },
+    "cyan": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.572549,
+          0.866667,
+          0.894118
+        ],
+        "alpha": 1,
+        "hex": "#92dde4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/300"
+        }
+      }
+    },
+    "white": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.737255,
+          0.737255,
+          0.737255
+        ],
+        "alpha": 1,
+        "hex": "#bcbcbc"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/300"
+        }
+      }
+    },
+    "brightBlack": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.090196,
+          0.090196,
+          0.090196
+        ],
+        "alpha": 1,
+        "hex": "#171717"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1000"
+        }
+      }
+    },
+    "brightRed": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.65098,
+          0.521569
+        ],
+        "alpha": 1,
+        "hex": "#ffa685"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "vermillion/300"
+        }
+      }
+    },
+    "brightGreen": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.572549,
+          0.866667,
+          0.894118
+        ],
+        "alpha": 1,
+        "hex": "#92dde4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/300"
+        }
+      }
+    },
+    "brightYellow": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.8,
+          0.505882
+        ],
+        "alpha": 1,
+        "hex": "#ffcc81"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "amber/300"
+        }
+      }
+    },
+    "brightBlue": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.592157,
+          0.768627,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#97c4ff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/300"
+        }
+      }
+    },
+    "brightMagenta": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.945098,
+          0.568627,
+          0.8
+        ],
+        "alpha": 1,
+        "hex": "#f191cc"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "magenta/300"
+        }
+      }
+    },
+    "brightCyan": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.572549,
+          0.866667,
+          0.894118
+        ],
+        "alpha": 1,
+        "hex": "#92dde4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/300"
+        }
+      }
+    },
+    "brightWhite": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.737255,
+          0.737255,
+          0.737255
+        ],
+        "alpha": 1,
+        "hex": "#bcbcbc"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/300"
+        }
+      }
+    }
+  }
+}

--- a/packages/theme/figma/semantic/dark.json
+++ b/packages/theme/figma/semantic/dark.json
@@ -1,0 +1,1118 @@
+{
+  "bg": {
+    "editor": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.039216,
+          0.039216,
+          0.039216
+        ],
+        "alpha": 1,
+        "hex": "#0a0a0a"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1040"
+        }
+      }
+    },
+    "window": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.090196,
+          0.090196,
+          0.090196
+        ],
+        "alpha": 1,
+        "hex": "#171717"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1000"
+        }
+      }
+    },
+    "inset": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/980"
+        }
+      }
+    },
+    "elevated": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.062745,
+          0.062745,
+          0.062745
+        ],
+        "alpha": 1,
+        "hex": "#101010"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1020"
+        }
+      }
+    }
+  },
+  "fg": {
+    "base": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.980392,
+          0.980392,
+          0.980392
+        ],
+        "alpha": 1,
+        "hex": "#fafafa"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/020"
+        }
+      }
+    },
+    "fg1": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.831373,
+          0.831373,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#d4d4d4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/200"
+        }
+      }
+    },
+    "fg2": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.639216,
+          0.639216,
+          0.639216
+        ],
+        "alpha": 1,
+        "hex": "#a3a3a3"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/400"
+        }
+      }
+    },
+    "fg3": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.45098,
+          0.45098,
+          0.45098
+        ],
+        "alpha": 1,
+        "hex": "#737373"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/600"
+        }
+      }
+    },
+    "fg4": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.388235,
+          0.388235,
+          0.388235
+        ],
+        "alpha": 1,
+        "hex": "#636363"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/700"
+        }
+      }
+    }
+  },
+  "border": {
+    "window": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.039216,
+          0.039216,
+          0.039216
+        ],
+        "alpha": 1,
+        "hex": "#0a0a0a"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1040"
+        }
+      }
+    },
+    "editor": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/980"
+        }
+      }
+    },
+    "indentGuide": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/980"
+        }
+      }
+    },
+    "indentGuideActive": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.14902,
+          0.14902,
+          0.14902
+        ],
+        "alpha": 1,
+        "hex": "#262626"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/960"
+        }
+      }
+    },
+    "inset": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/980"
+        }
+      }
+    },
+    "elevated": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/980"
+        }
+      }
+    }
+  },
+  "accent": {
+    "primary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.623529,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#009fff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/500"
+        }
+      }
+    },
+    "link": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.623529,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#009fff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/500"
+        }
+      }
+    },
+    "subtle": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.098039,
+          0.156863,
+          0.235294
+        ],
+        "alpha": 1,
+        "hex": "#19283c"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/950"
+        }
+      }
+    },
+    "contrastOnAccent": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.039216,
+          0.039216,
+          0.039216
+        ],
+        "alpha": 1,
+        "hex": "#0a0a0a"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1040"
+        }
+      }
+    }
+  },
+  "states": {
+    "merge": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.482353,
+          0.262745,
+          0.972549
+        ],
+        "alpha": 1,
+        "hex": "#7b43f8"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "indigo/500"
+        }
+      }
+    },
+    "success": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.027451,
+          0.768627,
+          0.501961
+        ],
+        "alpha": 1,
+        "hex": "#07c480"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "jade/500"
+        }
+      }
+    },
+    "danger": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.180392,
+          0.247059
+        ],
+        "alpha": 1,
+        "hex": "#ff2e3f"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "red/500"
+        }
+      }
+    },
+    "warn": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.792157,
+          0
+        ],
+        "alpha": 1,
+        "hex": "#ffca00"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "yellow/500"
+        }
+      }
+    },
+    "info": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.031373,
+          0.752941,
+          0.937255
+        ],
+        "alpha": 1,
+        "hex": "#08c0ef"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/500"
+        }
+      }
+    }
+  },
+  "syntax": {
+    "comment": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.45098,
+          0.45098,
+          0.45098
+        ],
+        "alpha": 1,
+        "hex": "#737373"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/600"
+        }
+      }
+    },
+    "string": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.368627,
+          0.8,
+          0.443137
+        ],
+        "alpha": 1,
+        "hex": "#5ecc71"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "green/400"
+        }
+      }
+    },
+    "number": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.407843,
+          0.803922,
+          0.94902
+        ],
+        "alpha": 1,
+        "hex": "#68cdf2"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/400"
+        }
+      }
+    },
+    "keyword": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.403922,
+          0.552941
+        ],
+        "alpha": 1,
+        "hex": "#ff678d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "pink/400"
+        }
+      }
+    },
+    "regexp": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.392157,
+          0.819608,
+          0.858824
+        ],
+        "alpha": 1,
+        "hex": "#64d1db"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/400"
+        }
+      }
+    },
+    "func": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.615686,
+          0.415686,
+          0.984314
+        ],
+        "alpha": 1,
+        "hex": "#9d6afb"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "indigo/400"
+        }
+      }
+    },
+    "type": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.835294,
+          0.407843,
+          0.917647
+        ],
+        "alpha": 1,
+        "hex": "#d568ea"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "purple/400"
+        }
+      }
+    },
+    "variable": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.639216,
+          0.34902
+        ],
+        "alpha": 1,
+        "hex": "#ffa359"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "orange/400"
+        }
+      }
+    },
+    "operator": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.031373,
+          0.752941,
+          0.937255
+        ],
+        "alpha": 1,
+        "hex": "#08c0ef"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/500"
+        }
+      }
+    },
+    "punctuation": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.388235,
+          0.388235,
+          0.388235
+        ],
+        "alpha": 1,
+        "hex": "#636363"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/700"
+        }
+      }
+    },
+    "constant": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.831373,
+          0.321569
+        ],
+        "alpha": 1,
+        "hex": "#ffd452"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "yellow/400"
+        }
+      }
+    },
+    "parameter": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.639216,
+          0.639216,
+          0.639216
+        ],
+        "alpha": 1,
+        "hex": "#a3a3a3"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/400"
+        }
+      }
+    },
+    "namespace": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.670588,
+          0.086275
+        ],
+        "alpha": 1,
+        "hex": "#ffab16"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "amber/500"
+        }
+      }
+    },
+    "decorator": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.411765,
+          0.694118,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#69b1ff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/400"
+        }
+      }
+    },
+    "escape": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.380392,
+          0.835294,
+          0.752941
+        ],
+        "alpha": 1,
+        "hex": "#61d5c0"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "mint/400"
+        }
+      }
+    },
+    "invalid": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.980392,
+          0.980392,
+          0.980392
+        ],
+        "alpha": 1,
+        "hex": "#fafafa"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/020"
+        }
+      }
+    },
+    "tag": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.521569,
+          0.368627
+        ],
+        "alpha": 1,
+        "hex": "#ff855e"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "vermillion/400"
+        }
+      }
+    },
+    "attribute": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.376471,
+          0.819608,
+          0.6
+        ],
+        "alpha": 1,
+        "hex": "#60d199"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "jade/400"
+        }
+      }
+    }
+  },
+  "ansi": {
+    "black": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.090196,
+          0.090196,
+          0.090196
+        ],
+        "alpha": 1,
+        "hex": "#171717"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1000"
+        }
+      }
+    },
+    "red": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.180392,
+          0.247059
+        ],
+        "alpha": 1,
+        "hex": "#ff2e3f"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "red/500"
+        }
+      }
+    },
+    "green": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.05098,
+          0.745098,
+          0.305882
+        ],
+        "alpha": 1,
+        "hex": "#0dbe4e"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "green/500"
+        }
+      }
+    },
+    "yellow": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.792157,
+          0
+        ],
+        "alpha": 1,
+        "hex": "#ffca00"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "yellow/500"
+        }
+      }
+    },
+    "blue": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.623529,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#009fff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/500"
+        }
+      }
+    },
+    "magenta": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.882353,
+          0.188235,
+          0.67451
+        ],
+        "alpha": 1,
+        "hex": "#e130ac"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "magenta/500"
+        }
+      }
+    },
+    "cyan": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.031373,
+          0.752941,
+          0.937255
+        ],
+        "alpha": 1,
+        "hex": "#08c0ef"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/500"
+        }
+      }
+    },
+    "white": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.737255,
+          0.737255,
+          0.737255
+        ],
+        "alpha": 1,
+        "hex": "#bcbcbc"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/300"
+        }
+      }
+    },
+    "brightBlack": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.090196,
+          0.090196,
+          0.090196
+        ],
+        "alpha": 1,
+        "hex": "#171717"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1000"
+        }
+      }
+    },
+    "brightRed": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.180392,
+          0.247059
+        ],
+        "alpha": 1,
+        "hex": "#ff2e3f"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "red/500"
+        }
+      }
+    },
+    "brightGreen": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.52549,
+          0.768627,
+          0.152941
+        ],
+        "alpha": 1,
+        "hex": "#86c427"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "lime/500"
+        }
+      }
+    },
+    "brightYellow": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.792157,
+          0
+        ],
+        "alpha": 1,
+        "hex": "#ffca00"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "yellow/500"
+        }
+      }
+    },
+    "brightBlue": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.623529,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#009fff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/500"
+        }
+      }
+    },
+    "brightMagenta": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.882353,
+          0.188235,
+          0.67451
+        ],
+        "alpha": 1,
+        "hex": "#e130ac"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "magenta/500"
+        }
+      }
+    },
+    "brightCyan": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.031373,
+          0.752941,
+          0.937255
+        ],
+        "alpha": 1,
+        "hex": "#08c0ef"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/500"
+        }
+      }
+    },
+    "brightWhite": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.737255,
+          0.737255,
+          0.737255
+        ],
+        "alpha": 1,
+        "hex": "#bcbcbc"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/300"
+        }
+      }
+    }
+  }
+}

--- a/packages/theme/figma/semantic/light-protanopia-deuteranopia.json
+++ b/packages/theme/figma/semantic/light-protanopia-deuteranopia.json
@@ -1,0 +1,1106 @@
+{
+  "bg": {
+    "editor": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#ffffff"
+      }
+    },
+    "window": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.960784,
+          0.960784,
+          0.960784
+        ],
+        "alpha": 1,
+        "hex": "#f5f5f5"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/060"
+        }
+      }
+    },
+    "inset": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.929412,
+          0.929412,
+          0.929412
+        ],
+        "alpha": 1,
+        "hex": "#ededed"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/080"
+        }
+      }
+    },
+    "elevated": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.968627,
+          0.968627,
+          0.968627
+        ],
+        "alpha": 1,
+        "hex": "#f7f7f7"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/040"
+        }
+      }
+    }
+  },
+  "fg": {
+    "base": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.039216,
+          0.039216,
+          0.039216
+        ],
+        "alpha": 1,
+        "hex": "#0a0a0a"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1040"
+        }
+      }
+    },
+    "fg1": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.25098,
+          0.25098,
+          0.25098
+        ],
+        "alpha": 1,
+        "hex": "#404040"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/900"
+        }
+      }
+    },
+    "fg2": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.321569,
+          0.321569,
+          0.321569
+        ],
+        "alpha": 1,
+        "hex": "#525252"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/800"
+        }
+      }
+    },
+    "fg3": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.45098,
+          0.45098,
+          0.45098
+        ],
+        "alpha": 1,
+        "hex": "#737373"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/600"
+        }
+      }
+    },
+    "fg4": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.541176,
+          0.541176,
+          0.541176
+        ],
+        "alpha": 1,
+        "hex": "#8a8a8a"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/500"
+        }
+      }
+    }
+  },
+  "border": {
+    "window": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.898039,
+          0.898039,
+          0.898039
+        ],
+        "alpha": 1,
+        "hex": "#e5e5e5"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/100"
+        }
+      }
+    },
+    "editor": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.831373,
+          0.831373,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#d4d4d4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/200"
+        }
+      }
+    },
+    "indentGuide": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.898039,
+          0.898039,
+          0.898039
+        ],
+        "alpha": 1,
+        "hex": "#e5e5e5"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/100"
+        }
+      }
+    },
+    "indentGuideActive": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.831373,
+          0.831373,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#d4d4d4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/200"
+        }
+      }
+    },
+    "inset": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.831373,
+          0.831373,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#d4d4d4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/200"
+        }
+      }
+    },
+    "elevated": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.898039,
+          0.898039,
+          0.898039
+        ],
+        "alpha": 1,
+        "hex": "#e5e5e5"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/100"
+        }
+      }
+    }
+  },
+  "accent": {
+    "primary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.623529,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#009fff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/500"
+        }
+      }
+    },
+    "link": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.623529,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#009fff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/500"
+        }
+      }
+    },
+    "subtle": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.87451,
+          0.921569,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#dfebff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/100"
+        }
+      }
+    },
+    "contrastOnAccent": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#ffffff"
+      }
+    }
+  },
+  "states": {
+    "success": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.129412,
+          0.423529,
+          0.670588
+        ],
+        "alpha": 1,
+        "hex": "#216cab"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/700"
+        }
+      }
+    },
+    "danger": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.67451,
+          0.376471,
+          0.137255
+        ],
+        "alpha": 1,
+        "hex": "#ac6023"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "orange/700"
+        }
+      }
+    },
+    "warn": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.792157,
+          0
+        ],
+        "alpha": 1,
+        "hex": "#ffca00"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "yellow/500"
+        }
+      }
+    },
+    "info": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.129412,
+          0.509804,
+          0.631373
+        ],
+        "alpha": 1,
+        "hex": "#2182a1"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/700"
+        }
+      }
+    },
+    "merge": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.345098,
+          0.156863,
+          0.486275
+        ],
+        "alpha": 1,
+        "hex": "#58287c"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "violet/800"
+        }
+      }
+    }
+  },
+  "syntax": {
+    "comment": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.45098,
+          0.45098,
+          0.45098
+        ],
+        "alpha": 1,
+        "hex": "#737373"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/600"
+        }
+      }
+    },
+    "string": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.129412,
+          0.333333,
+          0.517647
+        ],
+        "alpha": 1,
+        "hex": "#215584"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/800"
+        }
+      }
+    },
+    "number": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.129412,
+          0.509804,
+          0.631373
+        ],
+        "alpha": 1,
+        "hex": "#2182a1"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/700"
+        }
+      }
+    },
+    "keyword": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.533333,
+          0.211765,
+          0.780392
+        ],
+        "alpha": 1,
+        "hex": "#8836c7"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "violet/600"
+        }
+      }
+    },
+    "regexp": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.129412,
+          0.509804,
+          0.631373
+        ],
+        "alpha": 1,
+        "hex": "#2182a1"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/700"
+        }
+      }
+    },
+    "func": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.341176,
+          0.192157,
+          0.654902
+        ],
+        "alpha": 1,
+        "hex": "#5731a7"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "indigo/700"
+        }
+      }
+    },
+    "type": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.65098,
+          0.192157,
+          0.745098
+        ],
+        "alpha": 1,
+        "hex": "#a631be"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "purple/600"
+        }
+      }
+    },
+    "variable": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.67451,
+          0.376471,
+          0.137255
+        ],
+        "alpha": 1,
+        "hex": "#ac6023"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "orange/700"
+        }
+      }
+    },
+    "operator": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.129412,
+          0.509804,
+          0.631373
+        ],
+        "alpha": 1,
+        "hex": "#2182a1"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/700"
+        }
+      }
+    },
+    "punctuation": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.388235,
+          0.388235,
+          0.388235
+        ],
+        "alpha": 1,
+        "hex": "#636363"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/700"
+        }
+      }
+    },
+    "constant": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.67451,
+          0.454902,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#ac741d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "amber/700"
+        }
+      }
+    },
+    "parameter": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.388235,
+          0.388235,
+          0.388235
+        ],
+        "alpha": 1,
+        "hex": "#636363"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/700"
+        }
+      }
+    },
+    "namespace": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.67451,
+          0.454902,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#ac741d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "amber/700"
+        }
+      }
+    },
+    "decorator": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.129412,
+          0.423529,
+          0.670588
+        ],
+        "alpha": 1,
+        "hex": "#216cab"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/700"
+        }
+      }
+    },
+    "escape": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.117647,
+          0.521569,
+          0.556863
+        ],
+        "alpha": 1,
+        "hex": "#1e858e"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/700"
+        }
+      }
+    },
+    "invalid": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.039216,
+          0.039216,
+          0.039216
+        ],
+        "alpha": 1,
+        "hex": "#0a0a0a"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1040"
+        }
+      }
+    },
+    "tag": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.67451,
+          0.376471,
+          0.137255
+        ],
+        "alpha": 1,
+        "hex": "#ac6023"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "orange/700"
+        }
+      }
+    },
+    "attribute": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.67451,
+          0.454902,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#ac741d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "amber/700"
+        }
+      }
+    }
+  },
+  "ansi": {
+    "black": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/980"
+        }
+      }
+    },
+    "red": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.67451,
+          0.376471,
+          0.137255
+        ],
+        "alpha": 1,
+        "hex": "#ac6023"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "orange/700"
+        }
+      }
+    },
+    "green": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.129412,
+          0.423529,
+          0.670588
+        ],
+        "alpha": 1,
+        "hex": "#216cab"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/700"
+        }
+      }
+    },
+    "yellow": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.792157,
+          0
+        ],
+        "alpha": 1,
+        "hex": "#ffca00"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "yellow/500"
+        }
+      }
+    },
+    "blue": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.101961,
+          0.521569,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#1a85d4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/600"
+        }
+      }
+    },
+    "magenta": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.533333,
+          0.211765,
+          0.780392
+        ],
+        "alpha": 1,
+        "hex": "#8836c7"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "violet/600"
+        }
+      }
+    },
+    "cyan": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.129412,
+          0.509804,
+          0.631373
+        ],
+        "alpha": 1,
+        "hex": "#2182a1"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/700"
+        }
+      }
+    },
+    "white": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.737255,
+          0.737255,
+          0.737255
+        ],
+        "alpha": 1,
+        "hex": "#bcbcbc"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/300"
+        }
+      }
+    },
+    "brightBlack": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/980"
+        }
+      }
+    },
+    "brightRed": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.831373,
+          0.462745,
+          0.156863
+        ],
+        "alpha": 1,
+        "hex": "#d47628"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "orange/600"
+        }
+      }
+    },
+    "brightGreen": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.101961,
+          0.521569,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#1a85d4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/600"
+        }
+      }
+    },
+    "brightYellow": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.792157,
+          0
+        ],
+        "alpha": 1,
+        "hex": "#ffca00"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "yellow/500"
+        }
+      }
+    },
+    "brightBlue": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.623529,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#009fff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/500"
+        }
+      }
+    },
+    "brightMagenta": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.631373,
+          0.235294,
+          0.933333
+        ],
+        "alpha": 1,
+        "hex": "#a13cee"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "violet/500"
+        }
+      }
+    },
+    "brightCyan": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.109804,
+          0.631373,
+          0.780392
+        ],
+        "alpha": 1,
+        "hex": "#1ca1c7"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/600"
+        }
+      }
+    },
+    "brightWhite": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.737255,
+          0.737255,
+          0.737255
+        ],
+        "alpha": 1,
+        "hex": "#bcbcbc"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/300"
+        }
+      }
+    }
+  }
+}

--- a/packages/theme/figma/semantic/light-soft.json
+++ b/packages/theme/figma/semantic/light-soft.json
@@ -1,0 +1,1106 @@
+{
+  "bg": {
+    "editor": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#ffffff"
+      }
+    },
+    "window": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.968627,
+          0.968627,
+          0.968627
+        ],
+        "alpha": 1,
+        "hex": "#f7f7f7"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/040"
+        }
+      }
+    },
+    "inset": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.960784,
+          0.960784,
+          0.960784
+        ],
+        "alpha": 1,
+        "hex": "#f5f5f5"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/060"
+        }
+      }
+    },
+    "elevated": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.980392,
+          0.980392,
+          0.980392
+        ],
+        "alpha": 1,
+        "hex": "#fafafa"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/020"
+        }
+      }
+    }
+  },
+  "fg": {
+    "base": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.321569,
+          0.321569,
+          0.321569
+        ],
+        "alpha": 1,
+        "hex": "#525252"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/800"
+        }
+      }
+    },
+    "fg1": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.388235,
+          0.388235,
+          0.388235
+        ],
+        "alpha": 1,
+        "hex": "#636363"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/700"
+        }
+      }
+    },
+    "fg2": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.45098,
+          0.45098,
+          0.45098
+        ],
+        "alpha": 1,
+        "hex": "#737373"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/600"
+        }
+      }
+    },
+    "fg3": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.541176,
+          0.541176,
+          0.541176
+        ],
+        "alpha": 1,
+        "hex": "#8a8a8a"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/500"
+        }
+      }
+    },
+    "fg4": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.639216,
+          0.639216,
+          0.639216
+        ],
+        "alpha": 1,
+        "hex": "#a3a3a3"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/400"
+        }
+      }
+    }
+  },
+  "border": {
+    "window": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.929412,
+          0.929412,
+          0.929412
+        ],
+        "alpha": 1,
+        "hex": "#ededed"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/080"
+        }
+      }
+    },
+    "editor": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.898039,
+          0.898039,
+          0.898039
+        ],
+        "alpha": 1,
+        "hex": "#e5e5e5"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/100"
+        }
+      }
+    },
+    "indentGuide": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.929412,
+          0.929412,
+          0.929412
+        ],
+        "alpha": 1,
+        "hex": "#ededed"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/080"
+        }
+      }
+    },
+    "indentGuideActive": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.898039,
+          0.898039,
+          0.898039
+        ],
+        "alpha": 1,
+        "hex": "#e5e5e5"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/100"
+        }
+      }
+    },
+    "inset": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.831373,
+          0.831373,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#d4d4d4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/200"
+        }
+      }
+    },
+    "elevated": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.898039,
+          0.898039,
+          0.898039
+        ],
+        "alpha": 1,
+        "hex": "#e5e5e5"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/100"
+        }
+      }
+    }
+  },
+  "accent": {
+    "primary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.623529,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#009fff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/500"
+        }
+      }
+    },
+    "link": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.623529,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#009fff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/500"
+        }
+      }
+    },
+    "subtle": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.87451,
+          0.921569,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#dfebff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/100"
+        }
+      }
+    },
+    "contrastOnAccent": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#ffffff"
+      }
+    }
+  },
+  "states": {
+    "merge": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.482353,
+          0.262745,
+          0.972549
+        ],
+        "alpha": 1,
+        "hex": "#7b43f8"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "indigo/500"
+        }
+      }
+    },
+    "success": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.027451,
+          0.768627,
+          0.501961
+        ],
+        "alpha": 1,
+        "hex": "#07c480"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "jade/500"
+        }
+      }
+    },
+    "danger": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.180392,
+          0.247059
+        ],
+        "alpha": 1,
+        "hex": "#ff2e3f"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "red/500"
+        }
+      }
+    },
+    "warn": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.792157,
+          0
+        ],
+        "alpha": 1,
+        "hex": "#ffca00"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "yellow/500"
+        }
+      }
+    },
+    "info": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.031373,
+          0.752941,
+          0.937255
+        ],
+        "alpha": 1,
+        "hex": "#08c0ef"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/500"
+        }
+      }
+    }
+  },
+  "syntax": {
+    "comment": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.541176,
+          0.541176,
+          0.541176
+        ],
+        "alpha": 1,
+        "hex": "#8a8a8a"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/500"
+        }
+      }
+    },
+    "string": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.05098,
+          0.745098,
+          0.305882
+        ],
+        "alpha": 1,
+        "hex": "#0dbe4e"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "green/500"
+        }
+      }
+    },
+    "number": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.031373,
+          0.752941,
+          0.937255
+        ],
+        "alpha": 1,
+        "hex": "#08c0ef"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/500"
+        }
+      }
+    },
+    "keyword": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.403922,
+          0.552941
+        ],
+        "alpha": 1,
+        "hex": "#ff678d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "pink/400"
+        }
+      }
+    },
+    "regexp": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.772549,
+          0.823529
+        ],
+        "alpha": 1,
+        "hex": "#00c5d2"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/500"
+        }
+      }
+    },
+    "func": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.615686,
+          0.415686,
+          0.984314
+        ],
+        "alpha": 1,
+        "hex": "#9d6afb"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "indigo/400"
+        }
+      }
+    },
+    "type": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.835294,
+          0.407843,
+          0.917647
+        ],
+        "alpha": 1,
+        "hex": "#d568ea"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "purple/400"
+        }
+      }
+    },
+    "variable": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.996078,
+          0.54902,
+          0.172549
+        ],
+        "alpha": 1,
+        "hex": "#fe8c2c"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "orange/500"
+        }
+      }
+    },
+    "operator": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.407843,
+          0.803922,
+          0.94902
+        ],
+        "alpha": 1,
+        "hex": "#68cdf2"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/400"
+        }
+      }
+    },
+    "punctuation": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.45098,
+          0.45098,
+          0.45098
+        ],
+        "alpha": 1,
+        "hex": "#737373"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/600"
+        }
+      }
+    },
+    "constant": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.792157,
+          0
+        ],
+        "alpha": 1,
+        "hex": "#ffca00"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "yellow/500"
+        }
+      }
+    },
+    "parameter": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.45098,
+          0.45098,
+          0.45098
+        ],
+        "alpha": 1,
+        "hex": "#737373"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/600"
+        }
+      }
+    },
+    "namespace": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.670588,
+          0.086275
+        ],
+        "alpha": 1,
+        "hex": "#ffab16"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "amber/500"
+        }
+      }
+    },
+    "decorator": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.411765,
+          0.694118,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#69b1ff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/400"
+        }
+      }
+    },
+    "escape": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.792157,
+          0.694118
+        ],
+        "alpha": 1,
+        "hex": "#00cab1"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "mint/500"
+        }
+      }
+    },
+    "invalid": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.090196,
+          0.090196,
+          0.090196
+        ],
+        "alpha": 1,
+        "hex": "#171717"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1000"
+        }
+      }
+    },
+    "tag": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.364706,
+          0.211765
+        ],
+        "alpha": 1,
+        "hex": "#ff5d36"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "vermillion/500"
+        }
+      }
+    },
+    "attribute": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.027451,
+          0.768627,
+          0.501961
+        ],
+        "alpha": 1,
+        "hex": "#07c480"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "jade/500"
+        }
+      }
+    }
+  },
+  "ansi": {
+    "black": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/980"
+        }
+      }
+    },
+    "red": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.180392,
+          0.247059
+        ],
+        "alpha": 1,
+        "hex": "#ff2e3f"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "red/500"
+        }
+      }
+    },
+    "green": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.05098,
+          0.745098,
+          0.305882
+        ],
+        "alpha": 1,
+        "hex": "#0dbe4e"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "green/500"
+        }
+      }
+    },
+    "yellow": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.792157,
+          0
+        ],
+        "alpha": 1,
+        "hex": "#ffca00"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "yellow/500"
+        }
+      }
+    },
+    "blue": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.623529,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#009fff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/500"
+        }
+      }
+    },
+    "magenta": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.882353,
+          0.188235,
+          0.67451
+        ],
+        "alpha": 1,
+        "hex": "#e130ac"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "magenta/500"
+        }
+      }
+    },
+    "cyan": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.031373,
+          0.752941,
+          0.937255
+        ],
+        "alpha": 1,
+        "hex": "#08c0ef"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/500"
+        }
+      }
+    },
+    "white": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.737255,
+          0.737255,
+          0.737255
+        ],
+        "alpha": 1,
+        "hex": "#bcbcbc"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/300"
+        }
+      }
+    },
+    "brightBlack": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/980"
+        }
+      }
+    },
+    "brightRed": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.180392,
+          0.247059
+        ],
+        "alpha": 1,
+        "hex": "#ff2e3f"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "red/500"
+        }
+      }
+    },
+    "brightGreen": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.52549,
+          0.768627,
+          0.152941
+        ],
+        "alpha": 1,
+        "hex": "#86c427"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "lime/500"
+        }
+      }
+    },
+    "brightYellow": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.792157,
+          0
+        ],
+        "alpha": 1,
+        "hex": "#ffca00"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "yellow/500"
+        }
+      }
+    },
+    "brightBlue": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.623529,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#009fff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/500"
+        }
+      }
+    },
+    "brightMagenta": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.882353,
+          0.188235,
+          0.67451
+        ],
+        "alpha": 1,
+        "hex": "#e130ac"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "magenta/500"
+        }
+      }
+    },
+    "brightCyan": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.031373,
+          0.752941,
+          0.937255
+        ],
+        "alpha": 1,
+        "hex": "#08c0ef"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/500"
+        }
+      }
+    },
+    "brightWhite": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.737255,
+          0.737255,
+          0.737255
+        ],
+        "alpha": 1,
+        "hex": "#bcbcbc"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/300"
+        }
+      }
+    }
+  }
+}

--- a/packages/theme/figma/semantic/light-tritanopia.json
+++ b/packages/theme/figma/semantic/light-tritanopia.json
@@ -1,0 +1,1106 @@
+{
+  "bg": {
+    "editor": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#ffffff"
+      }
+    },
+    "window": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.960784,
+          0.960784,
+          0.960784
+        ],
+        "alpha": 1,
+        "hex": "#f5f5f5"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/060"
+        }
+      }
+    },
+    "inset": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.929412,
+          0.929412,
+          0.929412
+        ],
+        "alpha": 1,
+        "hex": "#ededed"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/080"
+        }
+      }
+    },
+    "elevated": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.968627,
+          0.968627,
+          0.968627
+        ],
+        "alpha": 1,
+        "hex": "#f7f7f7"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/040"
+        }
+      }
+    }
+  },
+  "fg": {
+    "base": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.039216,
+          0.039216,
+          0.039216
+        ],
+        "alpha": 1,
+        "hex": "#0a0a0a"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1040"
+        }
+      }
+    },
+    "fg1": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.25098,
+          0.25098,
+          0.25098
+        ],
+        "alpha": 1,
+        "hex": "#404040"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/900"
+        }
+      }
+    },
+    "fg2": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.321569,
+          0.321569,
+          0.321569
+        ],
+        "alpha": 1,
+        "hex": "#525252"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/800"
+        }
+      }
+    },
+    "fg3": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.45098,
+          0.45098,
+          0.45098
+        ],
+        "alpha": 1,
+        "hex": "#737373"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/600"
+        }
+      }
+    },
+    "fg4": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.541176,
+          0.541176,
+          0.541176
+        ],
+        "alpha": 1,
+        "hex": "#8a8a8a"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/500"
+        }
+      }
+    }
+  },
+  "border": {
+    "window": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.898039,
+          0.898039,
+          0.898039
+        ],
+        "alpha": 1,
+        "hex": "#e5e5e5"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/100"
+        }
+      }
+    },
+    "editor": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.831373,
+          0.831373,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#d4d4d4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/200"
+        }
+      }
+    },
+    "indentGuide": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.898039,
+          0.898039,
+          0.898039
+        ],
+        "alpha": 1,
+        "hex": "#e5e5e5"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/100"
+        }
+      }
+    },
+    "indentGuideActive": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.831373,
+          0.831373,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#d4d4d4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/200"
+        }
+      }
+    },
+    "inset": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.831373,
+          0.831373,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#d4d4d4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/200"
+        }
+      }
+    },
+    "elevated": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.898039,
+          0.898039,
+          0.898039
+        ],
+        "alpha": 1,
+        "hex": "#e5e5e5"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/100"
+        }
+      }
+    }
+  },
+  "accent": {
+    "primary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.623529,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#009fff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/500"
+        }
+      }
+    },
+    "link": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.623529,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#009fff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/500"
+        }
+      }
+    },
+    "subtle": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.87451,
+          0.921569,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#dfebff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/100"
+        }
+      }
+    },
+    "contrastOnAccent": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#ffffff"
+      }
+    }
+  },
+  "states": {
+    "success": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.117647,
+          0.521569,
+          0.556863
+        ],
+        "alpha": 1,
+        "hex": "#1e858e"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/700"
+        }
+      }
+    },
+    "danger": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.835294,
+          0.317647,
+          0.184314
+        ],
+        "alpha": 1,
+        "hex": "#d5512f"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "vermillion/600"
+        }
+      }
+    },
+    "warn": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.670588,
+          0.086275
+        ],
+        "alpha": 1,
+        "hex": "#ffab16"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "amber/500"
+        }
+      }
+    },
+    "info": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.101961,
+          0.521569,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#1a85d4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/600"
+        }
+      }
+    },
+    "merge": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6,
+          0.164706,
+          0.458824
+        ],
+        "alpha": 1,
+        "hex": "#992a75"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "magenta/700"
+        }
+      }
+    }
+  },
+  "syntax": {
+    "comment": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.45098,
+          0.45098,
+          0.45098
+        ],
+        "alpha": 1,
+        "hex": "#737373"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/600"
+        }
+      }
+    },
+    "string": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.117647,
+          0.521569,
+          0.556863
+        ],
+        "alpha": 1,
+        "hex": "#1e858e"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/700"
+        }
+      }
+    },
+    "number": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.101961,
+          0.521569,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#1a85d4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/600"
+        }
+      }
+    },
+    "keyword": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.65098,
+          0.192157,
+          0.745098
+        ],
+        "alpha": 1,
+        "hex": "#a631be"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "purple/600"
+        }
+      }
+    },
+    "regexp": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.117647,
+          0.521569,
+          0.556863
+        ],
+        "alpha": 1,
+        "hex": "#1e858e"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/700"
+        }
+      }
+    },
+    "func": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.129412,
+          0.423529,
+          0.670588
+        ],
+        "alpha": 1,
+        "hex": "#216cab"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/700"
+        }
+      }
+    },
+    "type": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.741176,
+          0.180392,
+          0.564706
+        ],
+        "alpha": 1,
+        "hex": "#bd2e90"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "magenta/600"
+        }
+      }
+    },
+    "variable": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.678431,
+          0.270588,
+          0.160784
+        ],
+        "alpha": 1,
+        "hex": "#ad4529"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "vermillion/700"
+        }
+      }
+    },
+    "operator": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.117647,
+          0.521569,
+          0.556863
+        ],
+        "alpha": 1,
+        "hex": "#1e858e"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/700"
+        }
+      }
+    },
+    "punctuation": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.388235,
+          0.388235,
+          0.388235
+        ],
+        "alpha": 1,
+        "hex": "#636363"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/700"
+        }
+      }
+    },
+    "constant": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.67451,
+          0.454902,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#ac741d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "amber/700"
+        }
+      }
+    },
+    "parameter": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.388235,
+          0.388235,
+          0.388235
+        ],
+        "alpha": 1,
+        "hex": "#636363"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/700"
+        }
+      }
+    },
+    "namespace": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.835294,
+          0.317647,
+          0.184314
+        ],
+        "alpha": 1,
+        "hex": "#d5512f"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "vermillion/600"
+        }
+      }
+    },
+    "decorator": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.101961,
+          0.521569,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#1a85d4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/600"
+        }
+      }
+    },
+    "escape": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.117647,
+          0.521569,
+          0.556863
+        ],
+        "alpha": 1,
+        "hex": "#1e858e"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/700"
+        }
+      }
+    },
+    "invalid": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.039216,
+          0.039216,
+          0.039216
+        ],
+        "alpha": 1,
+        "hex": "#0a0a0a"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1040"
+        }
+      }
+    },
+    "tag": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.835294,
+          0.317647,
+          0.184314
+        ],
+        "alpha": 1,
+        "hex": "#d5512f"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "vermillion/600"
+        }
+      }
+    },
+    "attribute": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.117647,
+          0.521569,
+          0.556863
+        ],
+        "alpha": 1,
+        "hex": "#1e858e"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/700"
+        }
+      }
+    }
+  },
+  "ansi": {
+    "black": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/980"
+        }
+      }
+    },
+    "red": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.835294,
+          0.317647,
+          0.184314
+        ],
+        "alpha": 1,
+        "hex": "#d5512f"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "vermillion/600"
+        }
+      }
+    },
+    "green": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.117647,
+          0.521569,
+          0.556863
+        ],
+        "alpha": 1,
+        "hex": "#1e858e"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/700"
+        }
+      }
+    },
+    "yellow": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.835294,
+          0.564706,
+          0.109804
+        ],
+        "alpha": 1,
+        "hex": "#d5901c"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "amber/600"
+        }
+      }
+    },
+    "blue": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.101961,
+          0.521569,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#1a85d4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/600"
+        }
+      }
+    },
+    "magenta": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6,
+          0.164706,
+          0.458824
+        ],
+        "alpha": 1,
+        "hex": "#992a75"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "magenta/700"
+        }
+      }
+    },
+    "cyan": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.090196,
+          0.647059,
+          0.686275
+        ],
+        "alpha": 1,
+        "hex": "#17a5af"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/600"
+        }
+      }
+    },
+    "white": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.737255,
+          0.737255,
+          0.737255
+        ],
+        "alpha": 1,
+        "hex": "#bcbcbc"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/300"
+        }
+      }
+    },
+    "brightBlack": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/980"
+        }
+      }
+    },
+    "brightRed": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.364706,
+          0.211765
+        ],
+        "alpha": 1,
+        "hex": "#ff5d36"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "vermillion/500"
+        }
+      }
+    },
+    "brightGreen": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.090196,
+          0.647059,
+          0.686275
+        ],
+        "alpha": 1,
+        "hex": "#17a5af"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/600"
+        }
+      }
+    },
+    "brightYellow": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          0.670588,
+          0.086275
+        ],
+        "alpha": 1,
+        "hex": "#ffab16"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "amber/500"
+        }
+      }
+    },
+    "brightBlue": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.623529,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#009fff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/500"
+        }
+      }
+    },
+    "brightMagenta": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.741176,
+          0.180392,
+          0.564706
+        ],
+        "alpha": 1,
+        "hex": "#bd2e90"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "magenta/600"
+        }
+      }
+    },
+    "brightCyan": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.772549,
+          0.823529
+        ],
+        "alpha": 1,
+        "hex": "#00c5d2"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/500"
+        }
+      }
+    },
+    "brightWhite": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.737255,
+          0.737255,
+          0.737255
+        ],
+        "alpha": 1,
+        "hex": "#bcbcbc"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/300"
+        }
+      }
+    }
+  }
+}

--- a/packages/theme/figma/semantic/light.json
+++ b/packages/theme/figma/semantic/light.json
@@ -1,0 +1,1106 @@
+{
+  "bg": {
+    "editor": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#ffffff"
+      }
+    },
+    "window": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.960784,
+          0.960784,
+          0.960784
+        ],
+        "alpha": 1,
+        "hex": "#f5f5f5"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/060"
+        }
+      }
+    },
+    "inset": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.929412,
+          0.929412,
+          0.929412
+        ],
+        "alpha": 1,
+        "hex": "#ededed"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/080"
+        }
+      }
+    },
+    "elevated": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.968627,
+          0.968627,
+          0.968627
+        ],
+        "alpha": 1,
+        "hex": "#f7f7f7"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/040"
+        }
+      }
+    }
+  },
+  "fg": {
+    "base": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.039216,
+          0.039216,
+          0.039216
+        ],
+        "alpha": 1,
+        "hex": "#0a0a0a"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1040"
+        }
+      }
+    },
+    "fg1": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.25098,
+          0.25098,
+          0.25098
+        ],
+        "alpha": 1,
+        "hex": "#404040"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/900"
+        }
+      }
+    },
+    "fg2": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.321569,
+          0.321569,
+          0.321569
+        ],
+        "alpha": 1,
+        "hex": "#525252"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/800"
+        }
+      }
+    },
+    "fg3": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.45098,
+          0.45098,
+          0.45098
+        ],
+        "alpha": 1,
+        "hex": "#737373"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/600"
+        }
+      }
+    },
+    "fg4": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.541176,
+          0.541176,
+          0.541176
+        ],
+        "alpha": 1,
+        "hex": "#8a8a8a"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/500"
+        }
+      }
+    }
+  },
+  "border": {
+    "window": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.898039,
+          0.898039,
+          0.898039
+        ],
+        "alpha": 1,
+        "hex": "#e5e5e5"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/100"
+        }
+      }
+    },
+    "editor": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.831373,
+          0.831373,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#d4d4d4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/200"
+        }
+      }
+    },
+    "indentGuide": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.898039,
+          0.898039,
+          0.898039
+        ],
+        "alpha": 1,
+        "hex": "#e5e5e5"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/100"
+        }
+      }
+    },
+    "indentGuideActive": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.831373,
+          0.831373,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#d4d4d4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/200"
+        }
+      }
+    },
+    "inset": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.831373,
+          0.831373,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#d4d4d4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/200"
+        }
+      }
+    },
+    "elevated": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.898039,
+          0.898039,
+          0.898039
+        ],
+        "alpha": 1,
+        "hex": "#e5e5e5"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/100"
+        }
+      }
+    }
+  },
+  "accent": {
+    "primary": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.623529,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#009fff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/500"
+        }
+      }
+    },
+    "link": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0.623529,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#009fff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/500"
+        }
+      }
+    },
+    "subtle": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.87451,
+          0.921569,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#dfebff"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/100"
+        }
+      }
+    },
+    "contrastOnAccent": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ],
+        "alpha": 1,
+        "hex": "#ffffff"
+      }
+    }
+  },
+  "states": {
+    "merge": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.411765,
+          0.227451,
+          0.811765
+        ],
+        "alpha": 1,
+        "hex": "#693acf"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "indigo/600"
+        }
+      }
+    },
+    "success": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.094118,
+          0.643137,
+          0.423529
+        ],
+        "alpha": 1,
+        "hex": "#18a46c"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "jade/600"
+        }
+      }
+    },
+    "danger": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.835294,
+          0.172549,
+          0.211765
+        ],
+        "alpha": 1,
+        "hex": "#d52c36"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "red/600"
+        }
+      }
+    },
+    "warn": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.835294,
+          0.662745,
+          0.062745
+        ],
+        "alpha": 1,
+        "hex": "#d5a910"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "yellow/600"
+        }
+      }
+    },
+    "info": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.109804,
+          0.631373,
+          0.780392
+        ],
+        "alpha": 1,
+        "hex": "#1ca1c7"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/600"
+        }
+      }
+    }
+  },
+  "syntax": {
+    "comment": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.45098,
+          0.45098,
+          0.45098
+        ],
+        "alpha": 1,
+        "hex": "#737373"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/600"
+        }
+      }
+    },
+    "string": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.098039,
+          0.623529,
+          0.262745
+        ],
+        "alpha": 1,
+        "hex": "#199f43"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "green/600"
+        }
+      }
+    },
+    "number": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.109804,
+          0.631373,
+          0.780392
+        ],
+        "alpha": 1,
+        "hex": "#1ca1c7"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/600"
+        }
+      }
+    },
+    "keyword": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.827451,
+          0.164706,
+          0.380392
+        ],
+        "alpha": 1,
+        "hex": "#d32a61"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "pink/600"
+        }
+      }
+    },
+    "regexp": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.090196,
+          0.647059,
+          0.686275
+        ],
+        "alpha": 1,
+        "hex": "#17a5af"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "teal/600"
+        }
+      }
+    },
+    "func": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.411765,
+          0.227451,
+          0.811765
+        ],
+        "alpha": 1,
+        "hex": "#693acf"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "indigo/600"
+        }
+      }
+    },
+    "type": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.65098,
+          0.192157,
+          0.745098
+        ],
+        "alpha": 1,
+        "hex": "#a631be"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "purple/600"
+        }
+      }
+    },
+    "variable": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.831373,
+          0.462745,
+          0.156863
+        ],
+        "alpha": 1,
+        "hex": "#d47628"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "orange/600"
+        }
+      }
+    },
+    "operator": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.031373,
+          0.752941,
+          0.937255
+        ],
+        "alpha": 1,
+        "hex": "#08c0ef"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/500"
+        }
+      }
+    },
+    "punctuation": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.388235,
+          0.388235,
+          0.388235
+        ],
+        "alpha": 1,
+        "hex": "#636363"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/700"
+        }
+      }
+    },
+    "constant": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.835294,
+          0.662745,
+          0.062745
+        ],
+        "alpha": 1,
+        "hex": "#d5a910"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "yellow/600"
+        }
+      }
+    },
+    "parameter": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.388235,
+          0.388235,
+          0.388235
+        ],
+        "alpha": 1,
+        "hex": "#636363"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/700"
+        }
+      }
+    },
+    "namespace": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.835294,
+          0.564706,
+          0.109804
+        ],
+        "alpha": 1,
+        "hex": "#d5901c"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "amber/600"
+        }
+      }
+    },
+    "decorator": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.101961,
+          0.521569,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#1a85d4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/600"
+        }
+      }
+    },
+    "escape": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.086275,
+          0.662745,
+          0.580392
+        ],
+        "alpha": 1,
+        "hex": "#16a994"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "mint/600"
+        }
+      }
+    },
+    "invalid": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.039216,
+          0.039216,
+          0.039216
+        ],
+        "alpha": 1,
+        "hex": "#0a0a0a"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/1040"
+        }
+      }
+    },
+    "tag": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.835294,
+          0.317647,
+          0.184314
+        ],
+        "alpha": 1,
+        "hex": "#d5512f"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "vermillion/600"
+        }
+      }
+    },
+    "attribute": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.094118,
+          0.643137,
+          0.423529
+        ],
+        "alpha": 1,
+        "hex": "#18a46c"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "jade/600"
+        }
+      }
+    }
+  },
+  "ansi": {
+    "black": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/980"
+        }
+      }
+    },
+    "red": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.835294,
+          0.172549,
+          0.211765
+        ],
+        "alpha": 1,
+        "hex": "#d52c36"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "red/600"
+        }
+      }
+    },
+    "green": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.094118,
+          0.643137,
+          0.423529
+        ],
+        "alpha": 1,
+        "hex": "#18a46c"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "jade/600"
+        }
+      }
+    },
+    "yellow": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.835294,
+          0.662745,
+          0.062745
+        ],
+        "alpha": 1,
+        "hex": "#d5a910"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "yellow/600"
+        }
+      }
+    },
+    "blue": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.101961,
+          0.521569,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#1a85d4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/600"
+        }
+      }
+    },
+    "magenta": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.741176,
+          0.180392,
+          0.564706
+        ],
+        "alpha": 1,
+        "hex": "#bd2e90"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "magenta/600"
+        }
+      }
+    },
+    "cyan": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.109804,
+          0.631373,
+          0.780392
+        ],
+        "alpha": 1,
+        "hex": "#1ca1c7"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/600"
+        }
+      }
+    },
+    "white": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.737255,
+          0.737255,
+          0.737255
+        ],
+        "alpha": 1,
+        "hex": "#bcbcbc"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/300"
+        }
+      }
+    },
+    "brightBlack": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.113725,
+          0.113725,
+          0.113725
+        ],
+        "alpha": 1,
+        "hex": "#1d1d1d"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/980"
+        }
+      }
+    },
+    "brightRed": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.835294,
+          0.172549,
+          0.211765
+        ],
+        "alpha": 1,
+        "hex": "#d52c36"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "red/600"
+        }
+      }
+    },
+    "brightGreen": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.466667,
+          0.643137,
+          0.164706
+        ],
+        "alpha": 1,
+        "hex": "#77a42a"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "lime/600"
+        }
+      }
+    },
+    "brightYellow": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.835294,
+          0.662745,
+          0.062745
+        ],
+        "alpha": 1,
+        "hex": "#d5a910"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "yellow/600"
+        }
+      }
+    },
+    "brightBlue": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.101961,
+          0.521569,
+          0.831373
+        ],
+        "alpha": 1,
+        "hex": "#1a85d4"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "blue/600"
+        }
+      }
+    },
+    "brightMagenta": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.741176,
+          0.180392,
+          0.564706
+        ],
+        "alpha": 1,
+        "hex": "#bd2e90"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "magenta/600"
+        }
+      }
+    },
+    "brightCyan": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.109804,
+          0.631373,
+          0.780392
+        ],
+        "alpha": 1,
+        "hex": "#1ca1c7"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "cyan/600"
+        }
+      }
+    },
+    "brightWhite": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.737255,
+          0.737255,
+          0.737255
+        ],
+        "alpha": 1,
+        "hex": "#bcbcbc"
+      },
+      "$extensions": {
+        "com.figma.aliasData": {
+          "targetVariableSetName": "Pierre Primitives",
+          "targetVariableName": "neutral/300"
+        }
+      }
+    }
+  }
+}

--- a/packages/theme/moon.yml
+++ b/packages/theme/moon.yml
@@ -15,6 +15,7 @@ tasks:
       - 'dist'
       - 'themes/*.json'
       - 'zed/themes/pierre.json'
+      - 'figma/**/*.json'
 
   # The generated-output suite reads themes/ and dist/ directly, so the
   # package build must run before tests just like the theming dist guards.

--- a/packages/theme/scripts/build.ts
+++ b/packages/theme/scripts/build.ts
@@ -1,6 +1,11 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 
 import { convertRolesToP3 } from '../src/color';
+import {
+  createFigmaPrimitives,
+  createFigmaSemanticMode,
+  stringifyFigmaTokens,
+} from '../src/createFigmaTokens';
 import { createTheme } from '../src/createTheme';
 import { createZedTheme } from '../src/createZedTheme';
 import {
@@ -16,6 +21,7 @@ import {
 
 mkdirSync('themes', { recursive: true });
 mkdirSync('zed/themes', { recursive: true });
+mkdirSync('figma/semantic', { recursive: true });
 
 // Convert palettes to Display P3 color space
 const rolesLightP3 = convertRolesToP3(rolesLight);
@@ -160,6 +166,41 @@ writeFileSync(
   'utf8'
 );
 console.log('Wrote zed/themes/pierre.json');
+
+// ============================================
+// Figma variables (DTCG design tokens)
+// ============================================
+// Each semantic file becomes one Figma mode on import, listed light-first so
+// dragging them in together makes light the collection's default mode.
+const figmaSemanticModes = [
+  { file: 'figma/semantic/light.json', roles: rolesLight },
+  { file: 'figma/semantic/light-soft.json', roles: rolesLightSoft },
+  {
+    file: 'figma/semantic/light-protanopia-deuteranopia.json',
+    roles: rolesProtanDeutanLight,
+  },
+  { file: 'figma/semantic/light-tritanopia.json', roles: rolesTritanopiaLight },
+  { file: 'figma/semantic/dark.json', roles: rolesDark },
+  { file: 'figma/semantic/dark-soft.json', roles: rolesDarkSoft },
+  {
+    file: 'figma/semantic/dark-protanopia-deuteranopia.json',
+    roles: rolesProtanDeutanDark,
+  },
+  { file: 'figma/semantic/dark-tritanopia.json', roles: rolesTritanopiaDark },
+];
+
+const figmaDocuments = [
+  { file: 'figma/primitives.json', document: createFigmaPrimitives() },
+  ...figmaSemanticModes.map(({ file, roles }) => ({
+    file,
+    document: createFigmaSemanticMode(roles),
+  })),
+];
+
+for (const { file, document } of figmaDocuments) {
+  writeFileSync(file, stringifyFigmaTokens(document), 'utf8');
+  console.log('Wrote', file);
+}
 
 // ============================================
 // ESM wrapper modules (for npm / Shiki consumers)

--- a/packages/theme/src/createFigmaTokens.ts
+++ b/packages/theme/src/createFigmaTokens.ts
@@ -1,0 +1,229 @@
+// Figma variable export. Emits Design Tokens Community Group (DTCG) JSON that
+// Figma can import directly from its Variables view, in two collections:
+//
+//   Primitives — every palette scale step, one mode. Written once.
+//   Semantic   — the Roles surface, one file per theme variant. Figma turns each
+//                imported file into a mode, and its values alias the primitives.
+//
+// Figma only creates a variable for tokens present in *every* file imported into
+// a collection, so all semantic modes must emit an identical token-name set. The
+// Display P3 "vibrant" variants are deliberately not exported: Figma import only
+// supports the sRGB and HSL color spaces.
+
+import { hexToRgb01 } from './color';
+import { palettes } from './palettes';
+import type { Roles } from './roles';
+
+/**
+ * The Figma collection that holds the palette primitives. Semantic tokens name
+ * it as their alias target, so the collection created in Figma must match it
+ * exactly for cross-collection aliases to resolve.
+ */
+export const PRIMITIVES_COLLECTION_NAME = 'Pierre Primitives';
+
+/**
+ * Role values that intentionally live outside the palette scales, so they import
+ * as plain color literals rather than aliases. Any *other* role value missing
+ * from the palette index means roles and palettes have drifted apart, which
+ * fails the build instead of silently producing an unlinked variable.
+ */
+const UNALIASED_ROLE_COLORS = new Set(['#ffffff']);
+
+type FigmaColorValue = {
+  colorSpace: 'srgb';
+  components: [number, number, number];
+  alpha: number;
+  hex: string;
+};
+
+/** Figma's extension for pointing a token at a variable in another collection. */
+type FigmaAliasData = {
+  targetVariableSetName: string;
+  targetVariableName: string;
+};
+
+type ColorToken = {
+  $type: 'color';
+  $value: FigmaColorValue;
+  $extensions?: { 'com.figma.aliasData': FigmaAliasData };
+};
+
+/**
+ * A DTCG document: nested groups of tokens, which Figma flattens into
+ * slash-separated variable names (`{ bg: { editor } }` imports as `bg/editor`).
+ *
+ * Groups are Maps rather than plain objects to keep authored order. Palette steps
+ * like "100" are integer-like keys, which `JSON.stringify` hoists ahead of
+ * leading-zero keys like "020" — that would list each scale's lightest steps
+ * after its darkest in Figma. See `stringifyFigmaTokens`.
+ */
+export type FigmaTokenDocument = Map<string, ColorToken | FigmaTokenDocument>;
+
+/** Expand shorthand hex and lowercase it so lookups and output stay consistent. */
+function normalizeHex(color: string): string {
+  const match = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(color);
+  if (match === null) {
+    throw new Error(
+      `Cannot export "${color}" as a Figma color: expected a #rgb or #rrggbb hex value.`
+    );
+  }
+
+  const digits = match[1].toLowerCase();
+  const expanded =
+    digits.length === 3
+      ? digits
+          .split('')
+          .map((d) => d + d)
+          .join('')
+      : digits;
+
+  return `#${expanded}`;
+}
+
+/**
+ * Build the DTCG color value Figma expects. `components` are the sRGB channels
+ * in the 0–1 range; the redundant `hex` is what Figma shows in its UI.
+ */
+function figmaColor(hex: string): FigmaColorValue {
+  const normalized = normalizeHex(hex);
+  const [r, g, b] = hexToRgb01(normalized);
+
+  return {
+    colorSpace: 'srgb',
+    components: [round6(r), round6(g), round6(b)],
+    alpha: 1,
+    hex: normalized,
+  };
+}
+
+function round6(channel: number): number {
+  return Math.round(channel * 1_000_000) / 1_000_000;
+}
+
+/**
+ * A scale's steps ordered light-to-dark by numeric value. Reading the object
+ * directly would not do: JavaScript hoists integer-like keys ("100") ahead of
+ * leading-zero ones ("020") on any plain object, so `Object.entries` hands back
+ * every scale with its lightest steps last.
+ */
+function paletteSteps(scale: Record<string, string>): [string, string][] {
+  return Object.entries(scale).sort(
+    ([a], [b]) => Number.parseInt(a, 10) - Number.parseInt(b, 10)
+  );
+}
+
+/**
+ * Reverse index from palette hex to primitive token name (e.g. `blue/500`), used
+ * to turn a flat role hex back into an alias. Palette scales are all distinct
+ * today; should two ever share a hex, the first one in `palettes` order wins so
+ * output stays deterministic.
+ */
+function buildPrimitiveIndex(): Map<string, string> {
+  const index = new Map<string, string>();
+
+  for (const [scaleName, scale] of Object.entries(palettes)) {
+    for (const [step, hex] of paletteSteps(scale)) {
+      const key = normalizeHex(hex);
+      if (!index.has(key)) {
+        index.set(key, `${scaleName}/${step}`);
+      }
+    }
+  }
+
+  return index;
+}
+
+const primitiveNamesByHex = buildPrimitiveIndex();
+
+/** Every palette scale step as a single-mode Primitives collection document. */
+export function createFigmaPrimitives(): FigmaTokenDocument {
+  const document: FigmaTokenDocument = new Map();
+
+  for (const [scaleName, scale] of Object.entries(palettes)) {
+    const group: FigmaTokenDocument = new Map();
+    for (const [step, hex] of paletteSteps(scale)) {
+      group.set(step, { $type: 'color', $value: figmaColor(hex) });
+    }
+    document.set(scaleName, group);
+  }
+
+  return document;
+}
+
+/**
+ * One theme variant as a Semantic collection document — a Figma mode once
+ * imported. Token names mirror the `Roles` shape (`bg/editor`, `syntax/keyword`)
+ * so they are identical across every variant.
+ */
+export function createFigmaSemanticMode(roles: Roles): FigmaTokenDocument {
+  const document: FigmaTokenDocument = new Map();
+  const groups = Object.entries(roles) as [string, Record<string, string>][];
+
+  for (const [groupName, group] of groups) {
+    const tokens: FigmaTokenDocument = new Map();
+    for (const [roleName, color] of Object.entries(group)) {
+      tokens.set(roleName, semanticToken(`${groupName}/${roleName}`, color));
+    }
+    document.set(groupName, tokens);
+  }
+
+  return document;
+}
+
+/**
+ * A semantic token always carries a concrete color so the file imports on its
+ * own, plus an alias to the matching primitive when one exists so Figma links
+ * the two collections.
+ */
+function semanticToken(tokenName: string, color: string): ColorToken {
+  const value = figmaColor(color);
+  const target = primitiveNamesByHex.get(value.hex);
+
+  if (target === undefined) {
+    if (!UNALIASED_ROLE_COLORS.has(value.hex)) {
+      throw new Error(
+        `Role "${tokenName}" uses ${value.hex}, which is not in any palette scale. ` +
+          `Point it at a palette step, or add the hex to UNALIASED_ROLE_COLORS if it ` +
+          `is meant to be a standalone literal.`
+      );
+    }
+    return { $type: 'color', $value: value };
+  }
+
+  return {
+    $type: 'color',
+    $value: value,
+    $extensions: {
+      'com.figma.aliasData': {
+        targetVariableSetName: PRIMITIVES_COLLECTION_NAME,
+        targetVariableName: target,
+      },
+    },
+  };
+}
+
+/**
+ * Render a document as JSON with groups in authored order, matching what
+ * `JSON.stringify(value, null, 2)` would produce apart from that ordering.
+ * Figma creates variables in file order, so this is what keeps each palette
+ * scale reading light-to-dark in the Variables view.
+ */
+export function stringifyFigmaTokens(document: FigmaTokenDocument): string {
+  return `${serializeGroup(document, 0)}\n`;
+}
+
+function serializeGroup(group: FigmaTokenDocument, depth: number): string {
+  const indent = '  '.repeat(depth + 1);
+  const entries = [...group].map(([name, node]) => {
+    const serialized =
+      node instanceof Map
+        ? serializeGroup(node, depth + 1)
+        : // Leaf tokens have no integer-like keys, so plain stringify is safe;
+          // its newlines just need shifting to this group's depth.
+          JSON.stringify(node, null, 2).replaceAll('\n', `\n${indent}`);
+
+    return `${indent}${JSON.stringify(name)}: ${serialized}`;
+  });
+
+  return `{\n${entries.join(',\n')}\n${'  '.repeat(depth)}}`;
+}

--- a/packages/theme/test/figma.test.ts
+++ b/packages/theme/test/figma.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Guards the Figma variable export written by `theme:build` into figma/. The
+ * rules being enforced come from Figma's design-token import:
+ *
+ *  - Every semantic file becomes one mode, and Figma only creates a variable for
+ *    tokens present in *all* imported files — so the token-name sets must match
+ *    exactly across modes.
+ *  - Cross-collection aliases resolve by name, so each alias target must exist in
+ *    the primitives collection.
+ *  - Figma creates variables in file order, so palette scales have to be written
+ *    light-to-dark rather than in JavaScript's integer-key-first order.
+ */
+import { describe, test } from 'bun:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+import { hexToRgb01 } from '../src/color';
+import { PRIMITIVES_COLLECTION_NAME } from '../src/createFigmaTokens';
+import { palettes } from '../src/palettes';
+
+const PRIMITIVES_FILE = 'figma/primitives.json';
+
+const SEMANTIC_FILES = [
+  'figma/semantic/light.json',
+  'figma/semantic/light-soft.json',
+  'figma/semantic/light-protanopia-deuteranopia.json',
+  'figma/semantic/light-tritanopia.json',
+  'figma/semantic/dark.json',
+  'figma/semantic/dark-soft.json',
+  'figma/semantic/dark-protanopia-deuteranopia.json',
+  'figma/semantic/dark-tritanopia.json',
+];
+
+/** Role tokens that carry a literal color instead of aliasing a palette step. */
+const EXPECTED_UNALIASED_TOKENS = ['bg/editor', 'accent/contrastOnAccent'];
+
+const LIGHT_FILES = SEMANTIC_FILES.filter((file) =>
+  file.includes('/semantic/light')
+);
+
+type ColorToken = {
+  $type: string;
+  $value: {
+    colorSpace: string;
+    components: [number, number, number];
+    alpha: number;
+    hex: string;
+  };
+  $extensions?: {
+    'com.figma.aliasData': {
+      targetVariableSetName: string;
+      targetVariableName: string;
+    };
+  };
+};
+
+type TokenGroup = { [name: string]: ColorToken | TokenGroup };
+
+function isColorToken(node: ColorToken | TokenGroup): node is ColorToken {
+  return '$type' in node;
+}
+
+/**
+ * Flatten a document into the slash-separated names Figma derives from nested
+ * groups, so tests can assert on the same names a designer will see.
+ */
+function readTokens(path: string): Map<string, ColorToken> {
+  const document = JSON.parse(readFileSync(path, 'utf8')) as TokenGroup;
+  const tokens = new Map<string, ColorToken>();
+
+  const walk = (group: TokenGroup, prefix: string) => {
+    for (const [name, node] of Object.entries(group)) {
+      const tokenName = prefix === '' ? name : `${prefix}/${name}`;
+      if (isColorToken(node)) {
+        tokens.set(tokenName, node);
+      } else {
+        walk(node, tokenName);
+      }
+    }
+  };
+
+  walk(document, '');
+  return tokens;
+}
+
+const primitives = readTokens(PRIMITIVES_FILE);
+
+describe('figma primitives collection', () => {
+  test('covers every palette scale step', () => {
+    const expected = Object.entries(palettes).flatMap(([scale, steps]) =>
+      Object.keys(steps).map((step) => `${scale}/${step}`)
+    );
+
+    assert.deepEqual(
+      [...primitives.keys()].sort(),
+      expected.sort(),
+      `${PRIMITIVES_FILE}: token names do not match the palettes source`
+    );
+  });
+
+  test('every token is a valid sRGB color whose components match its hex', () => {
+    for (const [name, token] of primitives) {
+      assert.equal(token.$type, 'color', `${name}: unexpected $type`);
+      assert.equal(
+        token.$value.colorSpace,
+        'srgb',
+        `${name}: Figma import only supports srgb and hsl`
+      );
+      assert.equal(token.$value.alpha, 1, `${name}: unexpected alpha`);
+      assert.match(
+        token.$value.hex,
+        /^#[0-9a-f]{6}$/,
+        `${name}: hex is not normalized`
+      );
+
+      const expected = hexToRgb01(token.$value.hex).map(
+        (channel) => Math.round(channel * 1_000_000) / 1_000_000
+      );
+      assert.deepEqual(
+        token.$value.components,
+        expected,
+        `${name}: components do not match hex ${token.$value.hex}`
+      );
+    }
+  });
+
+  test('primitives carry no aliases of their own', () => {
+    for (const [name, token] of primitives) {
+      assert.equal(
+        token.$extensions,
+        undefined,
+        `${name}: primitives should be raw values, not aliases`
+      );
+    }
+  });
+
+  test('each scale is written light-to-dark', () => {
+    const contents = readFileSync(PRIMITIVES_FILE, 'utf8');
+
+    for (const [scale, steps] of Object.entries(palettes)) {
+      const ordered = Object.keys(steps).sort(
+        (a, b) => Number.parseInt(a, 10) - Number.parseInt(b, 10)
+      );
+      const positions = ordered.map((step) =>
+        contents.indexOf(`"${step}"`, contents.indexOf(`"${scale}":`))
+      );
+
+      for (let i = 1; i < positions.length; i++) {
+        assert.ok(
+          positions[i] > positions[i - 1],
+          `${scale}: step ${ordered[i]} is written before ${ordered[i - 1]}`
+        );
+      }
+    }
+  });
+});
+
+describe('figma semantic collection', () => {
+  const tokensByFile = new Map(
+    SEMANTIC_FILES.map((file) => [file, readTokens(file)])
+  );
+
+  test('every mode declares an identical token-name set', () => {
+    const [reference, ...rest] = SEMANTIC_FILES;
+    const referenceNames = [...tokensByFile.get(reference)!.keys()].sort();
+
+    assert.ok(referenceNames.length > 0, `${reference}: no tokens found`);
+
+    for (const file of rest) {
+      assert.deepEqual(
+        [...tokensByFile.get(file)!.keys()].sort(),
+        referenceNames,
+        `${file}: token names differ from ${reference}, so Figma would drop the mismatched variables`
+      );
+    }
+  });
+
+  for (const [file, tokens] of tokensByFile) {
+    describe(file, () => {
+      test('aliases resolve to primitives holding the same color', () => {
+        for (const [name, token] of tokens) {
+          const alias = token.$extensions?.['com.figma.aliasData'];
+          if (alias === undefined) {
+            continue;
+          }
+
+          assert.equal(
+            alias.targetVariableSetName,
+            PRIMITIVES_COLLECTION_NAME,
+            `${name}: unexpected alias collection`
+          );
+
+          const target = primitives.get(alias.targetVariableName);
+          assert.ok(
+            target !== undefined,
+            `${name}: alias target ${alias.targetVariableName} is not in ${PRIMITIVES_FILE}`
+          );
+          assert.equal(
+            token.$value.hex,
+            target.$value.hex,
+            `${name}: alias to ${alias.targetVariableName} disagrees with its own value`
+          );
+        }
+      });
+
+      test('only the known literals are left unaliased', () => {
+        const unaliased = [...tokens]
+          .filter(([, token]) => token.$extensions === undefined)
+          .map(([name]) => name);
+
+        const expected = LIGHT_FILES.includes(file)
+          ? EXPECTED_UNALIASED_TOKENS
+          : [];
+
+        assert.deepEqual(
+          unaliased.sort(),
+          [...expected].sort(),
+          `${file}: unexpected set of tokens without a palette alias`
+        );
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Summary

`moonx theme:build` now also writes `packages/theme/figma/`, a Figma-importable copy of the same colors in [DTCG token format](https://www.designtokens.org/tr/2025.10/format/) — so designers can import the Pierre palette into Figma instead of copying hex values by hand.

Two collections, following Figma's [variable modes](https://help.figma.com/hc/en-us/articles/15343816063383-Modes-for-variables) import rules:

- **`figma/primitives.json`** — all 249 palette steps across the 21 scales, one mode. Tokens land as `blue/500`, `neutral/1040`, and so on.
- **`figma/semantic/*.json`** — 8 files, one per theme variant (light, dark, both `-soft`, and the four CVD variants). Figma turns each file into a **mode**, and every file carries the same 58 role tokens (`bg/editor`, `syntax/keyword`, `ansi/brightRed`, …).

Semantic values alias the primitives through the `com.figma.aliasData` extension, so editing a primitive in Figma updates every mode that uses it.

## Notes for reviewers

**Aliases carry a concrete color too.** Each semantic token has both a real hex `$value` and an alias, so a file still imports cleanly if the primitives collection is not present.

**Drift from the palette fails the build.** Aliases are resolved by matching role hexes back to palette steps, so a role value that is in no palette scale throws. That is deliberate — it catches roles drifting away from the palette. `#ffffff` (`bg.editor` and `accent.contrastOnAccent` in the four light variants) is the one intentional literal, allowlisted in `UNALIASED_ROLE_COLORS`.

**Why palette steps get sorted and serialized by hand.** JavaScript hoists integer-like object keys (`100`) ahead of leading-zero ones (`020`), so `Object.entries(neutral)` returns the lightest shades *last* and `JSON.stringify` preserves that. Since Figma creates variables in file order, the first draft listed every scale starting at `100` with `020`–`080` stranded at the bottom. Steps are now sorted numerically and groups serialized from `Map`s to hold that order.

**Vibrant variants are excluded.** Figma's importer supports only sRGB and HSL, and those themes use `color(display-p3 …)`.

**Packaging.** `figma/**` is added to `.vscodeignore` so the tokens do not ship inside the VSIX; npm was already covered by the `files` allowlist. The output is committed like `themes/*.json`, and `.oxfmtrc.json` ignores it the same way.

## Test plan

- [x] `moonx theme:build` — writes all 9 files
- [x] `moonx theme:test` — 376 pass, including 21 new in `test/figma.test.ts`
- [x] `moonx theme:typecheck`
- [x] `moon run root:format root:lint`
- [x] Deleting `figma/` and rebuilding reproduces byte-identical output
- [x] Mutation-checked the new tests: deleting a token from one mode and corrupting an alias target both fail with actionable messages
- [ ] **Needs a real Figma import.** The semantic files name `Pierre Primitives` as their alias target, so cross-collection linking only resolves if the collection is named exactly that (step 1 of the README instructions). Worth confirming aliases resolve and that the 8 files land as 8 modes.
