### PR TITLE
fix(diffshub): return real 404s for non-viewable paths

### DIFF
--- a/apps/diffshub/app/[...path]/DiffsHubViewByPathPage.tsx
+++ b/apps/diffshub/app/[...path]/DiffsHubViewByPathPage.tsx
@@ -1,24 +1,81 @@
-import { redirect } from 'next/navigation';
+import type { Metadata } from 'next';
+import { notFound, redirect } from 'next/navigation';
 
 import { ReviewUI } from '@/components/ReviewUI';
+import { describeDiffTarget } from '@/lib/describeDiffTarget';
 import { resolveDiffshubViewerRoute } from '@/lib/resolveDiffshubViewerRoute';
+import { SITE_DESCRIPTION, SITE_NAME, SITE_ORIGIN } from '@/lib/site';
+
+interface ViewByPathProps {
+  params: Promise<{ path: string[] }>;
+  searchParams: Promise<{ domain?: string | string[] }>;
+}
+
+function readRequestedDomain(domain: string | string[] | undefined) {
+  return Array.isArray(domain) ? domain[0] : domain;
+}
+
+// Viewer pages are deliberately excluded from search results: they render
+// third-party diffs fetched client-side, so there is no content of ours to
+// index, and the path space is unbounded. The canonical still points at the
+// normalized path so shared links with a `domain` query param collapse onto one
+// URL for social previews.
+export async function generateMetadata({
+  params,
+  searchParams,
+}: ViewByPathProps): Promise<Metadata> {
+  const { path } = await params;
+  const { domain } = await searchParams;
+  const route = resolveDiffshubViewerRoute(path, readRequestedDomain(domain));
+
+  if (route.kind !== 'render') {
+    return { title: SITE_NAME, robots: { index: false, follow: false } };
+  }
+
+  const label = describeDiffTarget(route.upstreamPath);
+  const title = label == null ? SITE_NAME : `${label} — ${SITE_NAME}`;
+  const description =
+    label == null ? SITE_DESCRIPTION : `Viewing code changes for ${label}.`;
+  const canonical = new URL(route.upstreamPath, SITE_ORIGIN).href;
+
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    robots: { index: false, follow: false },
+    openGraph: {
+      title,
+      description,
+      siteName: SITE_NAME,
+      type: 'website',
+      url: canonical,
+      images: ['/diffshub-brand/opengraph-image.png'],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: ['/diffshub-brand/twitter-image.png'],
+    },
+  };
+}
 
 // Viewer route that mirrors the upstream path. GitHub is the public default,
 // while hidden alternate domains can opt in through the `domain` query param.
 export async function DiffsHubViewByPathPage({
   params,
   searchParams,
-}: {
-  params: Promise<{ path: string[] }>;
-  searchParams: Promise<{ domain?: string | string[] }>;
-}) {
+}: ViewByPathProps) {
   const { path } = await params;
   const { domain } = await searchParams;
-  const requestedDomain = Array.isArray(domain) ? domain[0] : domain;
-  const route = resolveDiffshubViewerRoute(path, requestedDomain);
+  const route = resolveDiffshubViewerRoute(path, readRequestedDomain(domain));
 
   if (route.kind === 'redirect') {
     redirect(route.target);
+  }
+
+  if (route.kind === 'not-found') {
+    notFound();
   }
 
   return (

--- a/apps/diffshub/app/[...path]/page.tsx
+++ b/apps/diffshub/app/[...path]/page.tsx
@@ -1,1 +1,4 @@
-export { DiffsHubViewByPathPage as default } from './DiffsHubViewByPathPage';
+export {
+  DiffsHubViewByPathPage as default,
+  generateMetadata,
+} from './DiffsHubViewByPathPage';

--- a/apps/diffshub/lib/describeDiffTarget.ts
+++ b/apps/diffshub/lib/describeDiffTarget.ts
@@ -1,0 +1,43 @@
+const PULL_PATTERN = /^\/([^/]+)\/([^/]+)\/pull\/(\d+)/;
+const COMMIT_PATTERN = /^\/([^/]+)\/([^/]+)\/commit\/([^/]+)/;
+const COMPARE_PATTERN = /^\/([^/]+)\/([^/]+)\/compare\/(.+)$/;
+const REPO_PATTERN = /^\/([^/]+)\/([^/]+)/;
+
+// Commit SHAs are shown abbreviated, the way Git and GitHub display them.
+const SHORT_SHA_LENGTH = 7;
+
+/**
+ * Turn an upstream diff path into a short human label for the document title
+ * and link previews, e.g. `/owner/repo/pull/123` becomes "owner/repo #123".
+ *
+ * The viewer routes are noindex, so this is not about ranking: it is what makes
+ * browser tabs and Slack/iMessage unfurls distinguishable, instead of every
+ * diff sharing the site's generic home page title.
+ *
+ * Returns undefined when the path matches no known shape, so callers can fall
+ * back to the site defaults rather than inventing a label.
+ */
+export function describeDiffTarget(upstreamPath: string): string | undefined {
+  const pull = PULL_PATTERN.exec(upstreamPath);
+  if (pull != null) {
+    return `${pull[1]}/${pull[2]} #${pull[3]}`;
+  }
+
+  const commit = COMMIT_PATTERN.exec(upstreamPath);
+  if (commit != null) {
+    const sha = commit[3].slice(0, SHORT_SHA_LENGTH);
+    return `${commit[1]}/${commit[2]}@${sha}`;
+  }
+
+  const compare = COMPARE_PATTERN.exec(upstreamPath);
+  if (compare != null) {
+    return `${compare[1]}/${compare[2]} ${compare[3]}`;
+  }
+
+  const repo = REPO_PATTERN.exec(upstreamPath);
+  if (repo != null) {
+    return `${repo[1]}/${repo[2]}`;
+  }
+
+  return undefined;
+}

--- a/apps/diffshub/lib/resolveDiffshubViewerRoute.ts
+++ b/apps/diffshub/lib/resolveDiffshubViewerRoute.ts
@@ -4,6 +4,7 @@ const GITHUB_HOST = 'github.com';
 
 export type DiffshubViewerRoute =
   | { kind: 'redirect'; target: string }
+  | { kind: 'not-found' }
   | {
       kind: 'render';
       upstreamPath: string;
@@ -11,18 +12,31 @@ export type DiffshubViewerRoute =
       domain: string | undefined;
     };
 
-// Resolves the catch-all viewer route into either a redirect or the props the
+// The shortest thing the viewer can render is `owner/repo` (see
+// getPatchViewerHref), so a single segment can never be a valid diff target.
+const MIN_VIEWER_PATH_SEGMENTS = 2;
+
+// Resolves the catch-all viewer route into a redirect, a 404, or the props the
 // viewer needs to render. Extracted from the route page so it can be unit
 // tested without spinning up Next.js. Empty paths redirect to the home page;
 // GitHub paths are canonicalized via normalizeGitHubPath so direct navigation
 // matches the hrefs getPatchViewerHref produces from form input. Non-GitHub
 // hosts are passed through unchanged because their canonical form is unknown.
+//
+// Single-segment paths resolve to 'not-found' rather than rendering. Without
+// that, the catch-all answered HTTP 200 for every URL on the domain — including
+// /robots.txt and /sitemap.xml, which it shadowed with HTML — so search engines
+// saw an unbounded space of identical soft-404 pages.
 export function resolveDiffshubViewerRoute(
   pathSegments: readonly string[],
   requestedDomainInput: string | undefined
 ): DiffshubViewerRoute {
   if (pathSegments.length === 0) {
     return { kind: 'redirect', target: '/' };
+  }
+
+  if (pathSegments.length < MIN_VIEWER_PATH_SEGMENTS) {
+    return { kind: 'not-found' };
   }
 
   const domain =

--- a/apps/diffshub/lib/site.ts
+++ b/apps/diffshub/lib/site.ts
@@ -4,3 +4,15 @@
 export const SITE_DESCRIPTION =
   'View code changes from any public GitHub diff or patch URL with a super-freaking-fast, beautiful, and virtualized interface.';
 export const SITE_NAME = 'DiffsHub';
+
+export const PROD_ORIGIN = 'https://diffshub.com';
+
+const isDev = process.env.NODE_ENV !== 'production';
+const DEV_PORT = process.env.PORT ?? '3692';
+
+/**
+ * Origin that absolute metadata URLs resolve against: `metadataBase`,
+ * canonicals, `og:url`, and the sitemap/robots entries. In dev this points at
+ * localhost so OG previewers fetch in-progress assets instead of production.
+ */
+export const SITE_ORIGIN = isDev ? `http://localhost:${DEV_PORT}` : PROD_ORIGIN;

--- a/apps/diffshub/test/describeDiffTarget.test.ts
+++ b/apps/diffshub/test/describeDiffTarget.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'bun:test';
+
+import { describeDiffTarget } from '../lib/describeDiffTarget';
+
+describe('describeDiffTarget', () => {
+  describe('pull requests', () => {
+    test('labels owner, repo, and number', () => {
+      expect(describeDiffTarget('/owner/repo/pull/123')).toBe(
+        'owner/repo #123'
+      );
+    });
+
+    test('ignores trailing subroutes', () => {
+      expect(describeDiffTarget('/owner/repo/pull/123/files')).toBe(
+        'owner/repo #123'
+      );
+    });
+  });
+
+  describe('commits', () => {
+    test('abbreviates a full SHA', () => {
+      expect(
+        describeDiffTarget(
+          '/pierrecomputer/pierre/commit/83fea5e63ef8751ddbcfabe33154bc2e096c3d85'
+        )
+      ).toBe('pierrecomputer/pierre@83fea5e');
+    });
+
+    test('leaves an already-short SHA alone', () => {
+      expect(describeDiffTarget('/owner/repo/commit/abc1234')).toBe(
+        'owner/repo@abc1234'
+      );
+    });
+  });
+
+  describe('compare ranges', () => {
+    test('keeps the full range', () => {
+      expect(describeDiffTarget('/torvalds/linux/compare/v6.0...v7.0')).toBe(
+        'torvalds/linux v6.0...v7.0'
+      );
+    });
+  });
+
+  describe('repository-only paths', () => {
+    test('falls back to owner/repo', () => {
+      expect(describeDiffTarget('/owner/repo')).toBe('owner/repo');
+    });
+
+    test('unrecognized subroute still yields owner/repo', () => {
+      expect(describeDiffTarget('/owner/repo/tree/main')).toBe('owner/repo');
+    });
+  });
+
+  describe('unlabelable paths', () => {
+    test('single segment returns undefined', () => {
+      expect(describeDiffTarget('/owner')).toBeUndefined();
+    });
+
+    test('root returns undefined', () => {
+      expect(describeDiffTarget('/')).toBeUndefined();
+    });
+  });
+});

--- a/apps/diffshub/test/resolveDiffshubViewerRoute.test.ts
+++ b/apps/diffshub/test/resolveDiffshubViewerRoute.test.ts
@@ -12,6 +12,39 @@ describe('resolveDiffshubViewerRoute', () => {
     });
   });
 
+  describe('paths too short to be a diff target', () => {
+    test('single segment is not found', () => {
+      expect(resolveDiffshubViewerRoute(['owner'], undefined)).toEqual({
+        kind: 'not-found',
+      });
+    });
+
+    test('static file names are not found rather than rendered', () => {
+      // These used to be swallowed by the catch-all and answered with HTML,
+      // which shadowed the real robots.txt and sitemap.xml routes.
+      for (const file of ['robots.txt', 'sitemap.xml', 'llms.txt']) {
+        expect(resolveDiffshubViewerRoute([file], undefined)).toEqual({
+          kind: 'not-found',
+        });
+      }
+    });
+
+    test('a requested domain does not make a single segment valid', () => {
+      expect(resolveDiffshubViewerRoute(['owner'], 'gitlab.com')).toEqual({
+        kind: 'not-found',
+      });
+    });
+
+    test('owner/repo is the shortest renderable path', () => {
+      expect(resolveDiffshubViewerRoute(['owner', 'repo'], undefined)).toEqual({
+        domain: undefined,
+        kind: 'render',
+        upstreamPath: '/owner/repo',
+        url: 'https://github.com/owner/repo',
+      });
+    });
+  });
+
   describe('GitHub (default host) canonical paths', () => {
     test('PR path renders without rewrite', () => {
       expect(


### PR DESCRIPTION
## Summary
- The DiffsHub catch-all viewer answered **HTTP 200 for every URL** ever requested, including single-segment paths that can never be a valid `owner/repo` diff target. This also shadowed `/robots.txt` and `/sitemap.xml` with HTML (Lighthouse flagged an invalid robots.txt).
- `resolveDiffshubViewerRoute` now returns a `not-found` result for paths shorter than `owner/repo`, and the route page calls `notFound()`.
- Viewer pages gain per-target titles/descriptions (`describeDiffTarget`, e.g. `owner/repo #123`), a normalized canonical, and `noindex, nofollow` so shared links unfurl usefully without entering the index.
- Adds `SITE_ORIGIN` to `lib/site` so metadata routes and canonicals share one origin definition.

## Test plan
- [ ] `/definitely-not-a-real-path` returns 404 (was 200)
- [ ] `/robots.txt` and `/sitemap.xml` are no longer shadowed by the catch-all
- [ ] A real PR/commit/compare/repo path still renders and now has a distinct `<title>`
- [ ] `moonx diffshub:typecheck` and `moonx diffshub:test`

First of 4 stacked SEO PRs.
