### PR TITLE
[diffshub] Fallback to shiki-js when shiki-wasm is unavailable

### DIFF
--- a/apps/diffshub/components/PreloadHighlighter.tsx
+++ b/apps/diffshub/components/PreloadHighlighter.tsx
@@ -2,6 +2,8 @@
 import { preloadHighlighter } from '@pierre/diffs';
 import { useEffect } from 'react';
 
+import { getPreferredHighlighter } from '@/lib/getPreferredHighlighter';
+
 export function PreloadHighlighter() {
   useEffect(() => {
     void preloadHighlighter({
@@ -12,7 +14,7 @@ export function PreloadHighlighter() {
         'pierre-light-soft',
       ],
       langs: ['zig', 'rust', 'typescript', 'tsx', 'bash'],
-      preferredHighlighter: 'shiki-wasm',
+      preferredHighlighter: getPreferredHighlighter(),
     });
   }, []);
   return null;

--- a/apps/diffshub/components/WorkerPoolContext.tsx
+++ b/apps/diffshub/components/WorkerPoolContext.tsx
@@ -8,6 +8,8 @@ import {
 } from '@pierre/diffs/react';
 import type { ReactNode } from 'react';
 
+import { getPreferredHighlighter } from '@/lib/getPreferredHighlighter';
+
 function isMobileBrowser(): boolean {
   const navigator = global.navigator;
   if (navigator == null) {
@@ -63,7 +65,7 @@ const HighlighterOptions: WorkerInitializationRenderOptions = {
     'typescript',
     'zig',
   ],
-  preferredHighlighter: 'shiki-wasm',
+  preferredHighlighter: getPreferredHighlighter(),
 };
 
 interface WorkerPoolProps {

--- a/apps/diffshub/lib/getPreferredHighlighter.ts
+++ b/apps/diffshub/lib/getPreferredHighlighter.ts
@@ -1,0 +1,8 @@
+import type { HighlighterTypes } from '@pierre/diffs';
+
+/**
+ * Fallback to the JS build of Shiki when WASM is not available
+ */
+export function getPreferredHighlighter(): HighlighterTypes {
+  return typeof WebAssembly === 'undefined' ? 'shiki-js' : 'shiki-wasm';
+}

--- a/apps/diffshub/lib/test/getPreferredHighlighter.test.ts
+++ b/apps/diffshub/lib/test/getPreferredHighlighter.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { getPreferredHighlighter } from '../getPreferredHighlighter';
+
+const originalWebAssembly = globalThis.WebAssembly;
+
+afterEach(() => {
+  globalThis.WebAssembly = originalWebAssembly;
+});
+
+describe('getPreferredHighlighter', () => {
+  test('prefers the wasm highlighter when WebAssembly is available', () => {
+    expect(getPreferredHighlighter()).toBe('shiki-wasm');
+  });
+
+  test('falls back to the JS highlighter when WebAssembly is missing', () => {
+    // Managed browsers can remove the global entirely on unapproved origins.
+    // @ts-expect-error -- simulating a browser without WebAssembly
+    delete globalThis.WebAssembly;
+    expect(getPreferredHighlighter()).toBe('shiki-js');
+  });
+});


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality). You must have
      first discussed with the dev team and they should be aware that this PR is
      being opened
- [ ] Breaking change (fix or feature that would change existing functionality).
      You must have first discussed with the dev team and they should be aware
      that this PR is being opened
- [ ] Documentation update

### Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/pierrecomputer/pierre/blob/main/.github/CONTRIBUTING.md)
- [ ] My code follows the code style of the project (`moon run root:lint`)
- [ ] My code is formatted properly (`moon run root:format`)
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have added tests to cover my changes (if applicable)
- [ ] All new and existing tests pass (`moonx diffs:test`)

### How was AI used in generating this PR

<!-- You must disclosed any and all use of AI in PRs to help us asses how to
review it -->

### Related issues

<!-- Please link any related issues here. -->
