### PR TITLE
Add Vercel Analytics to site apps

### DIFF
--- a/apps/diffshub/components/RootLayout.tsx
+++ b/apps/diffshub/components/RootLayout.tsx
@@ -1,3 +1,5 @@
+import { Analytics } from '@vercel/analytics/next';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 import { Geist } from 'next/font/google';
 import localFont from 'next/font/local';
 import type { ReactNode } from 'react';
@@ -97,6 +99,8 @@ export function RootLayout({
           </ThemeProvider>
         </WorkerPoolContext>
         <PreloadHighlighter />
+        <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );

--- a/apps/diffshub/package.json
+++ b/apps/diffshub/package.json
@@ -12,6 +12,8 @@
     "@radix-ui/react-dropdown-menu": "catalog:",
     "@radix-ui/react-slot": "catalog:",
     "@radix-ui/react-switch": "catalog:",
+    "@vercel/analytics": "catalog:",
+    "@vercel/speed-insights": "catalog:",
     "babel-plugin-react-compiler": "catalog:",
     "class-variance-authority": "catalog:",
     "clsx": "catalog:",

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -1,3 +1,5 @@
+import { Analytics } from '@vercel/analytics/next';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 // sort-imports-ignore
 import type { Metadata, Viewport } from 'next';
 import {
@@ -247,6 +249,8 @@ export default function RootLayout({
           ></div>
         </ThemeProvider>
         <PreloadHighlighter />
+        <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -26,6 +26,8 @@
     "@radix-ui/react-tooltip": "catalog:",
     "@radix-ui/react-use-controllable-state": "catalog:",
     "@shikijs/transformers": "catalog:",
+    "@vercel/analytics": "catalog:",
+    "@vercel/speed-insights": "catalog:",
     "@vscode/web-custom-data": "catalog:",
     "babel-plugin-react-compiler": "catalog:",
     "class-variance-authority": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,12 @@ catalogs:
     '@typescript/native-preview':
       specifier: 7.0.0-dev.20260622.1
       version: 7.0.0-dev.20260622.1
+    '@vercel/analytics':
+      specifier: 2.0.1
+      version: 2.0.1
+    '@vercel/speed-insights':
+      specifier: 2.0.0
+      version: 2.0.0
     '@vitejs/plugin-react':
       specifier: 5.0.3
       version: 5.0.3
@@ -353,6 +359,12 @@ importers:
       '@radix-ui/react-switch':
         specifier: 'catalog:'
         version: 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@vercel/analytics':
+        specifier: 'catalog:'
+        version: 2.0.1(next@16.2.9(@playwright/test@1.51.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      '@vercel/speed-insights':
+        specifier: 'catalog:'
+        version: 2.0.0(next@16.2.9(@playwright/test@1.51.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       babel-plugin-react-compiler:
         specifier: 'catalog:'
         version: 1.0.0
@@ -483,6 +495,12 @@ importers:
       '@shikijs/transformers':
         specifier: 4.4.1
         version: 4.4.1
+      '@vercel/analytics':
+        specifier: 'catalog:'
+        version: 2.0.1(next@16.2.9(@playwright/test@1.51.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      '@vercel/speed-insights':
+        specifier: 'catalog:'
+        version: 2.0.0(next@16.2.9(@playwright/test@1.51.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       '@vscode/web-custom-data':
         specifier: 'catalog:'
         version: 0.6.3
@@ -2904,6 +2922,61 @@ packages:
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: 16.2.9
+      nuxt: '>= 3'
+      react: 19.2.7
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: 16.2.9
+      nuxt: '>= 3'
+      react: 19.2.7
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vitejs/plugin-react@5.0.3':
     resolution: {integrity: sha512-PFVHhosKkofGH0Yzrw1BipSedTH68BFF8ZWy1kfUpCtJcouXXY0+racG8sExw7hw0HoX36813ga5o3LTWZ4FUg==}
@@ -8195,6 +8268,16 @@ snapshots:
       - supports-color
 
   '@ungap/structured-clone@1.3.1': {}
+
+  '@vercel/analytics@2.0.1(next@16.2.9(@playwright/test@1.51.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+    optionalDependencies:
+      next: 16.2.9(@babel/core@7.29.7)(@playwright/test@1.51.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+
+  '@vercel/speed-insights@2.0.0(next@16.2.9(@playwright/test@1.51.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+    optionalDependencies:
+      next: 16.2.9(@babel/core@7.29.7)(@playwright/test@1.51.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
 
   '@vitejs/plugin-react@5.0.3(vite@8.1.0(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -91,6 +91,8 @@ catalog:
   '@types/node': '20.19.41'
   '@types/react': '19.2.7'
   '@types/react-dom': '19.2.3'
+  '@vercel/analytics': '2.0.1'
+  '@vercel/speed-insights': '2.0.0'
   '@vscode/vsce': '3.2.2'
   '@typescript/native-preview': '7.0.0-dev.20260622.1'
   '@vscode/web-custom-data': '0.6.3'


### PR DESCRIPTION
## Summary
- Add `@vercel/analytics` and `@vercel/speed-insights` to the workspace catalog
- Mount Web Analytics and Speed Insights in the docs root layout (covers diffs.com and trees.software) and the diffshub.com root layout

## Test plan
- [ ] Confirm docs and diffshub typecheck/build still pass
- [ ] After deploy, enable Analytics and Speed Insights in each Vercel project if not already enabled
- [ ] Verify `/_vercel/insights` / analytics requests fire on production page loads