### PR TITLE
fix(path-store): replace Symbol with string key for RSC serialization…

### DIFF
--- a/packages/path-store/src/builder.ts
+++ b/packages/path-store/src/builder.ts
@@ -39,7 +39,7 @@ export interface BuilderFinishOptions {
 
 type PreparedInputKind = 'prepared' | 'presorted';
 
-const PREPARED_INPUT_KIND = Symbol('pathStorePreparedInputKind');
+const PREPARED_INPUT_KIND = 'pathStorePreparedInputKind' as const;
 
 type ValidatedPreparedInput = InternalPreparedInput & {
   [PREPARED_INPUT_KIND]?: PreparedInputKind;


### PR DESCRIPTION
### Description

Replace `Symbol('pathStorePreparedInputKind')` with a string constant `'pathStorePreparedInputKind'` in `PathStoreBuilder`.

### Motivation & Context

`FileTreePreparedInput` includes a `Symbol`-keyed property, making it non-serializable. Passing this object from a Next.js Server Component to a Client Component triggers a serialization error, as `Symbol` values cannot cross the React Server Component (RSC) boundary.

Fixes #1109

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality). You must have
      first discussed with the dev team and they should be aware that this PR is
      being opened
- [ ] Breaking change (fix or feature that would change existing functionality).
      You must have first discussed with the dev team and they should be aware
      that this PR is being opened
- [ ] Documentation update

### Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/pierrecomputer/pierre/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project (`moon run root:lint`)
- [x] My code is formatted properly (`moon run root:format`)
- [ ] I have updated the documentation accordingly (if applicable)
- [ ] I have added tests to cover my changes (if applicable)
- [x] All new and existing tests pass (`moonx path-store:test`)

### Related issues

Closes #1109