### PR TITLE
fix(diffs): ignore keydown during IME composition

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -1981,6 +1981,11 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
         // typing, moving); let selectionchange sync #selections again.
         this.#suppressNativeSelectionSync = false;
 
+        // keyCode 229 opens the composition, before compositionstart fires.
+        if (e.isComposing || e.keyCode === 229) {
+          return;
+        }
+
         const command = resolveEditorCommandFromKeyboardEvent(
           e,
           this.#options.keymap

--- a/packages/diffs/src/editor/searchPanel.ts
+++ b/packages/diffs/src/editor/searchPanel.ts
@@ -306,6 +306,9 @@ export class SearchPanelWidget {
         updateMatches();
       },
       onkeydown: (e: KeyboardEvent) => {
+        if (e.isComposing) {
+          return;
+        }
         const findAgain = resolveFindAgainShortcut(e);
         if (e.key === 'Escape') {
           e.preventDefault();

--- a/packages/diffs/src/editor/searchPanel.ts
+++ b/packages/diffs/src/editor/searchPanel.ts
@@ -278,7 +278,7 @@ export class SearchPanelWidget {
         searchParams.replaceText = (e.target as HTMLInputElement).value;
       },
       onkeydown: (e: KeyboardEvent) => {
-        if (e.isComposing) {
+        if (e.isComposing || e.keyCode === 229) {
           return;
         }
         const findAgain = resolveFindAgainShortcut(e);
@@ -306,7 +306,7 @@ export class SearchPanelWidget {
         updateMatches();
       },
       onkeydown: (e: KeyboardEvent) => {
-        if (e.isComposing) {
+        if (e.isComposing || e.keyCode === 229) {
           return;
         }
         const findAgain = resolveFindAgainShortcut(e);

--- a/packages/diffs/test/editorComposition.test.ts
+++ b/packages/diffs/test/editorComposition.test.ts
@@ -166,6 +166,14 @@ function findReplaceInput(panel: HTMLElement): HTMLInputElement {
   return input;
 }
 
+function findSearchInput(panel: HTMLElement): HTMLInputElement {
+  const input = panel.querySelector<HTMLInputElement>('input[data-search]');
+  if (input == null) {
+    throw new Error('search input was not rendered');
+  }
+  return input;
+}
+
 function updateInputValue(input: HTMLInputElement, value: string): void {
   input.value = value;
   input.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
@@ -238,6 +246,37 @@ describe('Editor composition input', () => {
       );
 
       expect(editor.getText()).toBe('line 1');
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('leaves the caret alone for a composing ArrowDown', async () => {
+    const { cleanup, content, editor, window } = await createEditorFixture({
+      contents: 'alpha\nbeta',
+      selections: [
+        {
+          start: { line: 0, character: 2 },
+          end: { line: 0, character: 2 },
+          direction: 'none',
+        },
+      ],
+    });
+
+    try {
+      const event = dispatchKeydown(window, content, {
+        key: 'ArrowDown',
+        isComposing: true,
+      });
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(editor.getState().selections).toEqual([
+        {
+          start: { line: 0, character: 2 },
+          end: { line: 0, character: 2 },
+          direction: DirectionNone,
+        },
+      ]);
     } finally {
       cleanup();
     }
@@ -386,6 +425,70 @@ describe('Editor keyboard editing', () => {
       expect(event.defaultPrevented).toBe(false);
       expect(panel.isConnected).toBe(true);
       expect(editor.getText()).toBe('alpha beta');
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('lets composing Enter commit IME text in the search input', async () => {
+    const { cleanup, content, window } = await createEditorFixture({
+      contents: 'alpha beta',
+    });
+
+    try {
+      const panel = await openSearchReplacePanel({ content, window });
+      const searchInput = findSearchInput(panel);
+      updateInputValue(searchInput, 'beta');
+
+      const event = dispatchKeydown(window, searchInput, {
+        key: 'Enter',
+        isComposing: true,
+      });
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(panel.isConnected).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('keeps the panel open when Escape cancels a composition', async () => {
+    const { cleanup, content, window } = await createEditorFixture({
+      contents: 'alpha beta',
+    });
+
+    try {
+      const panel = await openSearchReplacePanel({ content, window });
+      const searchInput = findSearchInput(panel);
+
+      const event = dispatchKeydown(window, searchInput, {
+        key: 'Escape',
+        keyCode: 229,
+      });
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(panel.isConnected).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('keeps the panel open when Escape cancels a replace input composition', async () => {
+    const { cleanup, content, window } = await createEditorFixture({
+      contents: 'alpha beta',
+    });
+
+    try {
+      const panel = await openSearchReplacePanel({ content, window });
+      const replaceInput = findReplaceInput(panel);
+
+      const event = dispatchKeydown(window, replaceInput, {
+        key: 'Escape',
+        keyCode: 229,
+      });
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(panel.isConnected).toBe(true);
     } finally {
       cleanup();
     }


### PR DESCRIPTION
### Description

Skip editor and search panel keydown handling while an IME composition is open.

### Motivation & Context

Typing Japanese in the editor, `↓`/`↑` move the caret instead of walking the candidate list, `Enter` inserts a newline instead of confirming, and `Escape` runs `simplifySelection` instead of cancelling. The editor sets `#isComposing` but never reads it in keydown, so every key routes into `resolveEditorCommandFromKeyboardEvent`.

The search panel has the same gap. Its Search input has no guard at all. Its Replace input guards on `e.isComposing` alone, which is false when Safari fires `compositionend` before the keydown that ended the composition, so `keyCode === 229` is needed there too. That is also the case on the keydown that opens a composition, before `compositionstart`.

In the editor the guard sits after the two state resets, so a composing keydown keeps the same per-keydown state effects as any other and only dispatch is skipped.



Demo after the fix!

https://github.com/user-attachments/assets/2a0eb9f0-0cee-4009-bc8b-c9a8dd805beb



### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the contributing guidelines
- [x] My code follows the code style of the project
- [x] My code is formatted properly
- [ ] I have updated the documentation accordingly (if applicable)
- [x] I have added tests to cover my changes

4 tests added to `editorComposition.test.ts`. All 4 fail on `main` and pass here.