### PR TITLE
feat(seo): canonicals, per-page metadata, and OG url/type/site_name

### DIFF
--- a/apps/diffshub/app/layout.tsx
+++ b/apps/diffshub/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata, Viewport } from 'next';
 
 import './globals.css';
-import { SITE_DESCRIPTION, SITE_NAME } from '@/lib/site';
+import { SITE_DESCRIPTION, SITE_NAME, SITE_ORIGIN } from '@/lib/site';
 
 export const viewport: Viewport = {
   width: 'device-width',
@@ -47,12 +47,8 @@ function worktreeTitlePrefix(): string {
 
 const WORKTREE_PREFIX = worktreeTitlePrefix();
 
-const PROD_ORIGIN = 'https://diffshub.com';
-// In dev, point `metadataBase` at localhost so OG previewers fetch
-// in-progress assets instead of whatever's deployed.
-const isDev = process.env.NODE_ENV !== 'production';
-const DEV_PORT = process.env.PORT ?? '3692';
-const SITE_ORIGIN = isDev ? `http://localhost:${DEV_PORT}` : PROD_ORIGIN;
+// `SITE_ORIGIN` lives in `lib/site` so the metadata routes (`app/robots.ts`,
+// `app/sitemap.ts`) and the canonical URLs share one definition.
 const baseTitle = `${SITE_NAME}, from Pierre`;
 const taggedTitle = `${WORKTREE_PREFIX}${baseTitle}`;
 const description = SITE_DESCRIPTION;
@@ -81,6 +77,9 @@ export const metadata: Metadata = {
     },
     description,
     images: [SITE_OG_IMAGE],
+    siteName: SITE_NAME,
+    type: 'website',
+    url: `${SITE_ORIGIN}/`,
   },
   twitter: {
     card: 'summary_large_image',

--- a/apps/diffshub/app/page.tsx
+++ b/apps/diffshub/app/page.tsx
@@ -1,3 +1,22 @@
+import type { Metadata } from 'next';
+
+import { SITE_DESCRIPTION, SITE_NAME, SITE_ORIGIN } from '@/lib/site';
+
+// Declared here rather than in `app/layout.tsx` so only the home page claims `/`
+// as its canonical; a layout-level canonical would be inherited by every viewer
+// route that did not override it.
+export const metadata: Metadata = {
+  alternates: { canonical: `${SITE_ORIGIN}/` },
+  openGraph: {
+    title: `${SITE_NAME}, from Pierre`,
+    description: SITE_DESCRIPTION,
+    siteName: SITE_NAME,
+    type: 'website',
+    url: `${SITE_ORIGIN}/`,
+    images: ['/diffshub-brand/opengraph-image.png'],
+  },
+};
+
 // The diffshub home page. The implementation lives in `_home/HomePage.tsx` so it
 // keeps its sibling imports; this route file just re-exports it as the `/`
 // default.

--- a/apps/docs/app/(diffs)/_docs/DocsPage.tsx
+++ b/apps/docs/app/(diffs)/_docs/DocsPage.tsx
@@ -163,29 +163,17 @@ import { HeadingAnchors } from '@/components/docs/HeadingAnchors';
 import { ProseWrapper } from '@/components/docs/ProseWrapper';
 import Footer from '@/components/Footer';
 import { renderMDX } from '@/lib/mdx';
+import { pageMetadata } from '@/lib/page-metadata';
 
 const docsTitle = 'Diffs docs';
 const docsDescription =
   'Documentation for @pierre/diffs: React and vanilla APIs, virtualization, theming, token hooks, the worker pool, and SSR hydration.';
 
-// Next.js replaces (does not deep-merge) nested metadata objects like
-// `openGraph` and `twitter` from parent segments. Re-declare `images` here
-// so the diffs OG/Twitter cards from `app/layout.tsx` survive on `/docs`.
-export const metadata: Metadata = {
+export const metadata: Metadata = pageMetadata({
   title: docsTitle,
   description: docsDescription,
-  openGraph: {
-    title: docsTitle,
-    description: docsDescription,
-    images: ['/diffs-brand/opengraph-image.png'],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: docsTitle,
-    description: docsDescription,
-    images: ['/diffs-brand/twitter-image.png'],
-  },
-};
+  path: '/docs',
+});
 
 export default function DocsPage() {
   return (

--- a/apps/docs/app/(diffs)/edit/live/page.tsx
+++ b/apps/docs/app/(diffs)/edit/live/page.tsx
@@ -3,17 +3,17 @@ import type { Metadata } from 'next';
 import { WorkerPoolContext } from '../../_components/WorkerPoolContext';
 import { AgentUi } from '../../_home/AgentUi';
 import { preloadAuiPrerenderedDiffs } from '../../_home/preloadAuiDiffs';
+import { pageMetadata } from '@/lib/page-metadata';
 
 const title = 'Live editor — Pierre Diffs';
 const description =
   'A fullscreen, in-browser agent editing session: review and edit changed files with @pierre/diffs and navigate the change tree on the left, powered by @pierre/trees.';
 
-export const metadata: Metadata = {
+export const metadata: Metadata = pageMetadata({
   title,
   description,
-  openGraph: { title, description },
-  twitter: { card: 'summary_large_image', title, description },
-};
+  path: '/edit/live',
+});
 
 // The standalone fullscreen counterpart to the homepage's windowed agent demo.
 // Renders nothing but the AgentUi filling the viewport (no header/footer), so

--- a/apps/docs/app/(diffs)/edit/page.tsx
+++ b/apps/docs/app/(diffs)/edit/page.tsx
@@ -13,24 +13,17 @@ import {
   LIVE_EDITING_FILE_DIFF_EXAMPLE,
   LIVE_EDITING_FILE_EXAMPLE,
 } from '../_examples/LiveEditing/constants';
+import { pageMetadata } from '@/lib/page-metadata';
 
 const editTitle = 'Pierre Diffs — now with edit';
 const editDescription =
   'A lightweight, SSR, mobile-friendly editable file and diff layer for @pierre/diffs. Edit files and diffs in place with selection management, multiple cursors, undo history, find/replace, and lint markers.';
 
-export const metadata: Metadata = {
+export const metadata: Metadata = pageMetadata({
   title: editTitle,
   description: editDescription,
-  openGraph: {
-    title: editTitle,
-    description: editDescription,
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: editTitle,
-    description: editDescription,
-  },
-};
+  path: '/edit',
+});
 
 // Server-renders every edit demo so they all paint highlighted on first load
 // and hydrate cleanly (no flash): the "Live editing" File surface, and the

--- a/apps/docs/app/(diffs)/playground/page.tsx
+++ b/apps/docs/app/(diffs)/playground/page.tsx
@@ -7,6 +7,17 @@ import { PlaygroundClient } from './PlaygroundClient';
 import { parsePlaygroundSearchParams } from './searchParams';
 import Footer from '@/components/Footer';
 import { Header } from '@/components/Header';
+import { pageMetadata } from '@/lib/page-metadata';
+
+// The canonical here matters more than on a static page: every playground
+// control writes to the querystring, so without it each option combination
+// would be a separate indexable near-duplicate of this page.
+export const metadata = pageMetadata({
+  title: 'Playground — Pierre Diffs',
+  description:
+    'Try @pierre/diffs in the browser: switch between split and unified layouts, change themes and fonts, toggle virtualization and line wrapping, and see the result instantly.',
+  path: '/playground',
+});
 
 type PlaygroundSearchParams = Record<string, string | string[] | undefined>;
 

--- a/apps/docs/app/(diffs)/ssr/page.tsx
+++ b/apps/docs/app/(diffs)/ssr/page.tsx
@@ -3,6 +3,14 @@ import { preloadMultiFileDiff } from '@pierre/diffs/ssr';
 
 import type { AnnotationMetadata } from './ssr_types';
 import { SSRPage } from './SSRPage';
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const metadata = pageMetadata({
+  title: 'SSR demos — Pierre Diffs',
+  description:
+    'Server-rendered @pierre/diffs examples that paint fully syntax-highlighted before any JavaScript runs, then hydrate without a flash.',
+  path: '/ssr',
+});
 
 const OLD_FILE: FileContents = {
   name: 'main.zig',

--- a/apps/docs/app/(diffs)/theme/gallery/page.tsx
+++ b/apps/docs/app/(diffs)/theme/gallery/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next';
 import { Suspense } from 'react';
 
 import { ThemesGridClient } from './ThemesGridClient';
+import { pageMetadata } from '@/lib/page-metadata';
 
 const SAMPLE_OLD_FILE = {
   name: 'config.ts',
@@ -166,26 +167,16 @@ const THEMES = [
   'min-dark',
 ] as const;
 
-const themeTitle =
-  'Pierre Themes — Themes for Visual Studio Code, Cursor, Zed, and Shiki.';
-const themeDescription =
-  'Beautiful light and dark themes, generated from a shared color palette, for Visual Studio Code, Cursor, Zed, and Shiki.';
+const galleryTitle = 'Theme gallery — Pierre Themes';
+const galleryDescription =
+  'Browse every Pierre theme side by side, each rendered on a real syntax-highlighted diff in both light and dark mode.';
 
-export const metadata: Metadata = {
-  title: themeTitle,
-  description: themeDescription,
-  openGraph: {
-    title: themeTitle,
-    description: themeDescription,
-    images: ['/theme/opengraph-image.png'],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: themeTitle,
-    description: themeDescription,
-    images: ['/theme/opengraph-image.png'],
-  },
-};
+export const metadata: Metadata = pageMetadata({
+  title: galleryTitle,
+  description: galleryDescription,
+  path: '/theme/gallery',
+  image: '/theme/opengraph-image.png',
+});
 
 export default async function ThemeGalleryPage() {
   const resolvedThemes = await Promise.all(

--- a/apps/docs/app/(diffs)/theme/page.tsx
+++ b/apps/docs/app/(diffs)/theme/page.tsx
@@ -28,27 +28,20 @@ import Footer from '@/components/Footer';
 import { PierreCompanySection } from '@/components/PierreCompanySection';
 import { Button } from '@/components/ui/button';
 import { renderMDX } from '@/lib/mdx';
+import { pageMetadata } from '@/lib/page-metadata';
 
-const themeTitle =
-  'Pierre Themes — Themes for Visual Studio Code, Cursor, Zed, and Shiki.';
+// Kept under ~60 characters so it survives SERP truncation; the full editor
+// list still appears in the description below.
+const themeTitle = 'Pierre Themes for VS Code, Cursor, Zed, and Shiki';
 const themeDescription =
   'Beautiful light and dark themes, generated from a shared color palette, for Visual Studio Code, Cursor, Zed, and Shiki.';
 
-export const metadata: Metadata = {
+export const metadata: Metadata = pageMetadata({
   title: themeTitle,
   description: themeDescription,
-  openGraph: {
-    title: themeTitle,
-    description: themeDescription,
-    images: ['/theme/opengraph-image.png'],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: themeTitle,
-    description: themeDescription,
-    images: ['/theme/opengraph-image.png'],
-  },
-};
+  path: '/theme',
+  image: '/theme/opengraph-image.png',
+});
 
 export default async function ThemePage() {
   const [

--- a/apps/docs/app/(trees)/_docs/DocsPage.tsx
+++ b/apps/docs/app/(trees)/_docs/DocsPage.tsx
@@ -33,6 +33,7 @@ import { HeadingAnchors } from '@/components/docs/HeadingAnchors';
 import { ProseWrapper } from '@/components/docs/ProseWrapper';
 import Footer from '@/components/Footer';
 import { renderMDX, renderMDXWithPreloadedFiles } from '@/lib/mdx';
+import { pageMetadata } from '@/lib/page-metadata';
 
 interface DocsSection {
   filePath: string;
@@ -108,28 +109,15 @@ const REFERENCE_SECTIONS: readonly DocsSection[] = [
   { filePath: '(trees)/docs/Reference/Icons/content.mdx' },
 ];
 
-const treesDocsTitle = 'Trees, from Pierre';
+const treesDocsTitle = 'Trees docs';
 const treesDocsDescription =
   'Guide-first documentation for @pierre/trees, covering React, vanilla, prepared input, styling, icons, Git status, large trees, and SSR hydration.';
 
-// Next.js replaces (does not deep-merge) nested metadata objects like
-// `openGraph` and `twitter` from parent segments. Re-declare `images` here
-// so the trees OG/Twitter cards from `app/layout.tsx` survive on `/docs`.
-export const metadata: Metadata = {
+export const metadata: Metadata = pageMetadata({
   title: treesDocsTitle,
   description: treesDocsDescription,
-  openGraph: {
-    title: treesDocsTitle,
-    description: treesDocsDescription,
-    images: ['/trees-brand/opengraph-image.png'],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: treesDocsTitle,
-    description: treesDocsDescription,
-    images: ['/trees-brand/twitter-image.png'],
-  },
-};
+  path: '/docs',
+});
 
 export default function TreesDocsPage() {
   return (

--- a/apps/docs/app/(trees)/trees-dev/density/page.tsx
+++ b/apps/docs/app/(trees)/trees-dev/density/page.tsx
@@ -13,6 +13,14 @@ import {
   EXPLICIT_ITEM_HEIGHT,
   type SerializedDensityPayload,
 } from '../_demos/DensityDemoData';
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const metadata = pageMetadata({
+  title: 'Density demo — Pierre Trees',
+  description:
+    'The compact, default, and relaxed density presets in @pierre/trees side by side, plus custom numeric spacing and an explicit item height.',
+  path: '/trees-dev/density',
+});
 
 const KEYWORD_PRESETS = ['compact', 'default', 'relaxed'] as const;
 

--- a/apps/docs/app/(trees)/trees-dev/drag-and-drop/page.tsx
+++ b/apps/docs/app/(trees)/trees-dev/drag-and-drop/page.tsx
@@ -7,6 +7,14 @@ import type { FileTreePathOptions } from '@trees/_lib/fileTreePathOptions';
 import { readSettingsCookies } from '../_components/readSettingsCookies';
 import { DragAndDropDemoClient } from '../_demos/DragAndDropDemoClient';
 import { createPresortedPreparedInput } from '../_lib/createPresortedPreparedInput';
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const metadata = pageMetadata({
+  title: 'Drag and drop demo — Pierre Trees',
+  description:
+    'Pointer and touch drag-and-drop in @pierre/trees, moving files and folders within a virtualized tree with live drop-target feedback.',
+  path: '/trees-dev/drag-and-drop',
+});
 
 const DRAG_AND_DROP_DEMO_PATHS = [
   'assets/images/social/banner.png',

--- a/apps/docs/app/(trees)/trees-dev/git-status/page.tsx
+++ b/apps/docs/app/(trees)/trees-dev/git-status/page.tsx
@@ -13,6 +13,14 @@ import {
   ITEM_CUSTOMIZATION_DEMO_WORKLOAD_NAME,
 } from '../_lib/itemCustomizationDemoData';
 import { loadWorkloadDataPayload } from '../_lib/workloadLoader';
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const metadata = pageMetadata({
+  title: 'Git status demo — Pierre Trees',
+  description:
+    'Git status decoration in @pierre/trees: modified, added, deleted, renamed, untracked, and ignored badges, with change state rolled up onto parent folders.',
+  path: '/trees-dev/git-status',
+});
 
 const GIT_STATUS_VIEWPORT_HEIGHT = 280;
 

--- a/apps/docs/app/(trees)/trees-dev/item-customization/page.tsx
+++ b/apps/docs/app/(trees)/trees-dev/item-customization/page.tsx
@@ -15,6 +15,14 @@ import {
   ITEM_CUSTOMIZATION_DEMO_WORKLOAD_NAME,
 } from '../_lib/itemCustomizationDemoData';
 import { loadWorkloadDataPayload } from '../_lib/workloadLoader';
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const metadata = pageMetadata({
+  title: 'Item customization demo — Pierre Trees',
+  description:
+    'Customize individual rows in @pierre/trees with icon sets, per-row decorations, context menu trigger modes, and button visibility rules.',
+  path: '/trees-dev/item-customization',
+});
 
 const ITEM_CUSTOMIZATION_VIEWPORT_HEIGHT = 360;
 

--- a/apps/docs/app/(trees)/trees-dev/page.tsx
+++ b/apps/docs/app/(trees)/trees-dev/page.tsx
@@ -17,6 +17,16 @@ import {
   TREES_WORKLOAD_OPTIONS,
   type TreesPageSearchParams,
 } from './_lib/workloadMeta';
+import { pageMetadata } from '@/lib/page-metadata';
+
+// The workload and expansion-mode controls write to the querystring, so the
+// canonical keeps every workload permutation pointing at this one URL.
+export const metadata = pageMetadata({
+  title: 'Main demo — Pierre Trees',
+  description:
+    'Run @pierre/trees against real workloads up to 1.6 million paths: search, inline rename, drag and drop, context menus, and direct mutation on a single hydrated tree.',
+  path: '/trees-dev',
+});
 
 const TREE_HEADER_HTML =
   '<div data-tree-demo-header style="align-items:center;display:flex;gap:12px;padding:8px 12px"><strong>Trees demo header</strong><button type="button">Log header action</button></div>';

--- a/apps/docs/app/(trees)/trees-dev/react/page.tsx
+++ b/apps/docs/app/(trees)/trees-dev/react/page.tsx
@@ -2,6 +2,14 @@ import { preloadFileTree } from '@pierre/trees/ssr';
 
 import { readSettingsCookies } from '../_components/readSettingsCookies';
 import { ReactDemoClient } from '../_demos/ReactDemoClient';
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const metadata = pageMetadata({
+  title: 'React API demo — Pierre Trees',
+  description:
+    'The @pierre/trees React component rendering a server-prepared file tree, hydrating from SSR markup with search enabled and no flash of unstyled rows.',
+  path: '/trees-dev/react',
+});
 
 const DEMO_PATHS = [
   'README.md',

--- a/apps/docs/app/(trees)/trees-dev/responsiveness/page.tsx
+++ b/apps/docs/app/(trees)/trees-dev/responsiveness/page.tsx
@@ -1,4 +1,12 @@
 import { ResponsivenessDemoClient } from '../_demos/ResponsivenessDemoClient';
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const metadata = pageMetadata({
+  title: 'Responsiveness demo — Pierre Trees',
+  description:
+    'How @pierre/trees keeps scrolling, keyboard navigation, and search interactive while the tree is being mutated underneath.',
+  path: '/trees-dev/responsiveness',
+});
 
 export default function TreesDevResponsivenessPage() {
   return <ResponsivenessDemoClient />;

--- a/apps/docs/app/(trees)/trees-dev/search/page.tsx
+++ b/apps/docs/app/(trees)/trees-dev/search/page.tsx
@@ -7,6 +7,14 @@ import type { FileTreePathOptions } from '@trees/_lib/fileTreePathOptions';
 import { readSettingsCookies } from '../_components/readSettingsCookies';
 import { SearchDemoClient } from '../_demos/SearchDemoClient';
 import { sharedDemoPaths, sharedInitialExpandedPaths } from '../demo-data';
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const metadata = pageMetadata({
+  title: 'Search modes demo — Pierre Trees',
+  description:
+    'Compare the @pierre/trees search modes: expand-matches, collapse-non-matches, and hide-non-matches, each running on the same tree.',
+  path: '/trees-dev/search',
+});
 
 function getPayload(options: Omit<FileTreePathOptions, 'id'>, id: string) {
   return preloadFileTree({

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -19,6 +19,7 @@ import { ScrollbarGutterVariables } from '@/components/ScrollbarGutterVariables'
 import { ThemeProvider } from '@/components/theme-provider';
 import { Toaster } from '@/components/ui/sonner';
 import { type ProductId, PRODUCTS } from '@/lib/product-config';
+import { SITE, SITE_ORIGIN } from '@/lib/site-origin';
 
 const inter = Inter({
   variable: '--font-inter',
@@ -98,22 +99,9 @@ const WORKTREE_PREFIX = worktreeTitlePrefix();
 
 // Per-site branding (icons, OG/twitter) is set here explicitly so the
 // dispatcher route at `app/page.tsx` (outside the route groups) inherits it.
-const SITE = (process.env.NEXT_PUBLIC_SITE ?? 'diffs') as ProductId;
+// `SITE` and `SITE_ORIGIN` live in `lib/site-origin` so the metadata routes
+// (`app/robots.ts`, `app/sitemap.ts`) and canonical URLs share one definition.
 const SITE_PRODUCT = PRODUCTS[SITE];
-const PROD_ORIGIN_BY_SITE: Record<ProductId, string> = {
-  diffs: 'https://diffs.com',
-  trees: 'https://trees.software',
-};
-const DEV_PORT_BY_SITE: Record<ProductId, string> = {
-  diffs: '3690',
-  trees: '3691',
-};
-const PROD_ORIGIN = PROD_ORIGIN_BY_SITE[SITE];
-// In dev, point `metadataBase` at localhost so OG previewers fetch
-// in-progress assets instead of whatever's deployed.
-const isDev = process.env.NODE_ENV !== 'production';
-const DEV_PORT = process.env.PORT ?? DEV_PORT_BY_SITE[SITE];
-const SITE_ORIGIN = isDev ? `http://localhost:${DEV_PORT}` : PROD_ORIGIN;
 const baseTitle = `${SITE_PRODUCT.name}, from Pierre`;
 const taggedTitle = `${WORKTREE_PREFIX}${baseTitle}`;
 const description = SITE_PRODUCT.description;
@@ -198,6 +186,9 @@ export const metadata: Metadata = {
     },
     description,
     images: [SITE_OG_IMAGE],
+    siteName: SITE_PRODUCT.name,
+    type: 'website',
+    url: `${SITE_ORIGIN}/`,
   },
   twitter: {
     card: 'summary_large_image',

--- a/apps/docs/app/page.tsx
+++ b/apps/docs/app/page.tsx
@@ -3,13 +3,22 @@ import DiffsHome from './(diffs)/_home/Home';
 // own product's home page at `/`. All modules are imported statically so
 // webpack can dead-code-eliminate the inactive branch when
 // `process.env.NEXT_PUBLIC_SITE` is statically replaced at build.
-//
-// Page-level metadata is intentionally not re-exported here: the per-site
-// title, description, icons, and OG/twitter images come from
-// `app/layout.tsx`, which already reads `NEXT_PUBLIC_SITE`.
 import TreesHome from './(trees)/_home/Home';
+import { pageMetadata } from '@/lib/page-metadata';
+import { PRODUCTS } from '@/lib/product-config';
+import { SITE } from '@/lib/site-origin';
 
-const SITE = process.env.NEXT_PUBLIC_SITE;
+const SITE_PRODUCT = PRODUCTS[SITE];
+
+// The title and description repeat `app/layout.tsx`'s per-site defaults on
+// purpose: this export exists so `/` gets a canonical and `og:url` of its own.
+// Declaring those in the root layout instead would make every child route that
+// forgot to override them claim `/` as its canonical.
+export const metadata = pageMetadata({
+  title: `${SITE_PRODUCT.name}, from Pierre`,
+  description: SITE_PRODUCT.description,
+  path: '/',
+});
 
 const Page = SITE === 'trees' ? TreesHome : DiffsHome;
 export default Page;

--- a/apps/docs/lib/page-metadata.ts
+++ b/apps/docs/lib/page-metadata.ts
@@ -1,0 +1,66 @@
+import type { Metadata } from 'next';
+
+import { type ProductId, PRODUCTS } from './product-config';
+import { SITE, SITE_ORIGIN } from './site-origin';
+
+const OG_IMAGE_BY_SITE: Record<ProductId, string> = {
+  diffs: '/diffs-brand/opengraph-image.png',
+  trees: '/trees-brand/opengraph-image.png',
+};
+
+const TWITTER_IMAGE_BY_SITE: Record<ProductId, string> = {
+  diffs: '/diffs-brand/twitter-image.png',
+  trees: '/trees-brand/twitter-image.png',
+};
+
+export interface PageMetadataOptions {
+  /** Page title, slotted into the `%s` template from `app/layout.tsx`. */
+  title: string;
+  description: string;
+  /** Route this page is served from (e.g. `/docs`), used for the canonical. */
+  path: string;
+  /** Overrides the per-site card art for routes that ship their own image. */
+  image?: string;
+}
+
+/**
+ * Build a page's Metadata with the fields search engines and social cards need:
+ * a self-referencing canonical (so query-string variants such as
+ * `/playground?theme=…` collapse onto one indexable URL), `og:url`,
+ * `og:site_name`, `og:type`, and the correct per-site card images.
+ *
+ * This exists because Next.js REPLACES nested metadata objects like `openGraph`
+ * and `twitter` from parent segments instead of deep-merging them, so every
+ * page that overrides a title has to restate its entire card. Hand-writing that
+ * per page is how routes ended up sharing one title and shipping no canonical.
+ */
+export function pageMetadata({
+  title,
+  description,
+  path,
+  image,
+}: PageMetadataOptions): Metadata {
+  const canonical = new URL(path, SITE_ORIGIN).href;
+  const ogImage = image ?? OG_IMAGE_BY_SITE[SITE];
+  const twitterImage = image ?? TWITTER_IMAGE_BY_SITE[SITE];
+
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      title,
+      description,
+      images: [ogImage],
+      siteName: PRODUCTS[SITE].name,
+      type: 'website',
+      url: canonical,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [twitterImage],
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- **Canonicals (H1):** every route was missing `rel="canonical"`. Adds a self-referencing canonical to all docs routes and the diffshub home. Canonicals are declared **per page**, not in the layout, so query-string variants (e.g. `/playground?theme=…`) collapse onto one indexable URL without child routes inheriting the wrong canonical.
- **Per-page metadata (H2/M4/M5):** fixes the trees title collision (all 10 routes shipped the identical `"Trees, from Pierre"`), gives every route its own title/description, and trims the 70-char `/theme` title to ~49 chars.
- **OG fields (M2):** adds `og:url`, `og:type`, and `og:site_name` site-wide.
- New `apps/docs/lib/page-metadata.ts` centralizes this because Next.js *replaces* nested `openGraph`/`twitter` objects from parent segments instead of deep-merging, so each page must restate its full card.

Excludes JSON-LD structured data and demo/pipes noindex by design (kept for separate follow-ups).

## Test plan
- [ ] Every route emits a self-referencing `<link rel="canonical">`
- [ ] No two routes on any site share a `<title>`
- [ ] `og:url` / `og:type` / `og:site_name` present site-wide
- [ ] `moonx docs:typecheck` (passing) and `moonx diffshub:typecheck`

Stacked on #1086 (4 of 4).
