### PR TITLE
[diffs/edit] fix marker popover text contrast

### DIFF
--- a/packages/diffs/src/editor/editor.css
+++ b/packages/diffs/src/editor/editor.css
@@ -275,8 +275,14 @@
   border: 0;
   pointer-events: auto;
 
+  /* `contrast-color()` returns black or white against the severity fill. A
+     theme can set that fill through `editorWarning.foreground` and the similar
+     tokens, so a fixed text color can fail.
+     Pass one argument only. Two arguments make the declaration invalid at
+     computed-value time: `color` then inherits the editor foreground and
+     ignores the `--diffs-marker-contrast` declaration above. */
   @supports (color: contrast-color(red)) {
-    color: contrast-color(var(--diffs-marker-bg), var(--diffs-bg));
+    color: contrast-color(var(--diffs-marker-bg));
   }
 
   [data-marker-message] {

--- a/packages/diffs/test/cssContrastColorArity.test.ts
+++ b/packages/diffs/test/cssContrastColorArity.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+// CSS files that ship with the package. The tests below check every
+// `contrast-color()` call in them.
+const STYLESHEETS = ['../src/style.css', '../src/editor/editor.css'];
+
+// Splits a `contrast-color()` argument list into its top-level arguments. A
+// comma inside `var()`, `light-dark()`, or `color-mix()` does not split.
+function splitTopLevelArgs(args: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const char of args) {
+    if (char === '(') {
+      depth += 1;
+    } else if (char === ')') {
+      depth -= 1;
+    } else if (char === ',' && depth === 0) {
+      parts.push(current.trim());
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  parts.push(current.trim());
+  return parts;
+}
+
+// Returns the argument list of every `contrast-color()` call in `css`. It counts
+// nested parens to find the closing paren of each call.
+function findContrastColorArgs(css: string): string[] {
+  const calls: string[] = [];
+  const marker = 'contrast-color(';
+  let index = css.indexOf(marker);
+  while (index !== -1) {
+    let depth = 1;
+    let cursor = index + marker.length;
+    while (cursor < css.length && depth > 0) {
+      if (css[cursor] === '(') {
+        depth += 1;
+      } else if (css[cursor] === ')') {
+        depth -= 1;
+      }
+      cursor += 1;
+    }
+    calls.push(css.slice(index + marker.length, cursor - 1));
+    index = css.indexOf(marker, cursor);
+  }
+  return calls;
+}
+
+// Regression test for white text on the yellow warning popover.
+// `contrast-color()` takes one argument. A call with two arguments still parses,
+// because `var()` defers the grammar check to substitution. The declaration is
+// then invalid at computed-value time, so `color` inherits its value and ignores
+// the `--diffs-marker-contrast` declaration. No browser test catches this:
+// Playwright bundles an old Chromium without `contrast-color()`, so it runs the
+// fallback branch only.
+describe('contrast-color() arity in shipped CSS', () => {
+  for (const stylesheet of STYLESHEETS) {
+    test(`${stylesheet} passes one argument per call`, () => {
+      const css = readFileSync(resolve(__dirname, stylesheet), 'utf-8');
+      for (const args of findContrastColorArgs(css)) {
+        expect(
+          splitTopLevelArgs(args),
+          `contrast-color(${args}) must take exactly one argument`
+        ).toHaveLength(1);
+      }
+    });
+  }
+
+  test('detects a two-argument call', () => {
+    expect(
+      splitTopLevelArgs(
+        findContrastColorArgs(
+          'a { color: contrast-color(var(--a), light-dark(#000, #fff)); }'
+        )[0]
+      )
+    ).toHaveLength(2);
+  });
+});

--- a/packages/diffs/test/e2e/markers.pw.ts
+++ b/packages/diffs/test/e2e/markers.pw.ts
@@ -87,7 +87,9 @@ function openScrolledMarkerNearGutter(page: Page): Promise<{
 // contrast ratio between the popover's resolved text and background colors.
 // Guards the marker popover fallback in browsers without contrast-color(): the
 // severity fill is a theme editorX.foreground token, so its text candidate must
-// remain legible in both light and dark themes.
+// remain legible in both light and dark themes. Playwright bundles an old
+// Chromium without contrast-color(), so this test measures the fallback branch
+// only. cssContrastColorArity.test.ts covers the `@supports` branch.
 async function popoverContrast(
   page: Page,
   token: string


### PR DESCRIPTION
### Description

`contrast-color()` takes one argument. The marker popover in `editor.css` passed two:

```css
color: contrast-color(var(--diffs-marker-bg), var(--diffs-bg));
```

The arguments contain `var()`, so the browser cannot check the grammar at parse time and accepts the declaration. After substitution the value is invalid, so the declaration becomes invalid at computed-value time. `color` is an inherited property, so it then resolves to the **inherited** value. It does not fall back to the earlier `color: var(--diffs-marker-contrast)` declaration, because the cascade already chose a winner.

The popover therefore showed the near-white editor foreground on the severity fill.

The fix passes one argument. `contrast-color()` still adapts to a theme-supplied fill (`editorWarning.foreground` and the similar tokens), which the hard-coded per-severity fallback cannot do.

### Motivation & Context

A user reported poor contrast on the editor lint tooltip in the diffs docs app. The defect is in `@pierre/diffs`, not in the docs app. The docs app uses `workspace:*`, so it picks the fix up on the next build. Published consumers on `1.3.4` need a version bump.

Measured in Chrome 151 against the real stylesheet, with the existing e2e contrast test:

| State | Text on fill | Ratio |
| --- | --- | --- |
| Before | `rgb(250, 250, 250)` on `rgb(0, 159, 255)` | **2.72:1** — fails AA |
| After | black or white per fill | **5.71:1** or better |

All four severities in both themes now clear WCAG AA. `contrast-color()` picks white for the light-theme hint (dark grey fill) and black elsewhere.

CI could not catch this. Playwright 1.51.1 bundles Chromium 134, which predates `contrast-color()`, so the existing contrast test only ever measured the `@supports` fallback branch — the branch that was already correct.

`cssContrastColorArity.test.ts` closes that gap. It parses the shipped CSS with balanced-paren scanning and asserts one top-level argument per `contrast-color()` call. It runs in Bun with no browser, so it holds whatever browser CI uses. Confirmed red/green: it fails on the original CSS with `contrast-color(var(--diffs-marker-bg), var(--diffs-bg)) must take exactly one argument`.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality). You must have
      first discussed with the dev team and they should be aware that this PR is
      being opened
- [ ] Breaking change (fix or feature that would change existing functionality).
      You must have first discussed with the dev team and they should be aware
      that this PR is being opened
- [ ] Documentation update

### Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/pierrecomputer/pierre/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project (`moon run root:lint`)
- [x] My code is formatted properly (`moon run root:format`)
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have added tests to cover my changes (if applicable)
- [x] All new and existing tests pass (`moonx diffs:test` — 1504 pass, 0 fail)

Also ran `moonx diffs:typecheck` (clean) and `markers.pw.ts` in system Chrome 151 (5 passed).

### How was AI used in generating this PR

Claude Code (Opus 5) did the whole change: it traced the root cause, wrote the CSS fix and the regression test, and drafted this description. It verified the diagnosis in a real browser rather than by reasoning alone — it built a standalone harness in Chrome 151 to confirm that `CSS.supports('color', 'contrast-color(red, blue)')` is `false` while the one-argument form is `true`, then reproduced and fixed the failure end to end through the package's own e2e fixture.

### Related issues

None. Reported by a user against the diffs docs app.

### Notes for the reviewer

Two open points I did not act on:

1. **Release.** This needs a `@pierre/diffs` version bump for published consumers. Your history keeps those as separate `chore: bump` commits, so I left it out.
2. **Hint severity in e2e.** The contrast test covers info, error, and warning. The fixture's hint marker sits at character 80–100, off screen, and the scrolled-gutter test uses it, so a hover needs the horizontal-scroll setup. Hint was already uncovered before this change, and I measured it as 8.23:1 dark and 7.81:1 light, so I left the e2e coverage as it was.
