### PR TITLE
fix(a11y): restore pinch-zoom on the docs sites

### DIFF
--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -61,7 +61,6 @@ const geistMono = Geist_Mono({
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
-  userScalable: false,
   themeColor: [
     { media: '(prefers-color-scheme: light)', color: '#ffffff' },
     { media: '(prefers-color-scheme: dark)', color: '#252525' },


### PR DESCRIPTION
## Summary
- The docs layout set `userScalable: false` in its `viewport` export, which fails Lighthouse's `meta-viewport` audit and blocks pinch-zoom for low-vision users on diffs.com and trees.software.
- Removing it re-enables pinch-zoom. This is a genuine accessibility defect independent of any ranking effect.
- DiffsHub deliberately keeps its locked viewport, so it is untouched.

## Test plan
- [ ] Pinch-zoom works on diffs.com and trees.software
- [ ] Lighthouse `meta-viewport` audit passes on the docs sites

Stacked on #1085 (3 of 4).
