### PR TITLE
Remove unused vertical scrollbar gutter

### DIFF
--- a/packages/diffs/src/style.css
+++ b/packages/diffs/src/style.css
@@ -757,7 +757,6 @@
           var(--diffs-scrollbar-gutter)
       )
     );
-    scrollbar-gutter: stable;
   }
 
   [data-diffs-scrollbar-measure] {


### PR DESCRIPTION
`[data-code]` has `overflow-y: clip`, and `overflow-x: scroll`, so the effective `overflow-y` is actually `hidden`. Consequently, the vertical scrollbar can never appear, but `scrollbar-gutter: stable` can cause an empty gutter space to be reserved for the vertical scrollbar anyway. It does not always show up, but in our app it does show up in some cases and removing `scrollbar-gutter: stable` fixes that.

Given that `scrollbar-gutter: stable` only impacts the inline axis, here the vertical scrollbar, and said scrollbar should never appear, it seems like reserving a gutter is never desirable. I may be missing the original intent of the rule being added though.