### PR TITLE
Fix Lighthouse accessibility issues in docs components

### DIFF
--- a/apps/docs/app/(diffs)/_edit/EditPage.tsx
+++ b/apps/docs/app/(diffs)/_edit/EditPage.tsx
@@ -41,107 +41,110 @@ export function EditPage({
     <WorkerPoolContext>
       <div className="mx-auto min-h-screen max-w-5xl px-5 xl:max-w-[80rem]">
         <Header className="-mb-[1px]" />
-        <EditHero />
-        <HeadingAnchors />
+        <main>
+          <EditHero />
+          <HeadingAnchors />
 
-        <section className="space-y-16 pb-8">
-          <LiveEditing
-            prerenderedFile={liveEditingFile}
-            prerenderedDiff={liveEditingDiff}
-          />
-
-          <div className="space-y-5">
-            <FeatureHeader
-              id="selection-action"
-              title="Selection actions"
-              description={
-                <>
-                  Select any text to reveal a floating popover, anchored to the
-                  selection and rendered with{' '}
-                  <code>renderSelectionAction()</code>. Place any number of
-                  actions inside—here, an editor-style <em>Add to chat</em>{' '}
-                  sends the selected snippet to the panel on the right, while a
-                  secondary action copies it.
-                </>
-              }
+          <section className="space-y-16 pb-8">
+            <LiveEditing
+              prerenderedFile={liveEditingFile}
+              prerenderedDiff={liveEditingDiff}
             />
-            <SelectionDemo prerenderedFile={selectionFile} />
-          </div>
 
-          <div className="space-y-5">
-            <FeatureHeader
-              id="markers"
-              title="Annotate code with markers"
-              description={
-                <>
-                  Use <code>editor.setMarkers()</code> to inject inline context
-                  into your code for linter, formatting, and more. Includes
-                  support for severity-aware underlines and hover popovers.
-                  Hover over markers (shown with wavy, colored underlines) in
-                  the example below.
-                </>
-              }
-            />
-            <MarkerDemo prerenderedFile={markerFile} />
-          </div>
+            <div className="space-y-5">
+              <FeatureHeader
+                id="selection-action"
+                title="Selection actions"
+                description={
+                  <>
+                    Select any text to reveal a floating popover, anchored to
+                    the selection and rendered with{' '}
+                    <code>renderSelectionAction()</code>. Place any number of
+                    actions inside—here, an editor-style <em>Add to chat</em>{' '}
+                    sends the selected snippet to the panel on the right, while
+                    a secondary action copies it.
+                  </>
+                }
+              />
+              <SelectionDemo prerenderedFile={selectionFile} />
+            </div>
 
-          <div className="space-y-5">
-            <FeatureHeader
-              id="find"
-              title="Find and replace"
-              description={
-                <>
-                  Find strings across files with <code>Cmd/Ctrl-F</code> on any{' '}
-                  <code>File</code> or <code>FileDiff</code>. Find and replace
-                  with <code>Cmd-Opt-F</code>(Mac) or <code>Ctrl-Alt-F</code>
-                  (Linux/Windows). The search panel below is open—type a query
-                  to highlight matches, jump between them with{' '}
-                  <code>Enter</code> or its arrows, and toggle case, whole-word,
-                  or regex as you go.
-                </>
-              }
-            />
-            <FindDemo prerenderedFile={findFile} />
-          </div>
+            <div className="space-y-5">
+              <FeatureHeader
+                id="markers"
+                title="Annotate code with markers"
+                description={
+                  <>
+                    Use <code>editor.setMarkers()</code> to inject inline
+                    context into your code for linter, formatting, and more.
+                    Includes support for severity-aware underlines and hover
+                    popovers. Hover over markers (shown with wavy, colored
+                    underlines) in the example below.
+                  </>
+                }
+              />
+              <MarkerDemo prerenderedFile={markerFile} />
+            </div>
 
-          <div className="space-y-5">
-            <FeatureHeader
-              id="history"
-              title="Undo history"
-              description={
-                <>
-                  Edits land on a structure-aware undo stack out of the box.
-                  Walk it with keyboard shortcuts and the toolbar below, or
-                  drive it in code with <code>editor.undo()</code>,{' '}
-                  <code>editor.redo()</code>, and{' '}
-                  <code>editor.applyEdits()</code>. The example loads with a
-                  short refactor already applied across several commits.
-                </>
-              }
-            />
-            <HistoryDemo prerenderedFile={historyFile} />
-          </div>
+            <div className="space-y-5">
+              <FeatureHeader
+                id="find"
+                title="Find and replace"
+                description={
+                  <>
+                    Find strings across files with <code>Cmd/Ctrl-F</code> on
+                    any <code>File</code> or <code>FileDiff</code>. Find and
+                    replace with <code>Cmd-Opt-F</code>(Mac) or{' '}
+                    <code>Ctrl-Alt-F</code>
+                    (Linux/Windows). The search panel below is open—type a query
+                    to highlight matches, jump between them with{' '}
+                    <code>Enter</code> or its arrows, and toggle case,
+                    whole-word, or regex as you go.
+                  </>
+                }
+              />
+              <FindDemo prerenderedFile={findFile} />
+            </div>
 
-          <div className="space-y-5">
-            <FeatureHeader
-              id="shortcuts"
-              title="Keyboard shortcuts"
-              description={
-                <>
-                  Browse every default key binding and search by shortcut,
-                  action, or command. Switch to the editable JSON view to
-                  explore the <code>keymap</code> format used to customize
-                  editor commands.
-                </>
-              }
-            />
-            <KeyboardShortcuts prerenderedFile={keymapFile} />
-          </div>
+            <div className="space-y-5">
+              <FeatureHeader
+                id="history"
+                title="Undo history"
+                description={
+                  <>
+                    Edits land on a structure-aware undo stack out of the box.
+                    Walk it with keyboard shortcuts and the toolbar below, or
+                    drive it in code with <code>editor.undo()</code>,{' '}
+                    <code>editor.redo()</code>, and{' '}
+                    <code>editor.applyEdits()</code>. The example loads with a
+                    short refactor already applied across several commits.
+                  </>
+                }
+              />
+              <HistoryDemo prerenderedFile={historyFile} />
+            </div>
 
-          <EditReference />
-        </section>
+            <div className="space-y-5">
+              <FeatureHeader
+                id="shortcuts"
+                title="Keyboard shortcuts"
+                description={
+                  <>
+                    Browse every default key binding and search by shortcut,
+                    action, or command. Switch to the editable JSON view to
+                    explore the <code>keymap</code> format used to customize
+                    editor commands.
+                  </>
+                }
+              />
+              <KeyboardShortcuts prerenderedFile={keymapFile} />
+            </div>
 
-        <PierreCompanySection />
+            <EditReference />
+          </section>
+
+          <PierreCompanySection />
+        </main>
         <Footer />
       </div>
     </WorkerPoolContext>

--- a/apps/docs/app/(diffs)/_edit/SelectionDemo.tsx
+++ b/apps/docs/app/(diffs)/_edit/SelectionDemo.tsx
@@ -253,6 +253,7 @@ export function SelectionDemo({ prerenderedFile }: SelectionDemoProps) {
             <textarea
               className="min-h-10 w-full resize-none bg-transparent px-1 text-[13px] leading-normal text-white placeholder:text-neutral-500 focus:outline-none"
               placeholder="Ask for changes…"
+              aria-label="Ask for changes"
               rows={2}
               disabled
             />

--- a/apps/docs/app/(diffs)/_examples/Annotations/Annotations.tsx
+++ b/apps/docs/app/(diffs)/_examples/Annotations/Annotations.tsx
@@ -198,6 +198,7 @@ function CommentForm({
                 <textarea
                   ref={textareaRef}
                   placeholder="Leave a comment"
+                  aria-label="Leave a comment"
                   className="text-foreground bg-background focus:ring-ring min-h-[60px] w-full resize-none rounded-md border p-2 text-sm focus:ring-2 focus:outline-none"
                 />
                 <div className="mt-3 flex items-center gap-2">

--- a/apps/docs/app/(diffs)/_examples/ArbitraryFiles/ArbitraryFiles.tsx
+++ b/apps/docs/app/(diffs)/_examples/ArbitraryFiles/ArbitraryFiles.tsx
@@ -35,8 +35,9 @@ export function ArbitraryFiles({ prerenderedDiff }: ArbitraryFilesProps) {
 
       <div className="flex flex-col gap-4">
         <div className="relative">
-          <FileLabel>before.css</FileLabel>
+          <FileLabel htmlFor="arbitrary-before">before.css</FileLabel>
           <FileTextarea
+            id="arbitrary-before"
             value={oldFile.contents}
             onChange={(e) => {
               setOldFile({ ...oldFile, contents: e.target.value });
@@ -44,8 +45,9 @@ export function ArbitraryFiles({ prerenderedDiff }: ArbitraryFilesProps) {
           />
         </div>
         <div className="relative">
-          <FileLabel>after.css</FileLabel>
+          <FileLabel htmlFor="arbitrary-after">after.css</FileLabel>
           <FileTextarea
+            id="arbitrary-after"
             value={newFile.contents}
             onChange={(e) => {
               setNewFile({ ...newFile, contents: e.target.value });
@@ -65,26 +67,37 @@ export function ArbitraryFiles({ prerenderedDiff }: ArbitraryFilesProps) {
 
 interface FileLabelProps {
   children: React.ReactNode;
+  htmlFor: string;
 }
 
 // Local components to avoid class name duplication
-function FileLabel({ children }: FileLabelProps) {
+function FileLabel({ children, htmlFor }: FileLabelProps) {
   return (
-    <label className="text-muted-foreground bg-muted absolute top-[1px] left-[1px] block rounded-lg px-3 py-2 text-xs font-medium uppercase select-none">
+    <label
+      htmlFor={htmlFor}
+      className="text-muted-foreground bg-muted absolute top-[1px] left-[1px] block rounded-lg px-3 py-2 text-xs font-medium uppercase select-none"
+    >
       {children}
     </label>
   );
 }
 
 interface FileTextareaProps {
+  id: string;
   value: string;
   onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   className?: string;
 }
 
-function FileTextarea({ value, onChange, className = '' }: FileTextareaProps) {
+function FileTextarea({
+  id,
+  value,
+  onChange,
+  className = '',
+}: FileTextareaProps) {
   return (
     <textarea
+      id={id}
       value={value}
       onChange={onChange}
       className={`bg-muted field-sizing-content min-h-40 w-full resize-none rounded-lg border px-4 pt-10 font-mono text-sm ${className}`}

--- a/apps/docs/app/(diffs)/_examples/DiffStyles/DiffStyles.tsx
+++ b/apps/docs/app/(diffs)/_examples/DiffStyles/DiffStyles.tsx
@@ -25,7 +25,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Switch } from '@/components/ui/switch';
+import { ToggleSwitch } from '@/components/ui/toggle-switch';
 
 const diffStyleOptions = [
   {
@@ -142,69 +142,31 @@ export function DiffStyles({
             </DropdownMenuContent>
           </DropdownMenu>
 
-          <div className="gridstack">
-            <Button
-              variant="outline"
-              className="w-full justify-between gap-3 pr-11 pl-3 md:w-auto"
-              onClick={() => setDisableBackground(!disableBackground)}
-            >
-              <div className="flex items-center gap-2">
-                <IconCodeStyleBg />
-                Backgrounds
-              </div>
-            </Button>
-            <Switch
-              checked={!disableBackground}
-              onCheckedChange={(checked: boolean) =>
-                setDisableBackground(!checked)
-              }
-              onClick={(e) => e.stopPropagation()}
-              className="pointer-events-none mr-3 place-self-center justify-self-end"
-            />
-          </div>
+          <ToggleSwitch
+            icon={<IconCodeStyleBg />}
+            label="Backgrounds"
+            checked={!disableBackground}
+            onCheckedChange={(checked) => setDisableBackground(!checked)}
+            className="w-full md:w-auto"
+          />
 
-          <div className="gridstack">
-            <Button
-              variant="outline"
-              className="w-full justify-between gap-3 pr-11 pl-3 md:w-auto"
-              onClick={() =>
-                setOverflow(overflow === 'wrap' ? 'scroll' : 'wrap')
-              }
-            >
-              <div className="flex items-center gap-2">
-                <IconWordWrap />
-                Wrapping
-              </div>
-            </Button>
-            <Switch
-              checked={overflow === 'wrap'}
-              onCheckedChange={(checked: boolean) =>
-                setOverflow(checked ? 'wrap' : 'scroll')
-              }
-              onClick={(e) => e.stopPropagation()}
-              className="pointer-events-none mr-3 place-self-center justify-self-end"
-            />
-          </div>
-          <div className="gridstack">
-            <Button
-              variant="outline"
-              className="w-full justify-between gap-3 pr-11 pl-3 md:w-auto"
-              onClick={() => setDisableLineNumbers(!disableLineNumbers)}
-            >
-              <div className="flex items-center gap-2">
-                <IconListOrdered />
-                Line Numbers
-              </div>
-            </Button>
-            <Switch
-              checked={!disableLineNumbers}
-              onCheckedChange={(checked: boolean) =>
-                setDisableLineNumbers(!checked)
-              }
-              onClick={(e) => e.stopPropagation()}
-              className="pointer-events-none mr-3 place-self-center justify-self-end"
-            />
-          </div>
+          <ToggleSwitch
+            icon={<IconWordWrap />}
+            label="Wrapping"
+            checked={overflow === 'wrap'}
+            onCheckedChange={(checked) =>
+              setOverflow(checked ? 'wrap' : 'scroll')
+            }
+            className="w-full md:w-auto"
+          />
+
+          <ToggleSwitch
+            icon={<IconListOrdered />}
+            label="Line Numbers"
+            checked={!disableLineNumbers}
+            onCheckedChange={(checked) => setDisableLineNumbers(!checked)}
+            className="w-full md:w-auto"
+          />
         </div>
       </div>
       <MultiFileDiff

--- a/apps/docs/app/(diffs)/_examples/LineSelection/LineSelection.tsx
+++ b/apps/docs/app/(diffs)/_examples/LineSelection/LineSelection.tsx
@@ -98,6 +98,8 @@ export function LineSelection({ prerenderedDiff }: LineSelectionProps) {
             }}
             className="aspect-square px-0"
             disabled={selectedRange == null}
+            title="Clear selection"
+            aria-label="Clear selection"
           >
             <IconXSquircle className="text-muted-foreground" />
           </Button>

--- a/apps/docs/app/(diffs)/_home/AgentUi.tsx
+++ b/apps/docs/app/(diffs)/_home/AgentUi.tsx
@@ -1323,6 +1323,7 @@ export function AgentUi({
             <textarea
               className="aui-composer-input"
               placeholder="Ask for changes, @mention files, or run commands…"
+              aria-label="Ask for changes, @mention files, or run commands"
               rows={2}
               disabled
             />

--- a/apps/docs/app/(diffs)/_home/Home.tsx
+++ b/apps/docs/app/(diffs)/_home/Home.tsx
@@ -44,27 +44,29 @@ export default function Home() {
     <WorkerPoolContext>
       <div className="mx-auto min-h-screen max-w-5xl px-5 xl:max-w-[80rem]">
         <Header className="-mb-[1px]" />
-        <Hero productId={PRODUCT_ID} />
-        <HeadingAnchors />
-        <section className="space-y-12 pb-8">
-          <EditSection />
-          <SplitUnifiedSection />
-          <DiffStylesSection />
-          <MergeConflictSection />
-          <AnnotationsSection />
-          <AcceptRejectSection />
-          <LineSelectionSection />
-          <TokenHoverSection />
+        <main>
+          <Hero productId={PRODUCT_ID} />
+          <HeadingAnchors />
+          <section className="space-y-12 pb-8">
+            <EditSection />
+            <SplitUnifiedSection />
+            <DiffStylesSection />
+            <MergeConflictSection />
+            <AnnotationsSection />
+            <AcceptRejectSection />
+            <LineSelectionSection />
+            <TokenHoverSection />
 
-          <hr />
+            <hr />
 
-          <ShikiThemesSection />
-          <FontStylesSection />
-          <CustomHunkSeparatorsSection />
-          <CustomHeaderSection />
-          <ArbitraryFilesSection />
-        </section>
-        <PierreCompanySection />
+            <ShikiThemesSection />
+            <FontStylesSection />
+            <CustomHunkSeparatorsSection />
+            <CustomHeaderSection />
+            <ArbitraryFilesSection />
+          </section>
+          <PierreCompanySection />
+        </main>
         <Footer />
       </div>
     </WorkerPoolContext>

--- a/apps/docs/app/(diffs)/playground/PlaygroundClient.tsx
+++ b/apps/docs/app/(diffs)/playground/PlaygroundClient.tsx
@@ -82,7 +82,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Switch } from '@/components/ui/switch';
+import { ToggleSwitch } from '@/components/ui/toggle-switch';
 
 const LINE_DIFF_OPTIONS = [
   { value: 'word-alt', label: 'Word-Alt' },
@@ -1242,25 +1242,13 @@ function ToggleButton({
   title?: string;
 }) {
   return (
-    <div className="gridstack" title={title}>
-      <Button
-        variant="outline"
-        className="justify-between gap-3 pr-11 pl-3"
-        disabled={disabled}
-        onClick={() => onCheckedChange(!checked)}
-      >
-        <div className="flex items-center gap-2">
-          {icon}
-          {label}
-        </div>
-      </Button>
-      <Switch
-        checked={checked}
-        onCheckedChange={onCheckedChange}
-        disabled={disabled}
-        onClick={(e) => e.stopPropagation()}
-        className="pointer-events-none mr-3 place-self-center justify-self-end"
-      />
-    </div>
+    <ToggleSwitch
+      icon={icon}
+      label={label}
+      checked={checked}
+      onCheckedChange={onCheckedChange}
+      disabled={disabled}
+      title={title}
+    />
   );
 }

--- a/apps/docs/app/(diffs)/playground/PlaygroundComments.tsx
+++ b/apps/docs/app/(diffs)/playground/PlaygroundComments.tsx
@@ -77,6 +77,7 @@ export function CommentForm({
                 <textarea
                   ref={textareaRef}
                   placeholder="Leave a comment…"
+                  aria-label="Leave a comment"
                   className="text-foreground bg-background min-h-[60px] w-full resize-none rounded-md border p-2 text-sm focus:ring-2 focus:ring-offset-[-1px]"
                 />
                 <div className="mt-1 flex items-center gap-2">

--- a/apps/docs/app/(diffs)/theme/ThemeLayout.tsx
+++ b/apps/docs/app/(diffs)/theme/ThemeLayout.tsx
@@ -34,15 +34,17 @@ export function ThemeLayout({ header, children }: ThemeLayoutProps) {
         className="-mb-[1px]"
       />
 
-      {header}
+      <main>
+        {header}
 
-      <div className="relative gap-6 pt-6 md:grid md:grid-cols-[220px_1fr] md:gap-12">
-        <SidebarWrapper
-          isMobileMenuOpen={isMobileMenuOpen}
-          onMobileMenuClose={handleMobileMenuClose}
-        />
-        {children}
-      </div>
+        <div className="relative gap-6 pt-6 md:grid md:grid-cols-[220px_1fr] md:gap-12">
+          <SidebarWrapper
+            isMobileMenuOpen={isMobileMenuOpen}
+            onMobileMenuClose={handleMobileMenuClose}
+          />
+          {children}
+        </div>
+      </main>
     </>
   );
 }

--- a/apps/docs/app/(trees)/_components/DemoDragDropClient.tsx
+++ b/apps/docs/app/(trees)/_components/DemoDragDropClient.tsx
@@ -114,10 +114,13 @@ export function DemoDragDropClient({ preloadedData }: DemoDragDropClientProps) {
                 Lock package.json
               </div>
             </Button>
+            {/* Visual-only indicator stacked over the Button, which is the
+                interactive control. Keep the Switch out of the tab order and
+                hidden from assistive tech to avoid an unnamed duplicate toggle. */}
             <Switch
               checked={lockPackageJson}
-              onCheckedChange={setLockPackageJson}
-              onClick={(event) => event.stopPropagation()}
+              tabIndex={-1}
+              aria-hidden
               className="pointer-events-none mr-3 place-self-center justify-self-end"
             />
           </div>

--- a/apps/docs/app/(trees)/_components/DemoGitStatus.tsx
+++ b/apps/docs/app/(trees)/_components/DemoGitStatus.tsx
@@ -165,10 +165,13 @@ export function DemoGitStatus({ preloadedData }: DemoGitStatusProps) {
             >
               Show unmodified
             </Button>
+            {/* Visual-only indicator stacked over the Button, which is the
+                interactive control. Keep the Switch out of the tab order and
+                hidden from assistive tech to avoid an unnamed duplicate toggle. */}
             <Switch
               checked={showUnmodified}
-              onCheckedChange={setShowUnmodified}
-              onClick={(event) => event.stopPropagation()}
+              tabIndex={-1}
+              aria-hidden
               className="pointer-events-none mr-3 place-self-center justify-self-end"
             />
           </div>

--- a/apps/docs/app/(trees)/_home/Home.tsx
+++ b/apps/docs/app/(trees)/_home/Home.tsx
@@ -73,38 +73,40 @@ export default function TreesPage() {
   return (
     <div className="mx-auto min-h-screen max-w-5xl px-5 xl:max-w-[80rem]">
       <Header className="-mb-[1px]" />
-      <Hero productId={PRODUCT_ID} />
+      <main>
+        <Hero productId={PRODUCT_ID} />
 
-      <section className="relative mb-16 max-md:-mr-5 max-md:-ml-5 max-md:overflow-x-clip max-md:pl-5 md:-mt-6">
-        <DemoTreeApp />
-      </section>
+        <section className="relative mb-16 max-md:-mr-5 max-md:-ml-5 max-md:overflow-x-clip max-md:pl-5 md:-mt-6">
+          <DemoTreeApp />
+        </section>
 
-      <HeadingAnchors />
-      <section className="space-y-12 pb-8">
-        <DemoFlatten
-          preloadedData={{
-            flattened: flattenFlattenedPreloadedData,
-            hierarchical: flattenHierarchicalPreloadedData,
-          }}
-        />
-        <DemoGitStatus
-          preloadedData={{
-            filteredViewport: gitStatusFilteredViewportPreloadedData,
-            fullViewport: gitStatusFullViewportPreloadedData,
-          }}
-        />
-        <DemoContextMenu />
-        <DemoDragDrop />
-        <DemoSearch />
-        <DemoVirtualization />
-        <DemoA11y />
-        <DemoCustomIcons />
-        <DemoTheming />
-        <DemoStyling />
-        <DemoDensity />
-      </section>
+        <HeadingAnchors />
+        <section className="space-y-12 pb-8">
+          <DemoFlatten
+            preloadedData={{
+              flattened: flattenFlattenedPreloadedData,
+              hierarchical: flattenHierarchicalPreloadedData,
+            }}
+          />
+          <DemoGitStatus
+            preloadedData={{
+              filteredViewport: gitStatusFilteredViewportPreloadedData,
+              fullViewport: gitStatusFullViewportPreloadedData,
+            }}
+          />
+          <DemoContextMenu />
+          <DemoDragDrop />
+          <DemoSearch />
+          <DemoVirtualization />
+          <DemoA11y />
+          <DemoCustomIcons />
+          <DemoTheming />
+          <DemoStyling />
+          <DemoDensity />
+        </section>
 
-      <PierreCompanySection />
+        <PierreCompanySection />
+      </main>
       <Footer />
     </div>
   );

--- a/apps/docs/components/Footer.tsx
+++ b/apps/docs/components/Footer.tsx
@@ -23,7 +23,7 @@ export default function Footer() {
         </div>
         <div className="hidden md:block" />
         <div>
-          <h4 className="mb-2 text-sm font-medium">Diffs</h4>
+          <p className="mb-2 text-sm font-medium">Diffs</p>
           <nav className="flex flex-col gap-1">
             {isDiffs ? (
               <>
@@ -65,7 +65,7 @@ export default function Footer() {
           </nav>
         </div>
         <div>
-          <h4 className="mb-2 text-sm font-medium">Trees</h4>
+          <p className="mb-2 text-sm font-medium">Trees</p>
           <nav className="flex flex-col gap-1">
             {isTrees ? (
               <>
@@ -96,7 +96,7 @@ export default function Footer() {
           </nav>
         </div>
         <div>
-          <h4 className="mb-2 text-sm font-medium">DiffsHub</h4>
+          <p className="mb-2 text-sm font-medium">DiffsHub</p>
           <nav className="flex flex-col gap-1">
             {/* diffshub is a separate app on its own domain, so this is
                 always an external link. */}
@@ -106,7 +106,7 @@ export default function Footer() {
           </nav>
         </div>
         <div>
-          <h4 className="mb-2 text-sm font-medium">Community</h4>
+          <p className="mb-2 text-sm font-medium">Community</p>
           <nav className="flex flex-col gap-1">
             <Link
               href="https://x.com/pierrecomputer"

--- a/apps/docs/components/Header.tsx
+++ b/apps/docs/components/Header.tsx
@@ -147,7 +147,12 @@ export function Header({ onMobileMenuToggle, className }: HeaderProps) {
 
       <div className="mr-auto flex items-center gap-1 md:hidden">
         <IconChevronFlat size={16} className="text-border" />
-        <Button variant="ghost" size="icon" onClick={handleMobileToggle}>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={handleMobileToggle}
+          aria-label="Toggle table of contents"
+        >
           <IconParagraph />
         </Button>
       </div>

--- a/apps/docs/components/Header.tsx
+++ b/apps/docs/components/Header.tsx
@@ -151,7 +151,9 @@ export function Header({ onMobileMenuToggle, className }: HeaderProps) {
           variant="ghost"
           size="icon"
           onClick={handleMobileToggle}
-          aria-label="Toggle table of contents"
+          aria-label={
+            ownsPopover ? 'Toggle navigation menu' : 'Toggle table of contents'
+          }
         >
           <IconParagraph />
         </Button>

--- a/apps/docs/components/docs/CopyCodeButton.tsx
+++ b/apps/docs/components/docs/CopyCodeButton.tsx
@@ -36,15 +36,16 @@ export function CopyCodeButton({ content }: CopyButtonProps) {
     []
   );
   return (
-    <div
+    <button
+      type="button"
       onClick={copyToClipboard}
-      tabIndex={0}
+      aria-label={copied ? 'Copied' : 'Copy code'}
       className={cn(
         'hover:bg-accent -mr-[10px] cursor-pointer rounded-sm p-2 opacity-60 hover:opacity-100',
         copied ? 'text-emerald-500' : undefined
       )}
     >
       {copied ? <IconCheck /> : <IconCopy />}
-    </div>
+    </button>
   );
 }

--- a/apps/docs/components/docs/DocsLayout.tsx
+++ b/apps/docs/components/docs/DocsLayout.tsx
@@ -31,7 +31,7 @@ export function DocsLayout({ children }: DocsLayoutProps) {
           isMobileMenuOpen={isMobileMenuOpen}
           onMobileMenuClose={handleMobileMenuClose}
         />
-        {children}
+        <main className="min-w-0">{children}</main>
       </div>
     </>
   );

--- a/apps/docs/components/ui/toggle-switch.tsx
+++ b/apps/docs/components/ui/toggle-switch.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import * as React from 'react';
+
+import { buttonVariants } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+export interface ToggleSwitchProps {
+  label: React.ReactNode;
+  icon?: React.ReactNode;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  disabled?: boolean;
+  title?: string;
+  className?: string;
+}
+
+/**
+ * A toggle pill built as one native control: a `<label>` wrapping a
+ * visually-hidden checkbox styled to look like a switch.
+ */
+export function ToggleSwitch({
+  label,
+  icon,
+  checked,
+  onCheckedChange,
+  disabled = false,
+  title,
+  className,
+}: ToggleSwitchProps) {
+  return (
+    <label
+      title={title}
+      className={cn(
+        buttonVariants({ variant: checked ? 'outline' : 'secondary' }),
+        !checked && 'border border-transparent',
+        'justify-between gap-3 px-3',
+        disabled ? 'pointer-events-none opacity-50' : 'cursor-pointer',
+        className
+      )}
+    >
+      <span className="flex items-center gap-2">
+        {icon}
+        {label}
+      </span>
+      <input
+        type="checkbox"
+        role="switch"
+        checked={checked}
+        disabled={disabled}
+        onChange={(event) => onCheckedChange(event.target.checked)}
+        className="peer sr-only"
+      />
+      <span
+        aria-hidden
+        className={cn(
+          'bg-input peer-checked:bg-primary relative inline-flex h-4 w-6 shrink-0 items-center rounded-full border-2 border-transparent transition-colors',
+          'peer-focus-visible:ring-ring peer-focus-visible:ring-offset-background peer-focus-visible:ring-2 peer-focus-visible:ring-offset-2',
+          "after:pointer-events-none after:absolute after:top-0 after:left-0 after:h-3 after:w-3 after:rounded-full after:bg-background after:shadow-lg after:transition-transform after:content-['']",
+          'peer-checked:after:translate-x-2'
+        )}
+      />
+    </label>
+  );
+}


### PR DESCRIPTION
Fixes several Lighthouse accessibility audit failures in the docs app (diffs + trees), from two chats. Scoped to component-level a11y only; the `<main>` landmark work and the separate SEO metadata pass are intentionally excluded (see below).

- Rebuild the diff-style and playground toggles as a single `label` + native checkbox `ToggleSwitch` (`apps/docs/components/ui/toggle-switch.tsx`) instead of a `<button>` visually stacked with a Radix switch (which rendered a second, undersized `<button>`). This collapses each pill to one adequately sized tap target, fixing the `target-size` failure. Checked pills use the `outline` variant, unchecked use `secondary` with a transparent border so toggling never shifts layout.
- Mark the remaining decorative switches (`DemoGitStatus`, `DemoDragDropClient`) `aria-hidden` + `tabIndex={-1}` so the adjacent button is the sole named control.
- Name previously unlabeled controls: `aria-label` on the playground/AgentUi textareas and various buttons/switches.
- Convert `CopyCodeButton` from a clickable `<div>` to a real `<button>` with an `aria-label`.
- Convert the footer `<h4>` column headings to styled `<p>` elements to fix the `heading-order` violation (they were `h4`s with no preceding `h2`/`h3`).
