### PR TITLE
fix(diffs): reject mismatched custom language loaders

### DIFF
--- a/apps/docs/app/(diffs)/docs/Utilities/constants.ts
+++ b/apps/docs/app/(diffs)/docs/Utilities/constants.ts
@@ -215,7 +215,7 @@ export const HELPER_REGISTER_CUSTOM_LANGUAGE: PreloadFileOptions<
     contents: `import { registerCustomLanguage } from '@pierre/diffs';
 
 // Register a custom Shiki language loader before rendering.
-// The language name you register becomes available to Shiki.
+// my-lang.tmLanguage.json must declare "my-lang" as its name or an alias.
 
 // Option 1: Dynamic import (recommended for code splitting)
 registerCustomLanguage('my-lang', () => import('./my-lang.tmLanguage.json'), [

--- a/apps/docs/app/(diffs)/docs/Utilities/content.mdx
+++ b/apps/docs/app/(diffs)/docs/Utilities/content.mdx
@@ -138,6 +138,21 @@ Register a custom Shiki language loader and optionally map it to file names or
 extensions. Use this when you're working with languages not bundled by Shiki or
 want custom highlighting grammars.
 
+The grammar file or object returned by your loader has a `name` field and can
+have an `aliases` array. An alias is an additional language ID that uses the
+same highlighting rules. For example, Terraform's grammar has
+`name: 'terraform'` and `aliases: ['tf', 'tfvars']`, so Shiki accepts all three
+IDs (or `lang`/`language`) for that grammar.
+
+The first argument to `registerCustomLanguage` must match the grammar's `name`
+or an entry in its `aliases` array. Registering a loader does not change these
+fields. The optional filename and extension mappings tell Diffs which language
+ID to request; they do not add aliases to the grammar.
+
+If Shiki has already loaded a grammar under its `name`, loading another copy
+with extra aliases will not add them. Load your custom grammar before the
+original, or give your custom grammar a distinct `name` field.
+
 <DocsCodeExample {...registerCustomLanguage} />
 
 ### setLanguageOverride [toc-ignore]

--- a/packages/diffs/src/highlighter/languages/attachResolvedLanguages.ts
+++ b/packages/diffs/src/highlighter/languages/attachResolvedLanguages.ts
@@ -17,7 +17,25 @@ export function attachResolvedLanguages(
       lang = resolvedLang;
       ResolvedLanguages.set(resolvedLang.name, lang);
     }
-    AttachedLanguages.add(lang.name);
+    const grammar = lang.data.find(
+      (grammar) =>
+        grammar.name === lang.name ||
+        grammar.aliases?.includes(lang.name) === true
+    );
+    if (grammar == null) {
+      throw new Error(
+        `attachResolvedLanguages: No returned grammar declares "${lang.name}" as its name or an alias.`
+      );
+    }
     highlighter.loadLanguageSync(lang.data);
+    // Shiki can skip an already-loaded grammar, including any newly added aliases.
+    try {
+      highlighter.getLanguage(lang.name);
+    } catch {
+      throw new Error(
+        `attachResolvedLanguages: "${grammar.name}" is already loaded without alias "${lang.name}". Load the alias first or give the grammar a unique name.`
+      );
+    }
+    AttachedLanguages.add(lang.name);
   }
 }

--- a/packages/diffs/src/highlighter/languages/registerCustomLanguage.ts
+++ b/packages/diffs/src/highlighter/languages/registerCustomLanguage.ts
@@ -5,7 +5,9 @@ import { RegisteredCustomLanguages } from './constants';
 
 /**
  * Register a custom language loader and optionally map it to
- * file names or extensions.
+ * file names or extensions. The registered name must match a returned
+ * grammar's name or aliases; registering a loader does not automatically add a
+ * grammar alias.
  */
 export function registerCustomLanguage(
   lang: string,

--- a/packages/diffs/src/worker/WorkerPoolManager.ts
+++ b/packages/diffs/src/worker/WorkerPoolManager.ts
@@ -1060,6 +1060,13 @@ export class WorkerPoolManager {
         }
         throw error;
       } else {
+        // A failed request may not have attached its languages. Only remember
+        // them after success so later tasks resend grammars that were rejected.
+        if (isRenderTask(task)) {
+          for (const { name } of task.request.resolvedLanguages ?? []) {
+            managedWorker.langs.add(name);
+          }
+        }
         switch (response.requestType) {
           case 'initialize':
             if (task.type !== 'initialize') {
@@ -1180,9 +1187,6 @@ export class WorkerPoolManager {
     }
     if (!this.activeTaskById.has(task.id)) {
       this.assignWorkerToTask(task, managedWorker);
-    }
-    for (const lang of getLangsFromTask(task)) {
-      managedWorker.langs.add(lang);
     }
     try {
       // postMessage clones the request now, so keep the matching cache key on

--- a/packages/diffs/test/DiffHunksRendererLanguages.test.ts
+++ b/packages/diffs/test/DiffHunksRendererLanguages.test.ts
@@ -29,6 +29,30 @@ const renames = [
 const options = { theme: 'pierre-dark', diffStyle: 'split' } as const;
 
 describe('DiffHunksRenderer language loading without workers', () => {
+  test('the bundled Terraform loader renders an ordinary .tf edit and provides its aliases', async () => {
+    const renderer = new DiffHunksRenderer(options);
+    try {
+      const diff = parseDiffFromFile(
+        { name: 'example.tf', contents: 'locals {\n  label = "before"\n}\n' },
+        { name: 'example.tf', contents: 'locals {\n  label = "after"\n}\n' }
+      );
+      expect(await renderer.asyncRender(diff)).toBeDefined();
+      const highlighter = getHighlighterIfLoaded();
+      assertDefined(highlighter, 'expected the highlighter to be loaded');
+      for (const lang of ['terraform', 'tf', 'tfvars']) {
+        expect(highlighter.getLoadedLanguages()).toContain(lang);
+        expect(
+          highlighter.codeToTokens('locals { label = "after" }', {
+            lang,
+            theme: options.theme,
+          }).tokens.length
+        ).toBeGreaterThan(0);
+      }
+    } finally {
+      renderer.cleanUp();
+    }
+  });
+
   const cases = [
     [python, { ...python, contents: 'print("changed")\n' }],
     [javascript, { ...javascript, contents: 'console.log("changed");\n' }],

--- a/packages/diffs/test/WorkerPoolManager.test.ts
+++ b/packages/diffs/test/WorkerPoolManager.test.ts
@@ -8,8 +8,10 @@ import {
   spyOn,
   test,
 } from 'bun:test';
+import { bundledLanguages } from 'shiki';
 
-import { parseDiffFromFile } from '../src';
+import { parseDiffFromFile, registerCustomLanguage } from '../src';
+import { RegisteredCustomLanguages } from '../src/highlighter/languages/constants';
 import * as sharedHighlighter from '../src/highlighter/shared_highlighter';
 import { disposeHighlighter } from '../src/highlighter/shared_highlighter';
 import type {
@@ -17,7 +19,10 @@ import type {
   FileContents,
   FileDiffMetadata,
 } from '../src/types';
-import type { DiffRendererInstance } from '../src/worker/types';
+import type {
+  DiffRendererInstance,
+  RenderFileRequest,
+} from '../src/worker/types';
 import { createDeferred } from './testUtils';
 import {
   createInitializedManager,
@@ -140,6 +145,64 @@ describe('WorkerPoolManager lifecycle', () => {
 });
 
 describe('WorkerPoolManager cache priming', () => {
+  for (const rejectLanguage of [true, false]) {
+    test(`a worker ${rejectLanguage ? 'rejection resends' : 'success reuses'} the requested language on the next task`, async () => {
+      await disposeHighlighter();
+      const { manager, worker } = await createInitializedManager();
+      const mismatch =
+        'attachResolvedLanguages: No returned grammar declares "tf" as its name or an alias.';
+      if (rejectLanguage) {
+        registerCustomLanguage('tf', bundledLanguages.hcl);
+        spyOn(console, 'error').mockImplementation(() => {});
+      }
+      try {
+        for (let attempt = 0; attempt < 2; attempt++) {
+          const posted = createDeferred<RenderFileRequest>();
+          spyOn(worker, 'postMessage').mockImplementation((request) => {
+            if (request.type === 'file') {
+              posted.resolve(structuredClone(request));
+            }
+          });
+          const prime = manager.primeFileHighlightCache({
+            name: 'example.tf',
+            contents: `locals { label = "${attempt}" }`,
+            cacheKey: `terraform:${attempt}`,
+          });
+          const settled = prime.catch((error: unknown) => error);
+          const request = await withTimeout(posted.promise);
+          if (rejectLanguage) {
+            worker.respond({
+              type: 'error',
+              id: request.id,
+              error: mismatch,
+            });
+            expect(await withTimeout(settled)).toEqual(new Error(mismatch));
+            expect(request.resolvedLanguages?.map(({ name }) => name)).toEqual([
+              'tf',
+            ]);
+            expect(
+              request.resolvedLanguages?.[0]?.data.map(({ name }) => name)
+            ).toEqual(['hcl']);
+          } else {
+            respondToFileRequest(manager, worker, request);
+            expect(await withTimeout(settled)).toBeUndefined();
+            if (attempt === 0) {
+              expect(
+                request.resolvedLanguages?.map(({ name }) => name)
+              ).toEqual(['tf']);
+            } else {
+              expect(request.resolvedLanguages).toBeUndefined();
+            }
+          }
+        }
+      } finally {
+        manager.terminate();
+        RegisteredCustomLanguages.delete('tf');
+        await disposeHighlighter();
+      }
+    });
+  }
+
   test('reports a background preload failure without blocking worker rendering', async () => {
     await disposeHighlighter();
     const { manager, worker } = await createInitializedManager();

--- a/packages/diffs/test/languageAttachment.test.ts
+++ b/packages/diffs/test/languageAttachment.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test';
+import { bundledLanguages } from 'shiki';
+
+import {
+  areLanguagesAttached,
+  disposeHighlighter,
+  getSharedHighlighter,
+  registerCustomLanguage,
+} from '../src';
+import { RegisteredCustomLanguages } from '../src/highlighter/languages/constants';
+
+beforeEach(disposeHighlighter);
+afterEach(async () => {
+  await disposeHighlighter();
+  for (const name of ['tf', 'hcl', 'custom-hcl']) {
+    RegisteredCustomLanguages.delete(name);
+  }
+});
+
+describe('language attachment', () => {
+  for (const preloadTerraform of [false, true]) {
+    test(`rejects a mismatched custom loader and cached retries, Terraform ${preloadTerraform ? 'loaded' : 'absent'}`, async () => {
+      const highlighter = await getSharedHighlighter({
+        themes: [],
+        langs: preloadTerraform ? ['terraform'] : [],
+      });
+      registerCustomLanguage('tf', bundledLanguages.hcl);
+      const mismatch =
+        'attachResolvedLanguages: No returned grammar declares "tf" as its name or an alias.';
+
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const result = await getSharedHighlighter({
+          themes: [],
+          langs: ['tf'],
+        }).catch((error: unknown) => error);
+        expect(result).toEqual(new Error(mismatch));
+        expect(areLanguagesAttached('tf')).toBe(false);
+        expect(highlighter.getLoadedLanguages()).not.toContain('hcl');
+      }
+    });
+  }
+
+  for (const name of ['hcl', 'custom-hcl']) {
+    test(`accepts a custom grammar providing the requested name ${name}`, async () => {
+      registerCustomLanguage(
+        name,
+        name === 'hcl'
+          ? bundledLanguages.hcl
+          : async () => {
+              const { default: grammars } = await bundledLanguages.hcl();
+              return {
+                default: grammars.map((grammar) => ({
+                  ...grammar,
+                  aliases: [...(grammar.aliases ?? []), 'custom-hcl'],
+                })),
+              };
+            }
+      );
+      const highlighter = await getSharedHighlighter({
+        themes: ['pierre-dark'],
+        langs: [name],
+      });
+
+      expect(areLanguagesAttached(name)).toBe(true);
+      expect(highlighter.getLoadedLanguages()).toContain(name);
+      expect(
+        highlighter.codeToTokens('locals { label = "example" }', {
+          lang: name,
+          theme: 'pierre-dark',
+        }).tokens.length
+      ).toBeGreaterThan(0);
+    });
+  }
+
+  test('preserves a Shiki loading error and allows attachment to be retried', async () => {
+    const highlighter = await getSharedHighlighter({ themes: [], langs: [] });
+    const failure = new Error('grammar load failed');
+    const load = spyOn(highlighter, 'loadLanguageSync').mockImplementation(
+      () => {
+        throw failure;
+      }
+    );
+    try {
+      const result = await getSharedHighlighter({
+        themes: [],
+        langs: ['tf'],
+      }).catch((error: unknown) => error);
+      expect(result).toBe(failure);
+      expect(areLanguagesAttached('tf')).toBe(false);
+    } finally {
+      load.mockRestore();
+    }
+
+    await getSharedHighlighter({ themes: [], langs: ['tf'] });
+    expect(areLanguagesAttached('tf')).toBe(true);
+    expect(highlighter.getLoadedLanguages()).toContain('tf');
+  });
+
+  test('does not report a new alias attached when Shiki skips an already-loaded grammar', async () => {
+    await getSharedHighlighter({ themes: [], langs: ['hcl'] });
+    registerCustomLanguage('custom-hcl', async () => {
+      const { default: grammars } = await bundledLanguages.hcl();
+      return {
+        default: grammars.map((grammar) => ({
+          ...grammar,
+          aliases: [...(grammar.aliases ?? []), 'custom-hcl'],
+        })),
+      };
+    });
+
+    const result = await getSharedHighlighter({
+      themes: [],
+      langs: ['custom-hcl'],
+    }).catch((error: unknown) => error);
+    expect(result).toEqual(
+      new Error(
+        'attachResolvedLanguages: "hcl" is already loaded without alias "custom-hcl". Load the alias first or give the grammar a unique name.'
+      )
+    );
+    expect(areLanguagesAttached('custom-hcl')).toBe(false);
+  });
+});


### PR DESCRIPTION
Custom loaded languages must have a language name that matches the definition in their grammar file, and if it's off we need to clearly error out.