### PR TITLE
Preserve native ranges when dragging selections upward

### DIFF
--- a/packages/diffs/src/editor/editor.ts
+++ b/packages/diffs/src/editor/editor.ts
@@ -1758,7 +1758,7 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
             return;
           }
 
-          let selection = convertSelection(composedRange, DirectionNone);
+          const selection = convertSelection(composedRange, DirectionNone);
           if (selection === undefined) {
             return;
           }
@@ -1777,17 +1777,15 @@ export class Editor<LAnnotation> implements DiffsEditor<LAnnotation> {
             return;
           }
 
-          if (this.#isContentMouseDown) {
-            if (this.#selectionStart !== undefined) {
-              selection = createSelectionFrom(this.#selectionStart, selection);
-            } else {
-              this.#selectionStart = selection;
-            }
-          } else if (this.#selectionStart !== undefined) {
+          if (this.#selectionStart !== undefined) {
+            // Keep the browser's range for word and whole-line drags. Rebuilding
+            // it from the initial start drops that word or line when dragging up.
             selection.direction = createSelectionFrom(
               this.#selectionStart,
               selection
             ).direction;
+          } else if (this.#isContentMouseDown) {
+            this.#selectionStart = selection;
           } else if (
             this.#selections !== undefined &&
             this.#selections.length === 1

--- a/packages/diffs/test/editorSelection.test.ts
+++ b/packages/diffs/test/editorSelection.test.ts
@@ -3933,6 +3933,79 @@ async function createEditorFixture(contents: string): Promise<EditorFixture> {
   };
 }
 
+describe('Editor native text selection', () => {
+  test.each([
+    {
+      name: 'whole line',
+      initial: createSelection(2, 0, 3, 0),
+      backward: createSelection(1, 0, 3, 0, DirectionBackward),
+      forward: createSelection(2, 0, 4, 0, DirectionForward),
+    },
+    {
+      name: 'whole word',
+      initial: createSelection(2, 0, 2, 7),
+      backward: createSelection(1, 6, 2, 7, DirectionBackward),
+      forward: createSelection(2, 0, 3, 4, DirectionForward),
+    },
+    {
+      name: 'caret',
+      initial: createSelection(2, 3, 2, 3),
+      backward: createSelection(1, 6, 2, 3, DirectionBackward),
+      forward: createSelection(2, 3, 3, 4, DirectionForward),
+    },
+  ])(
+    'preserves the native range when dragging from a $name',
+    async ({ initial, backward, forward }) => {
+      const { cleanup, content, editor } = await createEditorFixture(
+        'before\nalpha bravo\ncharlie delta\necho foxtrot\nafter'
+      );
+      const originalGetSelection = document.getSelection.bind(document);
+      let nativeRange: StaticRange;
+
+      try {
+        content.dispatchEvent(new Event('focus'));
+        const lines = [...content.querySelectorAll<HTMLElement>('[data-line]')];
+        document.getSelection = (() => ({
+          getComposedRanges: () => [nativeRange],
+        })) as unknown as typeof document.getSelection;
+        content.dispatchEvent(
+          new PointerEvent('pointerdown', { pointerType: 'mouse' })
+        );
+
+        // Native word and line drags keep the initial range when changing
+        // direction. Exercise both reversals before releasing the pointer.
+        for (const selection of [initial, backward, forward, backward]) {
+          const [startContainer, startOffset] = getSelectionAnchor(
+            lines[selection.start.line],
+            selection.start.character
+          );
+          const [endContainer, endOffset] = getSelectionAnchor(
+            lines[selection.end.line],
+            selection.end.character
+          );
+          nativeRange = composedRange(
+            startContainer,
+            startOffset,
+            endContainer,
+            endOffset
+          );
+          document.dispatchEvent(new Event('selectionchange'));
+          expect(editor.getViewState().selections).toEqual([selection]);
+        }
+
+        document.dispatchEvent(
+          new PointerEvent('pointerup', { pointerType: 'mouse' })
+        );
+        document.dispatchEvent(new Event('selectionchange'));
+        expect(editor.getViewState().selections).toEqual([backward]);
+      } finally {
+        document.getSelection = originalGetSelection;
+        cleanup();
+      }
+    }
+  );
+});
+
 describe('Editor Alt-drag column selection', () => {
   test('normalizes short, empty, and Unicode lines independently', async () => {
     const { cleanup, content, editor } = await createEditorFixture(


### PR DESCRIPTION
Preserve browser-native word and whole-line selections while dragging in either direction.

fix https://x.com/kebabyusuf/status/2097590039106490725?s=20