### PR TITLE
chore(theme): Add link to neovim theme port in README.md

### DIFF
--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -43,6 +43,10 @@ Usage:
  Zed:
   Install "Pierre" from the Zed extension registry
 
+ Neovim:
+  A port of this colorscheme is available for Neovim.
+  Check out [pierre-theme.nvim](https://github.com/chaosteil/pierre-theme.nvim)
+
 ```
 
 ## Agent skill


### PR DESCRIPTION
### Description

Adds a link to the neovim port of the pierrecomputer/theme project. The reason for it not to be present in this repo directly is that neovim plugins usually occupy the root of a git repo, and are unable to work with subtrees in a repo.

The repo itself takes this current repo as input and generates the value from the existing theme values present here.

### Motivation & Context

Add visibility to the Neovim theme for whomever might desire it. Added the link here as the original repository is unmaintained.

### Type of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality). You must have
      first discussed with the dev team and they should be aware that this PR is
      being opened
- [ ] Breaking change (fix or feature that would change existing functionality).
      You must have first discussed with the dev team and they should be aware
      that this PR is being opened
- [x] Documentation update

### Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/pierrecomputer/pierre/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project (`moon run root:lint`)
- [x] My code is formatted properly (`moon run root:format`)
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have added tests to cover my changes (if applicable)
- [x] All new and existing tests pass (`moonx diffs:test`)

### How was AI used in generating this PR

The repo with the colors it links to is mostly AI generated, but the entirety of the corpus of this readme change is lovingly handcrafted.

### Related issues

https://github.com/pierrecomputer/theme/pull/49