### PR TITLE
Harden WorkerPool initialzation to better handle errors

### DIFF
--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -1152,8 +1152,14 @@ export class File<
           nextRenderRange
         );
         if (fileResult == null) {
-          if (this.workerManager?.isInitialized() === false) {
-            void this.workerManager.initialize().then(() => this.rerender());
+          if (
+            this.workerManager?.isInitialized() === false &&
+            this.workerManager.isWorkingPool()
+          ) {
+            void this.workerManager
+              .initialize()
+              .catch(() => {})
+              .then(() => this.rerender());
           }
           return false;
         }

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -1584,10 +1584,14 @@ export class FileDiff<
           nextRenderRange
         );
         if (hunksResult == null) {
-          // FIXME(amadeus): I don't think we actually need this check, as
-          // DiffHunksRenderer should probably take care of it for us?
-          if (this.workerManager?.isInitialized() === false) {
-            void this.workerManager.initialize().then(() => this.rerender());
+          if (
+            this.workerManager?.isInitialized() === false &&
+            this.workerManager.isWorkingPool()
+          ) {
+            void this.workerManager
+              .initialize()
+              .catch(() => {})
+              .then(() => this.rerender());
           }
           return false;
         }

--- a/packages/diffs/src/worker/WorkerPoolManager.ts
+++ b/packages/diffs/src/worker/WorkerPoolManager.ts
@@ -61,6 +61,7 @@ import type {
 } from './types';
 
 const IGNORE_RESPONSE = Symbol('IGNORE_RESPONSE');
+const DEFAULT_WORKER_INITIALIZATION_TIMEOUT = 10_000;
 
 class WorkerPoolTerminatedError extends Error {
   constructor() {
@@ -458,6 +459,11 @@ export class WorkerPoolManager {
             }
             this.initialized = false;
             this.workersFailed = true;
+            // A partial pool is not supported, so stop every worker before
+            // consumers rerender through the main-thread fallback.
+            this.cancelActiveWorkerTasks();
+            this.terminateWorkers();
+            this.activeTaskById.clear();
             for (const task of this.queuedTasks) {
               this.rejectRenderTaskCallbacks(task, normalizeWorkerError(e));
             }
@@ -501,7 +507,7 @@ export class WorkerPoolManager {
         }
       );
       worker.addEventListener('error', (error) =>
-        console.error('Worker error:', error, managedWorker)
+        this.handleWorkerError(managedWorker, error)
       );
       this.workers.push(managedWorker);
       initPromises.push(
@@ -528,12 +534,51 @@ export class WorkerPoolManager {
             reject,
             requestStart: Date.now(),
           };
+          managedWorker.pendingSetupRequestId = id;
           this.activeTaskById.set(id, task);
           this.executeTask(managedWorker, task);
         })
       );
     }
-    await Promise.all(initPromises);
+    const timeoutMs =
+      this.options.workerInitializationTimeout ??
+      DEFAULT_WORKER_INITIALIZATION_TIMEOUT;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        Promise.all(initPromises),
+        new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(() => {
+            reject(
+              new Error(
+                `WorkerPoolManager: worker initialization timed out after ${timeoutMs}ms`
+              )
+            );
+          }, timeoutMs);
+        }),
+      ]);
+    } finally {
+      if (timeoutId != null) {
+        clearTimeout(timeoutId);
+      }
+    }
+  }
+
+  private handleWorkerError(
+    managedWorker: ManagedWorker,
+    error: unknown
+  ): void {
+    console.error('Worker error:', error, managedWorker);
+    const { pendingSetupRequestId } = managedWorker;
+    if (pendingSetupRequestId == null) {
+      return;
+    }
+    const task = this.activeTaskById.get(pendingSetupRequestId);
+    if (task?.type !== 'initialize') {
+      return;
+    }
+    task.reject(normalizeWorkerError(error));
+    this.cleanWorkerAndTask(managedWorker, task);
   }
 
   private drainQueue = () => {
@@ -1506,5 +1551,16 @@ function getInstances(
 }
 
 function normalizeWorkerError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error));
+  if (error instanceof Error) {
+    return error;
+  }
+  if (error != null && typeof error === 'object') {
+    if ('error' in error && error.error instanceof Error) {
+      return error.error;
+    }
+    if ('message' in error && typeof error.message === 'string') {
+      return new Error(error.message);
+    }
+  }
+  return new Error(String(error));
 }

--- a/packages/diffs/src/worker/types.ts
+++ b/packages/diffs/src/worker/types.ts
@@ -158,6 +158,12 @@ export interface WorkerPoolOptions {
    */
   poolSize?: number;
 
+  /**
+   * Maximum time to wait for the worker pool to initialize, in milliseconds.
+   * @default 10000
+   */
+  workerInitializationTimeout?: number;
+
   totalASTLRUCacheSize?: number;
 }
 

--- a/packages/diffs/test/FileDiff.workerRendering.test.ts
+++ b/packages/diffs/test/FileDiff.workerRendering.test.ts
@@ -1,5 +1,6 @@
-import { afterAll, beforeAll, expect, test } from 'bun:test';
+import { afterAll, beforeAll, expect, spyOn, test } from 'bun:test';
 
+import { File } from '../src/components/File';
 import { FileDiff } from '../src/components/FileDiff';
 import {
   disposeHighlighter,
@@ -8,6 +9,7 @@ import {
 import type {
   DiffLineAnnotation,
   DiffsHighlighter,
+  FileContents,
   FileDiffMetadata,
   RenderDiffOptions,
   ThemedDiffResult,
@@ -15,7 +17,11 @@ import type {
 import { parseDiffFromFile } from '../src/utils/parseDiffFromFile';
 import { renderDiffWithHighlighter } from '../src/utils/renderDiffWithHighlighter';
 import { installDom, waitFor } from './domHarness';
-import { createInitializedManager, withTimeout } from './workerPoolHarness';
+import {
+  createInitializedManager,
+  createInitializingManager,
+  withTimeout,
+} from './workerPoolHarness';
 
 let sharedHighlighter: DiffsHighlighter;
 
@@ -45,6 +51,12 @@ class TestFileDiff extends FileDiff<string> {
   }
 }
 
+class TestFile extends File<string> {
+  getRenderedFileForTest(): FileContents | undefined {
+    return this.getRenderedFile();
+  }
+}
+
 function createDiff(cacheKey: string, contents: string): FileDiffMetadata {
   return parseDiffFromFile(
     {
@@ -68,6 +80,53 @@ function getAnnotationText(
     .querySelector<HTMLElement>(`[slot="${slot}"]`)
     ?.textContent?.trim();
 }
+
+test('standalone renderers fall back when worker initialization fails', async () => {
+  const dom = installDom();
+  const consoleError = spyOn(console, 'error').mockImplementation(() => {});
+  const { initialization, manager, worker } = createInitializingManager({
+    theme: 'pierre-dark',
+  });
+  const fileInstance = new TestFile(
+    { disableErrorHandling: true, disableFileHeader: true },
+    manager
+  );
+  const diffInstance = new TestFileDiff(
+    { disableErrorHandling: true, disableFileHeader: true },
+    manager
+  );
+  const fileContainer = document.createElement('div');
+  const diffContainer = document.createElement('div');
+  const file: FileContents = {
+    name: 'fallback.ts',
+    contents: 'const fallback = true;\n',
+    cacheKey: 'fallback:file',
+  };
+  const diff = createDiff('fallback:diff', 'const fallback = true;\n');
+
+  try {
+    fileInstance.render({ file, fileContainer });
+    diffInstance.render({ fileDiff: diff, fileContainer: diffContainer });
+    await worker.waitForInitializeRequest();
+
+    worker.emitError(new Error('worker failed to load'));
+    await initialization.catch(() => {});
+    await waitFor(
+      () =>
+        fileInstance.getRenderedFileForTest() === file &&
+        diffInstance.getRenderedDiffForTest() === diff
+    );
+
+    expect(fileInstance.getRenderedFileForTest()).toBe(file);
+    expect(diffInstance.getRenderedDiffForTest()).toBe(diff);
+  } finally {
+    fileInstance.cleanUp();
+    diffInstance.cleanUp();
+    manager.terminate();
+    consoleError.mockRestore();
+    dom.cleanup();
+  }
+});
 
 test('applies replacement annotations while its diff is highlighted', async () => {
   const dom = installDom();

--- a/packages/diffs/test/WorkerPoolManager.test.ts
+++ b/packages/diffs/test/WorkerPoolManager.test.ts
@@ -1,4 +1,13 @@
-import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from 'bun:test';
 
 import { parseDiffFromFile } from '../src';
 import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
@@ -24,7 +33,67 @@ afterAll(async () => {
   await disposeHighlighter();
 });
 
+afterEach(() => {
+  mock.restore();
+});
+
 describe('WorkerPoolManager lifecycle', () => {
+  test('fails initialization when a worker emits an error', async () => {
+    spyOn(console, 'error').mockImplementation(() => {});
+    const { initialization, manager, worker } = createInitializingManager();
+    await worker.waitForInitializeRequest();
+
+    worker.emitError(new Error('worker failed to load'));
+
+    const initializationError = await getRejection(initialization);
+    expect(initializationError.message).toContain('worker failed to load');
+    expect(manager.isWorkingPool()).toBe(false);
+    expect(manager.getStats()).toMatchObject({
+      managerState: 'waiting',
+      activeTasks: 0,
+      totalWorkers: 0,
+      workersFailed: true,
+    });
+    expect(worker.terminated).toBe(true);
+    manager.terminate();
+  });
+
+  test('fails a partial pool when any worker never responds', async () => {
+    spyOn(console, 'error').mockImplementation(() => {});
+    const { initialization, manager, workers } = createInitializingManager(
+      {},
+      { poolSize: 2, workerInitializationTimeout: 10 }
+    );
+    const [responsiveWorker, silentWorker] = workers;
+    if (responsiveWorker == null || silentWorker == null) {
+      throw new Error('Expected two test workers');
+    }
+    const [responsiveRequest] = await Promise.all(
+      workers.map((worker) => worker.waitForInitializeRequest())
+    );
+    responsiveWorker.respond({
+      type: 'success',
+      requestType: 'initialize',
+      id: responsiveRequest.id,
+      sentAt: Date.now(),
+    });
+
+    const initializationError = await getRejection(initialization);
+    expect(initializationError.message).toContain(
+      'worker initialization timed out after 10ms'
+    );
+    expect(manager.isWorkingPool()).toBe(false);
+    expect(manager.getStats()).toMatchObject({
+      managerState: 'waiting',
+      activeTasks: 0,
+      totalWorkers: 0,
+      workersFailed: true,
+    });
+    expect(responsiveWorker.terminated).toBe(true);
+    expect(silentWorker.terminated).toBe(true);
+    manager.terminate();
+  });
+
   test('ignores stale initialization after terminate', async () => {
     const { initialization, manager, worker } = createInitializingManager();
     const request = await worker.waitForInitializeRequest();
@@ -256,6 +325,15 @@ function createCacheableDiff(): FileDiffMetadata {
   const oldFile = createCacheableFile('file:old', 'const value = "old";\n');
   const newFile = createCacheableFile('file:new', 'const value = "new";\n');
   return parseDiffFromFile(oldFile, newFile);
+}
+
+async function getRejection(promise: Promise<unknown>): Promise<Error> {
+  try {
+    await withTimeout(promise);
+  } catch (error) {
+    return error instanceof Error ? error : new Error(String(error));
+  }
+  throw new Error('Expected promise to reject');
 }
 
 function createCacheableFile(

--- a/packages/diffs/test/workerPoolHarness.ts
+++ b/packages/diffs/test/workerPoolHarness.ts
@@ -5,6 +5,7 @@ import type {
   RenderDiffRequest,
   RenderFileRequest,
   WorkerInitializationRenderOptions,
+  WorkerPoolOptions,
   WorkerRequest,
   WorkerResponse,
 } from '../src/worker/types';
@@ -82,16 +83,14 @@ export class TestWorker {
     new Promise<InitializeWorkerRequest>((resolve) => {
       this.initializeRequestResolve = resolve;
     });
-  private readonly messageListeners = new Set<
-    (event: MessageEvent<WorkerResponse>) => void
-  >();
+  private readonly messageListeners = new Set<EventListener>();
+  private readonly errorListeners = new Set<EventListener>();
 
-  addEventListener(
-    type: string,
-    listener: (event: MessageEvent<WorkerResponse>) => void
-  ): void {
+  addEventListener(type: string, listener: EventListener): void {
     if (type === 'message') {
       this.messageListeners.add(listener);
+    } else if (type === 'error') {
+      this.errorListeners.add(listener);
     }
   }
 
@@ -153,20 +152,44 @@ export class TestWorker {
       listener({ data: response } as MessageEvent<WorkerResponse>);
     }
   }
+
+  emitError(error: Error): void {
+    const event = { error, message: error.message } as ErrorEvent;
+    for (const listener of this.errorListeners) {
+      listener(event);
+    }
+  }
 }
 
 export function createInitializingManager(
-  initOptions: Partial<WorkerInitializationRenderOptions> = {}
+  initOptions: Partial<WorkerInitializationRenderOptions> = {},
+  poolOptions: Pick<
+    WorkerPoolOptions,
+    'poolSize' | 'workerInitializationTimeout'
+  > = {}
 ): {
   initialization: Promise<void>;
   manager: WorkerPoolManager;
   worker: TestWorker;
+  workers: TestWorker[];
 } {
   const worker = new TestWorker();
+  const workers = [worker];
+  for (let i = 1; i < (poolOptions.poolSize ?? 1); i++) {
+    workers.push(new TestWorker());
+  }
+  let workerIndex = 0;
   const manager = new WorkerPoolManager(
     {
-      poolSize: 1,
-      workerFactory: () => worker as unknown as Worker,
+      poolSize: poolOptions.poolSize ?? 1,
+      workerFactory: () => {
+        const nextWorker = workers[workerIndex++];
+        if (nextWorker == null) {
+          throw new Error('Test worker pool exhausted');
+        }
+        return nextWorker as unknown as Worker;
+      },
+      ...poolOptions,
     },
     {
       langs: [],
@@ -179,6 +202,7 @@ export function createInitializingManager(
     initialization: manager.initialize(),
     manager,
     worker,
+    workers,
   };
 }
 


### PR DESCRIPTION
This PR hardens the initialization process of WorkerPool to ensure if something more obscure fails we can handle it properly. It also introduces a timeout in case something somehow hangs and never resolved.

Fixes #1076 