### PR TITLE
[diffs] Misc Fixes for 1.4 Release

### DIFF
--- a/apps/diffshub/lib/test/reactOverrides.test.tsx
+++ b/apps/diffshub/lib/test/reactOverrides.test.tsx
@@ -110,10 +110,10 @@ describe('React themed component overrides', () => {
           ref={codeViewRef}
           disableWorkerPool
           options={{
-            theme: { light: 'old-light', dark: 'old-dark' },
+            theme: { light: 'github-light', dark: 'github-dark' },
             themeType: 'system',
           }}
-          theme={{ light: 'next-light', dark: 'next-dark' }}
+          theme={{ light: 'pierre-light', dark: 'pierre-dark' }}
         />
       );
       await flushReact();
@@ -128,8 +128,8 @@ describe('React themed component overrides', () => {
         }
       | undefined;
     expect(instance?.options.theme).toEqual({
-      light: 'next-light',
-      dark: 'next-dark',
+      light: 'pierre-light',
+      dark: 'pierre-dark',
     });
     expect(instance?.options.themeType).toBe('system');
 

--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -16,6 +16,11 @@ import type {
   EditorChangeEvent,
   EditorType,
 } from '../editor/types';
+import {
+  isHighlighterLoaded,
+  preloadHighlighter,
+} from '../highlighter/shared_highlighter';
+import { areThemesAttached } from '../highlighter/themes/areThemesAttached';
 import type { SelectionWriteOptions } from '../managers/InteractionManager';
 import {
   dequeueRender,
@@ -47,6 +52,7 @@ import { areSelectionsEqual } from '../utils/areSelectionsEqual';
 import { areThemesEqual } from '../utils/areThemesEqual';
 import { createCodeViewHeaderFooterHostElement } from '../utils/createCodeViewHeaderFooterHostElement';
 import { createWindowFromScrollPosition } from '../utils/createWindowFromScrollPosition';
+import { getThemes } from '../utils/getThemes';
 import { isStyleNode } from '../utils/isStyleNode';
 import { prefersReducedMotion } from '../utils/prefersReducedMotion';
 import { roundToDevicePixel } from '../utils/roundToDevicePixel';
@@ -1829,14 +1835,13 @@ export class CodeView<LAnnotation = undefined, Caret = undefined> {
 
   private isReady(): boolean {
     const { workerManager } = this;
-    // A failed worker pool never reaches the 'initialized' state (it reverts to
-    // 'waiting' with workersFailed: true), so treat failure as ready and let
-    // the renderers fall back to synchronous highlighting.
-    if (
-      workerManager == null ||
-      workerManager.isInitialized() ||
-      workerManager.getStats().workersFailed
-    ) {
+    // A failed worker pool never reaches the 'initialized' state (it reverts
+    // to 'waiting' with workersFailed: true), so it renders through the shared
+    // highlighter instead.
+    if (workerManager == null || workerManager.getStats().workersFailed) {
+      return this.isSharedHighlighterReady();
+    }
+    if (workerManager.isInitialized()) {
       this.clearReadySubscription();
       return true;
     }
@@ -1866,6 +1871,35 @@ export class CodeView<LAnnotation = undefined, Caret = undefined> {
     }
     this.isReadySubscription();
     this.isReadySubscription = undefined;
+  }
+
+  private isSharedHighlighterReady(): boolean {
+    const theme =
+      this.workerManager?.getFileRenderOptions().theme ??
+      this.options.theme ??
+      DEFAULT_THEMES;
+    if (isHighlighterLoaded() && areThemesAttached(theme)) {
+      this.clearReadySubscription();
+      return true;
+    }
+    this.isReadySubscription ??= (() => {
+      let cancelled = false;
+      void preloadHighlighter({
+        themes: getThemes(theme),
+        langs: [],
+        preferredHighlighter: this.options.preferredHighlighter,
+      }).then(() => {
+        if (cancelled) {
+          return;
+        }
+        this.clearReadySubscription();
+        this.render(true);
+      });
+      return () => {
+        cancelled = true;
+      };
+    })();
+    return false;
   }
 
   public instanceChanged(

--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -37,11 +37,13 @@ import type {
   CodeViewRangeScrollTarget,
   CodeViewScrollBehavior,
   CodeViewScrollTarget,
+  DiffsThemeNames,
   HunkSeparators,
   PendingCodeViewLayoutReset,
   SelectedLineRange,
   SelectionSide,
   SmoothScrollSettings,
+  ThemesType,
   VirtualFileMetrics,
   VirtualWindowSpecs,
 } from '../types';
@@ -822,6 +824,7 @@ export class CodeView<LAnnotation = undefined, Caret = undefined> {
   private options: CodeViewOptions<LAnnotation, Caret>;
   private workerManager: WorkerPoolManager | undefined;
   private isReadySubscription: (() => void) | undefined;
+  private pendingHighlighterTheme: DiffsThemeNames | ThemesType | undefined;
   private isContainerManaged: boolean;
 
   constructor(
@@ -1871,6 +1874,7 @@ export class CodeView<LAnnotation = undefined, Caret = undefined> {
     }
     this.isReadySubscription();
     this.isReadySubscription = undefined;
+    this.pendingHighlighterTheme = undefined;
   }
 
   private isSharedHighlighterReady(): boolean {
@@ -1882,7 +1886,12 @@ export class CodeView<LAnnotation = undefined, Caret = undefined> {
       this.clearReadySubscription();
       return true;
     }
+    // A pending request for an obsolete theme must not block the current one.
+    if (!areThemesEqual(this.pendingHighlighterTheme, theme)) {
+      this.clearReadySubscription();
+    }
     this.isReadySubscription ??= (() => {
+      this.pendingHighlighterTheme = theme;
       let cancelled = false;
       void preloadHighlighter({
         themes: getThemes(theme),

--- a/packages/diffs/src/components/CodeView.ts
+++ b/packages/diffs/src/components/CodeView.ts
@@ -1897,13 +1897,23 @@ export class CodeView<LAnnotation = undefined, Caret = undefined> {
         themes: getThemes(theme),
         langs: [],
         preferredHighlighter: this.options.preferredHighlighter,
-      }).then(() => {
-        if (cancelled) {
-          return;
+      }).then(
+        () => {
+          if (cancelled) {
+            return;
+          }
+          this.clearReadySubscription();
+          this.render(true);
+        },
+        (error: unknown) => {
+          if (cancelled) {
+            return;
+          }
+          // Let a later render retry without looping on a failing loader.
+          this.clearReadySubscription();
+          console.error(error);
         }
-        this.clearReadySubscription();
-        this.render(true);
-      });
+      );
       return () => {
         cancelled = true;
       };

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -515,7 +515,7 @@ export class File<LAnnotation = undefined, Caret = undefined> {
   //
   // The editor delivers annotations through two calls. An edit that changes
   // the line count sends them with the structural rebuild
-  // (applyDocumentChange) and again with the change event (emitEditChange);
+  // (applyDocumentChange) and again with the change event (__acceptEditorChange);
   // the identity check makes the second call a no-op. An edit that keeps the
   // line count skips the rebuild, so the event is its only path here.
   //
@@ -834,7 +834,8 @@ export class File<LAnnotation = undefined, Caret = undefined> {
     }
   }
 
-  public emitEditChange(
+  /** @internal Settle component state before either observer can install a newer file. */
+  public __acceptEditorChange(
     event: EditorChangeEvent<'file', LAnnotation, Caret>
   ): void {
     // A change means the editor's document now carries the pending external
@@ -847,6 +848,11 @@ export class File<LAnnotation = undefined, Caret = undefined> {
     if (lineAnnotations != null) {
       this.syncEditSessionAnnotationsFromEditor(lineAnnotations);
     }
+  }
+
+  public emitEditChange(
+    event: EditorChangeEvent<'file', LAnnotation, Caret>
+  ): void {
     const { onEditChange } = this.options;
     onEditChange?.(event);
   }

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -181,22 +181,21 @@ interface HydrationSetup<LAnnotation> {
   lineAnnotations: LineAnnotation<LAnnotation>[] | undefined;
 }
 
+interface EditSession<LAnnotation> {
+  file: FileContents;
+  annotations: EditSessionAnnotations<LineAnnotation<LAnnotation>> | undefined;
+  /*
+   * `externalReplacement` records that the host swapped in a new file
+   * mid-session, so the next sync tells the editor to adopt `file` over its
+   * own document
+   */
+  externalReplacement: boolean;
+}
+
 function createEditSessionFile(file: FileContents): FileContents {
   const editSessionFile = { ...file };
   delete editSessionFile.cacheKey;
   return editSessionFile;
-}
-
-function shouldResetUndoState(
-  previousFile: FileContents,
-  nextFile: FileContents
-): boolean {
-  const previousLanguage =
-    previousFile.lang ?? getFiletypeFromFileName(previousFile.name);
-  const nextLanguage = nextFile.lang ?? getFiletypeFromFileName(nextFile.name);
-  return (
-    previousFile.name !== nextFile.name || previousLanguage !== nextLanguage
-  );
 }
 
 let instanceId = -1;
@@ -243,13 +242,7 @@ export class File<LAnnotation = undefined, Caret = undefined> {
   protected managersDirty = false;
 
   public file: FileContents | undefined;
-  private editSessionFile: FileContents | undefined;
-  private editSessionAnnotations:
-    | EditSessionAnnotations<LineAnnotation<LAnnotation>>
-    | undefined;
-  // Keeps the outgoing editable file until its replacement is ready to sync,
-  // so the editor can decide whether to preserve or reset undo history.
-  private outgoingSessionFile: FileContents | undefined;
+  private editSession: EditSession<LAnnotation> | undefined;
   protected renderedFile: FileContents | undefined;
   protected renderRange: RenderRange | undefined;
   protected enabled = true;
@@ -281,7 +274,7 @@ export class File<LAnnotation = undefined, Caret = undefined> {
     annotation: LineAnnotation<LAnnotation> | DiffLineAnnotation<LAnnotation>
   ): string => {
     return resolveEditSessionSlotName(
-      this.editSessionAnnotations,
+      this.editSession?.annotations,
       annotation,
       getLineAnnotationName
     );
@@ -313,7 +306,7 @@ export class File<LAnnotation = undefined, Caret = undefined> {
   protected getLatestFile(
     file: FileContents | undefined = this.file
   ): FileContents | undefined {
-    return this.editSessionFile ?? file;
+    return this.editSession?.file ?? file;
   }
 
   // Return the file that produced the DOM currently owned by this instance.
@@ -322,7 +315,7 @@ export class File<LAnnotation = undefined, Caret = undefined> {
   }
 
   protected getLatestAnnotations(): LineAnnotation<LAnnotation>[] {
-    return this.editSessionAnnotations?.current ?? this.lineAnnotations;
+    return this.editSession?.annotations?.current ?? this.lineAnnotations;
   }
 
   // Returns true when the caller passed annotations this component has not
@@ -333,10 +326,8 @@ export class File<LAnnotation = undefined, Caret = undefined> {
   protected isNewAnnotations(
     lineAnnotations: LineAnnotation<LAnnotation>[]
   ): boolean {
-    const {
-      editSessionAnnotations: session,
-      lineAnnotations: externalAnnotations,
-    } = this;
+    const session = this.editSession?.annotations;
+    const externalAnnotations = this.lineAnnotations;
     if (lineAnnotations === externalAnnotations) {
       return false;
     }
@@ -348,9 +339,9 @@ export class File<LAnnotation = undefined, Caret = undefined> {
   }
 
   // Install a replacement file from the caller; returns false when it is the
-  // file already installed. During an edit session, the outgoing session file
-  // is kept aside until the editor syncs so it can decide whether the swap
-  // keeps or resets undo history.
+  // file already installed. During an edit session the swap re-seeds the
+  // session as a host replacement, and the next sync decides whether it keeps
+  // or resets undo history.
   protected updateExternalFile(
     incomingFile: FileContents,
     lineAnnotations?: LineAnnotation<LAnnotation>[]
@@ -359,55 +350,73 @@ export class File<LAnnotation = undefined, Caret = undefined> {
       return false;
     }
 
-    const previousEditSessionFile =
-      this.outgoingSessionFile ?? this.editSessionFile;
-
+    const hadSession = this.editSession != null;
     this.file = incomingFile;
-    this.outgoingSessionFile = undefined;
 
-    if (previousEditSessionFile != null || this.editor != null) {
-      this.outgoingSessionFile = previousEditSessionFile;
+    if (hadSession || this.editor != null) {
       this.installEditSession(
         incomingFile,
-        previousEditSessionFile == null
-          ? this.editor?.__getDocumentContents(incomingFile)
-          : undefined
+        hadSession
+          ? undefined
+          : this.editor?.__getDocumentContents(incomingFile),
+        true
       );
     } else {
-      this.editSessionFile = undefined;
+      this.editSession = undefined;
     }
-    if (this.editSessionAnnotations != null && lineAnnotations != null) {
+    if (this.editSession?.annotations != null && lineAnnotations != null) {
       // These annotations arrived with the new file, so their line numbers
       // describe it. The positions the session tracked for the old document
       // mean nothing now: the session restarts from these annotations, and
       // they also become what renders once the session ends.
       this.lineAnnotations = lineAnnotations;
-      this.editSessionAnnotations = adoptEditSessionAnnotations(
+      this.editSession.annotations = adoptEditSessionAnnotations(
         lineAnnotations,
         getLineAnnotationName,
-        this.editSessionAnnotations
+        this.editSession.annotations
       );
     }
     return true;
   }
 
-  // A retained keyed document seeds a new session. Existing sessions omit it
-  // so incoming files render as external replacements and join undo history.
+  // Set up the edit session's working copy — the editable copy of this file that
+  // edit mode operates on: create the session if there isn't one, or replace its
+  // file if one is already running (its annotations carry over). The working
+  // copy's text is normally `externalFile`, but if `retainedDocument` is given
+  // and its text differs, the session keeps that content instead so text carried
+  // over from an earlier session isn't lost.
+  //
+  // `hostReplacement` is true only when the host swapped in a new file, not on a
+  // plain first attach — the one case where the editor should overwrite whatever
+  // it is currently showing with this file. It is recorded on the session for
+  // the next sync to act on.
   private installEditSession(
     externalFile: FileContents,
-    retainedDocument?: FileContents
+    retainedDocument?: FileContents,
+    hostReplacement = false
   ): void {
     const usesExternalDocument =
       retainedDocument == null ||
       (retainedDocument.name === externalFile.name &&
         retainedDocument.lang === externalFile.lang &&
         retainedDocument.contents === externalFile.contents);
-    const editSessionFile = createEditSessionFile(
-      retainedDocument ?? externalFile
-    );
-    this.editSessionFile = editSessionFile;
+    const file = createEditSessionFile(retainedDocument ?? externalFile);
+    this.editSession = {
+      file,
+      externalReplacement: hostReplacement && usesExternalDocument,
+      // Seed annotations when the session is created so the adopt-block in
+      // updateExternalFile fires on the next external update — this is what an
+      // attach-before-hydrate (React) mount relies on, since the session does
+      // not exist yet at attach. A live session keeps the ones it tracks.
+      annotations:
+        this.editSession?.annotations ??
+        adoptEditSessionAnnotations(
+          this.lineAnnotations,
+          getLineAnnotationName
+        ),
+    };
     this.fileRenderer.beginEditSession(
-      editSessionFile,
+      file,
       usesExternalDocument ? externalFile : undefined
     );
   }
@@ -479,7 +488,7 @@ export class File<LAnnotation = undefined, Caret = undefined> {
   public setLineAnnotations(
     lineAnnotations: LineAnnotation<LAnnotation>[]
   ): void {
-    const { editSessionAnnotations: sessionAnnotations } = this;
+    const sessionAnnotations = this.editSession?.annotations;
     if (sessionAnnotations == null) {
       this.lineAnnotations = lineAnnotations;
       return;
@@ -515,7 +524,7 @@ export class File<LAnnotation = undefined, Caret = undefined> {
   protected syncEditSessionAnnotationsFromEditor(
     lineAnnotations: LineAnnotation<LAnnotation>[]
   ): boolean {
-    const { editSessionAnnotations: session } = this;
+    const session = this.editSession?.annotations;
     if (session == null || lineAnnotations === session.current) {
       return false;
     }
@@ -637,9 +646,7 @@ export class File<LAnnotation = undefined, Caret = undefined> {
       this.fileRenderer.cleanUp();
       this.workerManager = undefined;
       this.file = undefined;
-      this.editSessionFile = undefined;
-      this.editSessionAnnotations = undefined;
-      this.outgoingSessionFile = undefined;
+      this.editSession = undefined;
       this.renderedFile = undefined;
     }
     this.enabled = false;
@@ -790,7 +797,7 @@ export class File<LAnnotation = undefined, Caret = undefined> {
     if (editor == null || fileContainer == null || file == null) {
       return;
     }
-    const sync = (highlighter: DiffsHighlighter): void => {
+    const syncEditor = (highlighter: DiffsHighlighter): void => {
       if (
         !this.enabled ||
         this.editor !== editor ||
@@ -799,31 +806,23 @@ export class File<LAnnotation = undefined, Caret = undefined> {
       ) {
         return;
       }
-      const { outgoingSessionFile: replacement, file: externalFile } = this;
-      const externalDocument =
-        replacement != null && externalFile != null && replacement !== file;
-      const resetHistory = externalDocument
-        ? shouldResetUndoState(replacement, externalFile)
-        : false;
-      if (externalDocument) {
-        this.outgoingSessionFile = undefined;
-      }
       editor.__syncRenderView({
         highlighter,
         fileContainer,
         file,
         lineAnnotations,
         renderRange,
-        externalDocument,
-        resetHistory,
+        externalDocument: this.editSession?.externalReplacement === true,
       });
     };
 
     const theme = this.getTheme();
     const lang = file.lang ?? getFiletypeFromFileName(file.name);
+    // Sync editor synchronously whenever the shared highlighter is ready;
+    // otherwise load it and sync once it resolves.
     const highlighter = getHighlighterIfLoaded({ theme, lang });
     if (highlighter != null) {
-      sync(highlighter);
+      syncEditor(highlighter);
     } else {
       void getSharedHighlighter({
         themes: getThemes(theme),
@@ -831,13 +830,19 @@ export class File<LAnnotation = undefined, Caret = undefined> {
         preferredHighlighter:
           this.workerManager?.getPreferredHighlighter() ??
           this.options.preferredHighlighter,
-      }).then(sync);
+      }).then(syncEditor);
     }
   }
 
   public emitEditChange(
     event: EditorChangeEvent<'file', LAnnotation, Caret>
   ): void {
+    // A change means the editor's document now carries the pending external
+    // replacement (or the user has edited past it), so the next sync no longer
+    // needs to force that content over the document.
+    if (this.editSession != null) {
+      this.editSession.externalReplacement = false;
+    }
     const { lineAnnotations } = event;
     if (lineAnnotations != null) {
       this.syncEditSessionAnnotationsFromEditor(lineAnnotations);
@@ -883,21 +888,22 @@ export class File<LAnnotation = undefined, Caret = undefined> {
   private resumeEditorRendering(
     editor: Editor<'file', LAnnotation, Caret>
   ): void {
-    this.editSessionAnnotations ??= adoptEditSessionAnnotations(
-      this.lineAnnotations,
-      getLineAnnotationName
-    );
-    if (this.editSessionFile == null && this.file != null) {
+    // A retained session just re-starts its render; a fresh attach with a file
+    // installs a session seeded from the editor's document. The editor can also
+    // attach before the file arrives, there is nothing to begin yet, so the
+    // session installs on the later hydrate.
+    if (this.editSession != null) {
+      this.fileRenderer.beginEditSession(this.editSession.file);
+    } else if (this.file != null) {
       this.installEditSession(
         this.file,
         editor.__getDocumentContents(this.file)
       );
-    } else {
-      this.fileRenderer.beginEditSession(this.editSessionFile);
     }
+    const editSessionFile = this.editSession?.file;
     if (this.fileRenderer.editorRenderReady()) {
-      if (this.fileRenderer.fileCache === this.editSessionFile) {
-        this.renderedFile = this.editSessionFile;
+      if (this.fileRenderer.fileCache === editSessionFile) {
+        this.renderedFile = editSessionFile;
       }
       this.syncRenderViewToEditor();
     } else {
@@ -934,14 +940,15 @@ export class File<LAnnotation = undefined, Caret = undefined> {
     editor: Editor<'file', LAnnotation, Caret> | undefined
   ): void {
     const {
-      editSessionFile,
-      editSessionAnnotations,
+      editSession,
       file: externalFile,
       lineAnnotations: externalAnnotations,
     } = this;
-    if (editSessionFile == null || externalFile == null) {
+    if (editSession == null || externalFile == null) {
       return;
     }
+    const { file: editSessionFile, annotations: editSessionAnnotations } =
+      editSession;
     if (this.editor != null) {
       throw new Error(
         'File.__completeEditSession: detach the editor before completing the session'
@@ -994,9 +1001,7 @@ export class File<LAnnotation = undefined, Caret = undefined> {
         this.lineAnnotations = sessionAnnotationsCurrent;
       }
     }
-    this.editSessionFile = undefined;
-    this.editSessionAnnotations = undefined;
-    this.outgoingSessionFile = undefined;
+    this.editSession = undefined;
     // Ending the session with the settled file lets the renderer adopt it as
     // the rendered identity when its cache already shows this content, so
     // the next render treats it as current instead of a new file.
@@ -1023,7 +1028,7 @@ export class File<LAnnotation = undefined, Caret = undefined> {
     textDocument: TextDocument<'file', LAnnotation>,
     newLineAnnotations?: LineAnnotation<LAnnotation>[]
   ): void {
-    const { editSessionFile } = this;
+    const editSessionFile = this.editSession?.file;
     if (editSessionFile == null) {
       throw new Error(
         'File.applyDocumentChange: requires an active edit session'
@@ -1043,7 +1048,7 @@ export class File<LAnnotation = undefined, Caret = undefined> {
       lineCountChangeInFlight?: boolean;
     }
   ): void {
-    const { editSessionFile } = this;
+    const editSessionFile = this.editSession?.file;
     if (editSessionFile == null) {
       throw new Error(
         'File.updateRenderCache: requires an active edit session'

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -1110,7 +1110,11 @@ export class File<LAnnotation = undefined, Caret = undefined> {
       !annotationsChanged &&
       !themeChanged
     ) {
-      return this.applyCachedThemeState(themeType);
+      const rendered = this.applyCachedThemeState(themeType);
+      if (rendered) {
+        this.finalizeRender();
+      }
+      return rendered;
     }
 
     this.renderRange = nextRenderRange;
@@ -1177,6 +1181,7 @@ export class File<LAnnotation = undefined, Caret = undefined> {
           this.applyErrorToDOM(error, fileContainer);
         }
       }
+      this.finalizeRender();
       if (!preventEmit) {
         this.emitPostRender();
       }
@@ -1242,6 +1247,7 @@ export class File<LAnnotation = undefined, Caret = undefined> {
         this.flushManagers();
       }
 
+      this.finalizeRender();
       if (this.editor != null) {
         this.syncRenderViewToEditor();
       }
@@ -1259,6 +1265,10 @@ export class File<LAnnotation = undefined, Caret = undefined> {
     }
     return true;
   }
+
+  // Finish subclass layout bookkeeping before editor sync or post-render
+  // callbacks can synchronously replace or dispose this component.
+  protected finalizeRender(): void {}
 
   private emitPostRender(unmount = false) {
     const {

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -834,16 +834,17 @@ export class File<LAnnotation = undefined, Caret = undefined> {
     }
   }
 
-  /** @internal Settle component state before either observer can install a newer file. */
-  public __acceptEditorChange(
-    event: EditorChangeEvent<'file', LAnnotation, Caret>
-  ): void {
-    // A change means the editor's document now carries the pending external
-    // replacement (or the user has edited past it), so the next sync no longer
-    // needs to force that content over the document.
+  /** @internal The editor applied or edited past the pending external replacement. */
+  public __acknowledgeDocumentUpdate(): void {
     if (this.editSession != null) {
       this.editSession.externalReplacement = false;
     }
+  }
+
+  /** @internal Settle annotations */
+  public __acceptEditorChange(
+    event: EditorChangeEvent<'file', LAnnotation, Caret>
+  ): void {
     const { lineAnnotations } = event;
     if (lineAnnotations != null) {
       this.syncEditSessionAnnotationsFromEditor(lineAnnotations);

--- a/packages/diffs/src/components/File.ts
+++ b/packages/diffs/src/components/File.ts
@@ -32,10 +32,15 @@ import { ResizeManager } from '../managers/ResizeManager';
 import { FileRenderer, type FileRenderResult } from '../renderers/FileRenderer';
 import { SVGSpriteSheet } from '../sprite';
 export type { FileEditCompleteEvent } from '../editor/types';
+import {
+  getHighlighterIfLoaded,
+  getSharedHighlighter,
+} from '../highlighter/shared_highlighter';
 import type {
   AppliedThemeStyleCache,
   BaseCodeOptions,
   DiffLineAnnotation,
+  DiffsHighlighter,
   FileContents,
   HighlightedToken,
   LineAnnotation,
@@ -69,6 +74,7 @@ import { getFileRendererOptions } from '../utils/getFileRendererOptions';
 import { getFiletypeFromFileName } from '../utils/getFiletypeFromFileName';
 import { getLineAnnotationName } from '../utils/getLineAnnotationName';
 import { getOrCreateCodeNode } from '../utils/getOrCreateCodeNode';
+import { getThemes } from '../utils/getThemes';
 import { guardWebKitScrollDuringRebuild } from '../utils/guardWebKitScrollDuringRebuild';
 import { upsertHostThemeStyle } from '../utils/hostTheme';
 import { isFilePlainText } from '../utils/isFilePlainText';
@@ -294,6 +300,14 @@ export class File<LAnnotation = undefined, Caret = undefined> {
     });
   }
 
+  private getTheme() {
+    return (
+      this.workerManager?.getFileRenderOptions().theme ??
+      this.options.theme ??
+      DEFAULT_THEMES
+    );
+  }
+
   // Return the newest file this component intends to display. Once editing
   // starts, the private edit-session file owns that state.
   protected getLatestFile(
@@ -454,10 +468,7 @@ export class File<LAnnotation = undefined, Caret = undefined> {
   private hasThemeChanged(): boolean {
     return (
       this.appliedThemeCSS != null &&
-      !areThemesEqual(
-        this.appliedThemeCSS.theme,
-        this.options.theme ?? DEFAULT_THEMES
-      )
+      !areThemesEqual(this.appliedThemeCSS.theme, this.getTheme())
     );
   }
 
@@ -779,7 +790,7 @@ export class File<LAnnotation = undefined, Caret = undefined> {
     if (editor == null || fileContainer == null || file == null) {
       return;
     }
-    void this.fileRenderer.initializeHighlighter().then((highlighter) => {
+    const sync = (highlighter: DiffsHighlighter): void => {
       if (
         !this.enabled ||
         this.editor !== editor ||
@@ -806,7 +817,22 @@ export class File<LAnnotation = undefined, Caret = undefined> {
         externalDocument,
         resetHistory,
       });
-    });
+    };
+
+    const theme = this.getTheme();
+    const lang = file.lang ?? getFiletypeFromFileName(file.name);
+    const highlighter = getHighlighterIfLoaded({ theme, lang });
+    if (highlighter != null) {
+      sync(highlighter);
+    } else {
+      void getSharedHighlighter({
+        themes: getThemes(theme),
+        langs: Array.from(new Set(['text', lang])),
+        preferredHighlighter:
+          this.workerManager?.getPreferredHighlighter() ??
+          this.options.preferredHighlighter,
+      }).then(sync);
+    }
   }
 
   public emitEditChange(
@@ -1485,7 +1511,7 @@ export class File<LAnnotation = undefined, Caret = undefined> {
     const shadowRoot =
       container.shadowRoot ?? container.attachShadow({ mode: 'open' });
     const effectiveThemeType = baseThemeType ?? themeType;
-    const currentTheme = this.options.theme ?? DEFAULT_THEMES;
+    const currentTheme = this.getTheme();
     const theme =
       typeof currentTheme === 'string' ? currentTheme : { ...currentTheme };
     const scrollbarGutter = getMeasuredScrollbarGutter(shadowRoot);

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -25,6 +25,10 @@ import type {
   RetainedDiffSessionSnapshot,
 } from '../editor/types';
 import {
+  getHighlighterIfLoaded,
+  getSharedHighlighter,
+} from '../highlighter/shared_highlighter';
+import {
   type GetHoveredLineResult,
   type GetLineIndexUtility,
   InteractionManager,
@@ -52,6 +56,7 @@ import type {
   CustomPreProperties,
   DiffLineAnnotation,
   ExpansionDirections,
+  DiffsHighlighter,
   FileContents,
   FileDiffMetadata,
   HighlightedToken,
@@ -106,6 +111,7 @@ import { getFiletypeFromFileName } from '../utils/getFiletypeFromFileName';
 import { getHunkSideStartBoundary } from '../utils/getHunkSideBoundaries';
 import { getLineAnnotationName } from '../utils/getLineAnnotationName';
 import { getOrCreateCodeNode } from '../utils/getOrCreateCodeNode';
+import { getThemes } from '../utils/getThemes';
 import { guardWebKitScrollDuringRebuild } from '../utils/guardWebKitScrollDuringRebuild';
 import { upsertHostThemeStyle } from '../utils/hostTheme';
 import { hydratePartialDiff } from '../utils/hydratePartialDiff';
@@ -465,6 +471,14 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
     this.rerender();
   };
 
+  private getTheme() {
+    return (
+      this.workerManager?.getDiffRenderOptions().theme ??
+      this.options.theme ??
+      DEFAULT_THEMES
+    );
+  }
+
   protected getHunksRendererOptions(
     options: FileDiffOptions<LAnnotation, Caret>
   ): DiffHunksRendererOptions {
@@ -650,10 +664,7 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
   private hasThemeChanged(): boolean {
     return (
       this.appliedThemeCSS != null &&
-      !areThemesEqual(
-        this.appliedThemeCSS.theme,
-        this.options.theme ?? DEFAULT_THEMES
-      )
+      !areThemesEqual(this.appliedThemeCSS.theme, this.getTheme())
     );
   }
 
@@ -1714,7 +1725,7 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
     ) {
       return;
     }
-    void this.hunksRenderer.initializeHighlighter().then((highlighter) => {
+    const sync = (highlighter: DiffsHighlighter): void => {
       if (
         !this.enabled ||
         this.editor !== editor ||
@@ -1741,7 +1752,21 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
         externalDocument,
         resetHistory,
       });
-    });
+    };
+    const theme = this.getTheme();
+    const lang = fileDiff.lang ?? getFiletypeFromFileName(fileDiff.name);
+    const highlighter = getHighlighterIfLoaded({ theme, lang });
+    if (highlighter != null) {
+      sync(highlighter);
+    } else {
+      void getSharedHighlighter({
+        themes: getThemes(theme),
+        langs: ['text', lang],
+        preferredHighlighter:
+          this.workerManager?.getPreferredHighlighter() ??
+          this.options.preferredHighlighter,
+      }).then(sync);
+    }
   }
 
   // The stored render range is in rendered-row units for the windowed AST
@@ -2895,7 +2920,7 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
     const shadowRoot =
       container.shadowRoot ?? container.attachShadow({ mode: 'open' });
     const effectiveThemeType = baseThemeType ?? themeType;
-    const currentTheme = this.options.theme ?? DEFAULT_THEMES;
+    const currentTheme = this.getTheme();
     const theme =
       typeof currentTheme === 'string' ? currentTheme : { ...currentTheme };
     const scrollbarGutter = getMeasuredScrollbarGutter(shadowRoot);

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -364,6 +364,20 @@ interface HeaderCache {
   fileDiff: FileDiffMetadata | undefined;
 }
 
+interface EditSession<LAnnotation> {
+  diff: FileDiffMetadata;
+  annotations:
+    | EditSessionAnnotations<DiffLineAnnotation<LAnnotation>>
+    | undefined;
+  /*
+   * `outgoingDiff` keeps the diff the document still holds (the render already
+   * shows the new `diff`): its presence signals the pending replacement, and it
+   * supplies the old-file side both for the undo-reset decision and for
+   * capturing session state.
+   */
+  outgoingDiff: FileDiffMetadata | undefined;
+}
+
 let instanceId = -1;
 
 export class FileDiff<LAnnotation = undefined, Caret = undefined> {
@@ -411,13 +425,7 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
   protected deletionFile?: FileContents | null;
   protected additionFile?: FileContents | null;
   public fileDiff: FileDiffMetadata | undefined;
-  private editSessionDiff: FileDiffMetadata | undefined;
-  private editSessionAnnotations:
-    | EditSessionAnnotations<DiffLineAnnotation<LAnnotation>>
-    | undefined;
-  // Keeps the outgoing editable diff until its replacement is ready to sync,
-  // so the editor can decide whether to preserve or reset undo history.
-  private outgoingSessionDiff: FileDiffMetadata | undefined;
+  private editSession: EditSession<LAnnotation> | undefined;
   protected renderedDiff: FileDiffMetadata | undefined;
   protected renderRange: RenderRange | undefined;
   protected pendingFiles: PendingFileLoad | undefined;
@@ -676,7 +684,7 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
     annotation: LineAnnotation<LAnnotation> | DiffLineAnnotation<LAnnotation>
   ): string => {
     return resolveEditSessionSlotName(
-      this.editSessionAnnotations,
+      this.editSession?.annotations,
       annotation,
       getLineAnnotationName
     );
@@ -685,7 +693,7 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
   // Return the annotations this component currently renders. Once editing
   // starts, the private session state owns them.
   protected getLatestAnnotations(): DiffLineAnnotation<LAnnotation>[] {
-    return this.editSessionAnnotations?.current ?? this.lineAnnotations;
+    return this.editSession?.annotations?.current ?? this.lineAnnotations;
   }
 
   // Returns true when the caller passed annotations this component has not
@@ -696,10 +704,8 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
   protected isNewAnnotations(
     lineAnnotations: DiffLineAnnotation<LAnnotation>[]
   ): boolean {
-    const {
-      editSessionAnnotations: session,
-      lineAnnotations: externalAnnotations,
-    } = this;
+    const session = this.editSession?.annotations;
+    const externalAnnotations = this.lineAnnotations;
     if (lineAnnotations === externalAnnotations) {
       return false;
     }
@@ -713,7 +719,7 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
   public setLineAnnotations(
     lineAnnotations: DiffLineAnnotation<LAnnotation>[]
   ): void {
-    const { editSessionAnnotations: sessionAnnotations } = this;
+    const sessionAnnotations = this.editSession?.annotations;
     if (sessionAnnotations == null) {
       this.lineAnnotations = lineAnnotations;
       return;
@@ -749,7 +755,7 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
   protected syncEditSessionAnnotationsFromEditor(
     lineAnnotations: DiffLineAnnotation<LAnnotation>[]
   ): boolean {
-    const { editSessionAnnotations: session } = this;
+    const session = this.editSession?.annotations;
     if (session == null || lineAnnotations === session.current) {
       return false;
     }
@@ -949,9 +955,7 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
       this.workerManager = undefined;
       // Clean up the data
       this.fileDiff = undefined;
-      this.editSessionDiff = undefined;
-      this.editSessionAnnotations = undefined;
-      this.outgoingSessionDiff = undefined;
+      this.editSession = undefined;
       this.renderedDiff = undefined;
       this.deletionFile = undefined;
       this.additionFile = undefined;
@@ -1254,11 +1258,11 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
       return false;
     }
     const { editor } = this;
-    if (this.outgoingSessionDiff != null) {
+    if (this.editSession?.outgoingDiff != null) {
       this.installEditSession(expectedDiff);
       return true;
     }
-    if (editor == null || this.editSessionDiff != null) {
+    if (editor == null || this.editSession != null) {
       return false;
     }
     this.installEditSession(
@@ -1270,11 +1274,9 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
   }
 
   // Install a replacement diff from the caller; returns false when it is the
-  // diff already installed. During an edit session, the outgoing session diff
-  // is kept aside until the editor syncs so it can decide whether the swap
-  // keeps or resets undo history. A hydrated
-  // replacement starts its new session immediately; a partial one starts
-  // loading its files and gets a session once hydrated.
+  // diff already installed. During an edit session the diff the editor's
+  // document still holds is kept as `outgoingDiff` until the editor syncs, so
+  // it can decide whether the swap keeps or resets undo history.
   protected updateExternalDiff(
     incomingExternalDiff: FileDiffMetadata,
     lineAnnotations?: DiffLineAnnotation<LAnnotation>[]
@@ -1283,16 +1285,18 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
       return false;
     }
 
-    const editSessionDiff = this.outgoingSessionDiff ?? this.editSessionDiff;
+    const outgoingDiff =
+      this.editSession?.outgoingDiff ?? this.editSession?.diff;
 
     this.fileDiff = incomingExternalDiff;
-    this.outgoingSessionDiff = undefined;
-    if (editSessionDiff != null) {
-      this.outgoingSessionDiff = editSessionDiff;
+    if (outgoingDiff != null) {
       if (incomingExternalDiff.isPartial) {
         this.loadFilesIfNecessary();
       } else {
         this.installEditSession(incomingExternalDiff);
+      }
+      if (this.editSession != null) {
+        this.editSession.outgoingDiff = outgoingDiff;
       }
     } else if (this.editor != null) {
       if (incomingExternalDiff.isPartial) {
@@ -1307,16 +1311,16 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
         );
       }
     }
-    if (this.editSessionAnnotations != null && lineAnnotations != null) {
+    if (this.editSession?.annotations != null && lineAnnotations != null) {
       // These annotations arrived with the new diff, so their line numbers
       // describe it. The positions the session tracked for the old document
       // mean nothing now: the session restarts from these annotations, and
       // they also become what renders once the session ends.
       this.lineAnnotations = lineAnnotations;
-      this.editSessionAnnotations = adoptEditSessionAnnotations(
+      this.editSession.annotations = adoptEditSessionAnnotations(
         lineAnnotations,
         getLineAnnotationName,
-        this.editSessionAnnotations
+        this.editSession.annotations
       );
     }
     return true;
@@ -1378,7 +1382,20 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
       sessionDiff.editSessionDirty = true;
       recomputeDiffRenderLineCounts(sessionDiff);
     }
-    this.editSessionDiff = sessionDiff;
+    this.editSession = {
+      diff: sessionDiff,
+      // Seed annotations when the session is created so the adopt-block in
+      // updateExternalDiff fires on the next external update — this is what an
+      // attach-before-hydrate (React) mount relies on, since the session does
+      // not exist yet at attach. A live session keeps the ones it tracks.
+      annotations:
+        this.editSession?.annotations ??
+        adoptEditSessionAnnotations(
+          this.lineAnnotations,
+          getLineAnnotationName
+        ),
+      outgoingDiff: this.editSession?.outgoingDiff,
+    };
     this.hunksRenderer.beginEditSession(
       sessionDiff,
       usesExternalDocument && !restoreRetainedSession ? externalDiff : undefined
@@ -1703,7 +1720,7 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
   protected getLatestDiff(
     fileDiff: FileDiffMetadata | undefined = this.fileDiff
   ): FileDiffMetadata | undefined {
-    return this.editSessionDiff ?? fileDiff;
+    return this.editSession?.diff ?? fileDiff;
   }
 
   // Return the diff that produced the DOM currently owned by this instance.
@@ -1734,15 +1751,13 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
       ) {
         return;
       }
-      const { outgoingSessionDiff: replacement, fileDiff: externalDiff } = this;
+      const replacement = this.editSession?.outgoingDiff;
+      const externalDiff = this.fileDiff;
       const externalDocument =
         replacement != null && externalDiff != null && replacement !== fileDiff;
       const resetHistory = externalDocument
         ? shouldResetUndoState(replacement, externalDiff)
         : false;
-      if (externalDocument) {
-        this.outgoingSessionDiff = undefined;
-      }
       editor.__syncRenderView({
         highlighter,
         fileContainer,
@@ -1755,6 +1770,8 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
     };
     const theme = this.getTheme();
     const lang = fileDiff.lang ?? getFiletypeFromFileName(fileDiff.name);
+    // Sync synchronously whenever the shared highlighter is ready; otherwise
+    // load it and sync once it resolves.
     const highlighter = getHighlighterIfLoaded({ theme, lang });
     if (highlighter != null) {
       sync(highlighter);
@@ -1822,6 +1839,14 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
   public emitEditChange(
     event: EditorChangeEvent<'file-diff', LAnnotation, Caret>
   ): void {
+    // A change means the editor's document now carries the pending replacement
+    // (or the user has edited past it), so the next sync no longer needs to
+    // force that diff over the document. Clearing here rather than per-sync
+    // keeps the signal alive across syncs that don't reconcile it — e.g. a
+    // render for an item being recycled before its editor detaches.
+    if (this.editSession != null) {
+      this.editSession.outgoingDiff = undefined;
+    }
     const { lineAnnotations } = event;
     if (lineAnnotations != null) {
       this.syncEditSessionAnnotationsFromEditor(lineAnnotations);
@@ -1839,15 +1864,13 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
   public __captureDocumentSessionState(
     clone = true
   ): CapturedDiffSessionState | undefined {
-    let { outgoingSessionDiff, fileDiff, editSessionDiff: sessionDiff } = this;
-    if (outgoingSessionDiff != null && fileDiff != null) {
-      if (
-        !fileDiff.isPartial &&
-        shouldResetUndoState(outgoingSessionDiff, fileDiff)
-      ) {
+    let { fileDiff, editSession: { diff: sessionDiff, outgoingDiff } = {} } =
+      this;
+    if (outgoingDiff != null && fileDiff != null) {
+      if (!fileDiff.isPartial && shouldResetUndoState(outgoingDiff, fileDiff)) {
         return undefined;
       }
-      sessionDiff = outgoingSessionDiff;
+      sessionDiff = outgoingDiff;
     }
     if (sessionDiff == null || sessionDiff.isPartial) {
       return undefined;
@@ -1909,22 +1932,20 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
   private resumeEditorRendering(
     editor: Editor<'file-diff', LAnnotation, Caret>
   ): void {
-    this.editSessionAnnotations ??= adoptEditSessionAnnotations(
-      this.lineAnnotations,
-      getLineAnnotationName
-    );
-    const { fileDiff: externalDiff, outgoingSessionDiff: pendingReplacement } =
-      this;
+    const { fileDiff: externalDiff } = this;
+    const pendingReplacement = this.editSession?.outgoingDiff;
+    // A pending replacement whose diff was partial when it arrived installs now
+    // that we are (re)attaching with a hydrated diff.
     if (
       pendingReplacement != null &&
       externalDiff != null &&
       !externalDiff.isPartial &&
-      this.editSessionDiff === pendingReplacement
+      this.editSession?.diff === pendingReplacement
     ) {
       this.installEditSession(externalDiff);
     }
     const initialExternalDiff =
-      this.editSessionDiff == null &&
+      this.editSession == null &&
       externalDiff != null &&
       !externalDiff.isPartial
         ? externalDiff
@@ -1935,8 +1956,8 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
         editor.__getDocumentContents(getAdditionFile(initialExternalDiff)),
         editor.__getDocumentSessionState()
       );
-    } else {
-      this.hunksRenderer.beginEditSession(this.editSessionDiff);
+    } else if (this.editSession != null) {
+      this.hunksRenderer.beginEditSession(this.editSession.diff);
     }
     this.editor = editor;
     // The editor sync below refuses partial diffs (it needs the full file
@@ -1944,8 +1965,8 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
     if (this.fileDiff?.isPartial === true) {
       this.loadFilesIfNecessary();
     }
+    const editSessionDiff = this.editSession?.diff;
     if (this.hunksRenderer.editorRenderReady()) {
-      const { editSessionDiff } = this;
       // Compatible markup can be reused without repainting. Once the renderer
       // transfers that cache to the private session, the existing DOM belongs
       // to the session as well.
@@ -1996,14 +2017,15 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
     editor: Editor<'file-diff', LAnnotation, Caret> | undefined
   ): void {
     const {
-      editSessionDiff,
-      editSessionAnnotations,
+      editSession,
       fileDiff: externalDiff,
       lineAnnotations: externalAnnotations,
     } = this;
-    if (editSessionDiff == null || externalDiff == null) {
+    if (editSession == null || externalDiff == null) {
       return;
     }
+    const { diff: editSessionDiff, annotations: editSessionAnnotations } =
+      editSession;
     if (this.editor != null) {
       throw new Error(
         'FileDiff.__completeEditSession: detach the editor before completing the session'
@@ -2085,9 +2107,7 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
         this.lineAnnotations = sessionAnnotationsCurrent;
       }
     }
-    this.editSessionDiff = undefined;
-    this.editSessionAnnotations = undefined;
-    this.outgoingSessionDiff = undefined;
+    this.editSession = undefined;
     if (installResult && this.fileContainer != null) {
       this.rerender();
     }
@@ -2134,7 +2154,7 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
     textDocument: TextDocument<'file-diff', LAnnotation>,
     newLineAnnotations?: DiffLineAnnotation<LAnnotation>[]
   ): void {
-    const { editSessionDiff } = this;
+    const editSessionDiff = this.editSession?.diff;
     if (editSessionDiff == null) {
       throw new Error(
         'FileDiff.applyDocumentChange: requires an active edit session'
@@ -2158,7 +2178,7 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
       lineCountChangeInFlight?: boolean;
     } = {}
   ): void {
-    const { editSessionDiff } = this;
+    const editSessionDiff = this.editSession?.diff;
     if (editSessionDiff == null) {
       throw new Error(
         'FileDiff.updateRenderCache: requires an active edit session'
@@ -2205,7 +2225,8 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
   }
 
   private detachAdditionLines(): void {
-    const { editSessionDiff, fileDiff } = this;
+    const editSessionDiff = this.editSession?.diff;
+    const { fileDiff } = this;
     if (
       editSessionDiff != null &&
       (editSessionDiff.additionLines === fileDiff?.additionLines ||
@@ -2746,8 +2767,8 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
         html: cachedHeaderHTML,
         lastRenderedHTML,
       },
-      editSessionDiff,
     } = this;
+    const editSessionDiff = this.editSession?.diff;
     const reusableHeaderHTML =
       fileDiff !== editSessionDiff &&
       areDiffTargetsEqual(cachedHeaderDiff, fileDiff)

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -1844,18 +1844,17 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
     };
   }
 
-  /** @internal Settle component state before either observer can install a newer diff. */
-  public __acceptEditorChange(
-    event: EditorChangeEvent<'file-diff', LAnnotation, Caret>
-  ): void {
-    // A change means the editor's document now carries the pending replacement
-    // (or the user has edited past it), so the next sync no longer needs to
-    // force that diff over the document. Clearing here rather than per-sync
-    // keeps the signal alive across syncs that don't reconcile it — e.g. a
-    // render for an item being recycled before its editor detaches.
+  /** @internal The editor applied or edited past the pending external replacement. */
+  public __acknowledgeDocumentUpdate(): void {
     if (this.editSession != null) {
       this.editSession.outgoingDiff = undefined;
     }
+  }
+
+  /** @internal Settle annotations locally. */
+  public __acceptEditorChange(
+    event: EditorChangeEvent<'file-diff', LAnnotation, Caret>
+  ): void {
     const { lineAnnotations } = event;
     if (lineAnnotations != null) {
       this.syncEditSessionAnnotationsFromEditor(lineAnnotations);

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -1469,7 +1469,11 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
         // equal
         (fileDiff == null && !filesDidChange))
     ) {
-      return this.applyCachedThemeState(themeType);
+      const rendered = this.applyCachedThemeState(themeType);
+      if (rendered) {
+        this.finalizeRender();
+      }
+      return rendered;
     }
 
     let nextParsedFileDiff: FileDiffMetadata | undefined;
@@ -1589,6 +1593,7 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
           this.applyErrorToDOM(error, fileContainer);
         }
       }
+      this.finalizeRender();
       if (!preventEmit) {
         this.emitPostRender();
       }
@@ -1670,6 +1675,7 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
         this.flushManagers();
       }
 
+      this.finalizeRender();
       if (this.editor != null) {
         this.syncRenderViewToEditor();
       }
@@ -1687,6 +1693,8 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
     }
     return true;
   }
+
+  protected finalizeRender(): void {}
 
   protected emitPostRender(unmount = false): void {
     const {

--- a/packages/diffs/src/components/FileDiff.ts
+++ b/packages/diffs/src/components/FileDiff.ts
@@ -746,7 +746,7 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
   //
   // The editor delivers annotations through two calls. An edit that changes
   // the line count sends them with the structural rebuild
-  // (applyDocumentChange) and again with the change event (emitEditChange);
+  // (applyDocumentChange) and again with the change event (__acceptEditorChange);
   // the identity check makes the second call a no-op. An edit that keeps the
   // line count skips the rebuild, so the event is its only path here.
   //
@@ -1836,7 +1836,8 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
     };
   }
 
-  public emitEditChange(
+  /** @internal Settle component state before either observer can install a newer diff. */
+  public __acceptEditorChange(
     event: EditorChangeEvent<'file-diff', LAnnotation, Caret>
   ): void {
     // A change means the editor's document now carries the pending replacement
@@ -1851,6 +1852,11 @@ export class FileDiff<LAnnotation = undefined, Caret = undefined> {
     if (lineAnnotations != null) {
       this.syncEditSessionAnnotationsFromEditor(lineAnnotations);
     }
+  }
+
+  public emitEditChange(
+    event: EditorChangeEvent<'file-diff', LAnnotation, Caret>
+  ): void {
     const { onEditChange } = this.options;
     onEditChange?.(event);
   }

--- a/packages/diffs/src/components/VirtualizedFile.ts
+++ b/packages/diffs/src/components/VirtualizedFile.ts
@@ -913,7 +913,7 @@ export class VirtualizedFile<
       fileTop,
       windowSpecs
     );
-    const rendered = super.render({
+    return super.render({
       file,
       fileContainer,
       renderRange,
@@ -925,23 +925,23 @@ export class VirtualizedFile<
         didFileChange,
       ...props,
     });
-    if (rendered) {
-      if (this.getRenderedFile() !== pendingRenderFile) {
-        throw new Error(
-          'VirtualizedFile.render: rendered a different file than its prepared layout'
-        );
-      }
-      this.pendingRender = undefined;
+  }
+
+  protected override finalizeRender(): void {
+    if (this.getRenderedFile() !== this.pendingRender?.file) {
+      throw new Error(
+        'VirtualizedFile.render: rendered a different file than its prepared layout'
+      );
     }
+    this.pendingRender = undefined;
     // Renders can be driven from outside the virtualizer (host/React render
     // calls, async highlight completions), and the virtualizer only
     // auto-reconciles renders it initiated. Queue a measured-height
     // reconciliation for every applied content render so line deltas
     // (wrapped lines, annotation heights) survive layout resets.
-    if (this.isSimpleMode() && rendered) {
+    if (this.isSimpleMode()) {
       this.getSimpleVirtualizer()?.requestHeightReconcile(this);
     }
-    return rendered;
   }
 
   private updatePendingRender(

--- a/packages/diffs/src/components/VirtualizedFile.ts
+++ b/packages/diffs/src/components/VirtualizedFile.ts
@@ -847,10 +847,7 @@ export class VirtualizedFile<
     } = (() => {
       if (
         this.pendingRender != null &&
-        areFileTargetsEqual(
-          this.pendingRender.latestFile,
-          this.getLatestFile(file) ?? file
-        )
+        this.pendingRender.latestFile === (this.getLatestFile(file) ?? file)
       ) {
         return {
           pendingRenderFile: this.pendingRender.file,

--- a/packages/diffs/src/components/VirtualizedFileDiff.ts
+++ b/packages/diffs/src/components/VirtualizedFileDiff.ts
@@ -1467,7 +1467,7 @@ export class VirtualizedFileDiff<
       fileTop,
       windowSpecs
     );
-    const rendered = super.render({
+    return super.render({
       fileDiff: nextFileDiff,
       fileContainer,
       renderRange,
@@ -1480,23 +1480,23 @@ export class VirtualizedFileDiff<
       ...fileInput,
       ...fileInputProps,
     });
-    if (rendered) {
-      if (this.getRenderedDiff() !== pendingRenderDiff) {
-        throw new Error(
-          'VirtualizedFileDiff.render: rendered a different diff than its prepared layout'
-        );
-      }
-      this.pendingRender = undefined;
+  }
+
+  protected override finalizeRender(): void {
+    if (this.getRenderedDiff() !== this.pendingRender?.diff) {
+      throw new Error(
+        'VirtualizedFileDiff.render: rendered a different diff than its prepared layout'
+      );
     }
+    this.pendingRender = undefined;
     // Renders can be driven from outside the virtualizer (host/React render
     // calls, async highlight completions), and the virtualizer only
     // auto-reconciles renders it initiated. Queue a measured-height
     // reconciliation for every applied content render so line deltas
     // (wrapped lines, annotation heights) survive layout resets.
-    if (this.isSimpleMode() && rendered) {
+    if (this.isSimpleMode()) {
       this.getSimpleVirtualizer()?.requestHeightReconcile(this);
     }
-    return rendered;
   }
 
   private updatePendingRender(

--- a/packages/diffs/src/components/VirtualizedFileDiff.ts
+++ b/packages/diffs/src/components/VirtualizedFileDiff.ts
@@ -1402,10 +1402,8 @@ export class VirtualizedFileDiff<
     } = (() => {
       if (
         this.pendingRender != null &&
-        areDiffTargetsEqual(
-          this.pendingRender.latestDiff,
-          this.getLatestDiff(nextFileDiff) ?? nextFileDiff
-        )
+        this.pendingRender.latestDiff ===
+          (this.getLatestDiff(nextFileDiff) ?? nextFileDiff)
       ) {
         return {
           pendingRenderDiff: this.pendingRender.diff,

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -764,6 +764,7 @@ export class Editor<
             editor,
             lineAnnotations,
           };
+          fileInstance.__acceptEditorChange(event);
           editor.#options.onChange?.(event);
           fileInstance.emitEditChange(event);
         };
@@ -788,6 +789,7 @@ export class Editor<
             editor,
             lineAnnotations,
           };
+          fileInstance.__acceptEditorChange(event);
           editor.#options.onChange?.(event);
           fileInstance.emitEditChange(event);
         };

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -1356,7 +1356,7 @@ export class Editor<
   }
 
   /** @internal */
-  __syncRenderView = (props: SyncRenderViewProps<EType, LAnnotation>): void => {
+  __syncRenderView(props: SyncRenderViewProps<EType, LAnnotation>): void {
     const {
       highlighter,
       fileContainer,
@@ -1705,6 +1705,11 @@ export class Editor<
         );
       }
 
+      // A reconciled replacement is current even when its text did not change.
+      // Retire it before checkpointing the new diff state or notifying observers.
+      if (externalDocument) {
+        fileInstance.__acknowledgeDocumentUpdate();
+      }
       this.#checkpointEditSessionState();
     } catch (error) {
       this.#restoreEditorStateOnSync = restoreEditorStateOnSync;
@@ -1717,7 +1722,7 @@ export class Editor<
     }
 
     this.#scheduleOnAttach(fileInstance);
-  };
+  }
 
   // The host component has already rendered these external contents. Update
   // only the editor document and history so the same replacement is not
@@ -7001,6 +7006,8 @@ export class Editor<
       this.#updateSelections(newSelections);
     }
 
+    // A completed local edit also supersedes any pending external replacement.
+    this.#fileInstance?.__acknowledgeDocumentUpdate();
     this.#checkpointEditSessionState();
 
     this.#recordEditPredictionHistory(change, options?.editSource ?? 'user');

--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -1359,7 +1359,7 @@ export class Editor<
       highlighter,
       fileContainer,
       renderRange,
-      resetHistory = false,
+      externalDocument = false,
     } = props;
     const renderView:
       | SyncFileRenderViewProps<LAnnotation>
@@ -1376,7 +1376,6 @@ export class Editor<
       | EditorLineAnnotation<EType, LAnnotation>[]
       | undefined;
     const editStateKey = this.#editStateKey;
-    const externalDocument = renderView.externalDocument === true;
     const fileInstance = this.#fileInstance;
     const editSession = this.#editSession;
     if (!this.#isRendering || fileInstance == null || editSession == null) {
@@ -1461,6 +1460,16 @@ export class Editor<
         ? fileOrDiff.contents
         : fileOrDiff.additionLines.join('');
     const previousTextDocument = editSession.document;
+    // The caller flags whether the host replaced the file (`externalDocument`)
+    // document that should win. Undo-reset, however, is derived here from the
+    // editor's own fileInfo: it resets only when name/language change or when
+    // the caller passes in resetHistory
+    const resetHistory =
+      props.resetHistory ??
+      (previousTextDocument != null &&
+        editSession.fileInfo != null &&
+        (editSession.fileInfo.name !== fileOrDiff.name ||
+          previousTextDocument.languageId !== languageId));
     const documentChanges =
       externalDocument &&
       previousTextDocument !== undefined &&

--- a/packages/diffs/src/highlighter/shared_highlighter.ts
+++ b/packages/diffs/src/highlighter/shared_highlighter.ts
@@ -12,11 +12,14 @@ import type {
   HighlighterTypes,
   SupportedLanguages,
   ThemeRegistrationResolved,
+  ThemesType,
 } from '../types';
 import type { ResolvedLanguage } from '../worker/types';
+import { areLanguagesAttached } from './languages/areLanguagesAttached';
 import { attachResolvedLanguages } from './languages/attachResolvedLanguages';
 import { cleanUpResolvedLanguages } from './languages/cleanUpResolvedLanguages';
 import { getResolvedOrResolveLanguage } from './languages/getResolvedOrResolveLanguage';
+import { areThemesAttached } from './themes/areThemesAttached';
 import { attachResolvedThemes } from './themes/attachResolvedThemes';
 import { cleanUpResolvedThemes } from './themes/cleanUpResolvedThemes';
 import { getResolvedOrResolveTheme } from './themes/getResolvedOrResolveTheme';
@@ -55,7 +58,7 @@ export async function getSharedHighlighter({
   highlighter = instance;
 
   const languageLoaders: Promise<ResolvedLanguage>[] = [];
-  for (const language of langs) {
+  for (const language of Array.from(new Set(langs))) {
     if (language === 'text' || language === 'ansi') continue;
     const maybeResolvedLanguage = getResolvedOrResolveLanguage(language);
     if ('then' in maybeResolvedLanguage) {
@@ -96,11 +99,25 @@ export function isHighlighterLoaded(
   return h != null && !('then' in h);
 }
 
-export function getHighlighterIfLoaded(): DiffsHighlighter | undefined {
-  if (highlighter != null && !('then' in highlighter)) {
-    return highlighter;
+interface GetHighlighterIfLoadedProps {
+  theme: DiffsThemeNames | ThemesType;
+  lang: SupportedLanguages;
+}
+
+export function getHighlighterIfLoaded(
+  withSettings?: GetHighlighterIfLoadedProps
+): DiffsHighlighter | undefined {
+  if (highlighter == null || 'then' in highlighter) {
+    return undefined;
   }
-  return undefined;
+  if (
+    withSettings != null &&
+    (!areThemesAttached(withSettings.theme) ||
+      !areLanguagesAttached(withSettings.lang))
+  ) {
+    return undefined;
+  }
+  return highlighter;
 }
 
 export function isHighlighterLoading(

--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -1158,6 +1158,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
       }
     } else {
       this.computedLang = diff.lang ?? getFiletypeFromFileName(diff.name);
+      this.highlighter ??= getHighlighterIfLoaded();
       const hasThemes =
         this.highlighter != null && areThemesAttached(options.theme);
       const hasLangs =

--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -308,7 +308,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
    * empty additions document gets one row for the editor's caret.
    */
   public beginEditSession(
-    diff?: FileDiffMetadata,
+    diff: FileDiffMetadata,
     externalDiff?: FileDiffMetadata
   ): void {
     const { editSessionActive: wasAlreadyActive, renderCache } = this;
@@ -316,28 +316,18 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
     if (!wasAlreadyActive) {
       this.pendingHighlightResult = undefined;
     }
-    if (diff != null) {
-      this.diff = diff;
-    }
+    this.diff = diff;
 
-    const currentDiff = diff ?? this.diffCache;
-    if (
-      currentDiff != null &&
-      !currentDiff.isPartial &&
-      currentDiff.additionLines.length === 0
-    ) {
+    if (!diff.isPartial && diff.additionLines.length === 0) {
       Object.assign(
-        currentDiff,
-        recomputeEmptyDocumentDiff(currentDiff, this.options.parseDiffOptions)
+        diff,
+        recomputeEmptyDocumentDiff(diff, this.options.parseDiffOptions)
       );
-      this.markEditSessionPass(currentDiff);
+      this.markEditSessionPass(diff);
       this.clearRenderCache();
       return;
     }
 
-    if (diff == null) {
-      return;
-    }
     if (renderCache == null) {
       return;
     }

--- a/packages/diffs/src/renderers/FileRenderer.ts
+++ b/packages/diffs/src/renderers/FileRenderer.ts
@@ -196,16 +196,13 @@ export class FileRenderer<LAnnotation = undefined> {
    * rendering resumes after recycle.
    */
   public beginEditSession(
-    file?: FileContents,
+    file: FileContents,
     externalFile?: FileContents
   ): void {
     const { editSessionActive: wasAlreadyActive, renderCache } = this;
     this.editSessionActive = true;
     if (!wasAlreadyActive) {
       this.pendingHighlightResult = undefined;
-    }
-    if (file == null) {
-      return;
     }
 
     this.file = file;

--- a/packages/diffs/src/renderers/FileRenderer.ts
+++ b/packages/diffs/src/renderers/FileRenderer.ts
@@ -769,6 +769,7 @@ export class FileRenderer<LAnnotation = undefined> {
       }
     } else {
       this.computedLang = file.lang ?? getFiletypeFromFileName(file.name);
+      this.highlighter ??= getHighlighterIfLoaded();
       const hasThemes =
         this.highlighter != null && areThemesAttached(options.theme);
       const hasLangs =

--- a/packages/diffs/src/worker/WorkerPoolManager.ts
+++ b/packages/diffs/src/worker/WorkerPoolManager.ts
@@ -2,6 +2,7 @@ import LRUMapPkg from 'lru_map';
 import type { LRUMap } from 'lru_map';
 
 import { DEFAULT_THEMES } from '../constants';
+import { areLanguagesAttached } from '../highlighter/languages/areLanguagesAttached';
 import { getResolvedLanguages } from '../highlighter/languages/getResolvedLanguages';
 import { hasResolvedLanguages } from '../highlighter/languages/hasResolvedLanguages';
 import { resolveLanguages } from '../highlighter/languages/resolveLanguages';
@@ -983,6 +984,18 @@ export class WorkerPoolManager {
     langs: SupportedLanguages[]
   ): Promise<void> {
     try {
+      // Lets keep the main thread highlighter in sync with loaded themes so
+      // edits can be more seamless
+      const mainThreadLangs = langs.filter(
+        (lang) => !areLanguagesAttached(lang)
+      );
+      if (mainThreadLangs.length > 0) {
+        void getSharedHighlighter({
+          themes: getThemes(this.renderOptions.theme),
+          langs: ['text', ...mainThreadLangs],
+          preferredHighlighter: this.preferredHighlighter,
+        });
+      }
       // Add resolved languages if required
       const workerMissingLangs = langs.filter(
         (lang) => !availableWorker.langs.has(lang)

--- a/packages/diffs/src/worker/WorkerPoolManager.ts
+++ b/packages/diffs/src/worker/WorkerPoolManager.ts
@@ -994,6 +994,8 @@ export class WorkerPoolManager {
           themes: getThemes(this.renderOptions.theme),
           langs: ['text', ...mainThreadLangs],
           preferredHighlighter: this.preferredHighlighter,
+        }).catch((error: unknown) => {
+          console.error(error);
         });
       }
       // Add resolved languages if required

--- a/packages/diffs/test/CodeView.edit.test.ts
+++ b/packages/diffs/test/CodeView.edit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { createTwoFilesPatch } from 'diff';
 
 import {
@@ -19,6 +19,10 @@ import type {
   EditorType,
   EditorViewState,
 } from '../src/editor/types';
+import {
+  disposeHighlighter,
+  getSharedHighlighter,
+} from '../src/highlighter/shared_highlighter';
 import type {
   CodeViewItem,
   DiffLineAnnotation,
@@ -226,6 +230,18 @@ async function expectMissingEditorFactoryOnRender(
     cleanup();
   }
 }
+
+beforeAll(async () => {
+  await getSharedHighlighter({
+    themes: ['pierre-dark', 'pierre-light'],
+    langs: ['typescript'],
+    preferredHighlighter: 'shiki-js',
+  });
+});
+
+afterAll(async () => {
+  await disposeHighlighter();
+});
 
 describe('CodeView item edit mode', () => {
   test('validates the factory only when a rendered item needs an editor', async () => {

--- a/packages/diffs/test/CodeView.edit.test.ts
+++ b/packages/diffs/test/CodeView.edit.test.ts
@@ -142,11 +142,13 @@ function insertAtStart(editor: AnyTrackedEditor, text: string): void {
 }
 
 function getEditSessionDiff(instance: unknown): FileDiffMetadata | undefined {
-  return (instance as { editSessionDiff?: FileDiffMetadata }).editSessionDiff;
+  return (instance as { editSession?: { diff: FileDiffMetadata } }).editSession
+    ?.diff;
 }
 
 function getEditSessionFile(instance: unknown): FileContents | undefined {
-  return (instance as { editSessionFile?: FileContents }).editSessionFile;
+  return (instance as { editSession?: { file: FileContents } }).editSession
+    ?.file;
 }
 
 function getExternalFile(instance: unknown): FileContents | undefined {

--- a/packages/diffs/test/CodeView.highlighterReady.test.ts
+++ b/packages/diffs/test/CodeView.highlighterReady.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, expect, spyOn, test } from 'bun:test';
+import { afterAll, expect, mock, spyOn, test } from 'bun:test';
 
 import { CodeView } from '../src/components/CodeView';
 import {
@@ -11,6 +11,59 @@ import { createRoot, installDom, wait, waitFor } from './domHarness';
 import { createDeferred } from './testUtils';
 
 afterAll(disposeHighlighter);
+
+test('retries a failed theme load on a later render without automatically retrying', async () => {
+  const theme = {
+    name: 'codeview-retry-theme',
+    type: 'dark',
+    colors: {},
+    tokenColors: [],
+  } satisfies ThemeRegistration;
+  const firstLoad = createDeferred<ThemeRegistration>();
+  const loader = mock(() => firstLoad.promise);
+  registerCustomTheme(theme.name, loader);
+  const error = new Error('Theme chunk failed to load');
+  const logError = spyOn(console, 'error').mockImplementation(() => {});
+  const dom = installDom();
+  const viewer = new CodeView({ theme: theme.name });
+  const render = spyOn(viewer, 'render');
+  try {
+    viewer.setup(createRoot());
+    viewer.setItems([
+      {
+        id: 'file',
+        type: 'file',
+        file: { name: 'ready.txt', lang: 'text', contents: 'ready\n' },
+      },
+    ]);
+    viewer.render(true);
+    await waitFor(() => loader.mock.calls.length === 1);
+    await wait(0);
+    render.mockClear();
+
+    firstLoad.reject(error);
+    await waitFor(() => logError.mock.calls.length > 0);
+    await wait(0);
+    expect(logError).toHaveBeenCalledWith(error);
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(render).not.toHaveBeenCalled();
+    expect(viewer.getRenderedItems()).toHaveLength(0);
+
+    loader.mockImplementation(() => Promise.resolve(theme));
+    viewer.render(true);
+    await waitFor(() => viewer.getRenderedItems().length === 1);
+    expect(loader).toHaveBeenCalledTimes(2);
+    expect(
+      viewer.getRenderedItems()[0]?.element.shadowRoot?.textContent
+    ).toContain('ready');
+  } finally {
+    viewer.cleanUp();
+    firstLoad.resolve(theme);
+    render.mockRestore();
+    logError.mockRestore();
+    dom.cleanup();
+  }
+});
 
 for (const obsoleteFinishesFirst of [false, true]) {
   test(`switches pending themes when the ${obsoleteFinishesFirst ? 'obsolete' : 'current'} loader finishes first`, async () => {

--- a/packages/diffs/test/CodeView.highlighterReady.test.ts
+++ b/packages/diffs/test/CodeView.highlighterReady.test.ts
@@ -1,0 +1,100 @@
+import { afterAll, expect, spyOn, test } from 'bun:test';
+
+import { CodeView } from '../src/components/CodeView';
+import {
+  disposeHighlighter,
+  getSharedHighlighter,
+} from '../src/highlighter/shared_highlighter';
+import { registerCustomTheme } from '../src/highlighter/themes/registerCustomTheme';
+import type { ThemeRegistration } from '../src/types';
+import { createRoot, installDom, wait, waitFor } from './domHarness';
+import { createDeferred } from './testUtils';
+
+afterAll(disposeHighlighter);
+
+for (const obsoleteFinishesFirst of [false, true]) {
+  test(`switches pending themes when the ${obsoleteFinishesFirst ? 'obsolete' : 'current'} loader finishes first`, async () => {
+    const obsoleteName = `codeview-obsolete-${obsoleteFinishesFirst}`;
+    const currentName = `codeview-current-${obsoleteFinishesFirst}`;
+    const obsoleteTheme: ThemeRegistration = {
+      name: obsoleteName,
+      type: 'dark',
+      colors: {},
+      tokenColors: [],
+    };
+    const currentTheme: ThemeRegistration = {
+      ...obsoleteTheme,
+      name: currentName,
+    };
+    const obsolete = createDeferred<ThemeRegistration>();
+    const current = createDeferred<ThemeRegistration>();
+    const started: string[] = [];
+    registerCustomTheme(obsoleteName, () => {
+      started.push(obsoleteName);
+      return obsolete.promise;
+    });
+    registerCustomTheme(currentName, () => {
+      started.push(currentName);
+      return current.promise;
+    });
+
+    const dom = installDom();
+    const viewer = new CodeView({ theme: obsoleteName });
+    const render = spyOn(viewer, 'render');
+    try {
+      viewer.setup(createRoot());
+      viewer.setItems([
+        {
+          id: 'file',
+          type: 'file',
+          file: { name: 'ready.txt', lang: 'text', contents: 'ready\n' },
+        },
+      ]);
+      viewer.render(true);
+      await waitFor(() => started.includes(obsoleteName));
+      expect(started).toEqual([obsoleteName]);
+      expect(viewer.getRenderedItems()).toHaveLength(0);
+
+      viewer.setOptions({ theme: currentName });
+      viewer.render(true);
+      await waitFor(() => started.includes(currentName));
+      expect(started).toEqual([obsoleteName, currentName]);
+      expect(viewer.getRenderedItems()).toHaveLength(0);
+
+      if (obsoleteFinishesFirst) {
+        await wait(0);
+        render.mockClear();
+        obsolete.resolve(obsoleteTheme);
+        await getSharedHighlighter({ themes: [obsoleteName], langs: [] });
+        await wait(0);
+        expect(render).not.toHaveBeenCalled();
+        expect(viewer.getRenderedItems()).toHaveLength(0);
+      }
+
+      current.resolve(currentTheme);
+      await waitFor(() => viewer.getRenderedItems().length === 1);
+      expect(
+        viewer.getRenderedItems()[0]?.element.shadowRoot?.textContent
+      ).toContain('ready');
+
+      if (!obsoleteFinishesFirst) {
+        await wait(0);
+        render.mockClear();
+        obsolete.resolve(obsoleteTheme);
+        await getSharedHighlighter({ themes: [obsoleteName], langs: [] });
+        await wait(0);
+        expect(render).not.toHaveBeenCalled();
+      }
+    } finally {
+      viewer.cleanUp();
+      obsolete.resolve(obsoleteTheme);
+      current.resolve(currentTheme);
+      await getSharedHighlighter({
+        themes: [obsoleteName, currentName],
+        langs: [],
+      });
+      render.mockRestore();
+      dom.cleanup();
+    }
+  });
+}

--- a/packages/diffs/test/DiffHunksRendererRecompute.test.ts
+++ b/packages/diffs/test/DiffHunksRendererRecompute.test.ts
@@ -267,7 +267,8 @@ describe('DiffHunksRenderer edit-session hunk updates', () => {
     );
     await renderer.asyncRender(diff);
     renderer.renderDiff(diff);
-    renderer.beginEditSession();
+    renderer.beginEditSession(diff);
+    renderer.renderDiff(diff);
     return { renderer, diff };
   }
 
@@ -289,8 +290,8 @@ describe('DiffHunksRenderer edit-session hunk updates', () => {
       { name: 'jump.ts', contents: newContents, cacheKey: 'jump:new' }
     );
     await renderer.asyncRender(diff);
+    renderer.beginEditSession(diff);
     renderer.renderDiff(diff);
-    renderer.beginEditSession();
 
     // The Enter keystroke: one blank line inserted below the changed line.
     const editedLines = newContents.split('\n');
@@ -382,8 +383,8 @@ describe('DiffHunksRenderer edit-session hunk updates', () => {
       { name: 'jump.ts', contents: newContents, cacheKey: 'jump:new' }
     );
     await renderer.asyncRender(diff);
+    renderer.beginEditSession(diff);
     renderer.renderDiff(diff);
-    renderer.beginEditSession();
 
     const editedLines = newContents.split('\n');
     // Mirror the dirty-token pass that precedes applyDocumentChange. The
@@ -450,8 +451,8 @@ describe('DiffHunksRenderer edit-session hunk updates', () => {
       { context: totalLines }
     );
     await renderer.asyncRender(diff);
+    renderer.beginEditSession(diff);
     renderer.renderDiff(diff);
-    renderer.beginEditSession();
 
     const styledRowTexts = (result: ReturnType<typeof renderer.renderDiff>) =>
       collectAllElements(result?.additionsContentAST ?? [])
@@ -546,8 +547,8 @@ describe('DiffHunksRenderer edit-session hunk updates', () => {
       { name: 'topology.ts', contents: 'a\na\na\nd\n' }
     );
     await renderer.asyncRender(diff);
+    renderer.beginEditSession(diff);
     renderer.renderDiff(diff);
-    renderer.beginEditSession();
     const boundsBefore = {
       additionLineIndex: diff.hunks[0].additionLineIndex,
       additionCount: diff.hunks[0].additionCount,
@@ -576,8 +577,8 @@ describe('DiffHunksRenderer edit-session hunk updates', () => {
       { name: 'pairing.ts', contents: '\n!\nb\nc\n' }
     );
     await renderer.asyncRender(diff);
+    renderer.beginEditSession(diff);
     renderer.renderDiff(diff);
-    renderer.beginEditSession();
     const boundsBefore = {
       additionLineIndex: diff.hunks[0].additionLineIndex,
       additionCount: diff.hunks[0].additionCount,
@@ -805,8 +806,8 @@ describe('DiffHunksRenderer edit-session hunk updates', () => {
       { name: 'after.ts', contents: 'temporary\n' }
     );
     await renderer.asyncRender(diff);
+    renderer.beginEditSession(diff);
     renderer.renderDiff(diff);
-    renderer.beginEditSession();
 
     renderer.applyDocumentChange(makeTextDocument(['']));
 

--- a/packages/diffs/test/WorkerPoolManager.test.ts
+++ b/packages/diffs/test/WorkerPoolManager.test.ts
@@ -10,9 +10,15 @@ import {
 } from 'bun:test';
 
 import { parseDiffFromFile } from '../src';
+import * as sharedHighlighter from '../src/highlighter/shared_highlighter';
 import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
-import type { FileContents, FileDiffMetadata } from '../src/types';
+import type {
+  DiffsHighlighter,
+  FileContents,
+  FileDiffMetadata,
+} from '../src/types';
 import type { DiffRendererInstance } from '../src/worker/types';
+import { createDeferred } from './testUtils';
 import {
   createInitializedManager,
   createInitializingManager,
@@ -134,6 +140,41 @@ describe('WorkerPoolManager lifecycle', () => {
 });
 
 describe('WorkerPoolManager cache priming', () => {
+  test('reports a background preload failure without blocking worker rendering', async () => {
+    await disposeHighlighter();
+    const { manager, worker } = await createInitializedManager();
+    const highlighter = await sharedHighlighter.getSharedHighlighter({
+      themes: [],
+      langs: [],
+    });
+    const preload = createDeferred<DiffsHighlighter>();
+    const logged = createDeferred<unknown>();
+    const error = new Error('Shared highlighter preload failed');
+    spyOn(sharedHighlighter, 'getSharedHighlighter').mockImplementation(
+      () => preload.promise
+    );
+    const logError = spyOn(console, 'error').mockImplementation((error) => {
+      logged.resolve(error);
+    });
+    try {
+      const file = { ...createCacheableFile(), lang: 'css' as const };
+      const prime = manager.primeFileHighlightCache(file);
+      const request = await withTimeout(worker.waitForFileRequest());
+      respondToFileRequest(manager, worker, request);
+      await withTimeout(prime);
+      expect(manager.getFileResultCache(file)).toBeDefined();
+
+      preload.reject(error);
+      expect(await withTimeout(logged.promise)).toBe(error);
+      expect(logError).toHaveBeenCalledTimes(1);
+      expect(manager.isWorkingPool()).toBe(true);
+      expect(manager.getStats().activeTasks).toBe(0);
+    } finally {
+      preload.resolve(highlighter);
+      manager.terminate();
+    }
+  });
+
   test('does not read or populate the shared cache for an unkeyed diff', async () => {
     const { manager, worker } = await createInitializedManager();
     const successes: FileDiffMetadata[] = [];

--- a/packages/diffs/test/e2e/code-view-prediction.pw.ts
+++ b/packages/diffs/test/e2e/code-view-prediction.pw.ts
@@ -209,15 +209,15 @@ test.describe('CodeView edit prediction layout', () => {
         page,
       }) => {
         const pageErrors = await openFixture(page, { overflow, diff });
-        // Errors logged while the items first rendered are outside this
-        // feature; the ghost text must add none from here on.
-        const settled = (await consoleErrors(page)).length;
+        // The items' first paint is deferred by the cold highlighter; the
+        // invariants must stay quiet through it and through the ghost text.
+        expect(await invariantErrorsSince(page, 0)).toEqual([]);
 
         await showGhost(page, 'first', ANCHOR_LINE);
-        expect(await invariantErrorsSince(page, settled)).toEqual([]);
+        expect(await invariantErrorsSince(page, 0)).toEqual([]);
 
         await hideGhost(page, 'first');
-        expect(await invariantErrorsSince(page, settled)).toEqual([]);
+        expect(await invariantErrorsSince(page, 0)).toEqual([]);
         expect(pageErrors).toEqual([]);
       });
     }

--- a/packages/diffs/test/editorDiffEmptyDocument.test.ts
+++ b/packages/diffs/test/editorDiffEmptyDocument.test.ts
@@ -56,8 +56,8 @@ function countEditableLineEls(content: HTMLElement): number {
 function getEditSessionDiff(
   fileDiff: FileDiff<undefined>
 ): FileDiffMetadata | undefined {
-  return (fileDiff as unknown as { editSessionDiff?: FileDiffMetadata })
-    .editSessionDiff;
+  return (fileDiff as unknown as { editSession?: { diff: FileDiffMetadata } })
+    .editSession?.diff;
 }
 
 interface DiffEditorFixture {

--- a/packages/diffs/test/editorFoldNavigation.test.ts
+++ b/packages/diffs/test/editorFoldNavigation.test.ts
@@ -34,8 +34,8 @@ function findAdditionContent(container: HTMLElement): HTMLElement | undefined {
 function getEditSessionDiff(
   fileDiff: FileDiff<undefined>
 ): FileDiffMetadata | undefined {
-  return (fileDiff as unknown as { editSessionDiff?: FileDiffMetadata })
-    .editSessionDiff;
+  return (fileDiff as unknown as { editSession?: { diff: FileDiffMetadata } })
+    .editSession?.diff;
 }
 
 interface FoldFixture {

--- a/packages/diffs/test/editorPredictionLayout.test.ts
+++ b/packages/diffs/test/editorPredictionLayout.test.ts
@@ -194,17 +194,6 @@ async function createHost(
     { editPrediction: { provider: createGhostProvider() } }
   );
 
-  // Let the component finish its first paint (a cold highlighter completes it
-  // asynchronously) before the editor takes over rendering.
-  const waitForCode = () =>
-    waitFor(
-      () =>
-        fileContainer.shadowRoot?.querySelector(
-          '[data-code]:not([data-deletions])'
-        ) instanceof HTMLElement,
-      { timeout: 3_000 }
-    );
-
   let host: Omit<LayoutHost, 'editor' | 'content' | 'reconcileRequests'>;
   if (surface === 'File') {
     const file: FileContents = { name: FILE_NAME, contents };
@@ -213,7 +202,6 @@ async function createHost(
       virtualizer
     );
     instance.render({ file, fileContainer, forceRender: true });
-    await waitForCode();
     editor.edit(instance);
     host = {
       instance,
@@ -254,7 +242,6 @@ async function createHost(
       virtualizer
     );
     instance.render({ fileDiff, fileContainer, forceRender: true });
-    await waitForCode();
     editor.edit(instance);
     host = {
       instance,

--- a/packages/diffs/test/editorPublicApi.test.ts
+++ b/packages/diffs/test/editorPublicApi.test.ts
@@ -1030,7 +1030,7 @@ describe('Editor document registry surfaces', () => {
     }
   });
 
-  test('a pending compatible replacement retains the outgoing edits', async () => {
+  test('a same-name pending push applies over retained edits and stays undoable', async () => {
     EditStateManager.clearAll();
     const documentKey = 'diff-pending-compatible-replacement';
     const first = await createDiffEditorFixture(
@@ -1055,8 +1055,13 @@ describe('Editor document registry surfaces', () => {
       'replacement contents'
     );
     try {
-      expect(resumed.editor.getText()).toBe(retainedText);
+      // A same-name/language push arriving while edits exist is applied
+      // deterministically as the current content, but the edit stays in history
+      // so undo recovers it.
+      expect(resumed.editor.getText()).toBe('replacement contents');
       expect(resumed.editor.canUndo).toBe(true);
+      resumed.editor.undo();
+      expect(resumed.editor.getText()).toBe(retainedText);
     } finally {
       resumed.cleanup();
       EditStateManager.clearAll();

--- a/packages/diffs/test/editorPublicApi.test.ts
+++ b/packages/diffs/test/editorPublicApi.test.ts
@@ -1030,7 +1030,7 @@ describe('Editor document registry surfaces', () => {
     }
   });
 
-  test('a same-name pending push applies over retained edits and stays undoable', async () => {
+  test('a pending compatible replacement applies but keeps the edits undoable', async () => {
     EditStateManager.clearAll();
     const documentKey = 'diff-pending-compatible-replacement';
     const first = await createDiffEditorFixture(
@@ -1055,9 +1055,9 @@ describe('Editor document registry surfaces', () => {
       'replacement contents'
     );
     try {
-      // A same-name/language push arriving while edits exist is applied
-      // deterministically as the current content, but the edit stays in history
-      // so undo recovers it.
+      // The external replacement wins (matching File), so the resumed document
+      // shows it — but the outgoing edits survive as undo history because the
+      // compatible swap kept it.
       expect(resumed.editor.getText()).toBe('replacement contents');
       expect(resumed.editor.canUndo).toBe(true);
       resumed.editor.undo();

--- a/packages/diffs/test/editorRecycle.test.ts
+++ b/packages/diffs/test/editorRecycle.test.ts
@@ -1,28 +1,40 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from 'bun:test';
 
 import { File, type FileRenderProps } from '../src/components/File';
 import { FileDiff } from '../src/components/FileDiff';
 import { DEFAULT_THEMES } from '../src/constants';
 import { Editor } from '../src/editor/editor';
 import { EditStateManager } from '../src/editor/EditStateManager';
+import {
+  disposeHighlighter,
+  getHighlighterIfLoaded,
+  getSharedHighlighter,
+} from '../src/highlighter/shared_highlighter';
 import { queueRender } from '../src/managers/UniversalRenderingManager';
-import type {
-  DiffsHighlighter,
-  FileContents,
-  LineAnnotation,
-} from '../src/types';
+import type { FileContents, LineAnnotation } from '../src/types';
 import { parseDiffFromFile } from '../src/utils/parseDiffFromFile';
 import { installDom, wait, waitFor } from './domHarness';
 
-function createTestHighlighter(): DiffsHighlighter {
-  return {
-    getLanguage: () => undefined,
-    getLoadedLanguages: () => [],
-    getTheme: () => ({ type: 'light', colors: {} }),
-    loadLanguage: async () => {},
-    setTheme: () => ({ theme: { type: 'light' }, colorMap: [''] }),
-  } as unknown as DiffsHighlighter;
-}
+// These lifecycle tests need a ready renderer so File owns every editor sync.
+beforeAll(async () => {
+  await getSharedHighlighter({
+    themes: ['pierre-dark', 'pierre-light'],
+    langs: ['text', 'typescript'],
+  });
+});
+
+afterAll(async () => {
+  await disposeHighlighter();
+});
 
 interface TestFileHarnessOptions {
   queueRerender?: boolean;
@@ -53,39 +65,26 @@ function createTestFile(
     onContentFocus,
   }: TestFileHarnessOptions = {}
 ): TestFile {
-  const component = new File<undefined>({
-    disableFileHeader: true,
-    theme: DEFAULT_THEMES,
-  }) as TestFile;
+  const component = new File<undefined>(
+    {
+      disableFileHeader: true,
+      theme: DEFAULT_THEMES,
+    },
+    undefined,
+    true
+  ) as TestFile;
   const fileContainer = document.createElement('div');
   document.body.appendChild(fileContainer);
 
   let currentFile = initialFile;
   let currentLineAnnotations: LineAnnotation<undefined>[] | undefined;
-  let currentRenderRange: FileRenderProps<undefined>['renderRange'];
-  let attachedEditor: Editor<'file', undefined> | undefined;
-  let completePendingAttach: (() => void) | undefined;
-
-  const syncRenderView = (externalDocument = false) => {
-    attachedEditor?.__syncRenderView({
-      highlighter: createTestHighlighter(),
-      fileContainer,
-      file: currentFile,
-      lineAnnotations: currentLineAnnotations,
-      renderRange: currentRenderRange,
-      externalDocument,
-      resetHistory: false,
-    });
-  };
+  let attaching = false;
 
   const render = component.render.bind(component);
   component.render = ((props: Partial<FileRenderProps<undefined>>) => {
     currentFile = props.file ?? currentFile;
     if ('lineAnnotations' in props) {
       currentLineAnnotations = props.lineAnnotations;
-    }
-    if ('renderRange' in props) {
-      currentRenderRange = props.renderRange;
     }
     const rendered = render({
       ...props,
@@ -103,7 +102,6 @@ function createTestFile(
 
   const applyDocumentChange = component.applyDocumentChange.bind(component);
   component.applyDocumentChange = ((textDocument, lineAnnotations) => {
-    currentFile = { ...currentFile, contents: textDocument.getText() };
     if (lineAnnotations !== undefined) {
       currentLineAnnotations = lineAnnotations;
     }
@@ -138,57 +136,37 @@ function createTestFile(
     lineAnnotations = currentLineAnnotations
   ) => {
     component.render({ file, lineAnnotations });
-    completePendingAttach?.();
-    syncRenderView(true);
   };
 
   const rerender = component.rerender.bind(component);
   component.rerender = () => {
+    // Hold the first editor render to exercise adoption before its DOM is
+    // ready. The real association and edit session are already installed.
+    if (attaching && !syncOnAttach) return;
     if (queueRerender) {
-      queueRender(() => {
-        rerender();
-        syncRenderView();
-      });
+      queueRender(rerender);
       return;
     }
     rerender();
-    syncRenderView();
   };
 
   const attach = component.__attachEditor.bind(component);
   component.__attachEditor = (editor) => {
-    attachedEditor = editor;
-    let detach: (() => void) | undefined;
-    let pending = !syncOnAttach;
-    const attachNow = () => {
-      detach = attach(editor);
-      completePendingAttach = undefined;
-      syncRenderView();
-    };
-    if (!pending) {
-      attachNow();
-    } else {
-      completePendingAttach = () => {
-        if (!pending) return;
-        pending = false;
-        attachNow();
-      };
+    attaching = true;
+    try {
+      return attach(editor);
+    } finally {
+      attaching = false;
     }
-    const resume = component.rerender.bind(component);
-    component.rerender = () => {
-      if (pending) {
-        pending = false;
-        attachNow();
-      } else {
-        resume();
-      }
-    };
-    return () => {
-      pending = false;
-      completePendingAttach = undefined;
-      attachedEditor = undefined;
-      detach?.();
-    };
+  };
+
+  const cleanUp = component.cleanUp.bind(component);
+  component.cleanUp = (recycle) => {
+    cleanUp(recycle);
+    // The host owns container cleanup, just as CodeView.cleanElement strips
+    // item DOM before putting a managed container back in its pool.
+    fileContainer.shadowRoot?.replaceChildren();
+    if (recycle !== true) fileContainer.remove();
   };
 
   component.render({ file: initialFile });
@@ -208,18 +186,6 @@ function createTestDiff(file: FileContents): FileDiff<undefined> {
     fileContainer,
     forceRender: true,
   });
-  const attach = component.__attachEditor.bind(component);
-  component.__attachEditor = (editor) => {
-    const detach = attach(editor);
-    editor.__syncRenderView({
-      highlighter: createTestHighlighter(),
-      fileContainer,
-      fileDiff,
-      lineAnnotations: undefined,
-      renderRange: undefined,
-    });
-    return detach;
-  };
   return component;
 }
 
@@ -365,7 +331,7 @@ describe('Editor onAttach lifecycle', () => {
 
       const file = createFile();
       editor.__syncRenderView({
-        highlighter: createTestHighlighter(),
+        highlighter: getHighlighterIfLoaded()!,
         fileContainer: component.testFileContainer,
         file,
         lineAnnotations: undefined,
@@ -1158,6 +1124,7 @@ describe('Editor edit-state manager', () => {
       first.cleanUp();
 
       secondEditor.edit(second);
+      expect(second.contentElement.contentEditable).not.toBe('true');
       second.renderExternalFile(
         createFile({ contents: `${retainedText}\nexternal` }),
         [{ lineNumber: 2, metadata: undefined }]
@@ -1536,11 +1503,11 @@ describe('Editor edit-state manager', () => {
 });
 
 describe('Editor recycle cleanUp', () => {
-  test('recycle keeps document and undo history across re-attach', async () => {
+  test('recycle keeps document and undo history across re-attach', () => {
     const dom = installDom();
+    const editor = new Editor('file');
+    const first = createTestFile(createFile());
     try {
-      const editor = new Editor('file');
-      const first = createTestFile(createFile());
       editor.edit(first);
       insertAtStart(editor, 'X');
       expect(editor.getText()).toBe(`X${FILE_CONTENTS}`);
@@ -1559,10 +1526,9 @@ describe('Editor recycle cleanUp', () => {
       // Undo history lives in the retained document and survives with it.
       editor.undo();
       expect(editor.getText()).toBe(FILE_CONTENTS);
-
-      editor.cleanUp();
-      await wait(0);
     } finally {
+      editor.cleanUp();
+      first.cleanUp();
       dom.cleanup();
     }
   });
@@ -1648,11 +1614,11 @@ describe('Editor recycle cleanUp', () => {
     }
   });
 
-  test('recycled re-attach recreates a tokenizer so edits still paint', async () => {
+  test('recycled re-attach recreates a tokenizer so edits still paint', () => {
     const dom = installDom();
+    const editor = new Editor('file');
+    const first = createTestFile(createFile());
     try {
-      const editor = new Editor('file');
-      const first = createTestFile(createFile());
       editor.edit(first);
 
       editor.cleanUp('recycle');
@@ -1663,24 +1629,29 @@ describe('Editor recycle cleanUp', () => {
       // rebuild. The tokenizer must be recreated anyway, otherwise #rerender
       // bails and this edit would update the model without painting.
       editor.edit(first);
+      expect(first.testFileContainer.isConnected).toBe(true);
+      expect(
+        first.testFileContainer.shadowRoot?.querySelectorAll('[data-content]')
+      ).toHaveLength(1);
+      expect(first.contentElement.contentEditable).toBe('true');
       insertAtStart(editor, 'Y');
 
       expect(editor.getText()).toBe(`Y${FILE_CONTENTS}`);
       const firstLine = first.contentElement.children[0] as HTMLElement;
       expect(firstLine.textContent).toBe('Yalpha');
-
-      editor.cleanUp();
-      await wait(0);
     } finally {
+      editor.cleanUp();
+      first.cleanUp();
       dom.cleanup();
     }
   });
 
   test('full cleanUp still rebuilds from host contents', () => {
     const dom = installDom();
+    const editor = new Editor('file');
+    const first = createTestFile(createFile());
+    let second: TestFile | undefined;
     try {
-      const editor = new Editor('file');
-      const first = createTestFile(createFile());
       editor.edit(first);
       insertAtStart(editor, 'X');
       expect(editor.getText()).toBe(`X${FILE_CONTENTS}`);
@@ -1690,27 +1661,28 @@ describe('Editor recycle cleanUp', () => {
 
       // A destructive cleanUp drops the document, so the next edit() builds
       // from whatever the host currently renders and undo history is gone.
-      const second = createTestFile(createFile());
+      second = createTestFile(createFile());
       editor.edit(second);
       expect(second.contentElement.textContent).toBe('alphabravocharlie');
 
       editor.undo();
       expect(second.contentElement.textContent).toBe('alphabravocharlie');
-
-      editor.cleanUp();
     } finally {
+      editor.cleanUp();
+      first.cleanUp();
+      second?.cleanUp();
       dom.cleanup();
     }
   });
 
   test('recycle re-attach to a different file rebuilds without re-notifying', async () => {
     const dom = installDom();
+    const onAttach = mock(
+      (_editor: Editor<'file', undefined>, _component: File<undefined>) => {}
+    );
+    const editor = new Editor('file', { onAttach });
+    const first = createTestFile(createFile());
     try {
-      const onAttach = mock(
-        (_editor: Editor<'file', undefined>, _component: File<undefined>) => {}
-      );
-      const editor = new Editor('file', { onAttach });
-      const first = createTestFile(createFile());
       editor.edit(first);
       await wait(0);
       expect(onAttach).toHaveBeenCalledTimes(1);
@@ -1740,9 +1712,9 @@ describe('Editor recycle cleanUp', () => {
       expect(editor.getText()).toBe('zulu');
       expect(editor.getViewState().selections).toBeUndefined();
       expect(onAttach).toHaveBeenCalledTimes(1);
-
-      editor.cleanUp();
     } finally {
+      editor.cleanUp();
+      first.cleanUp();
       dom.cleanup();
     }
   });

--- a/packages/diffs/test/editorRenderUpdateLifecycle.test.ts
+++ b/packages/diffs/test/editorRenderUpdateLifecycle.test.ts
@@ -9,6 +9,9 @@ import {
   parseDiffFromFile,
   parsePatchFiles,
   registerCustomTheme,
+  VirtualizedFile,
+  VirtualizedFileDiff,
+  Virtualizer,
 } from '../src';
 import { Editor } from '../src/editor/editor';
 import type { EditorChangeEvent } from '../src/editor/types';
@@ -19,7 +22,7 @@ import type {
   SupportedLanguages,
   ThemeRegistration,
 } from '../src/types';
-import { installDom, waitFor } from './domHarness';
+import { createRoot, installDom, waitFor } from './domHarness';
 import { assertDefined, createDeferred } from './testUtils';
 
 afterAll(async () => {
@@ -282,6 +285,99 @@ describe('external replacements from editor onChange', () => {
           editor.cleanUp();
           instance.cleanUp();
           await getSharedHighlighter({ themes: [themeName], langs: ['text'] });
+          dom.cleanup();
+        }
+      });
+    }
+  }
+});
+
+describe('virtualized render completion before notifications', () => {
+  for (const type of ['file', 'file-diff'] as const) {
+    for (const observer of [
+      'onChange',
+      'onEditChange',
+      'onPostRender',
+    ] as const) {
+      test(`${type} can dispose its host in ${observer} during an external replacement`, async () => {
+        await getSharedHighlighter({
+          themes: ['pierre-dark', 'pierre-light'],
+          langs: ['text'],
+        });
+        const dom = installDom();
+        const virtualizer = new Virtualizer();
+        const root = createRoot();
+        const fileContainer = document.createElement('diffs-container');
+        root.appendChild(fileContainer);
+        let armed = false;
+        let notifications = 0;
+        let renderReturned = false;
+        const disposeHost = () => {
+          if (!armed) return;
+          armed = false;
+          notifications++;
+          expect(renderReturned).toBe(false);
+          expect(editor.getText()).toBe('server\n');
+          editor.cleanUp();
+          instance.cleanUp();
+        };
+        const options = {
+          disableFileHeader: true,
+          disableErrorHandling: true,
+          onEditChange: observer === 'onEditChange' ? disposeHost : undefined,
+          onPostRender: observer === 'onPostRender' ? disposeHost : undefined,
+        };
+        const instance =
+          type === 'file'
+            ? new VirtualizedFile(options, virtualizer)
+            : new VirtualizedFileDiff(options, virtualizer);
+        const editorOptions = {
+          onChange: observer === 'onChange' ? disposeHost : undefined,
+        };
+        const editor =
+          type === 'file'
+            ? new Editor('file', editorOptions)
+            : new Editor('file-diff', editorOptions);
+        const render = (contents: string) => {
+          const file: FileContents = {
+            name: 'lifecycle.txt',
+            lang: 'text',
+            contents,
+          };
+          return instance.type === 'file'
+            ? instance.render({ file, fileContainer, forceRender: true })
+            : instance.render({
+                fileDiff: parseDiffFromFile(
+                  { ...file, contents: 'base\n' },
+                  file
+                ),
+                fileContainer,
+                forceRender: true,
+              });
+        };
+
+        try {
+          virtualizer.setup(root);
+          render('alpha\n');
+          if (instance.type === 'file' && editor.type === 'file') {
+            editor.edit(instance);
+          } else if (
+            instance.type === 'file-diff' &&
+            editor.type === 'file-diff'
+          ) {
+            editor.edit(instance);
+          }
+          await waitFor(() => editor.getText() === 'alpha\n');
+          armed = true;
+          expect(render('server\n')).toBe(true);
+          renderReturned = true;
+          expect(notifications).toBe(1);
+          expect(editor.getFile()).toBeUndefined();
+        } finally {
+          armed = false;
+          editor.cleanUp();
+          instance.cleanUp();
+          virtualizer.cleanUp();
           dom.cleanup();
         }
       });

--- a/packages/diffs/test/editorRenderUpdateLifecycle.test.ts
+++ b/packages/diffs/test/editorRenderUpdateLifecycle.test.ts
@@ -3,15 +3,21 @@ import { createTwoFilesPatch } from 'diff';
 
 import {
   disposeHighlighter,
+  File,
   FileDiff,
+  getSharedHighlighter,
   parseDiffFromFile,
   parsePatchFiles,
+  registerCustomTheme,
 } from '../src';
 import { Editor } from '../src/editor/editor';
+import type { EditorChangeEvent } from '../src/editor/types';
 import type {
+  FileContents,
   FileDiffLoadedFiles,
   FileDiffMetadata,
   SupportedLanguages,
+  ThemeRegistration,
 } from '../src/types';
 import { installDom, waitFor } from './domHarness';
 import { assertDefined, createDeferred } from './testUtils';
@@ -149,6 +155,139 @@ async function renderReplacement(
     timeout: 4_000,
   });
 }
+
+describe('external replacements from editor onChange', () => {
+  for (const type of ['file', 'file-diff'] as const) {
+    for (const deferredTheme of [false, true]) {
+      test(`${type} retains a callback replacement with a ${deferredTheme ? 'loading' : 'ready'} theme`, async () => {
+        await getSharedHighlighter({
+          themes: ['pierre-dark', 'pierre-light'],
+          langs: ['text'],
+        });
+        const themeName = `editor-callback-${type}-${deferredTheme}`;
+        const theme: ThemeRegistration = {
+          name: themeName,
+          type: 'dark',
+          colors: {
+            'editor.background': '#000000',
+            'editor.foreground': '#ffffff',
+          },
+          tokenColors: [],
+        };
+        const loadedTheme = createDeferred<ThemeRegistration>();
+        registerCustomTheme(themeName, () => loadedTheme.promise);
+        if (!deferredTheme) {
+          loadedTheme.resolve(theme);
+          await getSharedHighlighter({ themes: [themeName], langs: ['text'] });
+        }
+
+        const dom = installDom();
+        const fileContainer = document.createElement('div');
+        document.body.appendChild(fileContainer);
+        const notifications: string[] = [];
+        const onEditChange = (
+          event: EditorChangeEvent<'file' | 'file-diff', undefined, undefined>
+        ) => notifications.push(`component:${event.file.contents}`);
+        const options = {
+          disableErrorHandling: true,
+          disableFileHeader: true,
+          onEditChange,
+        };
+        const instance =
+          type === 'file' ? new File(options) : new FileDiff(options);
+        const render = (contents: string) => {
+          const file: FileContents = {
+            name: 'callback.txt',
+            lang: 'text',
+            contents,
+          };
+          if (instance.type === 'file') {
+            instance.render({ file, fileContainer, forceRender: true });
+          } else {
+            instance.render({
+              fileDiff: parseDiffFromFile(
+                { ...file, contents: 'base\n' },
+                file
+              ),
+              fileContainer,
+              forceRender: true,
+            });
+          }
+        };
+        let replaced = false;
+        const onChange = (
+          event: EditorChangeEvent<'file' | 'file-diff', undefined, undefined>
+        ) => {
+          notifications.push(`editor:${event.file.contents}`);
+          if (replaced) return;
+          replaced = true;
+          instance.setOptions({ ...options, theme: themeName });
+          render('server\n');
+        };
+        const editor =
+          type === 'file'
+            ? new Editor('file', { onChange })
+            : new Editor('file-diff', { onChange });
+
+        try {
+          render('alpha\n');
+          if (instance.type === 'file' && editor.type === 'file') {
+            editor.edit(instance);
+          } else if (
+            instance.type === 'file-diff' &&
+            editor.type === 'file-diff'
+          ) {
+            editor.edit(instance);
+          }
+          expect(editor.getText()).toBe('alpha\n');
+          editor.applyEdits([
+            {
+              range: {
+                start: { line: 0, character: 0 },
+                end: { line: 0, character: 0 },
+              },
+              newText: 'X',
+            },
+          ]);
+
+          if (deferredTheme) {
+            expect(editor.getText()).toBe('Xalpha\n');
+            expect(notifications).toEqual([
+              'editor:Xalpha\n',
+              'component:Xalpha\n',
+            ]);
+            loadedTheme.resolve(theme);
+            await waitFor(() => editor.getText() === 'server\n');
+            expect(notifications).toEqual([
+              'editor:Xalpha\n',
+              'component:Xalpha\n',
+              'editor:server\n',
+              'component:server\n',
+            ]);
+          }
+          // A ready theme must reconcile within applyEdits itself.
+          expect(editor.getText()).toBe('server\n');
+          const content = Array.from(
+            fileContainer.shadowRoot?.querySelectorAll<HTMLElement>(
+              '[data-content]'
+            ) ?? []
+          ).find((element) => element.contentEditable === 'true');
+          expect(content?.textContent).toContain('server');
+          editor.undo();
+          expect(editor.getText()).toBe('Xalpha\n');
+          editor.undo();
+          expect(editor.getText()).toBe('alpha\n');
+        } finally {
+          loadedTheme.resolve(theme);
+          editor.cleanUp();
+          instance.cleanUp();
+          await getSharedHighlighter({ themes: [themeName], langs: ['text'] });
+          dom.cleanup();
+        }
+      });
+    }
+  }
+});
 
 describe('external FileDiff updates during editing', () => {
   test('a compatible update becomes one undoable edit and emits its contents', async () => {

--- a/packages/diffs/test/editorRenderUpdateLifecycle.test.ts
+++ b/packages/diffs/test/editorRenderUpdateLifecycle.test.ts
@@ -435,6 +435,85 @@ describe('external FileDiff updates during editing', () => {
     }
   });
 
+  for (const deferredTheme of [false, true]) {
+    test(`an old-side-only replacement resets history once with a ${deferredTheme ? 'loading' : 'ready'} theme`, async () => {
+      const changes: string[] = [];
+      const fixture = await createFixture({
+        onChange: (contents) => changes.push(contents),
+      });
+      const themeName = `old-side-replacement-${deferredTheme}`;
+      const theme: ThemeRegistration = {
+        name: themeName,
+        type: 'dark',
+        colors: {},
+        tokenColors: [],
+      };
+      const loadedTheme = createDeferred<ThemeRegistration>();
+      const replacement = createDiff({
+        cacheKey: 'session:new-base',
+        oldContents: 'different base\n',
+        newContents: 'bravo\n',
+      });
+
+      try {
+        replaceDocument(fixture.editor, 'bravo\n');
+        expect(fixture.editor.canUndo).toBe(true);
+        if (deferredTheme) {
+          registerCustomTheme(themeName, () => loadedTheme.promise);
+          fixture.instance.setOptions({
+            disableErrorHandling: true,
+            disableFileHeader: true,
+            theme: themeName,
+          });
+        }
+        fixture.instance.render({
+          fileDiff: replacement,
+          fileContainer: fixture.fileContainer,
+          forceRender: true,
+        });
+        if (deferredTheme) {
+          expect(fixture.editor.canUndo).toBe(true);
+          loadedTheme.resolve(theme);
+          await waitFor(() => !fixture.editor.canUndo);
+        }
+        expect(fixture.editor.canUndo).toBe(false);
+        expect(fixture.editor.canRedo).toBe(false);
+        expect(changes).toEqual(['bravo\n']);
+        expect(
+          fixture.editor.__getDocumentSessionState()?.oldFile?.lines
+        ).toEqual(['different base\n']);
+
+        fixture.editor.setSelections([
+          {
+            start: { line: 0, character: 2 },
+            end: { line: 0, character: 2 },
+            direction: 'none',
+          },
+        ]);
+        const selections = fixture.editor.getViewState().selections;
+        expect(selections).toBeDefined();
+        fixture.instance.rerender();
+        fixture.instance.rerender();
+        expect(fixture.editor.getViewState().selections).toEqual(selections);
+        expect(changes).toEqual(['bravo\n']);
+
+        replaceDocument(fixture.editor, 'charlie\n');
+        fixture.instance.rerender();
+        fixture.editor.undo();
+        expect(fixture.editor.getText()).toBe('bravo\n');
+        expect(fixture.editor.canUndo).toBe(false);
+        fixture.editor.redo();
+        expect(fixture.editor.getText()).toBe('charlie\n');
+      } finally {
+        loadedTheme.resolve(theme);
+        if (deferredTheme) {
+          await getSharedHighlighter({ themes: [themeName], langs: ['text'] });
+        }
+        fixture.cleanup();
+      }
+    });
+  }
+
   test('an identical update changes external identity without adding history', async () => {
     const changes: string[] = [];
     const fixture = await createFixture({

--- a/packages/diffs/test/editorWorkerPool.test.ts
+++ b/packages/diffs/test/editorWorkerPool.test.ts
@@ -199,11 +199,10 @@ describe('FileRenderer edit session', () => {
       theme: 'pierre-dark',
     });
     try {
-      let renderUpdates = 0;
       const renderer = new FileRenderer(
         { theme: 'pierre-dark' },
         undefined,
-        () => renderUpdates++,
+        undefined,
         manager
       );
       const file = createFile('file:session');
@@ -214,9 +213,6 @@ describe('FileRenderer edit session', () => {
 
       const editSessionFile = createEditSessionFile(file);
       renderer.beginEditSession(editSessionFile, file);
-      renderer.renderFile(editSessionFile);
-
-      await waitFor(() => expect(renderUpdates).toBeGreaterThan(0));
       const result = renderer.renderFile(editSessionFile);
       if (result == null) {
         throw new Error('expected a render result');
@@ -235,11 +231,10 @@ describe('FileRenderer edit session', () => {
       theme: 'pierre-dark',
     });
     try {
-      let renderUpdates = 0;
       const renderer = new FileRenderer(
         { theme: 'pierre-dark' },
         undefined,
-        () => renderUpdates++,
+        undefined,
         manager
       );
       const file = createFile('file:late');
@@ -259,9 +254,9 @@ describe('FileRenderer edit session', () => {
         },
       ];
       respondToFileRequest(manager, worker, request, poolMarker);
-      // Refused outright: nothing is applied and nothing is requested — the
-      // session render issued at editor attach supplies the highlight.
-      await waitFor(() => expect(renderUpdates).toBeGreaterThan(0));
+      // Let the refused worker result have a chance to (wrongly) apply before
+      // asserting it did not; the session already painted synchronously.
+      await wait(50);
 
       const result = renderer.renderFile(editSessionFile);
       if (result == null) {
@@ -279,11 +274,10 @@ describe('FileRenderer edit session', () => {
       useTokenTransformer: true,
     });
     try {
-      let renderUpdates = 0;
       const renderer = new FileRenderer(
         { theme: 'pierre-dark' },
         undefined,
-        () => renderUpdates++,
+        undefined,
         manager
       );
       const file = createFile('file:pool-transformer');
@@ -306,17 +300,17 @@ describe('FileRenderer edit session', () => {
       // session options — the refused result must not sneak back in through
       // the manager's result cache on the next session render.
       respondToFileRequest(manager, worker, request, poolMarker);
-      await waitFor(() => expect(renderUpdates).toBeGreaterThan(0));
+      // Let the refused worker result have a chance to (wrongly) apply before
+      // asserting it did not; the session already painted synchronously.
+      await wait(50);
 
-      // The session render issued at editor attach stays local: no adoption
-      // of the refused result, and the local highlight lands when ready.
+      // The session render stays local: no adoption of the refused result.
       let result = renderer.renderFile(editSessionFile);
       if (result == null) {
         throw new Error('expected a render result');
       }
       expect(toHtml(result.contentAST)).not.toContain('data-pool-result');
 
-      await waitFor(() => expect(renderUpdates).toBeGreaterThan(0));
       result = renderer.renderFile(editSessionFile);
       if (result == null) {
         throw new Error('expected a render result');
@@ -357,11 +351,10 @@ describe('FileRenderer edit session', () => {
       theme: 'pierre-dark',
     });
     try {
-      let renderUpdates = 0;
       const renderer = new FileRenderer(
         { theme: 'pierre-dark' },
         undefined,
-        () => renderUpdates++,
+        undefined,
         manager
       );
       const file = createFile('file:dirty');
@@ -378,8 +371,6 @@ describe('FileRenderer edit session', () => {
 
       const editSessionFile = createEditSessionFile(file);
       renderer.beginEditSession(editSessionFile, file);
-      renderer.renderFile(editSessionFile);
-      await waitFor(() => expect(renderUpdates).toBeGreaterThan(1));
       renderer.renderFile(editSessionFile);
 
       // Simulate an editor keystroke: line 0 rewritten, cache marked dirty.
@@ -406,11 +397,10 @@ describe('FileRenderer edit session', () => {
       theme: 'pierre-dark',
     });
     try {
-      let renderUpdates = 0;
       const renderer = new FileRenderer(
         { theme: 'pierre-dark' },
         undefined,
-        () => renderUpdates++,
+        undefined,
         manager
       );
       const file = createFile('file:detach');
@@ -418,7 +408,6 @@ describe('FileRenderer edit session', () => {
       renderer.beginEditSession(editSessionFile, file);
 
       renderer.renderFile(editSessionFile);
-      await waitFor(() => expect(renderUpdates).toBeGreaterThan(0));
       expect(worker.fileRequestCount).toBe(0);
 
       renderer.endEditSession();
@@ -1011,11 +1000,9 @@ describe('DiffHunksRenderer edit session', () => {
       expect(renderUpdates).toBe(0);
 
       // The session render stays local and completes the highlight with
-      // editor-compatible markup.
-      renderer.renderDiff(sessionDiff);
-      expect(worker.diffRequestCount).toBe(1);
-      await waitFor(() => expect(renderUpdates).toBeGreaterThan(0));
+      // editor-compatible markup, synchronously.
       const result = renderer.renderDiff(sessionDiff);
+      expect(worker.diffRequestCount).toBe(1);
       if (result == null) {
         throw new Error('expected a render result');
       }
@@ -1038,11 +1025,10 @@ describe('DiffHunksRenderer edit session', () => {
       theme: 'pierre-dark',
     });
     try {
-      let renderUpdates = 0;
       const renderer = new DiffHunksRenderer(
         { theme: 'pierre-dark' },
         undefined,
-        () => renderUpdates++,
+        undefined,
         manager
       );
       const externalDiff = parseDiffFromFile(
@@ -1061,7 +1047,6 @@ describe('DiffHunksRenderer edit session', () => {
 
       renderer.beginEditSession(sessionDiff, externalDiff);
       renderer.renderDiff(sessionDiff);
-      await waitFor(() => expect(renderUpdates).toBeGreaterThan(0));
       expect(worker.diffRequestCount).toBe(0);
 
       await renderer.refreshHighlightedResult();
@@ -1150,11 +1135,10 @@ describe('DiffHunksRenderer edit session', () => {
       theme: 'pierre-dark',
       useTokenTransformer: true,
     });
-    let renderUpdates = 0;
     const renderer = new DiffHunksRenderer(
       { theme: 'pierre-dark' },
       undefined,
-      () => renderUpdates++,
+      undefined,
       manager
     );
     try {
@@ -1178,11 +1162,6 @@ describe('DiffHunksRenderer edit session', () => {
       renderer.beginEditSession(sessionDiff, externalDiff);
       expect(renderer.editorRenderReady()).toBe(false);
 
-      const updatesBeforeSessionRender = renderUpdates;
-      renderer.renderDiff(sessionDiff);
-      await waitFor(() => {
-        expect(renderUpdates).toBeGreaterThan(updatesBeforeSessionRender);
-      });
       const result = renderer.renderDiff(sessionDiff);
       expect(renderer.editorRenderReady()).toBe(true);
       expect(result?.fileDiff).toBe(sessionDiff);
@@ -1230,11 +1209,6 @@ describe('DiffHunksRenderer edit session', () => {
       renderer.beginEditSession(sessionDiff, externalDiff);
       expect(renderer.editorRenderReady()).toBe(false);
 
-      const updatesBeforeSessionHighlight = renderUpdates;
-      renderer.renderDiff(sessionDiff);
-      await waitFor(() =>
-        expect(renderUpdates).toBeGreaterThan(updatesBeforeSessionHighlight)
-      );
       const result = renderer.renderDiff(sessionDiff);
       expect(renderer.editorRenderReady()).toBe(true);
       if (result == null) {
@@ -1305,11 +1279,6 @@ describe('DiffHunksRenderer edit session', () => {
       renderer.beginEditSession(sessionDiff, sessionExternalDiff);
       expect(renderer.editorRenderReady()).toBe(false);
 
-      const updatesBeforeSessionHighlight = renderUpdates;
-      renderer.renderDiff(sessionDiff);
-      await waitFor(() =>
-        expect(renderUpdates).toBeGreaterThan(updatesBeforeSessionHighlight)
-      );
       const result = renderer.renderDiff(sessionDiff);
       expect(renderer.editorRenderReady()).toBe(true);
       if (result == null) {
@@ -1332,8 +1301,11 @@ describe('DiffHunksRenderer edit session', () => {
   });
 
   test('an older highlight result cannot overwrite the diff being edited', async () => {
+    // Use a theme no other test in this file loads, so it stays unattached and
+    // the renderer's grab cannot render synchronously — that keeps the async
+    // initialization path this test exercises.
     const renderer = new DeferredHighlighterDiffRenderer({
-      theme: 'pierre-dark',
+      theme: 'nord',
     });
     try {
       // Exercise the renderer's async initialization path without resetting
@@ -1363,7 +1335,12 @@ describe('DiffHunksRenderer edit session', () => {
         throw new Error('expected two pending highlighter initializations');
       }
 
-      sessionInitialization.resolve(sharedHighlighter);
+      const editHighlighter = await getSharedHighlighter({
+        themes: ['nord'],
+        langs: ['typescript'],
+        preferredHighlighter: 'shiki-js',
+      });
+      sessionInitialization.resolve(editHighlighter);
       await wait(0);
       renderer.renderDiff(sessionDiff);
       expect(renderer.diffCache).toBe(sessionDiff);
@@ -1391,7 +1368,7 @@ describe('DiffHunksRenderer edit session', () => {
 
       expect(renderSessionHtml()).toContain('sessionResult');
 
-      staleInitialization.resolve(sharedHighlighter);
+      staleInitialization.resolve(editHighlighter);
       await wait(0);
 
       expect(renderer.diffCache).toBe(sessionDiff);

--- a/packages/diffs/test/onPostRenderPhase.test.ts
+++ b/packages/diffs/test/onPostRenderPhase.test.ts
@@ -53,19 +53,26 @@ function makeFileItem(
 
 async function waitForPhases(
   phases: readonly { id: string; phase: PostRenderPhase }[],
-  expected: readonly { id: string; phase: PostRenderPhase }[]
+  expected: readonly { id: string; phase: PostRenderPhase }[],
+  { lifecycleOnly = false }: { lifecycleOnly?: boolean } = {}
 ): Promise<void> {
+  // A rendered item can emit an extra 'update' phase once its content settles
+  // (e.g. a virtualized item painting on scroll-in). lifecycleOnly asserts just
+  // the mount/unmount lifecycle so that incidental update does not race the
+  // match.
+  const view = () =>
+    lifecycleOnly ? phases.filter((entry) => entry.phase !== 'update') : phases;
   // ~4s budget: returns as soon as the phases match, so passing runs only pay
   // a few iterations; the headroom is for loaded CI runners.
   for (let attempt = 0; attempt < 400; attempt++) {
     try {
-      expect(phases).toEqual(expected);
+      expect(view()).toEqual(expected);
       return;
     } catch {
       await wait(10);
     }
   }
-  expect(phases).toEqual(expected);
+  expect(view()).toEqual(expected);
 }
 
 const file: FileContents = {
@@ -293,18 +300,24 @@ describe('onPostRender phases', () => {
       viewer.setup(root);
       await renderItems(viewer, items);
 
-      await waitForPhases(phases, [{ id: 'file:first', phase: 'mount' }]);
+      await waitForPhases(phases, [{ id: 'file:first', phase: 'mount' }], {
+        lifecycleOnly: true,
+      });
 
       root.scrollTop = 2_400;
       dispatchScroll(root);
       viewer.render(true);
       await wait(0);
 
-      await waitForPhases(phases, [
-        { id: 'file:first', phase: 'mount' },
-        { id: 'file:first', phase: 'unmount' },
-        { id: 'file:second', phase: 'mount' },
-      ]);
+      await waitForPhases(
+        phases,
+        [
+          { id: 'file:first', phase: 'mount' },
+          { id: 'file:first', phase: 'unmount' },
+          { id: 'file:second', phase: 'mount' },
+        ],
+        { lifecycleOnly: true }
+      );
     } finally {
       viewer.cleanUp();
       await wait(0);

--- a/packages/diffs/test/virtualizedApplyDocumentChange.test.ts
+++ b/packages/diffs/test/virtualizedApplyDocumentChange.test.ts
@@ -62,10 +62,10 @@ class BufferRecordingFile extends VirtualizedFile<undefined> {
 // explicitly after attaching the private edit session.
 function setRenderedEditSession(instance: BufferRecordingFile): void {
   const state = instance as unknown as {
-    editSessionFile: FileContents | undefined;
+    editSession: { file: FileContents } | undefined;
     renderedFile: FileContents | undefined;
   };
-  state.renderedFile = state.editSessionFile;
+  state.renderedFile = state.editSession?.file;
 }
 
 describe('applyDocumentChange buffer updates', () => {

--- a/packages/diffs/test/virtualizedColdStartEdit.test.ts
+++ b/packages/diffs/test/virtualizedColdStartEdit.test.ts
@@ -1,0 +1,120 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  type Mock,
+  spyOn,
+  test,
+} from 'bun:test';
+
+import { VirtualizedFile } from '../src/components/VirtualizedFile';
+import { VirtualizedFileDiff } from '../src/components/VirtualizedFileDiff';
+import { Virtualizer } from '../src/components/Virtualizer';
+import { DEFAULT_THEMES } from '../src/constants';
+import { Editor } from '../src/editor/editor';
+import type { EditorType } from '../src/editor/types';
+import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
+import type { FileContents, FileDiffMetadata } from '../src/types';
+import { parseDiffFromFile } from '../src/utils/parseDiffFromFile';
+import {
+  createRoot,
+  type DomHandle,
+  installDom,
+  wait,
+  waitFor,
+} from './domHarness';
+
+const FILE_NAME = 'src/cold.ts';
+const CONTENTS = 'alpha();\nnext();\nend();';
+const OLD_CONTENTS = 'alpha();\nprevious();\nend();';
+
+function findEditableContent(container: HTMLElement): HTMLElement | undefined {
+  return Array.from(
+    container.shadowRoot?.querySelectorAll<HTMLElement>('[data-content]') ?? []
+  ).find(
+    (element) =>
+      element.contentEditable === 'true' ||
+      element.getAttribute('contenteditable') === 'true'
+  );
+}
+
+let dom: DomHandle;
+let virtualizer: Virtualizer;
+let fileContainer: HTMLElement;
+let consoleError: Mock<typeof console.error>;
+
+// Every case starts from a cold highlighter so the first render cannot paint
+// synchronously and leaves a pending render behind.
+beforeEach(async () => {
+  await disposeHighlighter();
+  consoleError = spyOn(console, 'error').mockImplementation(() => {});
+  dom = installDom();
+  const root = createRoot();
+  fileContainer = document.createElement('diffs-container');
+  root.appendChild(fileContainer);
+  virtualizer = new Virtualizer();
+  virtualizer.setup(root);
+  await wait(10);
+});
+
+afterEach(async () => {
+  virtualizer.cleanUp();
+  await wait(10);
+  dom.cleanup();
+  consoleError.mockRestore();
+});
+
+// The rerender that completes the highlight runs in a queued frame, and the
+// render queue reports a throwing frame through console.error instead of
+// failing the test on its own, so that channel is asserted explicitly.
+async function expectEditableAfterHighlight(): Promise<void> {
+  await waitFor(() => findEditableContent(fileContainer) !== undefined, {
+    timeout: 3_000,
+  });
+  await wait(0);
+  expect(findEditableContent(fileContainer)).toBeDefined();
+  expect(
+    fileContainer.shadowRoot?.querySelector('[data-code]:not([data-deletions])')
+  ).toBeInstanceOf(HTMLElement);
+  expect(consoleError).not.toHaveBeenCalled();
+}
+
+describe('editing before a cold first render completes', () => {
+  test('VirtualizedFile renders the session file once the highlight lands', async () => {
+    const editor = new Editor<EditorType, undefined, undefined>('file');
+    const file: FileContents = { name: FILE_NAME, contents: CONTENTS };
+    const instance = new VirtualizedFile<undefined>(
+      { disableFileHeader: true, theme: DEFAULT_THEMES },
+      virtualizer
+    );
+    expect(instance.render({ file, fileContainer, forceRender: true })).toBe(
+      false
+    );
+    editor.edit(instance);
+    await expectEditableAfterHighlight();
+    editor.cleanUp();
+    instance.cleanUp();
+  });
+
+  for (const diffStyle of ['unified', 'split'] as const) {
+    test(`VirtualizedFileDiff ${diffStyle} renders the session diff once the highlight lands`, async () => {
+      const editor = new Editor<EditorType, undefined, undefined>('file-diff');
+      const fileDiff: FileDiffMetadata = parseDiffFromFile(
+        { name: FILE_NAME, contents: OLD_CONTENTS },
+        { name: FILE_NAME, contents: CONTENTS }
+      );
+      const instance = new VirtualizedFileDiff<undefined>(
+        { diffStyle, disableFileHeader: true, theme: DEFAULT_THEMES },
+        virtualizer
+      );
+      expect(
+        instance.render({ fileDiff, fileContainer, forceRender: true })
+      ).toBe(false);
+      editor.edit(instance);
+      await expectEditableAfterHighlight();
+      editor.cleanUp();
+      instance.cleanUp();
+    });
+  }
+});


### PR DESCRIPTION
Updating an edited file now updates the editor synchronously during the render call when the highlighter is ready. Previously, that update was deferred even when it was ready. Languages loaded for background highlighting are also made available to shared highlighter, reducing waits when entering edit mode.

The PR also fixes several rendering bugs:

- Change callbacks can replace a file or close the editor without losing the replacement or throwing a layout error.
- Changing only the original side of a diff resets undo history once and preserves selections made afterward.
- Editing can start before the first highlight finishes. CodeView waits for its initial theme before rendering, avoiding height errors from measuring empty content.
- Switching themes starts loading the selected theme without waiting for an obsolete request to finish.

Regression tests cover these cases. Editor reuse tests now exercise normal attachment and cleanup, and browser tests check layout errors from page load.

A lot of garbo tests should be removed or cleaned up.
