### PR TITLE
[diffs] Improve Invalid Diff Parsing

### DIFF
--- a/packages/diffs/src/utils/parsePatchFiles.ts
+++ b/packages/diffs/src/utils/parsePatchFiles.ts
@@ -345,14 +345,14 @@ function _processFile(
         parsedDeletionLines >= hunkData.deletionCount &&
         !rawLine.startsWith('\\')
       ) {
-        if (
-          throwOnError &&
-          isHunkBodyLine(rawLine) &&
-          !isFormatPatchVersionSeparator(rawLine)
-        ) {
+        const isUnexpectedBodyLine =
+          isHunkBodyLine(rawLine) && !isFormatPatchVersionSeparator(rawLine);
+        if (!isUnexpectedBodyLine) {
+          break;
+        }
+        if (throwOnError) {
           throw Error('parsePatchContent: hunk has more lines than expected');
         }
-        break;
       }
 
       const firstChar = rawLine[0];
@@ -491,20 +491,36 @@ function _processFile(
       console.error(
         `parsePatchContent: hunk line count mismatch: "${firstLine.trimEnd()}", declared old/new ${hunkData.deletionCount}/${hunkData.additionCount}, parsed old/new ${parsedDeletionLines}/${parsedAdditionLines}`
       );
-      // Zero-count ranges use their start as the boundary instead of start - 1.
-      // Preserve the header's original boundary when a repaired side becomes empty.
-      if (hunkData.additionCount > 0 && parsedAdditionLines === 0) {
-        hunkData.additionStart = getHunkSideStartBoundary(
+      // Re-encode each original boundary using the repaired count. Zero-count
+      // ranges use the boundary itself as their start; positive ranges use +1.
+      const repairedAdditionStart =
+        getHunkSideStartBoundary(
           hunkData.additionStart,
           hunkData.additionCount
-        );
-      }
-      if (hunkData.deletionCount > 0 && parsedDeletionLines === 0) {
-        hunkData.deletionStart = getHunkSideStartBoundary(
+        ) + (parsedAdditionLines === 0 ? 0 : 1);
+      const repairedDeletionStart =
+        getHunkSideStartBoundary(
           hunkData.deletionStart,
           hunkData.deletionCount
-        );
+        ) + (parsedDeletionLines === 0 ? 0 : 1);
+
+      // Hydrated hunks index into full-file line arrays, so their indexes must
+      // move with repaired starts. Partial hunks index patch-built arrays.
+      if (!isPartial) {
+        const additionStartDelta =
+          repairedAdditionStart - hunkData.additionStart;
+        const deletionStartDelta =
+          repairedDeletionStart - hunkData.deletionStart;
+        hunkData.additionLineIndex += additionStartDelta;
+        hunkData.deletionLineIndex += deletionStartDelta;
+        for (const content of hunkData.hunkContent) {
+          content.additionLineIndex += additionStartDelta;
+          content.deletionLineIndex += deletionStartDelta;
+        }
       }
+
+      hunkData.additionStart = repairedAdditionStart;
+      hunkData.deletionStart = repairedDeletionStart;
       hunkData.additionCount = parsedAdditionLines;
       hunkData.deletionCount = parsedDeletionLines;
     }

--- a/packages/diffs/src/utils/parsePatchFiles.ts
+++ b/packages/diffs/src/utils/parsePatchFiles.ts
@@ -482,11 +482,18 @@ function _processFile(
     }
 
     if (
-      throwOnError &&
-      (parsedAdditionLines !== hunkData.additionCount ||
-        parsedDeletionLines !== hunkData.deletionCount)
+      parsedAdditionLines !== hunkData.additionCount ||
+      parsedDeletionLines !== hunkData.deletionCount
     ) {
-      throw Error('parsePatchContent: hunk line count mismatch');
+      if (throwOnError) {
+        throw Error('parsePatchContent: hunk line count mismatch');
+      }
+      console.error(
+        `parsePatchContent: hunk line count mismatch: "${firstLine.trimEnd()}", declared old/new ${hunkData.deletionCount}/${hunkData.additionCount}, parsed old/new ${parsedDeletionLines}/${parsedAdditionLines}`
+      );
+      // We correct the count values in non-strict mode
+      hunkData.additionCount = parsedAdditionLines;
+      hunkData.deletionCount = parsedDeletionLines;
     }
 
     hunkData.additionLines = additionLines;

--- a/packages/diffs/src/utils/parsePatchFiles.ts
+++ b/packages/diffs/src/utils/parsePatchFiles.ts
@@ -610,6 +610,9 @@ function _processFile(
  * @param cacheKeyPrefix - Optional prefix for generating cache keys. When provided,
  *   each file in the patch will get a cache key in the format `prefix-patchIndex-fileIndex`.
  *   This enables caching of rendered diff results in the worker pool.
+ * @param throwOnError - When true, invalid data throws. When false, invalid data
+ *   is reported with `console.error` and the parser attempts to recover when
+ *   possible. Recovery is best-effort and does not guarantee valid output.
  */
 export function parsePatchFiles(
   data: string,

--- a/packages/diffs/src/utils/parsePatchFiles.ts
+++ b/packages/diffs/src/utils/parsePatchFiles.ts
@@ -491,7 +491,20 @@ function _processFile(
       console.error(
         `parsePatchContent: hunk line count mismatch: "${firstLine.trimEnd()}", declared old/new ${hunkData.deletionCount}/${hunkData.additionCount}, parsed old/new ${parsedDeletionLines}/${parsedAdditionLines}`
       );
-      // We correct the count values in non-strict mode
+      // Zero-count ranges use their start as the boundary instead of start - 1.
+      // Preserve the header's original boundary when a repaired side becomes empty.
+      if (hunkData.additionCount > 0 && parsedAdditionLines === 0) {
+        hunkData.additionStart = getHunkSideStartBoundary(
+          hunkData.additionStart,
+          hunkData.additionCount
+        );
+      }
+      if (hunkData.deletionCount > 0 && parsedDeletionLines === 0) {
+        hunkData.deletionStart = getHunkSideStartBoundary(
+          hunkData.deletionStart,
+          hunkData.deletionCount
+        );
+      }
       hunkData.additionCount = parsedAdditionLines;
       hunkData.deletionCount = parsedDeletionLines;
     }

--- a/packages/diffs/test/__snapshots__/parsePatchFiles.test.ts.snap
+++ b/packages/diffs/test/__snapshots__/parsePatchFiles.test.ts.snap
@@ -2002,7 +2002,7 @@ exports[`parsePatchFiles should warn on malformed patch with bare newline in hun
             "additionLines": 0,
             "additionStart": 0,
             "collapsedBefore": 0,
-            "deletionCount": 87,
+            "deletionCount": 86,
             "deletionLineIndex": 0,
             "deletionLines": 86,
             "deletionStart": 1,

--- a/packages/diffs/test/parsePatchFiles.test.ts
+++ b/packages/diffs/test/parsePatchFiles.test.ts
@@ -2,6 +2,7 @@ import { afterAll, describe, expect, spyOn, test } from 'bun:test';
 
 import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
 import { DiffHunksRenderer } from '../src/renderers/DiffHunksRenderer';
+import { getTotalLineCountFromHunks } from '../src/utils/getTotalLineCountFromHunks';
 import { parsePatchFiles, processFile } from '../src/utils/parsePatchFiles';
 import {
   diffPatch,
@@ -20,6 +21,23 @@ import {
 afterAll(async () => {
   await disposeHighlighter();
 });
+
+const issue1094Patch = [
+  '--- f\n',
+  '+++ f\n',
+  '@@ -1,6 +1,6 @@\n',
+  '-a\n',
+  '+A\n',
+  ' c0\n',
+  ' c1\n',
+  '-b\n',
+  '+B\n',
+].join('');
+
+const validIssue1094Patch = issue1094Patch.replace(
+  '@@ -1,6 +1,6 @@',
+  '@@ -1,4 +1,4 @@'
+);
 
 describe('parsePatchFiles', () => {
   const result = parsePatchFiles(diffPatch);
@@ -52,10 +70,11 @@ describe('parsePatchFiles', () => {
       expect(consoleError).toHaveBeenCalled();
       expect(consoleError.mock.calls[0][0]).toContain('Invalid firstChar');
 
-      // The hunk counts should be off by 1 due to the missing line
+      // The declared count should be repaired to match the usable hunk body.
       const hunk = result[0].files[0].hunks[0];
-      expect(hunk.deletionCount).toBe(87);
+      expect(hunk.deletionCount).toBe(86);
       expect(hunk.deletionLines).toBe(86);
+      expect(verifyPatchHunkValues(result).errors).toEqual([]);
       expect(result).toMatchSnapshot('malformed patch');
     } finally {
       consoleError.mockRestore();
@@ -81,6 +100,61 @@ describe('parsePatchFiles', () => {
         true
       )
     ).toThrow('hunk line count mismatch');
+  });
+
+  test('repairs issue 1094 hunk counts in forgiving mode', () => {
+    const consoleError = spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const result = parsePatchFiles(issue1094Patch);
+      const file = result[0].files[0];
+      const hunk = file.hunks[0];
+
+      expect(consoleError).toHaveBeenCalledTimes(1);
+      expect(consoleError.mock.calls[0][0]).toContain(
+        'parsePatchContent: hunk line count mismatch'
+      );
+      expect(consoleError.mock.calls[0][0]).toContain('@@ -1,6 +1,6 @@');
+      expect(consoleError.mock.calls[0][0]).toContain('declared old/new 6/6');
+      expect(consoleError.mock.calls[0][0]).toContain('parsed old/new 4/4');
+      expect(hunk.additionCount).toBe(4);
+      expect(hunk.deletionCount).toBe(4);
+      expect(file.additionLines).toEqual(['A\n', 'c0\n', 'c1\n', 'B\n']);
+      expect(file.deletionLines).toEqual(['a\n', 'c0\n', 'c1\n', 'b\n']);
+      expect(hunk.hunkContent.map((content) => content.type)).toEqual([
+        'change',
+        'context',
+        'change',
+      ]);
+      expect(hunk.hunkSpecs).toBe('@@ -1,6 +1,6 @@\n');
+      expect(getTotalLineCountFromHunks(file.hunks)).toBe(4);
+      expect(verifyPatchHunkValues(result).errors).toEqual([]);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  test('throws for the issue 1094 patch in strict mode', () => {
+    expect(() => parsePatchFiles(issue1094Patch, undefined, true)).toThrow(
+      'hunk line count mismatch'
+    );
+  });
+
+  test('leaves the valid issue 1094 patch unchanged', () => {
+    const consoleError = spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const result = parsePatchFiles(validIssue1094Patch);
+      const file = result[0].files[0];
+      const hunk = file.hunks[0];
+
+      expect(consoleError).not.toHaveBeenCalled();
+      expect(hunk.additionCount).toBe(4);
+      expect(hunk.deletionCount).toBe(4);
+      expect(hunk.hunkSpecs).toBe('@@ -1,4 +1,4 @@\n');
+      expect(getTotalLineCountFromHunks(file.hunks)).toBe(4);
+      expect(verifyPatchHunkValues(result).errors).toEqual([]);
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   test('throws in strict mode when a hunk has extra content lines', () => {

--- a/packages/diffs/test/parsePatchFiles.test.ts
+++ b/packages/diffs/test/parsePatchFiles.test.ts
@@ -184,6 +184,56 @@ describe('parsePatchFiles', () => {
     }
   });
 
+  test('preserves the addition boundary when repair reaches zero', () => {
+    const consoleError = spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const result = parsePatchFiles(
+        [
+          '--- deleted-line.txt\n',
+          '+++ deleted-line.txt\n',
+          '@@ -5,1 +5,1 @@\n',
+          '-gone\n',
+        ].join('')
+      );
+      const hunk = result[0].files[0].hunks[0];
+
+      expect(consoleError).toHaveBeenCalledTimes(1);
+      expect(hunk.additionStart).toBe(4);
+      expect(hunk.additionCount).toBe(0);
+      expect(hunk.deletionStart).toBe(5);
+      expect(hunk.deletionCount).toBe(1);
+      expect(hunk.collapsedBefore).toBe(4);
+      expect(verifyPatchHunkValues(result).errors).toEqual([]);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  test('preserves the deletion boundary when repair reaches zero', () => {
+    const consoleError = spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const result = parsePatchFiles(
+        [
+          '--- added-line.txt\n',
+          '+++ added-line.txt\n',
+          '@@ -5,1 +5,1 @@\n',
+          '+added\n',
+        ].join('')
+      );
+      const hunk = result[0].files[0].hunks[0];
+
+      expect(consoleError).toHaveBeenCalledTimes(1);
+      expect(hunk.additionStart).toBe(5);
+      expect(hunk.additionCount).toBe(1);
+      expect(hunk.deletionStart).toBe(4);
+      expect(hunk.deletionCount).toBe(0);
+      expect(hunk.collapsedBefore).toBe(4);
+      expect(verifyPatchHunkValues(result).errors).toEqual([]);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   test('uses repaired counts for geometry after an underfilled hunk', () => {
     const consoleError = spyOn(console, 'error').mockImplementation(() => {});
     try {

--- a/packages/diffs/test/parsePatchFiles.test.ts
+++ b/packages/diffs/test/parsePatchFiles.test.ts
@@ -184,50 +184,162 @@ describe('parsePatchFiles', () => {
     }
   });
 
-  test('preserves the addition boundary when repair reaches zero', () => {
+  for (const {
+    name,
+    header,
+    body,
+    expectedAddition,
+    expectedDeletion,
+    expectedError,
+  } of [
+    {
+      name: 'addition count changing from positive to zero',
+      header: '@@ -5,1 +5,1 @@\n',
+      body: '-gone\n',
+      expectedAddition: { start: 4, count: 0 },
+      expectedDeletion: { start: 5, count: 1 },
+      expectedError: true,
+    },
+    {
+      name: 'deletion count changing from positive to zero',
+      header: '@@ -5,1 +5,1 @@\n',
+      body: '+added\n',
+      expectedAddition: { start: 5, count: 1 },
+      expectedDeletion: { start: 4, count: 0 },
+      expectedError: true,
+    },
+    {
+      name: 'addition count changing from zero to positive',
+      header: '@@ -5,1 +4,0 @@\n',
+      body: '-old\n+new\n',
+      expectedAddition: { start: 5, count: 1 },
+      expectedDeletion: { start: 5, count: 1 },
+      expectedError: true,
+    },
+    {
+      name: 'deletion count changing from zero to positive',
+      header: '@@ -4,0 +5,1 @@\n',
+      body: '-old\n+new\n',
+      expectedAddition: { start: 5, count: 1 },
+      expectedDeletion: { start: 5, count: 1 },
+      expectedError: true,
+    },
+    {
+      name: 'both sides crossing zero in opposite directions',
+      header: '@@ -5,1 +4,0 @@\n',
+      body: '+added\n',
+      expectedAddition: { start: 5, count: 1 },
+      expectedDeletion: { start: 4, count: 0 },
+      expectedError: true,
+    },
+    {
+      name: 'both zero counts growing from hunk content',
+      header: '@@ -4,0 +4,0 @@\n',
+      body: '-old\n+new\n',
+      expectedAddition: { start: 5, count: 1 },
+      expectedDeletion: { start: 5, count: 1 },
+      expectedError: true,
+    },
+    {
+      name: 'a positive count growing from extra hunk content',
+      header: '@@ -5,1 +5,1 @@\n',
+      body: '-old\n+new\n-extra old\n',
+      expectedAddition: { start: 5, count: 1 },
+      expectedDeletion: { start: 5, count: 2 },
+      expectedError: true,
+    },
+    {
+      name: 'a valid zero-count side remaining unchanged',
+      header: '@@ -4,0 +5,1 @@\n',
+      body: '+added\n',
+      expectedAddition: { start: 5, count: 1 },
+      expectedDeletion: { start: 4, count: 0 },
+      expectedError: false,
+    },
+  ]) {
+    test(`preserves boundaries for ${name}`, () => {
+      const consoleError = spyOn(console, 'error').mockImplementation(() => {});
+      try {
+        const result = parsePatchFiles(
+          ['--- boundary.txt\n', '+++ boundary.txt\n', header, body].join('')
+        );
+        const hunk = result[0].files[0].hunks[0];
+
+        expect(consoleError).toHaveBeenCalledTimes(expectedError ? 1 : 0);
+        expect({
+          start: hunk.additionStart,
+          count: hunk.additionCount,
+        }).toEqual(expectedAddition);
+        expect({
+          start: hunk.deletionStart,
+          count: hunk.deletionCount,
+        }).toEqual(expectedDeletion);
+        expect(hunk.collapsedBefore).toBe(4);
+        expect(verifyPatchHunkValues(result).errors).toEqual([]);
+      } finally {
+        consoleError.mockRestore();
+      }
+    });
+  }
+
+  test('shifts hydrated hunk and content indexes with a repaired start', () => {
     const consoleError = spyOn(console, 'error').mockImplementation(() => {});
     try {
-      const result = parsePatchFiles(
+      const file = processFile(
         [
-          '--- deleted-line.txt\n',
-          '+++ deleted-line.txt\n',
-          '@@ -5,1 +5,1 @@\n',
-          '-gone\n',
-        ].join('')
+          '--- hydrated.txt\n',
+          '+++ hydrated.txt\n',
+          '@@ -5,1 +4,0 @@\n',
+          '+new\n',
+          '-old\n',
+        ].join(''),
+        {
+          oldFile: {
+            name: 'hydrated.txt',
+            contents: 'a\nb\nc\nd\nold\nz\n',
+          },
+          newFile: {
+            name: 'hydrated.txt',
+            contents: 'a\nb\nc\nd\nnew\nz\n',
+          },
+        }
       );
-      const hunk = result[0].files[0].hunks[0];
+      assertDefined(file, 'file should be parsed');
+      const hunk = file.hunks[0];
+      const content = hunk.hunkContent[0];
 
       expect(consoleError).toHaveBeenCalledTimes(1);
-      expect(hunk.additionStart).toBe(4);
-      expect(hunk.additionCount).toBe(0);
-      expect(hunk.deletionStart).toBe(5);
-      expect(hunk.deletionCount).toBe(1);
-      expect(hunk.collapsedBefore).toBe(4);
-      expect(verifyPatchHunkValues(result).errors).toEqual([]);
+      expect(hunk.additionLineIndex).toBe(4);
+      expect(hunk.deletionLineIndex).toBe(4);
+      expect(content.additionLineIndex).toBe(4);
+      expect(content.deletionLineIndex).toBe(4);
     } finally {
       consoleError.mockRestore();
     }
   });
 
-  test('preserves the deletion boundary when repair reaches zero', () => {
+  test('chains later hunk geometry from a zero-to-positive repair', () => {
     const consoleError = spyOn(console, 'error').mockImplementation(() => {});
     try {
       const result = parsePatchFiles(
         [
-          '--- added-line.txt\n',
-          '+++ added-line.txt\n',
-          '@@ -5,1 +5,1 @@\n',
-          '+added\n',
+          '--- multiple-zero.txt\n',
+          '+++ multiple-zero.txt\n',
+          '@@ -5,1 +4,0 @@\n',
+          '+new\n',
+          '-old\n',
+          '@@ -8 +8 @@\n',
+          '-later old\n',
+          '+later new\n',
         ].join('')
       );
-      const hunk = result[0].files[0].hunks[0];
+      const file = result[0].files[0];
+      const [firstHunk, secondHunk] = file.hunks;
 
       expect(consoleError).toHaveBeenCalledTimes(1);
-      expect(hunk.additionStart).toBe(5);
-      expect(hunk.additionCount).toBe(1);
-      expect(hunk.deletionStart).toBe(4);
-      expect(hunk.deletionCount).toBe(0);
-      expect(hunk.collapsedBefore).toBe(4);
+      expect(firstHunk.additionStart).toBe(5);
+      expect(firstHunk.additionCount).toBe(1);
+      expect(secondHunk.collapsedBefore).toBe(2);
       expect(verifyPatchHunkValues(result).errors).toEqual([]);
     } finally {
       consoleError.mockRestore();

--- a/packages/diffs/test/parsePatchFiles.test.ts
+++ b/packages/diffs/test/parsePatchFiles.test.ts
@@ -157,6 +157,73 @@ describe('parsePatchFiles', () => {
     }
   });
 
+  test('repairs only the underfilled side of an asymmetric hunk', () => {
+    const consoleError = spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const result = parsePatchFiles(
+        [
+          '--- asymmetric.txt\n',
+          '+++ asymmetric.txt\n',
+          '@@ -1,3 +1,2 @@\n',
+          '-old\n',
+          '+new\n',
+          ' context\n',
+        ].join('')
+      );
+      const hunk = result[0].files[0].hunks[0];
+
+      expect(consoleError).toHaveBeenCalledTimes(1);
+      expect(consoleError.mock.calls[0][0]).toContain('@@ -1,3 +1,2 @@');
+      expect(consoleError.mock.calls[0][0]).toContain('declared old/new 3/2');
+      expect(consoleError.mock.calls[0][0]).toContain('parsed old/new 2/2');
+      expect(hunk.deletionCount).toBe(2);
+      expect(hunk.additionCount).toBe(2);
+      expect(verifyPatchHunkValues(result).errors).toEqual([]);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  test('uses repaired counts for geometry after an underfilled hunk', () => {
+    const consoleError = spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const result = parsePatchFiles(
+        [
+          '--- multiple.txt\n',
+          '+++ multiple.txt\n',
+          '@@ -1,4 +1,4 @@\n',
+          '-old\n',
+          '+new\n',
+          ' context\n',
+          '-tail\n',
+          '+TAIL\n',
+          '@@ -6 +6 @@\n',
+          '-later old\n',
+          '+later new\n',
+        ].join('')
+      );
+      const file = result[0].files[0];
+      const [firstHunk, secondHunk] = file.hunks;
+
+      expect(consoleError).toHaveBeenCalledTimes(1);
+      expect(consoleError.mock.calls[0][0]).toContain('@@ -1,4 +1,4 @@');
+      expect(consoleError.mock.calls[0][0]).toContain('declared old/new 4/4');
+      expect(consoleError.mock.calls[0][0]).toContain('parsed old/new 3/3');
+      expect(firstHunk.additionCount).toBe(3);
+      expect(firstHunk.deletionCount).toBe(3);
+      expect(secondHunk.additionCount).toBe(1);
+      expect(secondHunk.deletionCount).toBe(1);
+      expect(secondHunk.collapsedBefore).toBe(2);
+      expect(secondHunk.splitLineStart).toBe(5);
+      expect(secondHunk.unifiedLineStart).toBe(7);
+      expect(file.splitLineCount).toBe(6);
+      expect(file.unifiedLineCount).toBe(9);
+      expect(verifyPatchHunkValues(result).errors).toEqual([]);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   test('throws in strict mode when a hunk has extra content lines', () => {
     expect(() =>
       parsePatchFiles(


### PR DESCRIPTION
This is a series of improvements related to #1094

The actual fix will involve #1055 and its related stack to merge.

At a high level this PR improves the non-strict diff patch parsing to handle invalid line counts (it will make its best effort to correct them and at least show a console error.

The core issue in #1094 is actually related to the auto generated cache keys from file names