### PR TITLE
[diffs] Ensure both languages are loaded on a diff that renames languages

### DIFF
--- a/packages/diffs/src/renderers/DiffHunksRenderer.ts
+++ b/packages/diffs/src/renderers/DiffHunksRenderer.ts
@@ -249,7 +249,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
   private deletionAnnotations: AnnotationLineMap<LAnnotation> = {};
   private additionAnnotations: AnnotationLineMap<LAnnotation> = {};
 
-  private computedLang: SupportedLanguages = 'text';
+  private computedLangs: SupportedLanguages[] = ['text'];
   private renderCache: DiffRenderCache | undefined;
   // Completed background work waits here until the next render can update its
   // DOM and layout together.
@@ -883,7 +883,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
 
   public async initializeHighlighter(): Promise<DiffsHighlighter> {
     this.highlighter = await getSharedHighlighter(
-      getHighlighterOptions(this.computedLang, {
+      getHighlighterOptions(this.computedLangs, {
         theme: this.getLocalHighlightTheme(),
         preferredHighlighter:
           this.workerManager?.getPreferredHighlighter() ??
@@ -923,7 +923,7 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
     }
     // Lets attempt to get the highlighter/languages ready immediately
     else if (this.highlighter == null) {
-      this.computedLang = diff.lang ?? getFiletypeFromFileName(diff.name);
+      this.computedLangs = getDiffLanguages(diff);
       void this.initializeHighlighter();
     }
   }
@@ -1147,12 +1147,12 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
         this.workerManager.highlightDiffAST(this, diff);
       }
     } else {
-      this.computedLang = diff.lang ?? getFiletypeFromFileName(diff.name);
+      this.computedLangs = getDiffLanguages(diff);
       this.highlighter ??= getHighlighterIfLoaded();
       const hasThemes =
         this.highlighter != null && areThemesAttached(options.theme);
       const hasLangs =
-        this.highlighter != null && areLanguagesAttached(this.computedLang);
+        this.highlighter != null && areLanguagesAttached(this.computedLangs);
       const canHighlight = !forcePlainText && hasLangs;
 
       // If we have any semblance of a highlighter with the correct theme(s)
@@ -1232,15 +1232,13 @@ export class DiffHunksRenderer<LAnnotation = undefined> {
     diff: FileDiffMetadata
   ): Promise<RenderDiffResult> {
     const forcePlainText = isDiffMassive(diff, this.getTokenizeMaxLength());
-    this.computedLang = forcePlainText
-      ? 'text'
-      : (diff.lang ?? getFiletypeFromFileName(diff.name));
+    this.computedLangs = forcePlainText ? ['text'] : getDiffLanguages(diff);
     const hasThemes =
       this.highlighter != null &&
       areThemesAttached(this.getLocalHighlightTheme());
     const hasLangs =
       forcePlainText ||
-      (this.highlighter != null && areLanguagesAttached(this.computedLang));
+      (this.highlighter != null && areLanguagesAttached(this.computedLangs));
     // If we don't have the required langs or themes, then we need to
     // initialize the highlighter to load the appropriate languages and themes
     if (this.highlighter == null || !hasThemes || !hasLangs) {
@@ -2597,6 +2595,19 @@ function getEditorDocumentLines<LAnnotation>(
     lines.push(textDocument.getLineText(line, true));
   }
   return lines;
+}
+
+// Renames can supply 2 different languages, so lets go ahead and figure out
+// the required languages
+function getDiffLanguages(diff: FileDiffMetadata): SupportedLanguages[] {
+  if (diff.lang != null) {
+    return [diff.lang];
+  }
+  const deletionLang = getFiletypeFromFileName(diff.prevName ?? diff.name);
+  const additionLang = getFiletypeFromFileName(diff.name);
+  return deletionLang === additionLang
+    ? [additionLang]
+    : [deletionLang, additionLang];
 }
 
 function isDiffMassive(

--- a/packages/diffs/src/utils/getHighlighterOptions.ts
+++ b/packages/diffs/src/utils/getHighlighterOptions.ts
@@ -18,11 +18,11 @@ interface GetHighlighterOptionsReturn {
 }
 
 export function getHighlighterOptions(
-  lang: SupportedLanguages | undefined,
+  lang: SupportedLanguages | SupportedLanguages[] | undefined,
   { theme, preferredHighlighter = 'shiki-js' }: HighlighterOptionsShape
 ): GetHighlighterOptionsReturn {
   return {
-    langs: [lang ?? 'text'],
+    langs: Array.isArray(lang) ? lang : [lang ?? 'text'],
     themes: getThemes(theme),
     preferredHighlighter,
   };

--- a/packages/diffs/test/DiffHunksRendererLanguages.test.ts
+++ b/packages/diffs/test/DiffHunksRendererLanguages.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test';
+
+import {
+  DiffHunksRenderer,
+  disposeHighlighter,
+  getHighlighterIfLoaded,
+  getSharedHighlighter,
+  parseDiffFromFile,
+} from '../src';
+import { assertDefined, createDeferred } from './testUtils';
+
+beforeEach(disposeHighlighter);
+afterEach(disposeHighlighter);
+
+const python = {
+  name: 'example.py',
+  contents: 'print("python")\n',
+  language: 'python',
+} as const;
+const javascript = {
+  name: 'example.js',
+  contents: 'console.log("javascript");\n',
+  language: 'javascript',
+} as const;
+const renames = [
+  [python, javascript],
+  [javascript, python],
+] as const;
+const options = { theme: 'pierre-dark', diffStyle: 'split' } as const;
+
+describe('DiffHunksRenderer language loading without workers', () => {
+  const cases = [
+    [python, { ...python, contents: 'print("changed")\n' }],
+    [javascript, { ...javascript, contents: 'console.log("changed");\n' }],
+    ...renames,
+  ] as const;
+
+  for (const [oldFile, newFile] of cases) {
+    for (const preloadDestination of [false, true]) {
+      test(`asyncRender ${oldFile.language} -> ${newFile.language}, ${preloadDestination ? 'destination loaded' : 'cold'}`, async () => {
+        if (preloadDestination) {
+          const highlighter = await getSharedHighlighter({
+            themes: [options.theme],
+            langs: [newFile.language],
+          });
+          if (oldFile.language !== newFile.language) {
+            expect(highlighter.getLoadedLanguages()).not.toContain(
+              oldFile.language
+            );
+          }
+        } else {
+          expect(getHighlighterIfLoaded()).toBeUndefined();
+        }
+
+        const renderer = new DiffHunksRenderer(options);
+        try {
+          const diff = parseDiffFromFile(oldFile, newFile);
+          if (oldFile.name === newFile.name) {
+            expect(diff.prevName).toBeUndefined();
+          }
+          await renderer.asyncRender(diff);
+          const highlighter = getHighlighterIfLoaded();
+          assertDefined(highlighter, 'expected the highlighter to be loaded');
+          expect(highlighter.getLoadedLanguages()).toContain(oldFile.language);
+          expect(highlighter.getLoadedLanguages()).toContain(newFile.language);
+        } finally {
+          renderer.cleanUp();
+        }
+      });
+    }
+  }
+
+  for (const [oldFile, newFile] of renames) {
+    test(`renderDiff ${oldFile.language} -> ${newFile.language} loads the missing source grammar`, async () => {
+      const highlighter = await getSharedHighlighter({
+        themes: [options.theme],
+        langs: [newFile.language],
+      });
+      expect(highlighter.getLoadedLanguages()).not.toContain(oldFile.language);
+      const updated = createDeferred<void>();
+      const renderer = new DiffHunksRenderer(options, undefined, () => {
+        updated.resolve();
+      });
+      try {
+        const diff = parseDiffFromFile(oldFile, newFile);
+        const initial = renderer.renderDiff(diff);
+        // Wait for the background render before assertions or cleanup can
+        // dispose a highlighter that is still loading the missing grammar.
+        await updated.promise;
+        expect(initial).toBeDefined();
+        expect(highlighter.getLoadedLanguages()).toContain(oldFile.language);
+        expect(highlighter.getLoadedLanguages()).toContain(newFile.language);
+        expect(renderer.renderDiff(diff)).toBeDefined();
+      } finally {
+        renderer.cleanUp();
+      }
+    });
+
+    test(`hydrate preloads both grammars for ${oldFile.language} -> ${newFile.language}`, async () => {
+      const renderer = new DiffHunksRenderer(options);
+      const initialize = spyOn(renderer, 'initializeHighlighter');
+      try {
+        const diff = parseDiffFromFile(oldFile, newFile);
+        renderer.hydrate(diff);
+        await initialize.mock.results[0]?.value;
+        expect(initialize).toHaveBeenCalledTimes(1);
+        const highlighter = getHighlighterIfLoaded();
+        assertDefined(highlighter, 'expected the highlighter to be loaded');
+        expect(highlighter.getLoadedLanguages()).toContain(oldFile.language);
+        expect(highlighter.getLoadedLanguages()).toContain(newFile.language);
+      } finally {
+        initialize.mockRestore();
+        renderer.cleanUp();
+      }
+    });
+  }
+
+  for (const lang of ['json', 'text'] as const) {
+    test(`an explicit ${lang} override takes precedence over both filenames`, async () => {
+      const renderer = new DiffHunksRenderer(options);
+      try {
+        const diff = { ...parseDiffFromFile(python, javascript), lang };
+        await renderer.asyncRender(diff);
+        const highlighter = getHighlighterIfLoaded();
+        assertDefined(highlighter, 'expected the highlighter to be loaded');
+        const languages = highlighter.getLoadedLanguages();
+        expect(languages).not.toContain('python');
+        expect(languages).not.toContain('javascript');
+        if (lang !== 'text') {
+          expect(languages).toContain(lang);
+        }
+      } finally {
+        renderer.cleanUp();
+      }
+    });
+  }
+
+  test('a rename above the size threshold does not load either grammar', async () => {
+    const renderer = new DiffHunksRenderer({
+      ...options,
+      tokenizeMaxLength: 0,
+    });
+    try {
+      await renderer.asyncRender(parseDiffFromFile(python, javascript));
+      const highlighter = getHighlighterIfLoaded();
+      assertDefined(highlighter, 'expected the highlighter to be loaded');
+      const languages = highlighter.getLoadedLanguages();
+      expect(languages).not.toContain('python');
+      expect(languages).not.toContain('javascript');
+    } finally {
+      renderer.cleanUp();
+    }
+  });
+});


### PR DESCRIPTION
This was a bug that only affected the non WorkerPool route, but the bug was essentially a diff rename that changed languages would not ensure that the old file language was properly loaded, which would result in a crash.

Added a few regression tests to ensure it doesn't happen again.