### PR TITLE
[diffs] Parse the icon sprite once per document

### DIFF
--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -23,7 +23,6 @@ import {
 } from '../managers/InteractionManager';
 import { ResizeManager } from '../managers/ResizeManager';
 import { FileRenderer, type FileRenderResult } from '../renderers/FileRenderer';
-import { SVGSpriteSheet } from '../sprite';
 export type { FileEditCompleteEvent } from '../editor/types';
 import type {
   AppliedThemeStyleCache,
@@ -52,6 +51,7 @@ import { areRenderRangesEqual } from '../utils/areRenderRangesEqual';
 import { areThemesEqual } from '../utils/areThemesEqual';
 import { createAnnotationWrapperNode } from '../utils/createAnnotationWrapperNode';
 import { createGutterUtilityContentNode } from '../utils/createGutterUtilityContentNode';
+import { createSVGSpriteElement } from '../utils/createSVGSpriteElement';
 import { createUnsafeCSSStyleNode } from '../utils/createUnsafeCSSStyleNode';
 import {
   patchScrollbarGutterSize,
@@ -2010,14 +2010,7 @@ export class File<
   private ensureSpriteSVG(fileContainer: HTMLElement): void {
     const shadowRoot =
       fileContainer.shadowRoot ?? fileContainer.attachShadow({ mode: 'open' });
-    if (this.spriteSVG == null) {
-      const fragment = document.createElement('div');
-      fragment.innerHTML = SVGSpriteSheet;
-      const firstChild = fragment.firstChild;
-      if (firstChild instanceof SVGElement) {
-        this.spriteSVG = firstChild;
-      }
-    }
+    this.spriteSVG ??= createSVGSpriteElement();
     if (this.spriteSVG != null && this.spriteSVG.parentNode !== shadowRoot) {
       shadowRoot.appendChild(this.spriteSVG);
     }

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -34,7 +34,6 @@ import {
   type DiffHunksRendererOptions,
   type HunksRenderResult,
 } from '../renderers/DiffHunksRenderer';
-import { SVGSpriteSheet } from '../sprite';
 export type { FileDiffEditCompleteEvent } from '../editor/types';
 import type {
   AppliedThemeStyleCache,
@@ -82,6 +81,7 @@ import {
 } from '../utils/cloneFileDiffMetadata';
 import { createAnnotationWrapperNode } from '../utils/createAnnotationWrapperNode';
 import { createGutterUtilityContentNode } from '../utils/createGutterUtilityContentNode';
+import { createSVGSpriteElement } from '../utils/createSVGSpriteElement';
 import { createUnsafeCSSStyleNode } from '../utils/createUnsafeCSSStyleNode';
 import {
   patchScrollbarGutterSize,
@@ -2633,14 +2633,7 @@ export class FileDiff<
   private ensureSpriteSVG(fileContainer: HTMLElement): void {
     const shadowRoot =
       fileContainer.shadowRoot ?? fileContainer.attachShadow({ mode: 'open' });
-    if (this.spriteSVG == null) {
-      const fragment = document.createElement('div');
-      fragment.innerHTML = SVGSpriteSheet;
-      const firstChild = fragment.firstChild;
-      if (firstChild instanceof SVGElement) {
-        this.spriteSVG = firstChild;
-      }
-    }
+    this.spriteSVG ??= createSVGSpriteElement();
     if (this.spriteSVG != null && this.spriteSVG.parentNode !== shadowRoot) {
       shadowRoot.appendChild(this.spriteSVG);
     }

--- a/packages/diffs/src/utils/createSVGSpriteElement.ts
+++ b/packages/diffs/src/utils/createSVGSpriteElement.ts
@@ -1,0 +1,20 @@
+import { SVGSpriteSheet } from '../sprite';
+
+const parsedSpriteSheets = new WeakMap<Document, SVGElement>();
+
+// Parsed once per document, cloned per call: much cheaper than re-parsing.
+export function createSVGSpriteElement(): SVGElement | undefined {
+  let parsed = parsedSpriteSheets.get(document);
+  if (parsed == null) {
+    const container = document.createElement('div');
+    container.innerHTML = SVGSpriteSheet;
+    const firstChild = container.firstChild;
+    if (!(firstChild instanceof SVGElement)) {
+      return undefined;
+    }
+    firstChild.remove();
+    parsed = firstChild;
+    parsedSpriteSheets.set(document, parsed);
+  }
+  return parsed.cloneNode(true) as SVGElement;
+}


### PR DESCRIPTION
### Description

`createSVGSpriteElement()` now parses the markup once per `document` (kept in a `WeakMap`, so a fresh jsdom document in tests gets its own copy) and returns a deep clone on each call. On pages that mount many instances, this is cheaper and faster than repeatedly parsing the the `SVGSpriteSheet` markup.

### Motivation & Context

`File` and `FileDiff` re-parsed the ~8.5 KB `SVGSpriteSheet` markup with `innerHTML` every time an instance mounted its shadow root. On pages with many instances that parse is a noticeable share of mount cost, and it produces the same nodes every time.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality). You must have
      first discussed with the dev team and they should be aware that this PR is
      being opened
- [ ] Breaking change (fix or feature that would change existing functionality).
      You must have first discussed with the dev team and they should be aware
      that this PR is being opened
- [ ] Documentation update

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/pierrecomputer/pierre/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project (`moon run root:lint`)
- [x] My code is formatted properly (`moon run root:format`)
- [x] I have updated the documentation accordingly (not applicable here)
- [x] I have added tests to cover my changes (IMO not needed here)
- [x] All new and existing tests pass (`moonx diffs:test`)

### How was AI used in generating this PR

The code for this performance improvement was written by Claude Code.